### PR TITLE
frontend/alerts: update latency SLO to p99 > 1s and add sensitive per-path alert

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
@@ -1670,7 +1670,7 @@ resource svcFrontendPathLatency 'Microsoft.AlertsManagement/prometheusRuleGroups
           summary: 'Frontend latency is high: 99th percentile exceeds 1 second for {{ $labels.method }} {{ $labels.route }}'
           title: 'Frontend latency is high: 99th percentile exceeds 1 second for {{ $labels.method }} {{ $labels.route }}'
         }
-        expression: 'histogram_quantile(0.99, sum by (le, route, method) (rate(frontend_http_requests_duration_seconds_bucket[30m]))) > 1'
+        expression: 'histogram_quantile(0.99, sum by (le, route, method) (rate(frontend_http_requests_duration_seconds_bucket{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[30m]))) > 1'
         for: 'PT1M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
@@ -1640,3 +1640,43 @@ resource svcKubernetesSystemControllerManager 'Microsoft.AlertsManagement/promet
     ]
   }
 }
+
+resource svcFrontendPathLatency 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'svc-frontend-path-latency'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'FrontendPathLatency'
+        enabled: true
+        labels: {
+          severity: 'info'
+        }
+        annotations: {
+          correlationId: 'FrontendPathLatency/{{ $labels.cluster }}/{{ $labels.method }}/{{ $labels.route }}'
+          description: 'The 99th percentile of frontend request latency for {{ $labels.method }} {{ $labels.route }} has exceeded 1 second over the past 30 minutes.'
+          info: 'The 99th percentile of frontend request latency for {{ $labels.method }} {{ $labels.route }} has exceeded 1 second over the past 30 minutes.'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/frontend-tsg.html'
+          summary: 'Frontend latency is high: 99th percentile exceeds 1 second for {{ $labels.method }} {{ $labels.route }}'
+          title: 'Frontend latency is high: 99th percentile exceeds 1 second for {{ $labels.method }} {{ $labels.route }}'
+        }
+        expression: 'histogram_quantile(0.99, sum by (le, route, method) (rate(frontend_http_requests_duration_seconds_bucket[30m]))) > 1'
+        for: 'PT1M'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}

--- a/dev-infrastructure/modules/metrics/rules/generatedSREServicePrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedSREServicePrometheusAlertingRules.bicep
@@ -32,15 +32,15 @@ resource frontendLatency 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           severity: 'info'
         }
         annotations: {
-          correlationId: 'FrontendLatency/{{ $labels.cluster }}'
-          description: 'The 95th percentile of frontend request latency has exceeded 5 seconds over the past hour.'
-          info: 'The 95th percentile of frontend request latency has exceeded 5 seconds over the past hour.'
+          correlationId: 'FrontendLatency/{{ $labels.cluster }}/{{ $labels.method }}/{{ $labels.route }}'
+          description: 'The 99th percentile of frontend request latency for {{ $labels.method }} {{ $labels.route }} has exceeded 1 second over the past hour.'
+          info: 'The 99th percentile of frontend request latency for {{ $labels.method }} {{ $labels.route }} has exceeded 1 second over the past hour.'
           runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/frontend-tsg.html'
-          summary: 'Frontend latency is high: 95th percentile exceeds 5 seconds'
-          title: 'Frontend latency is high: 95th percentile exceeds 5 seconds'
+          summary: 'Frontend latency is high: 99th percentile exceeds 1 second for {{ $labels.method }} {{ $labels.route }}'
+          title: 'Frontend latency is high: 99th percentile exceeds 1 second for {{ $labels.method }} {{ $labels.route }}'
         }
-        expression: 'histogram_quantile(0.95, rate(frontend_http_requests_duration_seconds_bucket[1h])) > 5'
-        for: 'PT15M'
+        expression: 'histogram_quantile(0.99, sum by (le, route, method) (rate(frontend_http_requests_duration_seconds_bucket[1h]))) > 1'
+        for: 'PT1M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
     ]

--- a/dev-infrastructure/modules/metrics/rules/generatedSREServicePrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedSREServicePrometheusAlertingRules.bicep
@@ -39,7 +39,7 @@ resource frontendLatency 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
           summary: 'Frontend latency is high: 99th percentile exceeds 1 second for {{ $labels.method }} {{ $labels.route }}'
           title: 'Frontend latency is high: 99th percentile exceeds 1 second for {{ $labels.method }} {{ $labels.route }}'
         }
-        expression: 'histogram_quantile(0.99, sum by (le, route, method) (rate(frontend_http_requests_duration_seconds_bucket[1h]))) > 1'
+        expression: 'histogram_quantile(0.99, sum by (le, route, method) (rate(frontend_http_requests_duration_seconds_bucket{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[1h]))) > 1'
         for: 'PT1M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }

