### PR TITLE
feat(slot-manager): resolve customer credentials across multiple cluster-profile dirs

### DIFF
--- a/test/cmd/aro-hcp-tests/slot-manager/DESIGN.md
+++ b/test/cmd/aro-hcp-tests/slot-manager/DESIGN.md
@@ -70,9 +70,21 @@ scale independently from the infrastructure-subscription work.
     - highest-precedence concrete runtime location
     - when set it overrides `ALLOWED_LOCATIONS` for fixed-mode pool selection
     - for runtime-selected pools it does not change pool identity, but it does become the concrete runtime location
+  - `CLUSTER_PROFILE_DIRS`
+    - optional comma/newline-separated list of cluster profile dirs to resolve the leased
+      subscription's owning tenant/service-principal across
+    - falls back to the single `CLUSTER_PROFILE_DIR` when unset (backward compatible)
+    - used by the cross-tenant prod gating job so a single job can lease slots that live
+      in more than one Azure tenant (RH-tenant subs + MSFT Test-Tenant sub); acquire matches
+      the leased `subscription_name` against the `customer-*-subscription-name` files across
+      all listed dirs and exports the single matching dir as `SELECTED_CLUSTER_PROFILE_DIR`
 - The runtime env contract is intentionally narrow and non-secret:
   - `CUSTOMER_SUBSCRIPTION`
   - `SELECTED_LOCATION`
+  - `SELECTED_CLUSTER_PROFILE_DIR`
+    - the single cluster profile dir whose `customer-*-subscription-name` matched the leased
+      subscription; downstream steps load the owning tenant/service-principal credentials from
+      it (`tenant`, `client-id`, `client-secret`) instead of a job-fixed profile
   - `LEASED_MSI_CONTAINERS`
   - `ARO_HCP_E2E_SLOT_NAME`
   - `ARO_HCP_E2E_SLOT_RESOURCE_TYPE`

