### PR TITLE
feat(kusto): add KustoEntityGroups pipeline step for cross-cluster sync

### DIFF
--- a/dev-infrastructure/geography-pipeline-stg.yaml
+++ b/dev-infrastructure/geography-pipeline-stg.yaml
@@ -26,23 +26,6 @@ resourceGroups:
     parameters: configurations/output-global-stg.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-- name: svc
-  resourceGroup: '{{ .regionRG }}'
-  subscription: '{{ .svc.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    environments:
-    - stg
-    regions:
-    - uksouth
-  steps:
-  - name: subscription-lookup
-    action: ARM
-    template: templates/subscription-lookup.bicep
-    parameters: configurations/subscription-lookup.tmpl.bicepparam
-    deploymentLevel: ResourceGroup
-    outputOnly: true
 - name: kusto-infra
   resourceGroup: '{{ .kusto.rg }}'
   # Hardcoded on purpose — see global-pipeline-stg.yaml. Removed at decommission.
@@ -60,96 +43,31 @@ resourceGroups:
     template: templates/kusto.bicep
     parameters: configurations/kusto-stg.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    variables:
+    - name: globalMSIId
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    dependsOn:
+    - resourceGroup: global
+      step: output
     automatedRetry:
       errorContainsAny:
       - "InternalServerError"
       - "Internal server error"
       maximumRetryCount: 3
       durationBetweenRetries: 1m
-  - name: kusto-lookup
-    action: ARM
-    template: templates/kusto-lookup.bicep
-    parameters: configurations/kusto-lookup.tmpl.bicepparam
-    deploymentLevel: ResourceGroup
-    outputOnly: true
-    dependsOn:
-    - resourceGroup: kusto-infra
-      step: deploy
-  - name: action-groups
-    action: ARM
-    template: templates/geography-actiongroups.bicep
-    parameters: configurations/geography-actiongroups.tmpl.bicepparam
-    deploymentLevel: ResourceGroup
-    variables:
-    - name: eventHubSubscriptionId
-      input:
-        resourceGroup: svc
-        step: subscription-lookup
-        name: subscriptionId
-    - name: kustoRegion
-      input:
-        resourceGroup: kusto-infra
-        step: kusto-lookup
-        name: kustoRegion
-    dependsOn:
-    - resourceGroup: kusto-infra
-      step: kusto-lookup
-    - resourceGroup: svc
-      step: subscription-lookup
-  - name: detach-legacy-monitoring-stack
-    action: Shell
-    command: ./detach-legacy-monitoring-stack.sh
-    workingDir: ./scripts
-    variables:
-    - name: KUSTO_RESOURCE_GROUP
-      configRef: kusto.rg
-    shellIdentity:
-      input:
-        resourceGroup: global
-        step: output
-        name: globalMSIId
-    dependsOn:
-    - resourceGroup: kusto-infra
-      step: deploy
-    - resourceGroup: global
+  - name: entity-groups
+    action: KustoEntityGroups
+    entityGroups:
+    - "AllServiceLogs:ServiceLogs"
+    - "AllHostedControlPlaneLogs:HostedControlPlaneLogs"
+    timeout: "10m"
+    identityFrom:
+      resourceGroup: global
       step: output
-  - name: kusto-monitoring
-    action: ARMStack
-    template: templates/kusto-monitoring.bicep
-    parameters: configurations/kusto-monitoring.tmpl.bicepparam
-    deploymentLevel: ResourceGroup
-    actionOnUnmanage: delete
-    bypassStackOutOfSyncError: false
-    automatedRetry:
-      errorContainsAny:
-      - "DeploymentStackInNonTerminalState"
-      maximumRetryCount: 3
-      durationBetweenRetries: 2m
-    variables:
-    - name: kustoClusterId
-      input:
-        resourceGroup: kusto-infra
-        step: kusto-lookup
-        name: kustoResourceId
-    - name: kustoRegion
-      input:
-        resourceGroup: kusto-infra
-        step: kusto-lookup
-        name: kustoRegion
-    - name: actionGroupSL
-      input:
-        resourceGroup: kusto-infra
-        step: action-groups
-        name: actionGroupSL
-    - name: actionGroupAlertEH
-      input:
-        resourceGroup: kusto-infra
-        step: action-groups
-        name: actionGroupAlertEH
+      name: globalMSIId
     dependsOn:
     - resourceGroup: kusto-infra
-      step: kusto-lookup
-    - resourceGroup: kusto-infra
-      step: action-groups
-    - resourceGroup: kusto-infra
-      step: detach-legacy-monitoring-stack
+      step: deploy

--- a/dev-infrastructure/geography-pipeline.yaml
+++ b/dev-infrastructure/geography-pipeline.yaml
@@ -12,44 +12,6 @@ resourceGroups:
     parameters: configurations/output-global.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
