### PR TITLE
feat(kube-applier): redact Secret data before persisting ReadDesire status

### DIFF
--- a/internal/api/kubeapplier/types_read_desire.go
+++ b/internal/api/kubeapplier/types_read_desire.go
@@ -69,5 +69,13 @@ type ReadDesireStatus struct {
 	// nil means the target either has not been observed yet or is absent
 	// from the cluster — distinguish those two via the "Successful"
 	// condition (Unknown vs. True).
+	//
+	// When TargetItem is a core/v1 Secret, KubeContent is redacted before
+	// storage: structural fields (apiVersion, kind, type) and metadata are
+	// preserved, but annotations that can embed the full Secret (e.g.
+	// kubectl.kubernetes.io/last-applied-configuration) are stripped. In the
+	// data map only known-safe keys (currently "tls.crt") survive; all other
+	// data keys and stringData are removed to prevent private keys,
+	// passwords, and tokens from leaking into Cosmos.
 	KubeContent *runtime.RawExtension `json:"kubeContent,omitempty"`
 }

--- a/kube-applier/docs/05-controllers.md
+++ b/kube-applier/docs/05-controllers.md
@@ -237,12 +237,16 @@ Run loop (per readme):
 - On each sync:
     1. Read the live object from the kube lister (may be nil if absent).
     2. Read the ReadDesire from the readDesireLister.
-    3. Marshal the live object to RawExtension. If absent, leave a sentinel
-       (e.g. RawExtension{Raw: nil}).
-    4. If new RawExtension differs from ReadDesire.Status.KubeContent
+    3. If the target is a core/v1 Secret, deep-copy and redact the object:
+       strip all data keys except known-safe ones (currently "tls.crt")
+       and remove stringData. This prevents private keys, passwords, and
+       tokens from being persisted to Cosmos.
+    4. Marshal the (possibly redacted) live object to RawExtension.
+       If absent, leave a sentinel (e.g. RawExtension{Raw: nil}).
+    5. If new RawExtension differs from ReadDesire.Status.KubeContent
        (byte-equal compare), write the new status and SetSuccessful(true).
        Otherwise no-op.