--- a/frontend/alerts/frontend-latency-prometheusRule.yaml
+++ b/frontend/alerts/frontend-latency-prometheusRule.yaml
@@ -16,7 +16,7 @@ spec:
       expr: |
         histogram_quantile(0.99,
           sum by (le, route, method) (
-            rate(frontend_http_requests_duration_seconds_bucket[1h])
+            rate(frontend_http_requests_duration_seconds_bucket{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[1h])
           )
         ) > 1
       for: 1m

--- a/frontend/alerts/frontend-path-latency-prometheusRule.yaml
+++ b/frontend/alerts/frontend-path-latency-prometheusRule.yaml
@@ -16,7 +16,7 @@ spec:
       expr: |
         histogram_quantile(0.99,
           sum by (le, route, method) (
-            rate(frontend_http_requests_duration_seconds_bucket[30m])
+            rate(frontend_http_requests_duration_seconds_bucket{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[30m])
           )
         ) > 1
       for: 1m

--- a/frontend/alerts/frontend-path-latency-prometheusRule.yaml
+++ b/frontend/alerts/frontend-path-latency-prometheusRule.yaml
@@ -6,23 +6,23 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     prometheus: k8s
     role: alert-rules
-  name: frontend-latency-monitoring-rules
+  name: frontend-path-latency-monitoring-rules
   namespace: monitoring
 spec:
   groups:
-  - name: frontend-latency
+  - name: frontend-path-latency
     rules:
-    - alert: FrontendLatency
+    - alert: FrontendPathLatency
       expr: |
         histogram_quantile(0.99,
           sum by (le, route, method) (
-            rate(frontend_http_requests_duration_seconds_bucket[1h])
+            rate(frontend_http_requests_duration_seconds_bucket[30m])
           )
         ) > 1
       for: 1m
       labels:
         severity: info
       annotations:
-        description: 'The 99th percentile of frontend request latency for {{ $labels.method }} {{ $labels.route }} has exceeded 1 second over the past hour.'
+        description: 'The 99th percentile of frontend request latency for {{ $labels.method }} {{ $labels.route }} has exceeded 1 second over the past 30 minutes.'
         runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/frontend-tsg.html'
         summary: 'Frontend latency is high: 99th percentile exceeds 1 second for {{ $labels.method }} {{ $labels.route }}'

--- a/frontend/alerts/frontend-path-latency-prometheusRule_test.yaml
+++ b/frontend/alerts/frontend-path-latency-prometheusRule_test.yaml
@@ -1,21 +1,21 @@
 rule_files:
-- frontend-latency-prometheusRule.yaml
+- frontend-path-latency-prometheusRule.yaml
 evaluation_interval: 1m
 tests:
-# Test: FrontendLatency does not fire when 99th percentile is below 1 second
+# Test: FrontendPathLatency does not fire when 99th percentile is below 1 second
 - interval: 1m
   input_series:
   - series: 'frontend_http_requests_duration_seconds_bucket{le="0.1", route="/api/clusters", method="GET"}'
-    values: '0+60x70'
+    values: '0+60x35'
   - series: 'frontend_http_requests_duration_seconds_bucket{le="0.5", route="/api/clusters", method="GET"}'
-    values: '0+60x90'
+    values: '0+60x45'
   - series: 'frontend_http_requests_duration_seconds_bucket{le="1", route="/api/clusters", method="GET"}'
-    values: '0+60x100'
+    values: '0+60x50'
   - series: 'frontend_http_requests_duration_seconds_bucket{le="5", route="/api/clusters", method="GET"}'
-    values: '0+60x100'
+    values: '0+60x50'
   - series: 'frontend_http_requests_duration_seconds_bucket{le="+Inf", route="/api/clusters", method="GET"}'
-    values: '0+60x100'
+    values: '0+60x50'
   alert_rule_test:
-  - eval_time: 62m
-    alertname: FrontendLatency
+  - eval_time: 32m
+    alertname: FrontendPathLatency
     exp_alerts: []

--- a/observability/alerts-kusto-services.yaml
+++ b/observability/alerts-kusto-services.yaml
@@ -1,5 +1,6 @@
 prometheusRules:
-  rulesFolders: []
+  rulesFolders:
+  - ../frontend/alerts/frontend-path-latency-prometheusRule.yaml
   untestedRules:
   - alerts/kubernetesControlPlane-prometheusRule.yaml
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep


### PR DESCRIPTION
frontend/alerts: update latency SLO to p99 > 1s and add sensitive per-path alert

Update the existing FrontendLatency alert from p95 > 5s to p99 > 1s over 1h,
aggregated by route and method. Add a new FrontendPathLatency alert with a 30m
window routed to kusto only (no IcM) for early detection of latency regressions.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

frontend/alerts: exclude hcpoperationresults route from latency alerts

This route has a known latency issue that will be addressed separately.
Exclude method=GET route=/subscriptions/{subscriptionid}/providers/
microsoft.redhatopenshift/locations/{location}/hcpoperationresults/
{operationid} from both FrontendLatency and FrontendPathLatency alerts.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