-- name: svc
-  resourceGroup: '{{ .regionRG }}'
-  subscription: '{{ .svc.subscription.key }}'
-  executionConstraints:
-  - clouds:
-    - public
-    environments:
-    - int
-    regions:
-    - uksouth
-    - westus3
-  - clouds:
-    - public
-    environments:
-    - stg
-    regions:
-    - uksouth
-  - clouds:
-    - public
-    environments:
-    - prod
-    regions:
-    - australiaeast
-    - brazilsouth
-    - canadacentral
-    - centralindia
-    - eastus2
-    - eastus2euap
-    - westeurope
-    - switzerlandnorth
-    - uksouth
-  steps:
-  - name: subscription-lookup
-    action: ARM
-    template: templates/subscription-lookup.bicep
-    parameters: configurations/subscription-lookup.tmpl.bicepparam
-    deploymentLevel: ResourceGroup
-    outputOnly: true
 - name: kusto-infra
   resourceGroup: '{{ .kusto.rg }}'
   subscription: '{{ .global.subscription.key }}'
@@ -87,96 +49,31 @@ resourceGroups:
     template: templates/kusto.bicep
     parameters: configurations/kusto.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    variables:
+    - name: globalMSIId
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    dependsOn:
+    - resourceGroup: global
+      step: output
     automatedRetry:
       errorContainsAny:
       - "InternalServerError"
       - "Internal server error"
       maximumRetryCount: 3
       durationBetweenRetries: 1m
-  - name: kusto-lookup
-    action: ARM
-    template: templates/kusto-lookup.bicep
-    parameters: configurations/kusto-lookup.tmpl.bicepparam
-    deploymentLevel: ResourceGroup
-    outputOnly: true
-    dependsOn:
-    - resourceGroup: kusto-infra
-      step: deploy
-  - name: action-groups
-    action: ARM
-    template: templates/geography-actiongroups.bicep
-    parameters: configurations/geography-actiongroups.tmpl.bicepparam
-    deploymentLevel: ResourceGroup
-    variables:
-    - name: eventHubSubscriptionId
-      input:
-        resourceGroup: svc
-        step: subscription-lookup
-        name: subscriptionId
-    - name: kustoRegion
-      input:
-        resourceGroup: kusto-infra
-        step: kusto-lookup
-        name: kustoRegion
-    dependsOn:
-    - resourceGroup: kusto-infra
-      step: kusto-lookup
-    - resourceGroup: svc
-      step: subscription-lookup
-  - name: detach-legacy-monitoring-stack
-    action: Shell
-    command: ./detach-legacy-monitoring-stack.sh
-    workingDir: ./scripts
-    variables:
-    - name: KUSTO_RESOURCE_GROUP
-      configRef: kusto.rg
-    shellIdentity:
-      input:
-        resourceGroup: global
-        step: output
-        name: globalMSIId
-    dependsOn:
-    - resourceGroup: kusto-infra
-      step: deploy
-    - resourceGroup: global
+  - name: entity-groups
+    action: KustoEntityGroups
+    entityGroups:
+    - "AllServiceLogs:ServiceLogs"
+    - "AllHostedControlPlaneLogs:HostedControlPlaneLogs"
+    timeout: "10m"
+    identityFrom:
+      resourceGroup: global
       step: output
-  - name: kusto-monitoring
-    action: ARMStack
-    template: templates/kusto-monitoring.bicep
-    parameters: configurations/kusto-monitoring.tmpl.bicepparam
-    deploymentLevel: ResourceGroup
-    actionOnUnmanage: delete
-    bypassStackOutOfSyncError: false
-    automatedRetry:
-      errorContainsAny:
-      - "DeploymentStackInNonTerminalState"
-      maximumRetryCount: 3
-      durationBetweenRetries: 2m
-    variables:
-    - name: kustoClusterId
-      input:
-        resourceGroup: kusto-infra
-        step: kusto-lookup
-        name: kustoResourceId
-    - name: kustoRegion
-      input:
-        resourceGroup: kusto-infra
-        step: kusto-lookup
-        name: kustoRegion
-    - name: actionGroupSL
-      input:
-        resourceGroup: kusto-infra
-        step: action-groups
-        name: actionGroupSL
-    - name: actionGroupAlertEH
-      input:
-        resourceGroup: kusto-infra
-        step: action-groups
-        name: actionGroupAlertEH
+      name: globalMSIId
     dependsOn:
     - resourceGroup: kusto-infra
-      step: kusto-lookup
-    - resourceGroup: kusto-infra
-      step: action-groups
-    - resourceGroup: kusto-infra
-      step: detach-legacy-monitoring-stack
+      step: deploy

--- a/test/go.mod
+++ b/test/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260715002326-2555e1130350 // indirect
 	github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260715002326-2555e1130350 // indirect
 	github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260715002326-2555e1130350 // indirect
