### PR TITLE
feat(hcpctl): capture client-side azure.log in snapshots

### DIFF
--- a/tooling/hcpctl/pkg/agent/prompts/system.md
+++ b/tooling/hcpctl/pkg/agent/prompts/system.md
@@ -210,6 +210,16 @@ resource. Review the manifest's `directory_layout` for the full structure. Key l
   `ignitionNotReached`, or `OSProvisioningTimedOut`, **always check these first** —
   they show the node's view of boot (ignition TLS errors, kubelet failures, CNI
   issues) that the orchestrator-side Kusto queries cannot reveal.
+- `azure_sdk_log/azure.log` — the client's own record of every Azure SDK call the
+  test makes, across all resource providers (ARO-HCP RP, Managed Identity, Key
+  Vault, Network, etc.): each request, response, error, retry, and LRO poll, with
+  correlation IDs and timing. Present when `manifest.azure_log` is set. It is the
+  only client-side view of these calls, so consult it for any failure that turns on
+  how the client issued or handled an Azure request — for example (not limited to):
+  retries behind a conflict/`DeploymentActive`/already-exists error; transient
+  5xx/429 with backoff; LRO polling problems such as a 404 while a create
+  propagates or a poll that times out; and client-side timeouts, cancellations, or
+  transport/auth errors.
 - `discovery/` — resource IDs, cluster associations, request mappings
 - `<phase>/resources/<type>/<name>/` — state, conditions, logs, events per resource
 - `<phase>/events/` — service-level Kubernetes events

--- a/tooling/hcpctl/pkg/snapshot/analysis.go
+++ b/tooling/hcpctl/pkg/snapshot/analysis.go
@@ -122,6 +122,22 @@ func WriteNodeConsoleLogs(outputDir string, logs []NodeConsoleLogFile) error {
 	return nil
 }
 
+// WriteAzureLog writes the client-side azure.log to azure_sdk_log/azure.log in
+// the output directory. It is a no-op when no log was captured.
+func WriteAzureLog(outputDir string, log *AzureLogFile) error {
+	if log == nil || len(log.Content) == 0 {
+		return nil
+	}
+	dir := filepath.Join(outputDir, "azure_sdk_log")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create azure_sdk_log dir: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "azure.log"), log.Content, 0o644); err != nil {
+		return fmt.Errorf("failed to write azure.log: %w", err)
+	}
+	return nil
+}
+
 // RecoverTimeWindow reads sibling_tests.json from a previously gathered data
 // directory and returns the start/end/cleanup-start times for the named test.
 // This is used when reusing gathered data from a previous run where the time

--- a/tooling/hcpctl/pkg/snapshot/azure_log_test.go
+++ b/tooling/hcpctl/pkg/snapshot/azure_log_test.go
@@ -1,0 +1,67 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteAzureLog(t *testing.T) {
+	t.Run("writes content to azure_sdk_log/azure.log", func(t *testing.T) {
+		dir := t.TempDir()
+		content := []byte(`{"time":"2025-01-01T00:00:00Z","msg":"Request","method":"PUT"}`)
+
+		if err := WriteAzureLog(dir, &AzureLogFile{Content: content}); err != nil {
+			t.Fatalf("WriteAzureLog returned error: %v", err)
+		}
+
+		got, err := os.ReadFile(filepath.Join(dir, "azure_sdk_log", "azure.log"))
+		if err != nil {
+			t.Fatalf("failed to read written azure.log: %v", err)
+		}
+		if string(got) != string(content) {
+			t.Errorf("azure.log content mismatch:\n got: %q\nwant: %q", got, content)
+		}
+	})
+
+	t.Run("nil log is a no-op", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := WriteAzureLog(dir, nil); err != nil {
+			t.Fatalf("WriteAzureLog(nil) returned error: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(dir, "azure_sdk_log")); !os.IsNotExist(err) {
+			t.Errorf("expected no azure_sdk_log directory, stat err=%v", err)
+		}
+	})
+
+	t.Run("empty content is a no-op", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := WriteAzureLog(dir, &AzureLogFile{Content: []byte{}}); err != nil {
+			t.Fatalf("WriteAzureLog(empty) returned error: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(dir, "azure_sdk_log")); !os.IsNotExist(err) {
+			t.Errorf("expected no azure_sdk_log directory, stat err=%v", err)
+		}
+	})
+}
+
+func TestDirectoryLayoutIncludesAzureSDKLog(t *testing.T) {
+	layout := directoryLayout()
+	if _, ok := layout["azure_sdk_log"]; !ok {
+		t.Errorf("directoryLayout() is missing the azure_sdk_log entry: %v", layout)
+	}
+}

--- a/tooling/hcpctl/pkg/snapshot/gather_enriched.go
+++ b/tooling/hcpctl/pkg/snapshot/gather_enriched.go
@@ -71,6 +71,9 @@ type GatherForTestOptions struct {
 	// NodeConsoleLogs contains VM serial console log files downloaded from
 	// the Prow job's GCS artifacts. These are optional — not every test creates VMs.
 	NodeConsoleLogs []NodeConsoleLogFile
+
+	// AzureLog is the client-side azure.log from GCS, or nil if not present.
+	AzureLog *AzureLogFile
 }
 
 // GatherForTestResult contains metadata about what was gathered.
