### PR TITLE
test(e2e): fix z-stream upgrade tests

### DIFF
--- a/test/e2e/control_plane_automated_z_stream_upgrade.go
+++ b/test/e2e/control_plane_automated_z_stream_upgrade.go
@@ -34,7 +34,7 @@ import (
 var _ = Describe("Service Provider", func() {
 	DescribeTable("should upgrade the control plane z-stream automatically on behalf of the customer",
 		labels.MIContainers(1),
-		func(ctx context.Context, minorVersion string, baseInstallVersion string) {
+		func(ctx context.Context, minorVersion string) {
 			const (
 				customerNetworkSecurityGroupName = "customer-nsg-zstream-"
 				customerVnetName                 = "customer-vnet-zstream-"
@@ -42,18 +42,24 @@ var _ = Describe("Service Provider", func() {
 				customerClusterNamePrefix        = "cluster-zstream-"
 			)
 
+			// ARRANGE
+
 			tc := framework.NewTestContext()
 
-			if len(baseInstallVersion) == 0 {
-				baseInstallVersion = minorVersion // set it to minor so that we defaul to .0 as the patch version
-			}
-			installVersion, hasUpgradePath, err := framework.GetInstallVersionForZStreamUpgrade(ctx, "candidate", baseInstallVersion)
+			By("checking if z-stream upgrade path exists")
+			installVersion, targetVersion, err := framework.GetInstallVersionForZStreamUpgrade(ctx, "candidate", minorVersion)
 			if err != nil {
 				if cincinnati.IsCincinnatiVersionNotFoundError(err) {
-					Skip(fmt.Sprintf("Cincinnati returned version not found for configured id %s (minor %s)", baseInstallVersion, minorVersion))
+					Skip(fmt.Sprintf("Cincinnati returned version not found for configured id %s", minorVersion))
 				}
 				Expect(err).NotTo(HaveOccurred(), "failed to get install version for z-stream upgrade of %s", minorVersion)
 			}
+
+			if targetVersion == "" {
+				Skip(fmt.Sprintf("the z-stream version %s is latest and has no z-stream upgrade path available on the candidate channel", installVersion))
+			}
+
+			By("setting up test prerequisites")
 			if tc.UsePooledIdentities() {
 				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
@@ -62,24 +68,20 @@ var _ = Describe("Service Provider", func() {
 			versionLabel := strings.ReplaceAll(minorVersion, ".", "-") // e.g. "4.20" -> "4-20"
 			suffix := rand.String(6)
 			clusterName := customerClusterNamePrefix + versionLabel + "-" + suffix
-			clusterParams := framework.NewDefaultClusterParams20240610()
-			clusterParams.ClusterName = clusterName
-			clusterParams.OpenshiftVersionId = installVersion
-
-			// We use the candidate channel to potentially catch early z-stream upgrades.
-			// issues before they reach stable.
-			By("using the candidate channel")
-			clusterParams.ChannelGroup = "candidate"
 
 			By("creating resource group")
 			resourceGroup, err := tc.NewResourceGroup(ctx, "rg-zstream-upgrade-"+versionLabel, tc.Location())
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for z-stream upgrade of %s", minorVersion)
 
-			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name+"-zstream-"+suffix, "-managed", 64)
-			clusterParams.ManagedResourceGroupName = managedResourceGroupName
-
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
+			clusterParams := framework.NewDefaultClusterParams20240610()
+			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name+"-zstream-"+suffix, "-managed", 64)
+			clusterParams.ClusterName = clusterName
+			clusterParams.OpenshiftVersionId = installVersion
+			clusterParams.ChannelGroup = "candidate" // use the candidate channel to potentially catch early z-stream upgrade issues before they reach stable.
+
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(
+				ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -96,8 +98,10 @@ var _ = Describe("Service Provider", func() {
 			// 4.22 control plane provisioning has been consistently slower and frequently hits the default timeout.
 			// Bump the create+wait budget to reduce flaky timeouts for this minor.
 			if minorVersion == "4.22" {
-				clusterCreationTimeout = 35 * time.Minute
+				clusterCreationTimeout += 15 * time.Minute
 			}
+
+			// ACT
 
 			By(fmt.Sprintf("creating the HCP cluster with version '%s' on candidate channel", installVersion))
 			err = tc.CreateHCPClusterFromParam20240610(
@@ -107,6 +111,9 @@ var _ = Describe("Service Provider", func() {
 				clusterParams,
 				clusterCreationTimeout,
 			)
+
+			// ASSERT
+
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with version %s on candidate channel", clusterName, installVersion)
 
 			By("verifying the cluster is viable")
@@ -121,25 +128,17 @@ var _ = Describe("Service Provider", func() {
 			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred(), "failed to verify HCP cluster %q is viable", clusterName)
 
-			if !hasUpgradePath {
-				By("skipping z-stream upgrade verification: no upgrade path (cluster installed at latest)")
-				return
-			}
-
 			By("verifying that only a z-stream upgrade was performed")
 			Eventually(func() error {
-				return verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyHostedControlPlaneZStreamUpgradeOnly(installVersion))
+				return verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyHostedControlPlaneZStreamUpgradeOnly(installVersion, targetVersion))
 			}, framework.HCPClusterVersionUpgradeTimeout, 2*time.Minute).Should(Succeed())
 			GinkgoLogr.Info("z-stream upgrade verification passed", "installVersion", installVersion)
 		},
 
-		// for 4.19, if we start with 4.19.0, the version that has an upgrade path to 4.19.latest is
-		// 4.19.3 but cluster install on this version fails with KMS authentication problem.
-		// For all the other minor versions, we can start with 4.y.0 and install the latest version in the candidate channel.
-		Entry("for 4.19", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.19", "4.19.25"),
-		Entry("for 4.20", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.20", ""),
-		Entry("for 4.21", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.21", ""),
-		Entry("for 4.22", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.AllowRetry, "4.22", ""), // owner: @raelga, tracking: AROSLSRE-1319. Known-issue test, retriable during EV2 gating. Remove this label when the issue is fixed.
-		Entry("for 4.23", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.23", ""),
+		Entry("for 4.19", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.19"),
+		Entry("for 4.20", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.20"),
+		Entry("for 4.21", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.21"),
+		Entry("for 4.22", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, labels.AllowRetry, "4.22"), // owner: @raelga, tracking: AROSLSRE-1319. Known-issue test, retriable during EV2 gating. Remove this label when the issue is fixed.
+		Entry("for 4.23", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.23"),
 	)
 })

--- a/test/e2e/control_plane_automated_z_stream_upgrade.go
+++ b/test/e2e/control_plane_automated_z_stream_upgrade.go
@@ -34,7 +34,8 @@ import (
 var _ = Describe("Service Provider", func() {
 	DescribeTable("should upgrade the control plane z-stream automatically on behalf of the customer",
 		labels.MIContainers(1),
-		func(ctx context.Context, minorVersion string, baseInstallVersion string) {
+		func(ctx context.Context, minorVersion string, installVersion string) {
+
 			const (
 				customerNetworkSecurityGroupName = "customer-nsg-zstream-"
 				customerVnetName                 = "customer-vnet-zstream-"
@@ -42,18 +43,24 @@ var _ = Describe("Service Provider", func() {
 				customerClusterNamePrefix        = "cluster-zstream-"
 			)
 
+			// ARRANGE
+
 			tc := framework.NewTestContext()
 
-			if len(baseInstallVersion) == 0 {
-				baseInstallVersion = minorVersion // set it to minor so that we defaul to .0 as the patch version
-			}
-			installVersion, hasUpgradePath, err := framework.GetInstallVersionForZStreamUpgrade(ctx, "candidate", baseInstallVersion)
+			By("checking if z-stream upgrade path exists")
+			hasUpgradePath, err := framework.HasZStreamUpgradePath(ctx, "candidate", installVersion)
 			if err != nil {
 				if cincinnati.IsCincinnatiVersionNotFoundError(err) {
-					Skip(fmt.Sprintf("Cincinnati returned version not found for configured id %s (minor %s)", baseInstallVersion, minorVersion))
+					Skip(fmt.Sprintf("Cincinnati returned version not found for configured id %s (minor %s)", installVersion, minorVersion))
 				}
 				Expect(err).NotTo(HaveOccurred(), "failed to get install version for z-stream upgrade of %s", minorVersion)
 			}
+
+			if !hasUpgradePath {
+				Skip(fmt.Sprintf("the z-stream version %s is latest and has no z-stream upgrade path available on the candidate channel", installVersion))
+			}
+
+			By("setting up test prerequisites")
 			if tc.UsePooledIdentities() {
 				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
@@ -62,24 +69,20 @@ var _ = Describe("Service Provider", func() {
 			versionLabel := strings.ReplaceAll(minorVersion, ".", "-") // e.g. "4.20" -> "4-20"
 			suffix := rand.String(6)
 			clusterName := customerClusterNamePrefix + versionLabel + "-" + suffix
-			clusterParams := framework.NewDefaultClusterParams20240610()
-			clusterParams.ClusterName = clusterName
-			clusterParams.OpenshiftVersionId = installVersion
-
-			// We use the candidate channel to potentially catch early z-stream upgrades.
-			// issues before they reach stable.
-			By("using the candidate channel")
-			clusterParams.ChannelGroup = "candidate"
 
 			By("creating resource group")
 			resourceGroup, err := tc.NewResourceGroup(ctx, "rg-zstream-upgrade-"+versionLabel, tc.Location())
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for z-stream upgrade of %s", minorVersion)
 
-			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name+"-zstream-"+suffix, "-managed", 64)
-			clusterParams.ManagedResourceGroupName = managedResourceGroupName
-
 			By("creating customer resources")
-			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
+			clusterParams := framework.NewDefaultClusterParams20240610()
+			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name+"-zstream-"+suffix, "-managed", 64)
+			clusterParams.ClusterName = clusterName
+			clusterParams.OpenshiftVersionId = installVersion
+			clusterParams.ChannelGroup = "candidate" // use the candidate channel to potentially catch early z-stream upgrade issues before they reach stable.
+
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(
+				ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{
@@ -96,8 +99,10 @@ var _ = Describe("Service Provider", func() {
 			// 4.22 control plane provisioning has been consistently slower and frequently hits the default timeout.
 			// Bump the create+wait budget to reduce flaky timeouts for this minor.
 			if minorVersion == "4.22" {
-				clusterCreationTimeout = 35 * time.Minute
+				clusterCreationTimeout += 15 * time.Minute
 			}
+
+			// ACT
 
 			By(fmt.Sprintf("creating the HCP cluster with version '%s' on candidate channel", installVersion))
 			err = tc.CreateHCPClusterFromParam20240610(
@@ -107,6 +112,9 @@ var _ = Describe("Service Provider", func() {
 				clusterParams,
 				clusterCreationTimeout,
 			)
+
+			// ASSERT
+
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with version %s on candidate channel", clusterName, installVersion)
 
 			By("verifying the cluster is viable")
@@ -121,11 +129,6 @@ var _ = Describe("Service Provider", func() {
 			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred(), "failed to verify HCP cluster %q is viable", clusterName)
 
-			if !hasUpgradePath {
-				By("skipping z-stream upgrade verification: no upgrade path (cluster installed at latest)")
-				return
-			}
-
 			By("verifying that only a z-stream upgrade was performed")
 			Eventually(func() error {
 				return verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyHostedControlPlaneZStreamUpgradeOnly(installVersion))
@@ -133,13 +136,11 @@ var _ = Describe("Service Provider", func() {
 			GinkgoLogr.Info("z-stream upgrade verification passed", "installVersion", installVersion)
 		},
 
-		// for 4.19, if we start with 4.19.0, the version that has an upgrade path to 4.19.latest is
-		// 4.19.3 but cluster install on this version fails with KMS authentication problem.
-		// For all the other minor versions, we can start with 4.y.0 and install the latest version in the candidate channel.
-		Entry("for 4.19", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.19", "4.19.25"),
-		Entry("for 4.20", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.20", ""),
-		Entry("for 4.21", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.21", ""),
-		Entry("for 4.22", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.22", ""),
-		Entry("for 4.23", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.23", ""),
+		// starting from 4.19.0 triggers a KMS authentication issue during z-stream upgrade to 4.19.3, so start from 4.19.4 instead.
+		Entry("for 4.19", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.19", "4.19.4"),
+		Entry("for 4.20", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.20", "4.20.0"),
+		Entry("for 4.21", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.21", "4.21.0"),
+		Entry("for 4.22", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.22", "4.22.0"),
+		Entry("for 4.23", labels.RequireNothing, labels.Critical, labels.Positive, labels.AroRpApiCompatible, "4.23", "4.23.0"),
 	)
 })

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -59,11 +59,16 @@ var _ = Describe("Customer", func() {
 			)
 			if nodePoolMinorVersion.EQ(targetMinorVersion) {
 				// z-stream: same y.z line — older patch on node pool, cluster on latest patch.
-				nodePoolInitialVersion, hasUpgradePath, err = framework.GetInstallVersionForZStreamUpgrade(ctx, channelGroup, targetMinor)
-				if cincinnati.IsCincinnatiVersionNotFoundError(err) {
-					Skip(fmt.Sprintf("Cincinnati returned version not found for target minor %s on channel %s", targetMinor, channelGroup))
+				installVersion, targetVersion, err := framework.GetInstallVersionForZStreamUpgrade(ctx, channelGroup, targetMinor)
+				if err != nil {
+					if cincinnati.IsCincinnatiVersionNotFoundError(err) {
+						Skip(fmt.Sprintf("Cincinnati returned version not found for target minor %s on channel %s", targetMinor, channelGroup))
+					}
+					Expect(err).NotTo(HaveOccurred(), "failed to determine z-stream install version for minor %s", targetMinor)
 				}
-				Expect(err).NotTo(HaveOccurred(), "failed to determine z-stream install version for minor %s", targetMinor)
+				nodePoolInitialVersion = installVersion
+				hasUpgradePath = targetVersion != ""
+
 				if !hasUpgradePath {
 					Skip(fmt.Sprintf("no z-stream upgrade path for minor %s on channel %s", targetMinor, channelGroup))
 				}

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -59,11 +59,15 @@ var _ = Describe("Customer", func() {
 			)
 			if nodePoolMinorVersion.EQ(targetMinorVersion) {
 				// z-stream: same y.z line — older patch on node pool, cluster on latest patch.
-				nodePoolInitialVersion, hasUpgradePath, err = framework.GetInstallVersionForZStreamUpgrade(ctx, channelGroup, targetMinor)
-				if cincinnati.IsCincinnatiVersionNotFoundError(err) {
-					Skip(fmt.Sprintf("Cincinnati returned version not found for target minor %s on channel %s", targetMinor, channelGroup))
+				nodePoolInitialVersion = targetMinor + ".0"
+				hasUpgradePath, err = framework.HasZStreamUpgradePath(ctx, channelGroup, nodePoolInitialVersion)
+				if err != nil {
+					if cincinnati.IsCincinnatiVersionNotFoundError(err) {
+						Skip(fmt.Sprintf("Cincinnati returned version not found for target minor %s on channel %s", targetMinor, channelGroup))
+					}
+					Expect(err).NotTo(HaveOccurred(), "failed to determine z-stream install version for minor %s", targetMinor)
 				}
-				Expect(err).NotTo(HaveOccurred(), "failed to determine z-stream install version for minor %s", targetMinor)
+
 				if !hasUpgradePath {
 					Skip(fmt.Sprintf("no z-stream upgrade path for minor %s on channel %s", targetMinor, channelGroup))
 				}

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -101,44 +101,35 @@ func isRetryableVersionError(err error) bool {
 	return true
 }
 
-// GetInstallVersionForZStreamUpgrade returns the version to install the cluster with when testing
-// a z-stream upgrade, and whether that version has an available z-stream upgrade path. It uses
-// configuredVersionID and queries Cincinnati for the given channelGroup (e.g. "candidate", "stable").
-// When no version with an upgrade path is found, it still returns the configured version so the
-// caller can install and optionally skip upgrade assertions.
-func GetInstallVersionForZStreamUpgrade(ctx context.Context, channelGroup string, configuredVersionID string) (installVersion string, hasUpgradePath bool, err error) {
-	candidates, err := GetAllVersionsInMinorStartingWith(ctx, channelGroup, configuredVersionID)
+// HasZStreamUpgradePath checks if a newer z-stream version is available
+func HasZStreamUpgradePath(ctx context.Context, channelGroup string, version string) (hasUpgradePath bool, err error) {
+	candidates, err := GetAllVersionsInMinorStartingWith(ctx, channelGroup, version)
 	if err != nil {
-		return "", false, err
-	}
-	if len(candidates) == 0 {
-		return "", false, &cvocincinnati.Error{Reason: "VersionNotFound", Message: fmt.Sprintf("no versions found for %s", configuredVersionID)}
-	}
-	if len(candidates) == 1 {
-		return candidates[0].String(), false, nil
+		return false, err
 	}
 
-	nextMinorVersion := api.NextMinorReleaseLine(candidates[0])
-	nextMinorStr := fmt.Sprintf("%d.%d", nextMinorVersion.Major, nextMinorVersion.Minor)
-	maxVersion, err := GetLatestVersionInMinor(ctx, channelGroup, nextMinorStr)
-	if err != nil {
-		if !cincinnati.IsCincinnatiVersionNotFoundError(err) {
-			return "", false, err
+	// nextMinorVersion := api.NextMinorReleaseLine(candidates[0])
+	// nextMinorStr := fmt.Sprintf("%d.%d", nextMinorVersion.Major, nextMinorVersion.Minor)
+	// maxVersion, err := GetLatestVersionInMinor(ctx, channelGroup, nextMinorStr)
+	// if err != nil {
+	// 	if !cincinnati.IsCincinnatiVersionNotFoundError(err) {
+	// 		return "", false, err
+
+	var numVersions int
+	for _, c := range candidates {
+		if len(c.Pre) == 0 { // skip pre-release versions
+			numVersions++
 		}
-		// we don't have the next minor, use the max version in the current minor
-		maxVersion = candidates[0].String()
 	}
 
-	for i := 0; i < len(candidates)-1; i++ {
-		upgradeTargets, err := GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx, channelGroup, maxVersion, candidates[i].String())
-		if err != nil {
-			return "", false, err
-		}
-		if len(upgradeTargets) > 0 {
-			return candidates[i+1].String(), true, nil
-		}
+	switch numVersions {
+	case 0:
+		return false, &cvocincinnati.Error{Reason: "VersionNotFound", Message: fmt.Sprintf("no versions found for %s", version)}
+	case 1: // only the current version was returned
+		return false, nil
+	default:
+		return true, nil
 	}
-	return candidates[0].String(), false, nil
 }
 
 // GetAllVersionsInMinorStartingWith returns all OpenShift versions in the same major.minor as the given version,

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -42,6 +42,7 @@ var (
 	ErrNoParseableNightlyTags       = errors.New("no parseable nightly tags found")
 	ErrVersionNotFound              = errors.New("no graph nodes found")
 	ErrNoEdgePairFound              = errors.New("no version pair without upgrade edge found")
+	ErrNoUpgradePath                = errors.New("no upgrade path found")
 )
 
 const (
@@ -92,7 +93,8 @@ func isRetryableVersionError(err error) bool {
 		errors.Is(err, ErrNightlyReleaseStreamNotFound) ||
 		errors.Is(err, ErrNoAcceptedNightlyTags) ||
 		errors.Is(err, ErrNoParseableNightlyTags) ||
-		errors.Is(err, ErrNoEdgePairFound) {
+		errors.Is(err, ErrNoEdgePairFound) ||
+		errors.Is(err, ErrNoUpgradePath) {
 		return false
 	}
 	if cincinnati.IsCincinnatiVersionNotFoundError(err) {
@@ -101,44 +103,85 @@ func isRetryableVersionError(err error) bool {
 	return true
 }
 
-// GetInstallVersionForZStreamUpgrade returns the version to install the cluster with when testing
-// a z-stream upgrade, and whether that version has an available z-stream upgrade path. It uses
-// configuredVersionID and queries Cincinnati for the given channelGroup (e.g. "candidate", "stable").
-// When no version with an upgrade path is found, it still returns the configured version so the
-// caller can install and optionally skip upgrade assertions.
-func GetInstallVersionForZStreamUpgrade(ctx context.Context, channelGroup string, configuredVersionID string) (installVersion string, hasUpgradePath bool, err error) {
+// GetInstallVersionForZStreamUpgrade returns the initial cluster installVersion, and the targetVersion we
+// should expect the cluster to upgrade to during a z-stream upgrade.
+// It uses the input parameters channelGroup (e.g. "candidate", "stable") and configuredVersionID (x.y or x.y.z)
+// to query Cincinnati for valid upgrade paths.
+// When an upgrade path cannot be found, it returns the target version as the installVersion and
+// leaves the targetVersion as "" so that the caller can choose how to handle this scenario.
+func GetInstallVersionForZStreamUpgrade(
+	ctx context.Context,
+	channelGroup string,
+	configuredVersionID string,
+) (
+	installVersion string,
+	targetVersion string,
+	err error,
+) {
 	candidates, err := GetAllVersionsInMinorStartingWith(ctx, channelGroup, configuredVersionID)
 	if err != nil {
-		return "", false, err
+		return "", "", err
 	}
 	if len(candidates) == 0 {
-		return "", false, &cvocincinnati.Error{Reason: "VersionNotFound", Message: fmt.Sprintf("no versions found for %s", configuredVersionID)}
+		return "", "", &cvocincinnati.Error{Reason: "VersionNotFound", Message: fmt.Sprintf("no versions found for %s", configuredVersionID)}
 	}
 	if len(candidates) == 1 {
-		return candidates[0].String(), false, nil
+		return candidates[0].String(), "", nil
 	}
+
+	// Phase 1: If x.y+1 exists, set targetVersion to the latest z candidate in x.y with an upgrade path to x.y+1.zLatest
+	//          Else set targetVersion to candidates[0] (the latest candidate in the current minor)
+	targetIdx := 0
+	isNextMinorVersionAvailable := true
 
 	nextMinorVersion := metadataapi.NextMinorReleaseLine(candidates[0])
 	nextMinorStr := fmt.Sprintf("%d.%d", nextMinorVersion.Major, nextMinorVersion.Minor)
-	maxVersion, err := GetLatestVersionInMinor(ctx, channelGroup, nextMinorStr)
+	latestInNextMinor, err := GetLatestVersionInMinor(ctx, channelGroup, nextMinorStr)
 	if err != nil {
-		if !cincinnati.IsCincinnatiVersionNotFoundError(err) {
-			return "", false, err
+		if cincinnati.IsCincinnatiVersionNotFoundError(err) {
+			isNextMinorVersionAvailable = false
+		} else {
+			return "", "", err
 		}
-		// we don't have the next minor, use the max version in the current minor
-		maxVersion = candidates[0].String()
 	}
 
-	for i := 0; i < len(candidates)-1; i++ {
-		upgradeTargets, err := GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx, channelGroup, maxVersion, candidates[i].String())
-		if err != nil {
-			return "", false, err
-		}
-		if len(upgradeTargets) > 0 {
-			return candidates[i+1].String(), true, nil
+	if isNextMinorVersionAvailable {
+		for i, candidate := range candidates {
+			_, err := GetShortestUpgradePath(ctx, channelGroup, candidate.String(), latestInNextMinor)
+			if err != nil {
+				if errors.Is(err, ErrNoUpgradePath) {
+					if i == len(candidates)-1 {
+						return "", "", fmt.Errorf("no candidates in %s contain an upgrade path to %s", configuredVersionID, latestInNextMinor)
+					}
+					continue
+				}
+				return "", "", err
+			}
+
+			targetIdx = i
+			break
 		}
 	}
-	return candidates[0].String(), false, nil
+
+	targetVersion = candidates[targetIdx].String()
+
+	// Phase 2: find the latest z candidate in x.y with an upgrade path to targetVersion (if one exists)
+	for i := targetIdx + 1; i < len(candidates); i++ {
+		path, err := GetShortestUpgradePath(ctx, channelGroup, candidates[i].String(), targetVersion)
+		if err != nil {
+			if errors.Is(err, ErrNoUpgradePath) {
+				continue
+			}
+			return "", "", err
+		}
+		if len(path) > 1 {
+			return candidates[i].String(), targetVersion, nil
+		}
+	}
+
+	// No z candidate in x.y contains an upgrade path to targetVersion.
+	// Set the installVersion to targetVersion and set the target to "", implying no upgrade path exists.
+	return targetVersion, "", nil
 }
 
 // GetAllVersionsInMinorStartingWith returns all OpenShift versions in the same major.minor as the given version,
@@ -302,6 +345,148 @@ func GetUpgradeCandidatesInMaxMinorFromCincinnati(ctx context.Context, channelGr
 		return out[i].LT(out[j])
 	})
 	return out, nil
+}
+
+// GetShortestUpgradePath returns the shortest upgrade path from fromVersion to toVersion as a
+// slice of versions in reverse order [toVersion, ..., fromVersion].
+//
+// Important: this function can only span at most one minor boundary at a time (e.g. 4.20 to 4.21).
+// This is because when the Cincinnati API is supplied a channel such as "candidate-4.21",
+// it only returns the upgrade graphs for the current and previous minor versions.
+//
+// Returns ErrNoUpgradePath if no path exists.
+func GetShortestUpgradePath(ctx context.Context, channelGroup string, fromVersion string, toVersion string) ([]string, error) {
+	return retryOnTransientError(ctx, func() ([]string, error) {
+		fromVer, err := semver.ParseTolerant(fromVersion)
+		if err != nil {
+			return nil, fmt.Errorf("parse fromVersion %q: %w", fromVersion, err)
+		}
+		toVer, err := semver.ParseTolerant(toVersion)
+		if err != nil {
+			return nil, fmt.Errorf("parse toVersion %q: %w", toVersion, err)
+		}
+		if fromVer.EQ(toVer) {
+			return []string{fromVersion}, nil
+		}
+
+		channel := fmt.Sprintf("%s-%d.%d", channelGroup, toVer.Major, toVer.Minor)
+		graphURL := fmt.Sprintf("https://api.openshift.com/api/upgrades_info/v1/graph?channel=%s", url.QueryEscape(channel))
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, graphURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("create graph request for %s: %w", channel, err)
+		}
+
+		client := &http.Client{Timeout: graphAPIRequestTimeout}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("query graph for %s: %w", channel, err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			return nil, fmt.Errorf("query graph for %s returned %s: %s", channel, resp.Status, strings.TrimSpace(string(body)))
+		}
+
+		var payload struct {
+			Nodes []struct {
+				Version string `json:"version"`
+			} `json:"nodes"`
+			Edges [][]int `json:"edges"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			return nil, fmt.Errorf("decode graph response for %s: %w", channel, err)
+		}
+
+		// example payload:
+		// {
+		//   "nodes": [
+		//     { "version": "4.19.25" },   // index 0
+		//     { "version": "4.20.0" },    // index 1
+		//     { "version": "4.20.1" },    // index 2
+		//     { "version": "4.20.2" },    // index 3
+		//     { "version": "4.20.3" }     // index 4
+		//   ],
+		//   "edges": [[0,3],[0,4],[1,2],[1,3],[1,4],[2,3],[2,4],[3,4]]
+		// }
+		//
+		// "nodes" is a positional array. The index dictates the node's identity (nodes[0] is 4.19.25, nodes[3] is 4.20.2, etc.)
+		// "edges" are [from_index, to_index] pairs. [0, 3] means "you can upgrade from nodes[0] (4.19.25) to nodes[3] (4.20.2)."
+
+		// copy the nodes to a local array and keep track of the fromVersion and toVersion indices, e.g.:
+		// nodeArr = [4.19.25, 4.20.0, 4.20.1, 4.20.2, 4.20.3]
+		// fromIdx = 1 (4.20.0)
+		// toIdx = 4 (4.20.3)
+		nodeArr := make([]semver.Version, len(payload.Nodes))
+		fromIdx, toIdx := -1, -1
+		for i, node := range payload.Nodes {
+			version, parseErr := semver.ParseTolerant(node.Version)
+			if parseErr != nil {
+				return nil, fmt.Errorf("unparseable version %q at index %d: %w", node.Version, i, parseErr)
+			}
+			nodeArr[i] = version // 1-to-1 mapping
+			if version.EQ(fromVer) {
+				fromIdx = i
+			}
+			if version.EQ(toVer) {
+				toIdx = i
+			}
+		}
+		if fromIdx < 0 {
+			return nil, fmt.Errorf("%w: %s not found in channel %s", ErrNoUpgradePath, fromVersion, channel)
+		}
+		if toIdx < 0 {
+			return nil, fmt.Errorf("%w: %s not found in channel %s", ErrNoUpgradePath, toVersion, channel)
+		}
+
+		// convert the flat edge pairs into a map where the node index is the key and the target indices are the value, e.g.:
+		// edgesMap[0] = [3, 4]       // 4.19.25 -> 4.20.2, 4.20.3
+		// edgesMap[1] = [2, 3, 4]    // 4.20.0  -> 4.20.1, 4.20.2, 4.20.3
+		// edgesMap[2] = [3, 4]       // 4.20.1  -> 4.20.2, 4.20.3
+		// edgesMap[3] = [4]          // 4.20.2  -> 4.20.3
+		edgesMap := make(map[int][]int, len(payload.Edges))
+		for _, edge := range payload.Edges {
+			if len(edge) == 2 {
+				edgesMap[edge[0]] = append(edgesMap[edge[0]], edge[1])
+			}
+		}
+
+		// Breadth-First Search to find path from fromIdx to toIdx
+		found := false
+		queue := []int{fromIdx}
+		prev := make(map[int]int, len(nodeArr))
+		visited := make(map[int]bool, len(nodeArr))
+		visited[fromIdx] = true
+
+		for len(queue) > 0 {
+			curr := queue[0]
+			queue = queue[1:]
+			if curr == toIdx {
+				found = true
+				break
+			}
+			for _, next := range edgesMap[curr] {
+				if !visited[next] {
+					visited[next] = true
+					prev[next] = curr
+					queue = append(queue, next)
+				}
+			}
+		}
+
+		if !found {
+			return nil, fmt.Errorf("%w: no path from %s to %s in channel %s", ErrNoUpgradePath, fromVersion, toVersion, channel)
+		}
+
+		var path []string // toVersion is first, fromVersion is last
+		for idx := toIdx; idx != fromIdx; idx = prev[idx] {
+			path = append(path, nodeArr[idx].String())
+		}
+		path = append(path, nodeArr[fromIdx].String())
+
+		return path, nil
+	})
 }
 
 // GetVersionPairWithoutUpgradeEdge finds two versions A < B in the given minor where Cincinnati

--- a/test/util/verifiers/hosted_control_plane_version.go
+++ b/test/util/verifiers/hosted_control_plane_version.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
@@ -33,62 +34,115 @@ import (
 	"github.com/Azure/ARO-HCP/test/util/framework"
 )
 
+// VerifyHostedControlPlaneZStreamUpgradeOnly returns a verifier that the HCP control plane has updated to the targetVersion,
+// that only the z-stream portion of the version was modified, and that no downgrades occurred at any point in the upgrade history.
+func VerifyHostedControlPlaneZStreamUpgradeOnly(initialVersion string, targetVersion string) HostedClusterVerifier {
+	return verifyHostedControlPlaneZStreamUpgradeOnly{
+		initialVersion: initialVersion,
+		targetVersion:  targetVersion,
+	}
+}
+
 type verifyHostedControlPlaneZStreamUpgradeOnly struct {
 	initialVersion string
+	targetVersion  string
 }
 
 func (v verifyHostedControlPlaneZStreamUpgradeOnly) Name() string {
-	return fmt.Sprintf("VerifyHostedControlPlaneZStreamUpgradeOnly(initial=%s)", v.initialVersion)
+	return fmt.Sprintf("VerifyHostedControlPlaneZStreamUpgradeOnly(initialVersion=%s, targetVersion=%s)", v.initialVersion, v.targetVersion)
 }
 
 func (v verifyHostedControlPlaneZStreamUpgradeOnly) Verify(ctx context.Context, adminRESTConfig *rest.Config) error {
 	initialSemver, err := semver.ParseTolerant(v.initialVersion)
 	if err != nil {
-		return fmt.Errorf("parse initial version %q: %w", v.initialVersion, err)
+		return gomega.StopTrying(fmt.Sprintf("error parsing v.initialVersion: %q", v.initialVersion)).Wrap(err)
 	}
 
 	configClient, err := configv1client.NewForConfig(adminRESTConfig)
 	if err != nil {
-		return fmt.Errorf("failed to create config client: %w", err)
+		return gomega.StopTrying("failed to create configClient").Wrap(err)
 	}
 
 	clusterVersion, err := configClient.ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get clusterversion %q: %w", "version", err)
+		return fmt.Errorf("failed to get clusterVersions from configClient: %w", err)
+	}
+	if len(clusterVersion.Status.History) < 1 {
+		return fmt.Errorf("ClusterVersion.Status.History is empty; no upgrade history to verify")
 	}
 
-	ginkgo.GinkgoLogr.Info("Retrieved openshift cluster version history",
-		"history", framework.SummarizeClusterVersionHistory(clusterVersion.Status.History))
+	ginkgo.GinkgoLogr.Info(
+		"Retrieved openshift cluster version history",
+		"history",
+		framework.SummarizeClusterVersionHistory(clusterVersion.Status.History),
+	)
 
-	var sawUpgrade bool
-	for _, history := range clusterVersion.Status.History {
+	if clusterVersion.Status.History[len(clusterVersion.Status.History)-1].Version != v.initialVersion {
+		return fmt.Errorf("cluster did not install to the correct install version. Expected: %s. Actual: %s",
+			v.initialVersion,
+			clusterVersion.Status.History[len(clusterVersion.Status.History)-1].Version,
+		)
+	}
+
+	if clusterVersion.Status.History[0].Version != v.targetVersion {
+		return fmt.Errorf("cluster did not upgrade to the correct target. Expected: %s. Actual: %s",
+			v.targetVersion,
+			clusterVersion.Status.History[0].Version,
+		)
+	}
+
+	// note that clusterVersion.Status.History should have the latest version first and the install version last
+	for i, history := range clusterVersion.Status.History {
 		historyVersion, err := semver.ParseTolerant(history.Version)
 		if err != nil {
-			return fmt.Errorf("parse version %q in history: %w", history.Version, err)
+			return gomega.StopTrying(fmt.Sprintf("error parsing history.Version: %q", history.Version)).Wrap(err)
 		}
+
 		if historyVersion.Major != initialSemver.Major || historyVersion.Minor != initialSemver.Minor {
-			return fmt.Errorf("version %q in clusterversion history has different major.minor than initial %q (expected %d.%d.x)",
-				historyVersion.String(), v.initialVersion, initialSemver.Major, initialSemver.Minor)
+			return gomega.StopTrying(
+				fmt.Sprintf("clusterversion history contains at least one upgrade that altered the major or minor version. Expected: %d.%d.z. Actual: %s",
+					initialSemver.Major,
+					initialSemver.Minor,
+					history.Version,
+				),
+			)
 		}
-		if historyVersion.GT(initialSemver) {
-			sawUpgrade = true
-		}
-		if historyVersion.LT(initialSemver) {
-			return fmt.Errorf("downgrade unexpected: version %q is less than initial %q", historyVersion.String(), initialSemver.String())
+
+		if i > 0 {
+			// "prev" here means previously visited index
+			prevHistoryVersion, err := semver.ParseTolerant(clusterVersion.Status.History[i-1].Version)
+			if err != nil {
+				return gomega.StopTrying(
+					fmt.Sprintf("error parsing clusterVersion.Status.History[i-1].Version: %q",
+						clusterVersion.Status.History[i-1].Version,
+					),
+				).Wrap(err)
+			}
+
+			// Given this test's setup, versions at earlier indices should be larger than or equal to versions at later indices. A rollback here is unexpected behavior.
+			// Equal adjacent versions are allowed (e.g. a version re-applied after an aborted update) and are not treated as a downgrade.
+			if prevHistoryVersion.LT(historyVersion) {
+				return gomega.StopTrying(
+					fmt.Sprintf(
+						"downgrade unexpected: cluster went from version %q and unexpectedly downgraded to version %q. clusterVersion history: %v. Error when version at index %d downgraded to version at index %d",
+						history.Version,
+						prevHistoryVersion.String(),
+						framework.SummarizeClusterVersionHistory(clusterVersion.Status.History),
+						i,
+						i-1,
+					),
+				)
+			}
 		}
 	}
-	if !sawUpgrade {
-		return fmt.Errorf("no version in clusterversion/version status.history is greater than initial %q", v.initialVersion)
-	}
+
 	return nil
 }
 
-// VerifyHostedControlPlaneZStreamUpgradeOnly returns a verifier that the HCP control plane has
-// performed only a z-stream upgrade from the initial version: at least one entry in
-// ClusterVersion status.history is greater than initialVersion, and every entry has the same
-// major.minor as initialVersion.
-func VerifyHostedControlPlaneZStreamUpgradeOnly(initialVersion string) HostedClusterVerifier {
-	return verifyHostedControlPlaneZStreamUpgradeOnly{initialVersion: initialVersion}
+// VerifyHostedControlPlaneYStreamUpgrade returns a verifier that clusterversion status.history
+// contains at least one parseable version in previousMinor and at least one in targetMinor.
+func VerifyHostedControlPlaneYStreamUpgrade(previousMinor, targetMinor string) HostedClusterVerifier {
+	return verifyHostedControlPlaneYStreamUpgrade{previousMinor: previousMinor, targetMinor: targetMinor}
 }
 
 type verifyHostedControlPlaneYStreamUpgrade struct {
@@ -142,10 +196,10 @@ func (v verifyHostedControlPlaneYStreamUpgrade) Verify(ctx context.Context, admi
 	return nil
 }
 
-// VerifyHostedControlPlaneYStreamUpgrade returns a verifier that clusterversion status.history
-// contains at least one parseable version in previousMinor and at least one in targetMinor.
-func VerifyHostedControlPlaneYStreamUpgrade(previousMinor, targetMinor string) HostedClusterVerifier {
-	return verifyHostedControlPlaneYStreamUpgrade{previousMinor: previousMinor, targetMinor: targetMinor}
+// VerifyKubeAPIServerServerVersionUpgraded fails if the kube-apiserver version is the same as before the upgrade.
+// preUpgrade is the kubernetes discovery ServerVersion (/version) read from the cluster before upgrading.
+func VerifyKubeAPIServerServerVersionUpgraded(preUpgrade *version.Info) HostedClusterVerifier {
+	return verifyKubeAPIServerServerVersionUpgraded{preUpgrade: preUpgrade}
 }
 
 type verifyKubeAPIServerServerVersionUpgraded struct {
@@ -171,10 +225,4 @@ func (v verifyKubeAPIServerServerVersionUpgraded) Verify(ctx context.Context, ad
 		return fmt.Errorf("kube-apiserver ServerVersion not updated (unchanged from pre-upgrade)")
 	}
 	return nil
-}
-
-// VerifyKubeAPIServerServerVersionUpgraded fails if the kube-apiserver version is the same as before the upgrade.
-// preUpgrade is the kubernetes discovery ServerVersion (/version) read from the cluster before upgrading.
-func VerifyKubeAPIServerServerVersionUpgraded(preUpgrade *version.Info) HostedClusterVerifier {
-	return verifyKubeAPIServerServerVersionUpgraded{preUpgrade: preUpgrade}
 }


### PR DESCRIPTION
NOTE: This PR is awaiting the completion of the following:
- https://github.com/Azure/ARO-HCP/pull/6538

UPDATE: Above PR has completed.

Jira:
https://redhat.atlassian.net/browse/ARO-27283

### What

- made the z-stream tests more robust by updating logic to determine the initial install version and the target version (the latest z-stream version the cluster should upgrade to). This required writing a new method `GetShortestUpgradePath` to reach out to Cincinnati to get the graph of all valid upgrade paths for the current minor version `x.y`, and next minor version `x.y+1`. The data returned from Cincinnati was then used to:
  1. calculate the target version by determining the shortest path to `x.y+1.zLatest` from valid z candidates in `x.y`. (Note that if `x.y` is the latest available minor version, `x.y.zLatest` is automatically made the target version.)
  2. calculate the install version by determining the shortest path to the target version from the remaining valid z candidates within `x.y`. (If no remaining valid z candidates exist in `x.y`, the target version is made the install version and the target version is set to `""`, indicating that no upgrade path exists. Currently, this edge case causes the test to skip since there is no z-stream upgrade to test.)
- cleaned up and simplified z-stream tests:
  - removed the `baseInstallVersion` test data parameter as the install version is now determined automatically. The test should now automatically account for broken upgrade paths, so there is no need to manually specify an initial installation version in order to skip known broken versions. If the e2e test fails due to installing a broken version, that means we caught a regression in Cincinnati that could affect our customers.
  - skip the test early if no z-stream upgrade path exists, before provisioning resources.
  - added comments, `By()` annotations, and reordered lines for clarity.
  - end tests early with `gomega.StopTrying()` in order to stop the `Eventually()` loop from repeatedly looping over unrecoverable errors. This should save us ~45min per test when those errors are encountered.

### Why

- z-stream bug was causing test runs to fail.
- e2e z-stream test control flow was difficult to follow.

### Testing

e2e test validation here: https://github.com/Azure/ARO-HCP/pull/6241

The above PR filters the e2e tests down to only the modified tests:
<img width="972" height="49" alt="image" src="https://github.com/user-attachments/assets/36b81b88-e3d0-48b4-9ee1-e9b272629dcb" />

z-stream e2e tests passed: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/6241/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2080312215386198016
<img width="1378" height="1189" alt="image" src="https://github.com/user-attachments/assets/f1bd3a7c-28a1-40cd-b336-c29107fff316" />

Note that the e2e test `Service Provider should upgrade the control plane z-stream automatically on behalf of the customer for 4.23` is currently being skipped on main, and is not a byproduct of this PR.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [x] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