+	github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707 // indirect
 	github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260715002326-2555e1130350 // indirect
 	github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260715002326-2555e1130350 // indirect
 	github.com/Azure/ARO-Tools/tools/yamlwrap v0.0.0-20260715002326-2555e1130350 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -79,6 +79,8 @@ github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260715002326-2555e1130350 h
 github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260715002326-2555e1130350/go.mod h1:YrrfIHROa3fg+mMyE6OhqM3pjcUXXAmcbcdHLwMb6ac=
 github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260715002326-2555e1130350 h1:oHYub03vXUpyw8PYZY8FBPHnJju62IQtu3FmV4EsdtY=
 github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260715002326-2555e1130350/go.mod h1:p0FcYeq5sRcsNrgLSpxCZfoh7B/O819/4RKaW+OKq80=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707 h1:9PebQsjEluc2PlP70Joug0e9KJ7POK28/IB/V72fgB0=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707/go.mod h1:6eOFGWnLVSTCxOPAzY0/21bf/WppxEVhemxiz3m7gdw=
 github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260727130050-e42f10b99914 h1:xA88xrxz0sFAb/uWyrOXmXDMcVsd4WBG+uppPFf5whY=
 github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260727130050-e42f10b99914/go.mod h1:pRJ0Qa8BaixSoIyS6Dw2icSSZ4zbAT2bPUURD9SsHH4=
 github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260715002326-2555e1130350 h1:nIXBFOJJBQBF5s8EUCwHmjpo8LsSzpLj2x3J5bnG8AM=

--- a/tooling/templatize/go.mod
+++ b/tooling/templatize/go.mod
@@ -41,6 +41,7 @@ require (
 )
 
 require (
+	github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0
 	k8s.io/api v0.35.3
 )
@@ -56,6 +57,7 @@ require (
 	cloud.google.com/go/storage v1.62.1 // indirect
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/ARO-Tools/tools/yamlwrap v0.0.0-20260715002326-2555e1130350 // indirect
+	github.com/Azure/azure-kusto-go/azkustodata v1.2.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dashboard/armdashboard/v2 v2.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0 // indirect
@@ -229,6 +231,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rubenv/sql-migrate v1.8.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/samber/lo v1.53.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/tooling/templatize/go.sum
+++ b/tooling/templatize/go.sum
@@ -79,6 +79,8 @@ github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260715002326-2555e1130350 h
 github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260715002326-2555e1130350/go.mod h1:YrrfIHROa3fg+mMyE6OhqM3pjcUXXAmcbcdHLwMb6ac=
 github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260715002326-2555e1130350 h1:oHYub03vXUpyw8PYZY8FBPHnJju62IQtu3FmV4EsdtY=
 github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260715002326-2555e1130350/go.mod h1:p0FcYeq5sRcsNrgLSpxCZfoh7B/O819/4RKaW+OKq80=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707 h1:9PebQsjEluc2PlP70Joug0e9KJ7POK28/IB/V72fgB0=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707/go.mod h1:6eOFGWnLVSTCxOPAzY0/21bf/WppxEVhemxiz3m7gdw=
 github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260727130050-e42f10b99914 h1:xA88xrxz0sFAb/uWyrOXmXDMcVsd4WBG+uppPFf5whY=
 github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260727130050-e42f10b99914/go.mod h1:pRJ0Qa8BaixSoIyS6Dw2icSSZ4zbAT2bPUURD9SsHH4=
 github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260715002326-2555e1130350 h1:nIXBFOJJBQBF5s8EUCwHmjpo8LsSzpLj2x3J5bnG8AM=
@@ -87,6 +89,8 @@ github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260715002326-2555e1130350 
 github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260715002326-2555e1130350/go.mod h1:WVXfK6MgM/X9ZMZXF++4jQZMQUn+bTSGq2fm83CABv8=
 github.com/Azure/ARO-Tools/tools/yamlwrap v0.0.0-20260715002326-2555e1130350 h1:TvqZBV3fB+PZHiJaobz5uuAlZMvH/M/1xdQNlXm7IyI=
 github.com/Azure/ARO-Tools/tools/yamlwrap v0.0.0-20260715002326-2555e1130350/go.mod h1:3q92ds6RcyVJU6pGPksdhCIThw0mDq2hndXFidHsMB4=
+github.com/Azure/azure-kusto-go/azkustodata v1.2.1 h1:De25JIENJVLYUMB4Z9LfAFzbgjGz1ozYJiL2zprs1KA=
+github.com/Azure/azure-kusto-go/azkustodata v1.2.1/go.mod h1:pYbM6A7z4XDU+3S0+OgoyUOuCOWPUe/hyEfnOCT6Gok=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 h1:jHb/wfvRikGdxMXYV3QG/SzUOPYN9KEUUuC0Yd0/vC0=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1/go.mod h1:pzBXCYn05zvYIrwLgtK8Ap8QcjRg+0i76tMQdWN6wOk=
@@ -785,6 +789,8 @@ github.com/rubenv/sql-migrate v1.8.1/go.mod h1:BTIKBORjzyxZDS6dzoiw6eAFYJ1iNlGAt
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
+github.com/samber/lo v1.53.0 h1:t975lj2py4kJPQ6haz1QMgtId2gtmfktACxIXArw3HM=
+github.com/samber/lo v1.53.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
@@ -843,6 +849,8 @@ github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 h1:ZF+QBjOI+tILZ
 github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834/go.mod h1:m9ymHTgNSEjuxvw8E7WWe4Pl4hZQHXONY8wE6dMLaRk=
 github.com/tetratelabs/wazero v1.11.0 h1:+gKemEuKCTevU4d7ZTzlsvgd1uaToIDtlQlmNbwqYhA=
 github.com/tetratelabs/wazero v1.11.0/go.mod h1:eV28rsN8Q+xwjogd7f4/Pp4xFxO7uOGbLcD/LzB1wiU=
+github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
+github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=
 github.com/trivago/tgo v1.0.7 h1:uaWH/XIy9aWYWpjm2CU3RpcqZXmX2ysQ9/Go+d9gyrM=
 github.com/trivago/tgo v1.0.7/go.mod h1:w4dpD+3tzNIIiIfkWWa85w5/B77tlvdZckQ+6PkFnhc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/tooling/templatize/pkg/pipeline/kusto_entity_groups.go
+++ b/tooling/templatize/pkg/pipeline/kusto_entity_groups.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/ARO-Tools/pipelines/graph"
+	"github.com/Azure/ARO-Tools/pipelines/types"
+	"github.com/Azure/ARO-Tools/tools/kustoctl/cmd/entitygroups"
+)
+
+func runKustoEntityGroupsStep(_ graph.Identifier, step *types.KustoEntityGroupsStep, ctx context.Context) error {
+	opts := entitygroups.DefaultSyncOptions()
+	opts.EntityGroups = step.EntityGroups
+
+	if step.Timeout != "" {
+		d, err := time.ParseDuration(step.Timeout)
+		if err != nil {
+			return fmt.Errorf("failed to parse timeout %q: %w", step.Timeout, err)
+		}
+		opts.Timeout = d
+	}
+
+	return opts.Run(ctx)
+}

