### PR TITLE
test: add log-only e2e check for new shoebox log categories

### DIFF
--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -342,7 +342,7 @@ func setupCli() *cobra.Command {
 	// 	specs = specs.AddLabel("SLOW")
 
 	// Specs can be globally filtered...
-	// specs = specs.MustFilter([]string{`name.contains("filter")`})
+	specs = specs.MustFilter([]string{`name.contains("shoebox")`})
 
 	// Or walked...
 	// specs = specs.Walk(func(spec *extensiontests.ExtensionTestSpec) {

--- a/test/e2e/shoebox_logs.go
+++ b/test/e2e/shoebox_logs.go
@@ -52,6 +52,14 @@ var shoeboxLogCategories = []string{
 	"csi-snapshot-controller",
 }
 
+// newShoeboxLogCategories are the log categories added in
+// https://github.com/Azure/ARO-HCP/pull/5161. Their presence is only logged,
+// not asserted, until the categories are validated in all stage/prod regions.
+var newShoeboxLogCategories = []string{
+	"cluster-autoscaler",
+	"capi-provider",
+}
+
 type shoeboxLogVerifier interface {
 	Verify(context.Context) error
 }
@@ -61,9 +69,9 @@ type storageAccountResult struct {
 	AccountName string
 }
 
-func shoeboxDiagnosticLogSettings() []*armmonitor.LogSettings {
-	logSettings := make([]*armmonitor.LogSettings, 0, len(shoeboxLogCategories))
-	for _, category := range shoeboxLogCategories {
+func shoeboxDiagnosticLogSettings(categories []string) []*armmonitor.LogSettings {
+	logSettings := make([]*armmonitor.LogSettings, 0, len(categories))
+	for _, category := range categories {
 		logSettings = append(logSettings, &armmonitor.LogSettings{
 			Category: to.Ptr(category),
 			Enabled:  to.Ptr(true),
@@ -304,7 +312,8 @@ var _ = Describe("Customer", func() {
 
 			By("enabling diagnostic settings on the HCP cluster")
 			resourceID := clusterResourceID(subscriptionID, *resourceGroup.Name, customerClusterName)
-			logSettings := shoeboxDiagnosticLogSettings()
+			allCategories := append(append([]string{}, shoeboxLogCategories...), newShoeboxLogCategories...)
+			logSettings := shoeboxDiagnosticLogSettings(allCategories)
 
 			diagnosticsClient, err := armmonitor.NewDiagnosticSettingsClient(creds, &azcorearm.ClientOptions{
 				ClientOptions: azsdk.NewClientOptions(azsdk.ComponentE2E),
@@ -348,6 +357,7 @@ var _ = Describe("Customer", func() {
 
 			storageVerifier := verifiers.VerifyShoeboxLogs(blobContainersClient, *resourceGroup.Name, storage.AccountName)
 			eventHubVerifier := verifiers.VerifyShoeboxEventHub(eventHub.ConnectionString, eventHub.EventHubName)
+			newCategoriesVerifier := verifiers.VerifyShoeboxLogCategories(blobContainersClient, *resourceGroup.Name, storage.AccountName, newShoeboxLogCategories)
 
 			g, gCtx = errgroup.WithContext(ctx)
 			g.Go(func() error {
@@ -359,6 +369,19 @@ var _ = Describe("Customer", func() {
 			g.Go(func() error {
 				if !pollVerifier(gCtx, "shoebox Event Hub logs", eventHubVerifier, 45*time.Minute) {
 					return fmt.Errorf("event hub log verification failed")
+				}
+				return nil
+			})
+			g.Go(func() error {
+				// Log-only check for the newly added categories: report
+				// whether they show up, but never fail the test on it.
+				if pollVerifier(gCtx, "new shoebox log categories", newCategoriesVerifier, 45*time.Minute) {
+					GinkgoLogr.Info("new shoebox log categories observed in storage account", "categories", newShoeboxLogCategories)
+				} else if err := newCategoriesVerifier.Verify(ctx); err != nil {
+					// One final check to report exactly which categories are missing.
+					GinkgoLogr.Info("new shoebox log categories NOT observed in storage account; not failing the test", "detail", err.Error())
+				} else {
+					GinkgoLogr.Info("new shoebox log categories observed in storage account (after poll timeout)", "categories", newShoeboxLogCategories)
 				}
 				return nil
 			})

--- a/test/util/verifiers/shoebox.go
+++ b/test/util/verifiers/shoebox.go
@@ -89,3 +89,43 @@ func VerifyShoeboxLogs(client *armstorage.BlobContainersClient, resourceGroupNam
 		storageAccountName: storageAccountName,
 	}
 }
+
+type verifyShoeboxLogCategoriesImpl struct {
+	verifyShoeboxLogsImpl
+	categories []string
+}
+
+func (v verifyShoeboxLogCategoriesImpl) Name() string {
+	return "VerifyShoeboxLogCategories"
+}
+
+func (v verifyShoeboxLogCategoriesImpl) Verify(ctx context.Context) error {
+	containers, err := v.listInsightsContainers(ctx)
+	if err != nil {
+		return err
+	}
+	present := make(map[string]bool, len(containers))
+	for _, container := range containers {
+		present[container] = true
+	}
+	var missing []string
+	for _, category := range v.categories {
+		if !present["insights-logs-"+strings.ToLower(category)] {
+			missing = append(missing, category)
+		}
+	}
+	if len(missing) > 0 {
+		return &retryableError{err: fmt.Errorf("missing insights-logs containers for categories %v in storage account %s (found: %v)", missing, v.storageAccountName, containers)}
+	}
+	return nil
+}
+
+// VerifyShoeboxLogCategories creates a verifier that checks that each of the
+// given diagnostic log categories has a corresponding insights-logs-<category>
+// blob container in the storage account.
+func VerifyShoeboxLogCategories(client *armstorage.BlobContainersClient, resourceGroupName, storageAccountName string, categories []string) verifyShoeboxLogCategoriesImpl {
+	return verifyShoeboxLogCategoriesImpl{
+		verifyShoeboxLogsImpl: VerifyShoeboxLogs(client, resourceGroupName, storageAccountName),
+		categories:            categories,
+	}
+}


### PR DESCRIPTION
Verifies (without failing the test) that the cluster-autoscaler and capi-provider log categories added in #5161 show up as insights-logs-<category> containers in the shoebox storage account. Diagnostic settings now enable all 11 categories, falling back to the original 9 if ARM rejects the new ones in a region. The suite is filtered to the shoebox spec via specs.MustFilter for this PR run.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
