### PR TITLE
fix: move dev-ci CI bot identity lifecycle to the privileged entrypoint

### DIFF
--- a/dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
@@ -15,12 +15,6 @@ rolloutName: Dev CI E2E Subscription RBAC Grants Rollout
 # apply these grants. Run the Microsoft.Azure.ARO.HCP.DevCI.Privileged
 # entrypoint on demand with `make dev-ci-privileged-local-run` as a member
 # of the OWNERS group (who has real Owner) when a change touches these grants.
-#
-# Prerequisite: the CI bot service principals must already exist —
-# ci-bot-rbac.bicep looks them up via `existing` (by uniqueName). This service
-# group is nested under Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC in the
-# topology, which creates those identities, so within a single privileged
-# rollout the identities are guaranteed to exist before these grants run.
 resourceGroups:
 - name: grants
   resourceGroup: '{{ .global.rg }}'

--- a/dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
@@ -16,9 +16,11 @@ rolloutName: Dev CI E2E Subscription RBAC Grants Rollout
 # entrypoint on demand with `make dev-ci-privileged-local-run` as a member
 # of the OWNERS group (who has real Owner) when a change touches these grants.
 #
-# Prerequisite: the Microsoft.Azure.ARO.HCP.DevCI.Unprivileged entrypoint must
-# have run at least once so the CI bot service principals exist —
-# ci-bot-rbac.bicep looks them up via `existing` (by uniqueName).
+# Prerequisite: the CI bot service principals must already exist —
+# ci-bot-rbac.bicep looks them up via `existing` (by uniqueName). This service
+# group is nested under Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC in the
+# topology, which creates those identities, so within a single privileged
+# rollout the identities are guaranteed to exist before these grants run.
 resourceGroups:
 - name: grants
   resourceGroup: '{{ .global.rg }}'

--- a/dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
@@ -1,16 +1,22 @@
 $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC
 rolloutName: Dev CI E2E Subscription RBAC Rollout
-# NON-PRIVILEGED pipeline: only reconciles the CI bot Entra identities (Graph
-# Application.ReadWrite.OwnedBy axis, not Azure RBAC) and rotates their Key Vault
-# secrets (data-plane). None of these steps require Owner/User Access
-# Administrator on any subscription, so this pipeline runs unattended as part of
-# the Microsoft.Azure.ARO.HCP.DevCI.Unprivileged entrypoint (dev-ci postsubmit).
+# PRIVILEGED pipeline: reconciles the CI bot Entra identities. The
+# ci-bot-identity ARM step creates/updates the bot Entra applications and their
+# service principals, and the ci-bot-secret-* steps mint client secrets into
+# those applications (via Microsoft Graph addPassword) — both are Entra
+# directory-object writes, not Azure RBAC. An unattended CI identity is not
+# meant to hold app/SP-management or credential-minting rights on directory
+# objects, so this pipeline is deliberately kept OUT of the unattended
+# Microsoft.Azure.ARO.HCP.DevCI.Unprivileged entrypoint (dev-ci postsubmit).
 #
-# The privileged subscription-scoped role definitions and role assignments are
-# instead applied by the separate Microsoft.Azure.ARO.HCP.DevCI.Privileged
-# entrypoint, which is run on demand by an OWNERS-group member
-# (`make dev-ci-privileged-local-run`).
+# It is instead a child of the Microsoft.Azure.ARO.HCP.DevCI.Privileged
+# entrypoint and is run on demand by an OWNERS-group member
+# (`make dev-ci-privileged-local-run`), who holds the directory privileges to
+# manage these identities. Bot identity changes are infrequent, so running this
+# on demand adds negligible operational burden. The subscription-scoped role
+# definitions and role assignments live in the E2ESubscriptionRBACGrants child
+# service group, which is nested under this one so it runs afterwards.
 resourceGroups:
 - name: ci-bots
   resourceGroup: '{{ .global.rg }}'

--- a/dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
@@ -1,22 +1,10 @@
 $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC
 rolloutName: Dev CI E2E Subscription RBAC Rollout