--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -964,6 +964,11 @@ func RunStep(id graph.Identifier, s types.Step, ctx context.Context, executionTa
 			return nil, nil, fmt.Errorf("error running Grafana Manage Step: %w", err)
 		}
 		return nil, nil, nil
+	case *types.KustoEntityGroupsStep:
+		if err := runKustoEntityGroupsStep(id, step, ctx); err != nil {
+			return nil, nil, fmt.Errorf("error running Kusto Entity Groups Step: %w", err)
+		}
+		return nil, nil, nil
 	case *types.ARMStep:
 		a, err := newArmClient(executionTarget.GetSubscriptionID(), executionTarget.GetRegion(), options.BicepClient)
 		if err != nil {


### PR DESCRIPTION
Re-lands [#6150](https://github.com/Azure/ARO-HCP/pull/6150) (reverted in [#6258](https://github.com/Azure/ARO-HCP/pull/6258)) and adds the pipeline step that actually runs the entity group sync.

### What

**From #6150 (re-landed):**
- `aroHCPPurpose` tag on Kusto clusters
- Global MSI Database Admin role assignment
- Pipeline wiring for kustoctl

**New in this PR:**
- Templatize pipeline runner for the `KustoEntityGroups` action type (calls `entitygroups.DefaultSyncOptions().Run()` from ARO-Tools kustoctl)
- `entity-groups` steps in `geography-pipeline.yaml` and `geography-pipeline-stg.yaml`, running after Kusto deploy with the global MSI identity
- Syncs two entity groups:
  - `AllServiceLogs:ServiceLogs`
  - `AllHostedControlPlaneLogs:HostedControlPlaneLogs`

### Why

Without this step, the infrastructure deploys (tag + MSI role) but the cross-cluster entity groups never get created.

### Dependencies

- [ARO-Tools #267](https://github.com/Azure/ARO-Tools/pull/267) (merged): kustoctl entity-groups sync command
- [#6150](https://github.com/Azure/ARO-HCP/pull/6150) (merged, then reverted in #6258): infrastructure prerequisites (re-landed here)
- [sdp-pipelines PR #16614060](https://dev.azure.com/msazure/AzureRedHatOpenShift/_git/sdp-pipelines/pullrequest/16614060): pipeline step config that consumes this runner

Jira: [ARO-27830](https://redhat.atlassian.net/browse/ARO-27830)