### PR TITLE
exclude managed-cluster-lease from the LeaderElectionLeaseStale alert

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -2165,7 +2165,7 @@ resource leaderelection 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           summary: 'Leader election lease {{ $labels.lease }} in namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} stale for more than 37 minutes'
           title: 'Leader election lease {{ $labels.lease }} in namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} stale for more than 37 minutes'
         }
-        expression: 'time() - max without (prometheus_replica) (kube_lease_renew_time{namespace!~"^(kube-system|kube-public|kube-node-lease|default|kube-applier|aro-hcp|mgmt-agent)$"}) > 720'
+        expression: 'time() - max without (prometheus_replica) (kube_lease_renew_time{lease!="managed-cluster-lease",namespace!~"^(kube-system|kube-public|kube-node-lease|default|kube-applier|aro-hcp|mgmt-agent)$"}) > 720'
         for: 'PT25M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }

--- a/observability/alerts/leaderelection-prometheusRule.yaml
+++ b/observability/alerts/leaderelection-prometheusRule.yaml
@@ -14,9 +14,10 @@ spec:
     rules:
     - alert: LeaderElectionLeaseStale
       # Fires when a leader election lease has not been renewed for >37m (12m expr threshold + 25m for:); excludes namespaces covered by LeaderElectionLeaseStaleCritical and standard k8s system namespaces (kube-node-lease has node heartbeat leases that are not leader election).
+      # Excludes managed-cluster-lease: this is the OCM/ACM cluster-availability heartbeat lease (renewed by the registration-agent, lease_holder == lease name), not a leader-election lock. It lives per-HCP in hashed managedcluster namespaces on management clusters and routinely goes stale when an HCP is deprovisioned, producing false positives.
       expr: |
         time() - max without(prometheus_replica) (
-          kube_lease_renew_time{namespace!~"^(kube-system|kube-public|kube-node-lease|default|kube-applier|aro-hcp|mgmt-agent)$"}
+          kube_lease_renew_time{namespace!~"^(kube-system|kube-public|kube-node-lease|default|kube-applier|aro-hcp|mgmt-agent)$", lease!="managed-cluster-lease"}
         ) > 720
       for: 25m
       labels:

--- a/observability/alerts/leaderelection-prometheusRule_test.yaml
+++ b/observability/alerts/leaderelection-prometheusRule_test.yaml
@@ -43,6 +43,15 @@ tests:
   - eval_time: 38m
     alertname: LeaderElectionLeaseStale
     exp_alerts: []
+# Test: LeaderElectionLeaseStale does not fire for the OCM managed-cluster-lease heartbeat (excluded by lease name)
+- interval: 1m
+  input_series:
+  - series: 'kube_lease_renew_time{namespace="2qvkr3r0qqaeqmblu92io1n4tmnfn6u3", lease="managed-cluster-lease", cluster="prod-mgmt-1"}'
+    values: "0x39" # stale, but lease excluded
+  alert_rule_test:
+  - eval_time: 38m
+    alertname: LeaderElectionLeaseStale
+    exp_alerts: []
 # Test: LeaderElectionLeaseStale does not fire for kube-applier namespace (covered by LeaderElectionLeaseStaleCritical)
 - interval: 1m
   input_series:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-28544

### What

excludes managed-cluster-lease from the LeaderElectionLeaseStale alert

### Why

Because otherwise the alert fires for `managed-cluster-lease` which is a heartbeat lease - and gives the impression you're dealing with a leader election gone wrong (LeaderElectionLeaseStale alert). And that would be wrong.

### Testing

- Ran the query in Grafana. ✅
- Unit tests (part of this PR) ✅

-> as it is only a very small and predictable change this should suffice.

### Special notes for your reviewer

why is managed-cluster-lease a heartbeat?

* Agent explicitly renews it as a heartbeat: the registration agent periodically updates only Lease.spec.renewTime ; the source describes this as keeping the heartbeat.

  [OCM lease updater](https://github.com/open-cluster-management-io/ocm/blob/5e56af3cdbce3f8f27bc5fcacd81eea9ea41f40a/pkg/registration/spoke/lease/lease_controller.go#L99-L139) · [renewal implementation](https://github.com/open-cluster-management-io/ocm/blob/5e56af3cdbce3f8f27bc5fcacd81eea9ea41f40a/pkg/registration/spoke/lease/lease_controller.go#L99-L139)

* Its identity is static: the hub creates it as managed-cluster-lease  with holderIdentity: managed-cluster-lease , rather than recording the unique identity of whichever process won an election.

  [Lease creation](https://github.com/open-cluster-management-io/ocm/blob/5e56af3cdbce3f8f27bc5fcacd81eea9ea41f40a/pkg/registration/hub/lease/controller.go#L90-L110)



### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