-    5. On any kube error en route, SetSuccessful(false, "KubeAPIError"/"PreCheckFailed").
+    6. On any kube error en route, SetSuccessful(false, "KubeAPIError"/"PreCheckFailed").
 ```
 
 Stop behaviour: when the parent manager calls `cancel()`, the workqueue is

--- a/kube-applier/pkg/controllers/read_desire_kubernetes/controller.go
+++ b/kube-applier/pkg/controllers/read_desire_kubernetes/controller.go
@@ -308,6 +308,10 @@ func (c *ReadDesireKubernetesController) SyncOnce(ctx context.Context) error {
 					fmt.Errorf("informer cached unexpected type %T", rawObj)))
 			})
 		}
+		if isSecret(c.target) {
+			obj = obj.DeepCopy()
+			redactSecret(obj)
+		}
 		newRaw, err = json.Marshal(obj)
 		if err != nil {
 			return c.writer.UpdateStatus(ctx, c.key, func(d *kubeapplier.ReadDesire) {

--- a/kube-applier/pkg/controllers/read_desire_kubernetes/redact.go
+++ b/kube-applier/pkg/controllers/read_desire_kubernetes/redact.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package read_desire_kubernetes
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+)
+
+// safeSecretDataKeys lists the data keys that are safe to mirror into
+// ReadDesire.status.kubeContent when the target is a v1 Secret. All other
+// data keys are stripped before the object is persisted to Cosmos. This
+// prevents private keys, passwords, and tokens from leaking into the
+// service cluster's database.
+var safeSecretDataKeys = map[string]struct{}{
+	"tls.crt": {},
+}
+
+// isSecret returns true when the ResourceReference points at a core/v1 Secret.
+func isSecret(ref kubeapplier.ResourceReference) bool {
+	return ref.Group == "" && ref.Version == "v1" && ref.Resource == "secrets"
+}
+
+// unsafeAnnotations lists metadata annotations that can embed the full
+// Secret manifest (including private keys and tokens). These are removed
+// during redaction even though the rest of metadata is preserved.
+var unsafeAnnotations = map[string]struct{}{
+	"kubectl.kubernetes.io/last-applied-configuration": {},
+}
+
+// redactSecret strips all unsafe fields from a Secret. Structural fields
+// (apiVersion, kind, type) and metadata are preserved, except for
+// annotations that can embed the full Secret (e.g.
+// kubectl.kubernetes.io/last-applied-configuration). In the data map, only
+// keys listed in safeSecretDataKeys survive; on any error reading data the
+// field is removed entirely (fail closed). The object is modified in place;
+// callers must pass a deep copy if the original must be preserved (e.g.
+// informer cache objects).
+func redactSecret(obj *unstructured.Unstructured) {
+	data, found, err := unstructured.NestedMap(obj.Object, "data")
+	if err != nil {
+		unstructured.RemoveNestedField(obj.Object, "data")
+	} else if found {
+		for key := range data {
+			if _, safe := safeSecretDataKeys[key]; !safe {
+				delete(data, key)
+			}
+		}
+		if len(data) > 0 {
+			_ = unstructured.SetNestedField(obj.Object, data, "data")
+		} else {
+			unstructured.RemoveNestedField(obj.Object, "data")
+		}
+	}
+
+	// stringData is the write-only variant of data; the API server never
+	// returns it, but strip it defensively.
+	unstructured.RemoveNestedField(obj.Object, "stringData")
+
+	stripUnsafeAnnotations(obj)
+}
+
+// stripUnsafeAnnotations removes annotations that can embed a full Secret
+// manifest. If the annotations map becomes empty it is removed entirely so
+// the serialized object stays clean.
+func stripUnsafeAnnotations(obj *unstructured.Unstructured) {
+	annotations, found, err := unstructured.NestedStringMap(obj.Object, "metadata", "annotations")
+	if !found || err != nil {
+		return
+	}
+	for key := range unsafeAnnotations {
+		delete(annotations, key)
+	}
+	if len(annotations) > 0 {
+		_ = unstructured.SetNestedStringMap(obj.Object, annotations, "metadata", "annotations")
+	} else {
+		unstructured.RemoveNestedField(obj.Object, "metadata", "annotations")
+	}
+}

--- a/kube-applier/pkg/controllers/read_desire_kubernetes/redact_test.go
+++ b/kube-applier/pkg/controllers/read_desire_kubernetes/redact_test.go
@@ -1,0 +1,284 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package read_desire_kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+)
+
+func TestIsSecret(t *testing.T) {
+	cases := []struct {
+		name string
+		ref  kubeapplier.ResourceReference
+		want bool
+	}{
+		{
+			name: "core v1 secrets",
+			ref:  kubeapplier.ResourceReference{Group: "", Version: "v1", Resource: "secrets"},
+			want: true,
+		},
+		{
+			name: "configmaps are not secrets",
+			ref:  kubeapplier.ResourceReference{Group: "", Version: "v1", Resource: "configmaps"},
+			want: false,
+		},
+		{
+			name: "non-core group with secrets resource name",
+			ref:  kubeapplier.ResourceReference{Group: "example.com", Version: "v1", Resource: "secrets"},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSecret(tc.ref); got != tc.want {
+				t.Errorf("isSecret(%+v) = %v, want %v", tc.ref, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRedactSecret(t *testing.T) {
+	cases := []struct {
+		name         string
+		obj          *unstructured.Unstructured
+		wantDataKeys []string
+	}{
+		{
+			name: "strips unsafe data keys, keeps tls.crt",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata":   map[string]any{"name": "s", "namespace": "ns"},
+				"data": map[string]any{
+					"tls.crt": "Y2VydA==",
+					"tls.key": "a2V5",
+					"ca.crt":  "Y2E=",
+				},
+			}},
+			wantDataKeys: []string{"tls.crt"},
+		},
+		{
+			name: "no safe keys present removes data entirely",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata":   map[string]any{"name": "s", "namespace": "ns"},
+				"data": map[string]any{
+					"password": "c2VjcmV0",
+					"token":    "dG9rZW4=",
+				},
+			}},
+			wantDataKeys: nil,
+		},
+		{
+			name: "secret with no data field",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata":   map[string]any{"name": "s", "namespace": "ns"},
+			}},
+			wantDataKeys: nil,
+		},
+		{
+			name: "stringData is removed",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata":   map[string]any{"name": "s", "namespace": "ns"},
+				"data":       map[string]any{"tls.crt": "Y2VydA=="},
+				"stringData": map[string]any{"extra": "value"},
+			}},
+			wantDataKeys: []string{"tls.crt"},
+		},
+		{
+			name: "data error fails closed",
+			obj: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata":   map[string]any{"name": "s", "namespace": "ns"},
+				"data":       "not-a-map",
+			}},
+			wantDataKeys: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			redactSecret(tc.obj)
+
+			data, found, _ := unstructured.NestedMap(tc.obj.Object, "data")
+			if tc.wantDataKeys == nil {
+				if found && len(data) > 0 {
+					t.Errorf("expected no data keys, got %v", data)
+				}
+				return
+			}
+			if !found {
+				t.Fatalf("expected data to be present")
+			}
+			if len(data) != len(tc.wantDataKeys) {
+				t.Errorf("data has %d keys, want %d: %v", len(data), len(tc.wantDataKeys), data)
+			}
+			for _, key := range tc.wantDataKeys {
+				if _, ok := data[key]; !ok {
+					t.Errorf("expected data key %q to be present", key)
+				}
+			}
+
+			if _, found, _ := unstructured.NestedMap(tc.obj.Object, "stringData"); found {
+				t.Error("stringData should have been removed")
+			}
+
+			if tc.obj.Object["metadata"] == nil {
+				t.Error("metadata should be preserved")
+			}
+		})
+	}
+}
+
+func TestRedactSecret_StripsUnsafeAnnotations(t *testing.T) {
+	cases := []struct {
+		name            string
+		annotations     map[string]any
+		wantAnnotations map[string]string
+	}{
+		{
+			name: "last-applied-configuration removed",
+			annotations: map[string]any{
+				"kubectl.kubernetes.io/last-applied-configuration": `{"data":{"tls.key":"PRIVATE"}}`,
+				"safe-annotation": "keep",
+			},
+			wantAnnotations: map[string]string{"safe-annotation": "keep"},
+		},
+		{
+			name: "annotations removed entirely when only unsafe ones exist",
+			annotations: map[string]any{
+				"kubectl.kubernetes.io/last-applied-configuration": `{"secret":"stuff"}`,
+			},
+			wantAnnotations: nil,
+		},
+		{
+			name:            "no annotations is a no-op",
+			annotations:     nil,
+			wantAnnotations: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			md := map[string]any{"name": "s", "namespace": "ns"}
+			if tc.annotations != nil {
+				md["annotations"] = tc.annotations
+			}
+			obj := &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata":   md,
+			}}
+			redactSecret(obj)
+
+			got, found, _ := unstructured.NestedStringMap(obj.Object, "metadata", "annotations")
+			if tc.wantAnnotations == nil {
+				if found && len(got) > 0 {
+					t.Errorf("expected no annotations, got %v", got)
+				}
+				return
+			}
+			if !found {
+				t.Fatal("expected annotations to be present")
+			}
+			for k, v := range tc.wantAnnotations {
+				if got[k] != v {
+					t.Errorf("annotation %q = %q, want %q", k, got[k], v)
+				}
+			}
+			if len(got) != len(tc.wantAnnotations) {
+				t.Errorf("annotations has %d keys, want %d", len(got), len(tc.wantAnnotations))
+			}
+		})
+	}
+}
+
+func secretTarget(name string) kubeapplier.ResourceReference {
+	return kubeapplier.ResourceReference{
+		Group: "", Version: "v1", Resource: "secrets", Namespace: testTargetNs, Name: name,
+	}
+}
+
+func TestSyncOnce_SecretTarget_RedactsUnsafeKeys(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	target := secretTarget("my-tls-secret")
+	desire := newReadDesire(t, target)
+	dyn := dynamicForTestdata(t, "testdata/secret_present")
+
+	c, w := startSyncedController(t, ctx, target, desire, dyn)
+	if err := c.SyncOnce(ctx); err != nil {
+		t.Fatalf("SyncOnce: %v", err)
+	}
+	if len(w.updates) == 0 {
+		t.Fatal("no status update recorded")
+	}
+	last := w.updates[len(w.updates)-1]
+	if last.Status.KubeContent == nil || len(last.Status.KubeContent.Raw) == 0 {
+		t.Fatal("KubeContent is empty after sync")
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(last.Status.KubeContent.Raw, &got); err != nil {
+		t.Fatalf("unmarshal kubeContent: %v", err)
+	}
+
+	if got["kind"] != "Secret" {
+		t.Errorf("kind = %v, want Secret", got["kind"])
+	}
+
+	md, _ := got["metadata"].(map[string]any)
+	if md == nil || md["name"] != "my-tls-secret" {
+		t.Errorf("metadata.name = %v, want my-tls-secret", md["name"])
+	}
+
+	data, _ := got["data"].(map[string]any)
+	if data == nil {
+		t.Fatal("data should be present (tls.crt is safe)")
+	}
+	if _, ok := data["tls.crt"]; !ok {
+		t.Error("data[tls.crt] should be preserved")
+	}
+	if _, ok := data["tls.key"]; ok {
+		t.Error("data[tls.key] should have been redacted")
+	}
+	if _, ok := data["ca.crt"]; ok {
+		t.Error("data[ca.crt] should have been redacted")
+	}
+
+	annotations, _ := md["annotations"].(map[string]any)
+	if annotations != nil {
+		if _, ok := annotations["kubectl.kubernetes.io/last-applied-configuration"]; ok {
+			t.Error("last-applied-configuration annotation should have been stripped")
+		}
+	}
+
+	cond := findCond(last.Status.Conditions, kubeapplier.ConditionTypeSuccessful)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Errorf("Successful=%v, want True", cond)
+	}
+}

--- a/kube-applier/readme.md
+++ b/kube-applier/readme.md
@@ -11,6 +11,10 @@ At a high level:
 2. `ReadDesire` indicates a kube item in .spec.targetItem to issue a list/watch+informer for.
    The actual list/watch result to be written to `.status.kubeContent`.
    Success/failure to be written to the `.status.conditions["Successful"]` condition.
+   When the target is a core/v1 Secret, `.status.kubeContent` is redacted before storage:
+   only metadata and known-safe data keys (currently `tls.crt`) are preserved. All other
+   data keys and `stringData` are stripped to prevent private keys, passwords, and tokens
+   from leaking into Cosmos.
 
 ## Scale
 The scale of the kube-applier is tiny: it covers a single management cluster.


### PR DESCRIPTION
ReadDesire targets that point at core/v1 Secrets now have their kubeContent redacted before it is written to Cosmos. Only metadata and known-safe data keys (currently "tls.crt") are preserved; all other data keys and stringData are stripped.

This prevents private keys, passwords, and tokens from leaking into the service cluster database when a ReadDesire watches a Secret.

This is a build block to pull the public part of a serving cert into the cosmos for use building a kubeconfig.