@@ -123,6 +126,11 @@ func GatherForTest(ctx context.Context, opts GatherForTestOptions) (*GatherForTe
 		return nil, fmt.Errorf("failed to write node console logs: %w", err)
 	}
 
+	// Write the client-side azure.log (if present).
+	if err := WriteAzureLog(opts.OutputDir, opts.AzureLog); err != nil {
+		return nil, fmt.Errorf("failed to write azure.log: %w", err)
+	}
+
 	// Build the gather input with 5-minute padding.
 	startTime := test.StartTime.Add(-5 * time.Minute)
 	endTime := test.EndTime.Add(5 * time.Minute)
@@ -166,6 +174,12 @@ func GatherForTest(ctx context.Context, opts GatherForTestOptions) (*GatherForTe
 			File:        fmt.Sprintf("node_boot_logs/%s", cl.FileName),
 			ArtifactURL: cl.ArtifactURL,
 		})
+	}
+	if opts.AzureLog != nil && len(opts.AzureLog.Content) > 0 {
+		manifest.AzureLog = &AzureLog{
+			File:        "azure_sdk_log/azure.log",
+			ArtifactURL: opts.AzureLog.ArtifactURL,
+		}
 	}
 	if err := WriteManifest(opts.OutputDir, manifest); err != nil {
 		return nil, fmt.Errorf("failed to write manifest: %w", err)

--- a/tooling/hcpctl/pkg/snapshot/manifest.go
+++ b/tooling/hcpctl/pkg/snapshot/manifest.go
@@ -53,6 +53,9 @@ type Manifest struct {
 	// node pool creation fails, providing boot diagnostic output.
 	NodeConsoleLogs []NodeConsoleLog `json:"node_console_logs,omitempty"`
 
+	// AzureLog references the client-side Azure SDK log (azure.log), when present.
+	AzureLog *AzureLog `json:"azure_log,omitempty"`
+
 	// DirectoryLayout describes the output directory structure.
 	DirectoryLayout map[string]string `json:"directory_layout"`
 }
@@ -168,6 +171,15 @@ type NodeConsoleLog struct {
 	ArtifactURL string `json:"artifact_url"`
 }
 
+// AzureLog references the client-side Azure SDK (azcore) log for the failing test.
+type AzureLog struct {
+	// File is the azure.log path, relative to the snapshot root.
+	File string `json:"file"`
+
+	// ArtifactURL is the gcsweb URL for downloading the original artifact.
+	ArtifactURL string `json:"artifact_url"`
+}
+
 // directoryLayout returns the static directory layout descriptions.
 func directoryLayout() map[string]string {
 	return map[string]string{
@@ -182,6 +194,7 @@ func directoryLayout() map[string]string {
 		"logs":           "<phase>/resources/<type>/<name>/logs/ — filtered or aggregated container and audit logs (operator logs, Maestro server/agent logs)",
 		"requests":       "<phase>/resources/<type>/<name>/requests/<METHOD>-<client_request_id>/ — per-request trace data with state/ and logs/ subdirectories",
 		"node_boot_logs": "node_boot_logs/ — VM serial console output (boot diagnostics) from nodes in the test. Files are named <node-name>-console.log. Each entry in manifest.json node_console_logs includes an artifact_url for downloading the original from the Prow job artifacts.",
+		"azure_sdk_log":  "azure_sdk_log/azure.log — client-side Azure SDK request/response log. Present only when manifest.json azure_log is set.",
 	}
 }
 

--- a/tooling/hcpctl/pkg/snapshot/prow.go
+++ b/tooling/hcpctl/pkg/snapshot/prow.go
@@ -700,6 +700,16 @@ type NodeConsoleLogFile struct {
 	ArtifactURL string
 }
 
+// AzureLogFile holds the downloaded per-test azure.log from GCS: the client-side
+// azcore request/response/retry log (correlation IDs, retries, LRO).
+type AzureLogFile struct {
+	// Content is the raw azure.log content (JSON-lines slog output), uncleaned.
+	Content []byte
+
+	// ArtifactURL is the gcsweb URL for downloading the original artifact.
+	ArtifactURL string
+}
+
 // sanitizeTestNameForGCS replicates the test framework's sanitization logic
 // from test/util/framework/per_test_framework.go:sanitizeTestName. This is
 // different from SanitizeTestName (which is stricter) — the test framework
@@ -787,6 +797,54 @@ func FetchNodeConsoleLogs(ctx context.Context, info *ProwJobInfo, testName strin
 	}
 
 	return consoleLogs, nil
+}
+
+// FetchAzureLog downloads a test's client-side azure.log from the Prow job's
+// GCS artifacts (same per-test prefix as node console logs). It returns
+// (nil, nil) when the test produced no azure.log, so absence is non-fatal.
+func FetchAzureLog(ctx context.Context, info *ProwJobInfo, testName string) (*AzureLogFile, error) {
+	logger := logr.FromContextOrDiscard(ctx)
+
+	gcsClient, err := storage.NewClient(ctx, option.WithoutAuthentication())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCS client: %w", err)
+	}
+	defer gcsClient.Close()
+
+	artifactDir, err := findArtifactDir(ctx, gcsClient, info.JobName, info.GCSPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find artifact directory: %w", err)
+	}
+
+	testStep := testStepPersistent
+	if info.IsPullRequest() {
+		testStep = testStepLocal
+	}
+
+	sanitizedName := sanitizeTestNameForGCS(testName)
+	objPath := fmt.Sprintf("%s/artifacts/%s/%s/artifacts/%s/azure.log", info.GCSPrefix, artifactDir, testStep, sanitizedName)
+
+	logger.V(1).Info("Fetching azure.log", "path", objPath)
+	data, err := downloadObject(ctx, gcsClient, objPath)
+	if err != nil {
+		if errors.Is(err, storage.ErrObjectNotExist) {
+			logger.V(1).Info("No azure.log found for test", "path", objPath)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to download azure.log: %w", err)
+	}
+
+	artifactURL := (&url.URL{
+		Scheme: "https",
+		Host:   "gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com",
+		Path:   "/gcs/" + gcsBucket + "/" + objPath,
+	}).String()
+
+	logger.Info("Found azure.log", "size", len(data))
+	return &AzureLogFile{
+		Content:     data,
+		ArtifactURL: artifactURL,
+	}, nil
 }
 
 // SanitizeTestName replaces characters that are not alphanumeric, dashes, or

--- a/tooling/hcpctl/pkg/snapshot/prow_job_context.go
+++ b/tooling/hcpctl/pkg/snapshot/prow_job_context.go
@@ -116,14 +116,21 @@ func (p *ProwJobContext) Close() error {
 }
 
 // GatherOptionsForTest returns a GatherForTestOptions pre-populated with all
-// per-job fields derived from this context, including node console logs fetched
-// from GCS. The caller must set OutputDir (and optionally QueryTimeout and
-// Concurrency) on the returned value before passing it to GatherForTest.
+// per-job fields derived from this context, including node console logs and the
+// client-side azure.log fetched from GCS. The caller must set OutputDir (and
+// optionally QueryTimeout and Concurrency) on the returned value before passing
+// it to GatherForTest.
 func (p *ProwJobContext) GatherOptionsForTest(ctx context.Context, test *TestResult) GatherForTestOptions {
 	nodeConsoleLogs, err := FetchNodeConsoleLogs(ctx, p.ProwInfo, test.Name)
 	if err != nil {
 		slog.Warn("Failed to fetch node console logs, continuing without them", "error", err, "test", test.Name)
 		nodeConsoleLogs = nil
+	}
+
+	azureLog, err := FetchAzureLog(ctx, p.ProwInfo, test.Name)
+	if err != nil {
+		slog.Warn("Failed to fetch azure.log, continuing without it", "error", err, "test", test.Name)
+		azureLog = nil
 	}
 
 	return GatherForTestOptions{
@@ -138,5 +145,6 @@ func (p *ProwJobContext) GatherOptionsForTest(ctx context.Context, test *TestRes
 		ManagementClusterName:    p.JobConfig.ManagementClusterName,
 		SiblingTests:             p.SiblingTests,
 		NodeConsoleLogs:          nodeConsoleLogs,
+		AzureLog:                 azureLog,
 	}
 }


### PR DESCRIPTION
## Why

Each e2e test's `azure.log` — the client-side azcore request/response/retry log the test framework writes per test to `${ARTIFACT_DIR}/<test>/azure.log` — records correlation IDs, client request IDs, retries, and LRO polling for every Azure SDK call the test makes. That client-side view was decisive in [AROSLSRE-1569](https://redhat.atlassian.net/browse/AROSLSRE-1569), where it reconstructed a 503→retry→409 `DeploymentActive` race. Until now `hcpctl snapshot` never captured it, so analysts had to fetch it by hand.

Jira: https://redhat.atlassian.net/browse/AROSLSRE-1569 (motivating RCA) / [AROSLSRE-1571](https://redhat.atlassian.net/browse/AROSLSRE-1571) (this enhancement)

## What

- `hcpctl snapshot from-prow-job` now downloads the per-test `azure.log` from the Prow job's GCS artifacts (same per-test prefix as node console logs), writes it to `azure_sdk_log/azure.log`, and indexes it in `manifest.json` under `azure_log` (with an `artifact_url`). Absence is non-fatal — not every test enables Azure SDK logging.
- `hcpctl snapshot analyze` is made aware of the artifact via the agent's data-directory layout (`pkg/agent/prompts/system.md`), so the client-side Azure SDK timeline is available for automated root-cause analysis (retries, racing/duplicate/conflicting deployments).
- Added unit tests for the writer and directory-layout entry.

Deliberately scoped: this makes the log **available** to analysis; it does not add a new structured proof-item type (like `node_console_log`), which would be a much larger cross-cutting change.

## Testing

- `go build ./...`, `go vet`, `gofmt -l` clean
- `go test ./pkg/snapshot/... ./cmd/snapshot/...` passes (new `azure_log_test.go`)