-# PRIVILEGED pipeline: reconciles the CI bot Entra identities. The
-# ci-bot-identity ARM step creates/updates the bot Entra applications and their
-# service principals, and the ci-bot-secret-* steps mint client secrets into
-# those applications (via Microsoft Graph addPassword) — both are Entra
-# directory-object writes, not Azure RBAC. An unattended CI identity is not
-# meant to hold app/SP-management or credential-minting rights on directory
-# objects, so this pipeline is deliberately kept OUT of the unattended
-# Microsoft.Azure.ARO.HCP.DevCI.Unprivileged entrypoint (dev-ci postsubmit).
-#
-# It is instead a child of the Microsoft.Azure.ARO.HCP.DevCI.Privileged
-# entrypoint and is run on demand by an OWNERS-group member
-# (`make dev-ci-privileged-local-run`), who holds the directory privileges to
-# manage these identities. Bot identity changes are infrequent, so running this
-# on demand adds negligible operational burden. The subscription-scoped role
-# definitions and role assignments live in the E2ESubscriptionRBACGrants child
-# service group, which is nested under this one so it runs afterwards.
+# Reconciles the CI bot Entra identities: the ci-bot-identity step creates the
+# bot Entra applications and service principals, and the ci-bot-secret-* steps
+# mint their client secrets. These are Entra directory-object writes, so this is
+# a privileged pipeline that the unattended dev-ci postsubmit never runs.
 resourceGroups:
 - name: ci-bots
   resourceGroup: '{{ .global.rg }}'

--- a/docs/ci/dev-ci-topology.md
+++ b/docs/ci/dev-ci-topology.md
@@ -16,14 +16,12 @@ This keeps persistent CI-support infrastructure separate from the per-job RP foo
 
 ## What The Topology Manages Today
 
-Today `topology-dev-ci.yaml`'s `Microsoft.Azure.ARO.HCP.DevCI.Unprivileged` entrypoint contains one root service group plus five child service groups:
+Today `topology-dev-ci.yaml`'s `Microsoft.Azure.ARO.HCP.DevCI.Unprivileged` entrypoint contains one root service group plus four child service groups:
 
 - `Microsoft.Azure.ARO.HCP.DevCI.Unprivileged`
   - Deploys shared dev/CI network resources, the `opstool` AKS cluster, and the shared Prometheus monitoring stack.
 - `Microsoft.Azure.ARO.HCP.DevCI.TenantQuota`
   - Deploys the `tenant-quota-collector` workload that monitors Azure quotas relevant to CI capacity.
-- `Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC`
-  - Reconciles the non-privileged CI bot Entra identities (Graph `Application.ReadWrite.OwnedBy` axis) and rotates their Key Vault secrets. Requires no subscription Owner, so it runs unattended as part of the `DevCI.Unprivileged` entrypoint.
 - `Microsoft.Azure.ARO.HCP.DevCI.Gateway`
   - Deploys the shared Istio gateway and DNS wiring for `opstool`.
 - `Microsoft.Azure.ARO.HCP.DevCI.CertManager`
@@ -35,19 +33,22 @@ In other words, `dev-ci` owns the persistent CI support layer, not the full runt
 
 ## The Privileged Entrypoint
 
-`topology-dev-ci.yaml` also declares a **standalone, on-demand** privileged tree rooted at the `Microsoft.Azure.ARO.HCP.DevCI.Privileged` entrypoint, deliberately kept **separate** from the unattended `Microsoft.Azure.ARO.HCP.DevCI.Unprivileged` entrypoint. It applies the DEV E2E customer-subscription RBAC (custom role definitions + shared-principal role assignments) and the CI bot subscription-scoped RBAC. Every step creates subscription-scoped custom role definitions and/or role assignments, which require **Owner** (or an *unconstrained* User Access Administrator) on the target subscriptions — specifically the rights to write custom role definitions and to assign the privileged `Role Based Access Control Administrator` role to the mock arm-helper principal.
+`topology-dev-ci.yaml` also declares a **standalone, on-demand** privileged tree rooted at the `Microsoft.Azure.ARO.HCP.DevCI.Privileged` entrypoint, deliberately kept **separate** from the unattended `Microsoft.Azure.ARO.HCP.DevCI.Unprivileged` entrypoint. It owns two privileged concerns:
 
-> Implementation detail: because the topology framework requires every service group to reference a pipeline, the `DevCI.Privileged` root is a **no-op grouping pipeline** (`dev-infrastructure/dev-ci/privileged/pipeline.yaml`, empty step list) and the actual grants live in a child service group. Operators never target that child directly — always use the entrypoint via the make target below.
+1. **The CI bot Entra identity lifecycle** (`E2ESubscriptionRBAC` service group): creating/reconciling the bot Entra applications + service principals and minting their Key Vault client secrets. These are Entra **directory-object writes** (create app/SP, `addPassword`) — an unattended CI identity is deliberately not given app/SP-management or credential-minting rights over directory objects, so this runs on demand instead.
+2. **The subscription-scoped RBAC grants** (`E2ESubscriptionRBACGrants` service group): the DEV E2E customer-subscription RBAC (custom role definitions + shared-principal role assignments) and the CI bot subscription-scoped RBAC. Every step creates subscription-scoped custom role definitions and/or role assignments, which require **Owner** (or an *unconstrained* User Access Administrator) on the target subscriptions — specifically the rights to write custom role definitions and to assign the privileged `Role Based Access Control Administrator` role to the mock arm-helper principal.
 