--- a/test/cmd/aro-hcp-tests/slot-manager/acquire.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/acquire.go
@@ -39,6 +39,7 @@ func DefaultAcquireOptions() *RawAcquireOptions {
 	allowedSubscriptions, allowedLocations, selectedLocation := defaultAcquireSelectors()
 	return &RawAcquireOptions{
 		ClusterProfileDir:    strings.TrimSpace(os.Getenv("CLUSTER_PROFILE_DIR")),
+		ClusterProfileDirs:   splitSelectorValues(os.Getenv("CLUSTER_PROFILE_DIRS")),
 		DeployEnv:            strings.TrimSpace(os.Getenv("ARO_HCP_DEPLOY_ENV")),
 		AllowedSubscriptions: allowedSubscriptions,
 		AllowedLocations:     allowedLocations,
@@ -66,6 +67,12 @@ func splitSelectorValues(raw string) []string {
 	parts := strings.FieldsFunc(raw, func(r rune) bool {
 		return r == ',' || r == '\n'
 	})
+	return normalizeValues(parts)
+}
+
+// normalizeValues trims whitespace, drops empty entries, and de-duplicates
+// while preserving first-seen order.
+func normalizeValues(parts []string) []string {
 	values := make([]string, 0, len(parts))
 	seen := map[string]struct{}{}
 	for _, part := range parts {
@@ -84,6 +91,7 @@ func splitSelectorValues(raw string) []string {
 
 func BindAcquireOptions(opts *RawAcquireOptions, cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&opts.ClusterProfileDir, "cluster-profile-dir", opts.ClusterProfileDir, "Path to CLUSTER_PROFILE_DIR")
+	cmd.Flags().StringSliceVar(&opts.ClusterProfileDirs, "cluster-profile-dirs", opts.ClusterProfileDirs, "Optional list of cluster profile dirs to resolve the leased subscription's owning tenant/credentials across. Falls back to --cluster-profile-dir when unset.")
 	cmd.Flags().StringVar(&opts.DeployEnv, "deploy-env", opts.DeployEnv, "Deploy environment name (ci00, ci01, int, stg, prod)")
 	cmd.Flags().StringSliceVar(&opts.AllowedSubscriptions, "allowed-subscriptions", opts.AllowedSubscriptions, "Optional catalog subscription_name values allowed for candidate pool selection.")
 	cmd.Flags().StringSliceVar(&opts.AllowedLocations, "allowed-locations", opts.AllowedLocations, "Optional Azure regions allowed for fixed-mode candidate pool selection.")
@@ -98,6 +106,7 @@ func BindAcquireOptions(opts *RawAcquireOptions, cmd *cobra.Command) error {
 
 type RawAcquireOptions struct {
 	ClusterProfileDir    string
+	ClusterProfileDirs   []string
 	DeployEnv            string
 	AllowedSubscriptions []string
 	AllowedLocations     []string
@@ -120,13 +129,13 @@ type ValidatedAcquireOptions struct {
 }
 
 type completedAcquireOptions struct {
-	ClusterProfileDir string
-	DeployEnvironment string
-	SharedDir         string
-	LeaseProxyURL     string
-	LeaseProxyTimeout time.Duration
-	MaxWaitForLease   time.Duration
-	LeaseWaitInterval time.Duration
+	ClusterProfileDirs []string
+	DeployEnvironment  string
+	SharedDir          string
+	LeaseProxyURL      string
+	LeaseProxyTimeout  time.Duration
+	MaxWaitForLease    time.Duration
+	LeaseWaitInterval  time.Duration
 	// RuntimeLocationOverride carries the concrete runtime region when pool
 	// identity is decoupled from region selection.
 	RuntimeLocationOverride string
@@ -171,8 +180,8 @@ func Acquire(ctx context.Context, opts *RawAcquireOptions) error {
 
 func (o *RawAcquireOptions) Validate() (*ValidatedAcquireOptions, error) {
 	switch {
-	case o.ClusterProfileDir == "":
-		return nil, fmt.Errorf("--cluster-profile-dir must not be empty")
+	case len(o.effectiveClusterProfileDirs()) == 0:
+		return nil, fmt.Errorf("--cluster-profile-dir or --cluster-profile-dirs must not be empty")
 	case o.DeployEnv == "":
 		return nil, fmt.Errorf("--deploy-env must not be empty")
 	case o.SharedDir == "":
@@ -190,6 +199,23 @@ func (o *RawAcquireOptions) Validate() (*ValidatedAcquireOptions, error) {
 	return &ValidatedAcquireOptions{
 		validatedAcquireOptions: &validatedAcquireOptions{RawAcquireOptions: o},
 	}, nil
+}
+
+// effectiveClusterProfileDirs returns the cluster profile dirs to resolve the
+// leased subscription's owning credentials across. --cluster-profile-dirs
+// (CLUSTER_PROFILE_DIRS) takes precedence; otherwise it falls back to the
+// single --cluster-profile-dir (CLUSTER_PROFILE_DIR) for backward
+// compatibility. Values are trimmed, de-duplicated, and empty entries dropped
+// so callers get a clean list regardless of how they were supplied (flag or
+// env, e.g. trailing commas or stray whitespace).
+func (o *RawAcquireOptions) effectiveClusterProfileDirs() []string {
+	if dirs := normalizeValues(o.ClusterProfileDirs); len(dirs) > 0 {
+		return dirs
+	}
+	if dir := strings.TrimSpace(o.ClusterProfileDir); dir != "" {
+		return []string{dir}
+	}
+	return nil
 }
 
 func (o *ValidatedAcquireOptions) Complete(_ context.Context) (*AcquireOptions, error) {
@@ -210,7 +236,7 @@ func (o *ValidatedAcquireOptions) Complete(_ context.Context) (*AcquireOptions, 
 
 	return &AcquireOptions{
 		completedAcquireOptions: &completedAcquireOptions{
-			ClusterProfileDir:       o.ClusterProfileDir,
+			ClusterProfileDirs:      o.effectiveClusterProfileDirs(),
 			DeployEnvironment:       o.DeployEnv,
 			SharedDir:               o.SharedDir,
 			LeaseProxyURL:           o.LeaseProxyServerURL,
@@ -381,7 +407,7 @@ func (o *AcquireOptions) finalizeAcquiredLease(ctx context.Context, logger logr.
 		return err
 	}
 
-	customerSubscription, err := slots.VerifyCustomerSubscriptionName(o.ClusterProfileDir, pool.SubscriptionName)
+	customerSubscription, selectedClusterProfileDir, err := slots.VerifyCustomerSubscriptionName(o.ClusterProfileDirs, pool.SubscriptionName)
 	if err != nil {
 		return err
 	}
@@ -404,7 +430,7 @@ func (o *AcquireOptions) finalizeAcquiredLease(ctx context.Context, logger logr.
 	// The release step can now clean up this lease from the persisted state
 	// file, so subsequent failures should not try to release it again here.
 	rollbackLease = false
-	if err := slots.WriteEnvFile(o.SharedDir, state, customerSubscription); err != nil {
+	if err := slots.WriteEnvFile(o.SharedDir, state, customerSubscription, selectedClusterProfileDir); err != nil {
 		return err
 	}
 

--- a/test/cmd/aro-hcp-tests/slot-manager/acquire_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/acquire_test.go
@@ -266,6 +266,47 @@ func TestDefaultAcquireOptionsSelectorDefaults(t *testing.T) {
 	}
 }
 
+func TestEffectiveClusterProfileDirs(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		dirs []string
+		dir  string
+		want []string
+	}{
+		{
+			name: "dirs normalized: trimmed, deduped, empties dropped",
+			dirs: []string{" /var/run/a ", "", "/var/run/b", "/var/run/a", "  "},
+			dir:  "/var/run/fallback",
+			want: []string{"/var/run/a", "/var/run/b"},
+		},
+		{
+			name: "dirs that normalize to empty fall back to single dir",
+			dirs: []string{"", "  "},
+			dir:  " /var/run/fallback ",
+			want: []string{"/var/run/fallback"},
+		},
+		{
+			name: "single dir fallback is trimmed",
+			dir:  "  /var/run/only  ",
+			want: []string{"/var/run/only"},
+		},
+		{
+			name: "nothing supplied yields nil",
+			want: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			opts := &RawAcquireOptions{ClusterProfileDirs: tc.dirs, ClusterProfileDir: tc.dir}
+			if got := opts.effectiveClusterProfileDirs(); !equalStrings(got, tc.want) {
+				t.Fatalf("unexpected effective cluster profile dirs: got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestDefaultAcquireOptionsDoesNotUseLegacyLocationForSelection(t *testing.T) {
 	t.Setenv("LOCATION", "westus3")
 

--- a/test/cmd/aro-hcp-tests/slot-manager/release_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/release_test.go
@@ -51,7 +51,7 @@ func writeReleaseTestState(t *testing.T, sharedDir string) {
 	if err := slots.WriteAcquiredSlotState(sharedDir, state); err != nil {
 		t.Fatalf("expected state write to succeed: %v", err)
 	}
-	if err := slots.WriteEnvFile(sharedDir, state, "dev-sub"); err != nil {
+	if err := slots.WriteEnvFile(sharedDir, state, "dev-sub", "/var/run/aro-hcp-dev"); err != nil {
 		t.Fatalf("expected env file write to succeed: %v", err)
 	}
 }

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/runtime_contract.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/runtime_contract.go
@@ -23,56 +23,67 @@ import (
 )
 
 // VerifyCustomerSubscriptionName checks that slotSubscriptionName matches
-// exactly one customer-*-subscription-name file inside clusterProfileDir.
-// It returns the validated name (not a subscription ID) because downstream
-// E2E steps expect the human-readable subscription name.
-func VerifyCustomerSubscriptionName(clusterProfileDir, slotSubscriptionName string) (string, error) {
-	if clusterProfileDir == "" {
-		return "", errors.New("cluster profile dir is empty")
+// exactly one customer-*-subscription-name file across the supplied cluster
+// profile dirs. It returns the validated name (not a subscription ID) and the
+// single cluster profile dir that matched. Downstream E2E steps use the
+// returned dir to load the tenant/service-principal credentials that own the
+// leased subscription, which is what allows a single job to lease slots that
+// live in more than one Azure tenant.
+func VerifyCustomerSubscriptionName(clusterProfileDirs []string, slotSubscriptionName string) (string, string, error) {
+	if len(clusterProfileDirs) == 0 {
+		return "", "", errors.New("cluster profile dirs are empty")
 	}
 
 	if slotSubscriptionName == "" {
-		return "", errors.New("slot subscription name is empty")
-	}
-
-	entries, err := os.ReadDir(clusterProfileDir)
-	if err != nil {
-		return "", fmt.Errorf("failed to read cluster profile dir %q: %w", clusterProfileDir, err)
+		return "", "", errors.New("slot subscription name is empty")
 	}
 
 	var matchedFile string
-	for _, entry := range entries {
-		if entry.IsDir() || !isCustomerSubscriptionNameFile(entry.Name()) {
-			continue
+	var matchedDir string
+	for _, clusterProfileDir := range clusterProfileDirs {
+		if clusterProfileDir == "" {
+			return "", "", errors.New("cluster profile dir is empty")
 		}
 
-		candidatePath := filepath.Join(clusterProfileDir, entry.Name())
-		data, err := os.ReadFile(candidatePath)
+		entries, err := os.ReadDir(clusterProfileDir)
 		if err != nil {
-			return "", fmt.Errorf("failed to read customer subscription name %q: %w", candidatePath, err)
+			return "", "", fmt.Errorf("failed to read cluster profile dir %q: %w", clusterProfileDir, err)
 		}
 
-		if strings.TrimSpace(string(data)) != slotSubscriptionName {
-			continue
-		}
+		for _, entry := range entries {
+			if entry.IsDir() || !isCustomerSubscriptionNameFile(entry.Name()) {
+				continue
+			}
 
-		if matchedFile != "" {
-			return "", fmt.Errorf(
-				"multiple customer subscription name files matched slot subscription %q: %s, %s",
-				slotSubscriptionName,
-				matchedFile,
-				candidatePath,
-			)
-		}
+			candidatePath := filepath.Join(clusterProfileDir, entry.Name())
+			data, err := os.ReadFile(candidatePath)
+			if err != nil {
+				return "", "", fmt.Errorf("failed to read customer subscription name %q: %w", candidatePath, err)
+			}
 
-		matchedFile = candidatePath
+			if strings.TrimSpace(string(data)) != slotSubscriptionName {
+				continue
+			}
+
+			if matchedFile != "" {
+				return "", "", fmt.Errorf(
+					"multiple customer subscription name files matched slot subscription %q: %s, %s",
+					slotSubscriptionName,
+					matchedFile,
+					candidatePath,
+				)
+			}
+
+			matchedFile = candidatePath
+			matchedDir = clusterProfileDir
+		}
 	}
 
 	if matchedFile == "" {
-		return "", fmt.Errorf("no customer subscription name file matched slot subscription %q in %q", slotSubscriptionName, clusterProfileDir)
+		return "", "", fmt.Errorf("no customer subscription name file matched slot subscription %q in %s", slotSubscriptionName, strings.Join(clusterProfileDirs, ", "))
 	}
 
-	return slotSubscriptionName, nil
+	return slotSubscriptionName, matchedDir, nil
 }
 
 func isCustomerSubscriptionNameFile(name string) bool {

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/runtime_contract_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/runtime_contract_test.go
@@ -32,12 +32,59 @@ func TestVerifyCustomerSubscriptionName(t *testing.T) {
 		t.Fatalf("expected write to succeed: %v", err)
 	}
 
-	resolved, err := VerifyCustomerSubscriptionName(clusterProfileDir, "customer-dev")
+	resolved, matchedDir, err := VerifyCustomerSubscriptionName([]string{clusterProfileDir}, "customer-dev")
 	if err != nil {
 		t.Fatalf("expected subscription verification to succeed: %v", err)
 	}
 	if resolved != "customer-dev" {
 		t.Fatalf("expected verified subscription %q, got %q", "customer-dev", resolved)
+	}
+	if matchedDir != clusterProfileDir {
+		t.Fatalf("expected matched dir %q, got %q", clusterProfileDir, matchedDir)
+	}
+}
+
+func TestVerifyCustomerSubscriptionNameResolvesAcrossDirs(t *testing.T) {
+	t.Parallel()
+
+	rhDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rhDir, "customer-shard0-subscription-name"), []byte("rh-sub\n"), 0o644); err != nil {
+		t.Fatalf("expected write to succeed: %v", err)
+	}
+	testTenantDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(testTenantDir, "customer-shard0-subscription-name"), []byte("test-tenant-sub\n"), 0o644); err != nil {
+		t.Fatalf("expected write to succeed: %v", err)
+	}
+
+	resolved, matchedDir, err := VerifyCustomerSubscriptionName([]string{rhDir, testTenantDir}, "test-tenant-sub")
+	if err != nil {
+		t.Fatalf("expected subscription verification to succeed: %v", err)
+	}
+	if resolved != "test-tenant-sub" {
+		t.Fatalf("expected verified subscription %q, got %q", "test-tenant-sub", resolved)
+	}
+	if matchedDir != testTenantDir {
+		t.Fatalf("expected matched dir %q, got %q", testTenantDir, matchedDir)
+	}
+}
+
+func TestVerifyCustomerSubscriptionNameRejectsMatchInMultipleDirs(t *testing.T) {
+	t.Parallel()
+
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	for _, dir := range []string{dirA, dirB} {
+		if err := os.WriteFile(filepath.Join(dir, "customer-shard0-subscription-name"), []byte("dup-sub\n"), 0o644); err != nil {
+			t.Fatalf("expected write to succeed: %v", err)
+		}
+	}
+
+	_, _, err := VerifyCustomerSubscriptionName([]string{dirA, dirB}, "dup-sub")
+	if err == nil {
+		t.Fatal("expected cross-dir duplicate match verification to fail")
+	}
+	if !strings.Contains(err.Error(), "multiple customer subscription name files matched") {
+		t.Fatalf("expected duplicate match error, got %v", err)
 	}
 }
 
@@ -54,7 +101,7 @@ func TestVerifyCustomerSubscriptionNameRejectsDuplicateMatches(t *testing.T) {
 		}
 	}
 
-	_, err := VerifyCustomerSubscriptionName(clusterProfileDir, "customer-dev")
+	_, _, err := VerifyCustomerSubscriptionName([]string{clusterProfileDir}, "customer-dev")
 	if err == nil {
 		t.Fatal("expected duplicate match verification to fail")
 	}

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/state.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/state.go
@@ -136,12 +136,15 @@ func (s *AcquiredSlotState) Validate() error {
 	return nil
 }
 
-func WriteEnvFile(sharedDir string, state *AcquiredSlotState, customerSubscription string) error {
+func WriteEnvFile(sharedDir string, state *AcquiredSlotState, customerSubscription, selectedClusterProfileDir string) error {
 	if err := state.Validate(); err != nil {
 		return err
 	}
 	if customerSubscription == "" {
 		return errors.New("customer subscription is empty")
+	}
+	if selectedClusterProfileDir == "" {
+		return errors.New("selected cluster profile dir is empty")
 	}
 	if _, err := EnsureStateDir(sharedDir); err != nil {
 		return err
@@ -157,6 +160,7 @@ func WriteEnvFile(sharedDir string, state *AcquiredSlotState, customerSubscripti
 		"ARO_HCP_E2E_SLOT_RESOURCE_TYPE": state.Slot.ResourceType,
 		"CUSTOMER_SUBSCRIPTION":          customerSubscription,
 		"LEASED_MSI_CONTAINERS":          strings.Join(state.Slot.IdentityContainerNames(), " "),
+		"SELECTED_CLUSTER_PROFILE_DIR":   selectedClusterProfileDir,
 		"SELECTED_LOCATION":              state.RuntimeRegion,
 	}
 

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/state_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/state_test.go
@@ -43,7 +43,7 @@ func TestWriteAndLoadAcquiredSlotStateAndEnvFile(t *testing.T) {
 	if err := WriteAcquiredSlotState(sharedDir, state); err != nil {
 		t.Fatalf("expected state write to succeed: %v", err)
 	}
-	if err := WriteEnvFile(sharedDir, state, "ARO HCP E2E Hosted Clusters (EA Subscription)"); err != nil {
+	if err := WriteEnvFile(sharedDir, state, "ARO HCP E2E Hosted Clusters (EA Subscription)", "/var/run/aro-hcp-dev"); err != nil {
 		t.Fatalf("expected env file write to succeed: %v", err)
 	}
 
@@ -78,6 +78,9 @@ func TestWriteAndLoadAcquiredSlotStateAndEnvFile(t *testing.T) {
 	}
 	if !strings.Contains(content, `export LEASED_MSI_CONTAINERS='aro-hcp-msi-container-dev-00-00 aro-hcp-msi-container-dev-00-01 aro-hcp-msi-container-dev-00-02'`) {
 		t.Fatalf("expected env file to contain LEASED_MSI_CONTAINERS export, got %q", content)
+	}
+	if !strings.Contains(content, `export SELECTED_CLUSTER_PROFILE_DIR='/var/run/aro-hcp-dev'`) {
+		t.Fatalf("expected env file to contain SELECTED_CLUSTER_PROFILE_DIR export, got %q", content)
 	}
 	if !strings.Contains(content, `export SELECTED_LOCATION='eastus2'`) {
 		t.Fatalf("expected env file to contain SELECTED_LOCATION export, got %q", content)

--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -95,3 +95,17 @@ environments:
       slot_count: 3
       identity_container_prefix: aro-hcp-msi-container-prod
       identity_container_count: 25
+    # Test-Test tenant (MSFT) prod sub "ARO HCP E2E" (403d9de9). Cross-tenant, so
+    # identities are provisioned externally (identity_provisioning: unmanaged).
+    # Kept in the pool so the single prod gating job can lease it for the canary
+    # region (eastus2euap), which only this sub is EUAP-onboarded for. The test
+    # step resolves this sub's owning tenant/service principal from the
+    # /var/run/aro-hcp-prod cluster profile via SELECTED_CLUSTER_PROFILE_DIR.
+    - subscription_name: "ARO HCP E2E"
+      region: uksouth
+      region_mode: runtime-selected
+      resource_type: aro-hcp-prod-testtenant-slot
+      slot_count: 4
+      identity_container_prefix: aro-hcp-msi-container-prod-testtenant
+      identity_container_count: 25
+      identity_provisioning: unmanaged


### PR DESCRIPTION
## Why

DEV/INT/STG e2e gating already run under the slot-manager leasing model. We are bringing PROD e2e gating back into the RH tenant, but the newly-provisioned RH PROD subscriptions' EUAP/canary onboarding is backlogged, so we still need the spare capacity of the MSFT Test-Tenant subscription (`ARO HCP E2E`). Running one gating job across subscriptions in **two different tenants** requires the acquire step to select the correct tenant/credentials for whichever slot it leases.

Previously `VerifyCustomerSubscriptionName` matched the leased slot's customer subscription name against a **single** cluster-profile directory, hard-tying a job to one tenant's credentials.

## What

- `VerifyCustomerSubscriptionName` now accepts a list of cluster-profile dirs, requires exactly one match across their union, and returns the matched dir.
- `acquire` gains `--cluster-profile-dirs` / `CLUSTER_PROFILE_DIRS` (falls back to the single `--cluster-profile-dir` when unset).
- `WriteEnvFile` emits `SELECTED_CLUSTER_PROFILE_DIR` so the test step loads the correct per-subscription tenant/client credentials.
- `test/e2e-config/e2e-slots.yaml`: adds the Test-Tenant `ARO HCP E2E` prod slot pool.
- `DESIGN.md` updated to document the two new env vars.

## Backward compatibility

Single-tenant jobs (INT/STG/dev) are unaffected: with `CLUSTER_PROFILE_DIRS` unset, `SELECTED_CLUSTER_PROFILE_DIR` resolves to their existing single dir — a no-op.

## Testing

- `go vet` + `go test ./cmd/aro-hcp-tests/slot-manager/...` green (added tests for multi-dir resolution and multi-dir-match rejection).

## Related

Paired with openshift/release#82340 migrating `prod-e2e-parallel` to the slot-manager workflow.

> Draft: depends on external prerequisites (MSFT prod Vault `customer-shard0-subscription-name: "ARO HCP E2E"`; Test-Tenant identity-container provisioning).