-The identity that runs the unattended `dev-ci` postsubmit (the `OpenShift Release Bot` service principal, app `38335e22-716a-4a21-bf20-15ab141823f0`) is deliberately **not** an Owner. It holds `Contributor` plus a *condition-constrained* `Role Based Access Control Administrator` / `User Access Administrator` whose Azure ABAC condition forbids assigning the `Owner`, `User Access Administrator`, and `Role Based Access Control Administrator` roles. That is exactly one of the assignments this entrypoint makes, and on some target subscriptions the bot also lacks `Microsoft.Authorization/roleDefinitions/write` — so the grants would fail if the postsubmit tried to apply them. The `DevCI.Privileged` entrypoint is therefore never wired into the unattended `DevCI.Unprivileged` graph and is run manually by a member of the OWNERS group (who has real Owner) whenever a change touches these grants:
+> Implementation detail: because the topology framework requires every service group to reference a pipeline, the `DevCI.Privileged` root is a **no-op grouping pipeline** (`dev-infrastructure/dev-ci/privileged/pipeline.yaml`, empty step list). The identity service group (`E2ESubscriptionRBAC`) hangs off that root, and the grants service group (`E2ESubscriptionRBACGrants`) is nested as its child. That nesting matters: the topology runs a parent's steps before its child's, so the identities are created before the grants that look them up via `existing`. Operators never target these service groups directly — always use the entrypoint via the make target below.
+
+The identity that runs the unattended `dev-ci` postsubmit (the `OpenShift Release Bot` service principal, app `38335e22-716a-4a21-bf20-15ab141823f0`) is deliberately **not** an Owner. It holds `Contributor` plus a *condition-constrained* `Role Based Access Control Administrator` / `User Access Administrator` whose Azure ABAC condition forbids assigning the `Owner`, `User Access Administrator`, and `Role Based Access Control Administrator` roles. That is exactly one of the assignments this entrypoint makes, and on some target subscriptions the bot also lacks `Microsoft.Authorization/roleDefinitions/write` — so the grants would fail if the postsubmit tried to apply them. It is likewise not meant to hold the Entra directory-object rights needed to create the bot apps/SPs or mint their secrets. The `DevCI.Privileged` entrypoint is therefore never wired into the unattended `DevCI.Unprivileged` graph and is run manually by a member of the OWNERS group (who has real Owner and the directory privileges to manage these identities) whenever a change touches the bot identities or these grants:
 
 ```bash
 make dev-ci-privileged-local-run
 ```
 
-This grants rollout looks up the CI bot service principals via `existing`, so the `DevCI.Unprivileged` entrypoint must have run at least once first — it creates those identities.
+Because the identity service group is the parent of the grants service group within this same entrypoint, a single privileged run creates/reconciles the CI bot identities first and then applies the grants (which look up the service principals via `existing`) — no separate bootstrap run of another entrypoint is required.
 
-This split keeps the blast radius of the standing CI automation small: the postsubmit reconciles everything that does not need Owner, and the rare Owner-only changes are applied on demand.
+This split keeps the blast radius of the standing CI automation small: the postsubmit reconciles only the CI support layer that needs no Owner and no directory-object management, and the rare identity/credential and Owner-only changes are applied on demand.
 
 ## What It Does Not Manage
 
@@ -92,7 +93,7 @@ make dev-ci-local-run
 make dev-ci-privileged-local-run
 ```
 
-Use the first command for the full standalone `dev-ci` entrypoint, which includes the non-privileged CI bot identity/secret rollout. Use the second — **an Owner-only, on-demand run performed by an OWNERS-group member** — when the subscription-scoped custom roles and role assignments need to be applied.
+Use the first command for the standalone `dev-ci` postsubmit surface (shared network, `opstool` AKS, monitoring, gateway, cert-manager, CIHealth, quota) — it no longer touches the CI bot identities. Use the second — **an Owner-only, on-demand run performed by an OWNERS-group member** — when the CI bot Entra identities need to be created/reconciled or their secrets rotated, or when the subscription-scoped custom roles and role assignments need to be applied; that entrypoint does both, in order.
 
 ## Where To Look
 

--- a/topology-dev-ci.yaml
+++ b/topology-dev-ci.yaml
@@ -2,13 +2,13 @@ entrypoints:
 - identifier: 'Microsoft.Azure.ARO.HCP.DevCI.Unprivileged'
   metadata:
     name: Dev CI Infrastructure
-# PRIVILEGED, on-demand only. Rolls out the CI bot Entra identity lifecycle
-# (Entra application + service principal directory-object writes) and the
-# subscription-scoped custom role definitions and role assignments that require
-# Owner (or User Access Administrator) on the target subscriptions. Kept as a
-# separate entrypoint so the unattended dev-ci postsubmit (which runs the
-# Unprivileged entrypoint) never touches it. Run manually by an OWNERS-group
-# member.
+# PRIVILEGED, on-demand only. Running this entrypoint requires BOTH Entra
+# directory privileges (to create and manage the CI bot Entra applications and
+# service principals) AND subscription Owner or User Access Administrator (to
+# write the custom role definitions and role assignments) — Azure RBAC alone is
+# not sufficient. Kept as a separate entrypoint so the unattended dev-ci
+# postsubmit (which runs the Unprivileged entrypoint) never touches it. Run
+# manually by an OWNERS-group member.
 - identifier: 'Microsoft.Azure.ARO.HCP.DevCI.Privileged'
   metadata:
     name: Dev CI Privileged Identities and Grants
@@ -29,14 +29,6 @@ services:
   - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.CIHealth
     pipelinePath: dev-infrastructure/dev-ci/cihealth/pipeline.yaml
     purpose: Deploy the CIHealth runtime on cihealth.tools.hcpsvc.osadev.cloud.
-# PRIVILEGED, on-demand only. The `Privileged` root is a no-op grouping
-# pipeline. Its E2ESubscriptionRBAC child creates/reconciles the CI bot Entra
-# identities (directory-object writes) and rotates their Key Vault secrets, and
-# that child's own E2ESubscriptionRBACGrants child applies the Owner-only
-# subscription-scoped grants. Nesting grants under the identity service group
-# guarantees the identities exist (they are looked up via `existing`) before the
-# grants run, within a single privileged rollout. An OWNERS-group member runs it
-# manually with `make dev-ci-privileged-local-run`. See docs/ci/dev-ci-topology.md.
 - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Privileged
   pipelinePath: dev-infrastructure/dev-ci/privileged/pipeline.yaml
   purpose: No-op grouping root for the on-demand privileged entrypoint. Owner-only; run manually by an OWNERS-group member.

--- a/topology-dev-ci.yaml
+++ b/topology-dev-ci.yaml
@@ -2,14 +2,16 @@ entrypoints:
 - identifier: 'Microsoft.Azure.ARO.HCP.DevCI.Unprivileged'
   metadata:
     name: Dev CI Infrastructure
-# PRIVILEGED, on-demand only. Rolls out the subscription-scoped custom role
-# definitions and role assignments that require Owner (or User Access
-# Administrator) on the target subscriptions. Kept as a separate entrypoint so
-# the unattended dev-ci postsubmit (which runs the Unprivileged entrypoint)
-# never touches it. Run manually by an OWNERS-group member.
+# PRIVILEGED, on-demand only. Rolls out the CI bot Entra identity lifecycle
+# (Entra application + service principal directory-object writes) and the
+# subscription-scoped custom role definitions and role assignments that require
+# Owner (or User Access Administrator) on the target subscriptions. Kept as a
+# separate entrypoint so the unattended dev-ci postsubmit (which runs the
+# Unprivileged entrypoint) never touches it. Run manually by an OWNERS-group
+# member.
 - identifier: 'Microsoft.Azure.ARO.HCP.DevCI.Privileged'
   metadata:
-    name: Dev CI Privileged Grants
+    name: Dev CI Privileged Identities and Grants
 services:
 - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Unprivileged
   pipelinePath: dev-infrastructure/dev-ci/cluster/opstool-aks-pipeline.yaml
@@ -18,9 +20,6 @@ services:
   - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.TenantQuota
     pipelinePath: tooling/tenant-quota/pipeline.yaml
     purpose: Deploy the tenant-quota-collector.
-  - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC
-    pipelinePath: dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
-    purpose: Reconcile the non-privileged CI bot Entra identities and rotate their Key Vault secrets. Requires no subscription Owner, so it runs unattended in the dev-ci postsubmit.
   - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Gateway
     pipelinePath: dev-infrastructure/dev-ci/gateway/pipeline.yaml
     purpose: Deploy the shared Istio gateway and DNS wiring for opstool.
@@ -31,13 +30,21 @@ services:
     pipelinePath: dev-infrastructure/dev-ci/cihealth/pipeline.yaml
     purpose: Deploy the CIHealth runtime on cihealth.tools.hcpsvc.osadev.cloud.
 # PRIVILEGED, on-demand only. The `Privileged` root is a no-op grouping
-# pipeline; the actual grants live in its E2ESubscriptionRBACGrants child. An
-# OWNERS-group member runs it manually with `make dev-ci-privileged-local-run`
-# when a change touches these grants. See docs/ci/dev-ci-topology.md.
+# pipeline. Its E2ESubscriptionRBAC child creates/reconciles the CI bot Entra
+# identities (directory-object writes) and rotates their Key Vault secrets, and
+# that child's own E2ESubscriptionRBACGrants child applies the Owner-only
+# subscription-scoped grants. Nesting grants under the identity service group
+# guarantees the identities exist (they are looked up via `existing`) before the
+# grants run, within a single privileged rollout. An OWNERS-group member runs it
+# manually with `make dev-ci-privileged-local-run`. See docs/ci/dev-ci-topology.md.
 - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Privileged
   pipelinePath: dev-infrastructure/dev-ci/privileged/pipeline.yaml
-  purpose: No-op grouping root for the on-demand privileged grants entrypoint. Owner-only; run manually by an OWNERS-group member.
+  purpose: No-op grouping root for the on-demand privileged entrypoint. Owner-only; run manually by an OWNERS-group member.
   children:
-  - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants
-    pipelinePath: dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
-    purpose: Manage explicit dev E2E customer-subscription RBAC and shared custom-role assignable scopes, plus the CI bot subscription-scoped RBAC. Owner-only; run on demand by an OWNERS-group member.
+  - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC
+    pipelinePath: dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
+    purpose: Create/reconcile the CI bot Entra applications + service principals and rotate their Key Vault secrets. Involves Entra directory-object writes, so it runs on demand under an OWNERS-group member, not the unattended postsubmit.
+    children:
+    - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBACGrants
+      pipelinePath: dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
+      purpose: Manage explicit dev E2E customer-subscription RBAC and shared custom-role assignable scopes, plus the CI bot subscription-scoped RBAC. Runs after the CI bot identities exist. Owner-only; run on demand by an OWNERS-group member.


### PR DESCRIPTION
## Why

The unattended dev-ci postsubmit (`Microsoft.Azure.ARO.HCP.DevCI.Unprivileged`) ran the `E2ESubscriptionRBAC` pipeline, whose `ci-bot-identity` ARM step **creates the CI bot Entra applications + service principals** and whose `ci-bot-secret-*` steps **mint client secrets** into those apps (Graph `addPassword`). Both are Entra **directory-object writes**.

The postsubmit runs as the `OpenShift Release Bot` service principal, which only holds `Application.ReadWrite.OwnedBy` — it can manage only the apps it **owns**. When the bot apps are first created under a different identity (e.g. an operator running the pipeline locally), the postsubmit is not an owner and the reconcile fails:

```
Authorization_RequestDenied: Insufficient privileges to complete the operation (target /resources/entraApp)
```

Working around this by making the CI service principal an **owner** of those apps would give an unattended CI identity standing rights to manage other apps/SPs and mint their credentials — a security gap.

## What

Move the whole CI bot identity lifecycle out of the unattended entrypoint and into the on-demand **Privileged** entrypoint, run by an OWNERS-group member who legitimately holds the directory privileges. Bot identity changes are infrequent, so on-demand execution adds negligible operational burden.

- `E2ESubscriptionRBAC` (identity lifecycle) is now a **child of the `Privileged` root**, removed from `Unprivileged`.
- `E2ESubscriptionRBACGrants` (Owner-only grants) is **nested under `E2ESubscriptionRBAC`**. The topology runs a parent's steps before its child's, so a single privileged run creates the identities first, then applies the grants (which look them up via `existing`) — eliminating the previous cross-entrypoint bootstrap ordering that required `Unprivileged` to have run first.
- Updated pipeline header comments and `docs/ci/dev-ci-topology.md`.

No change to the `openshift/release` postsubmit `run_if_changed` is required. `Application.ReadWrite.OwnedBy` on the SP remains in place (still used by other entrypoints); the temporary app-ownership grant added while diagnosing this can now be reverted.

## Validation

- `templatize pipeline validate` on `topology-dev-ci.yaml` produces the identical pre-existing bicepparam-only failure set ([ARO-28081](https://redhat.atlassian.net/browse/ARO-28081)) as clean `main` — the nested topology resolves and adds **no new** errors.
- `yamlfmt -lint` clean on all changed YAML.

Jira: https://redhat.atlassian.net/browse/ARO-28206