### PR TITLE
fix(test): force-delete orphaned managed RGs in reaper (AROSLSRE-1591)

### DIFF
--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -523,9 +523,10 @@ func (tc *perItOrDescribeTestContext) waitForManagedResourceGroupsDeletion(ctx c
 }
 
 // cleanupResourceGroup is the standard resourcegroup cleanup.  It attempts to
-// 1. delete all HCP clusters via the RP and wait for success
-// 2. wait for any managed resource groups to be deleted
-// 3. delete the resource group
+//  1. delete all HCP clusters via the RP and wait for success
+//  2. wait for any managed resource groups to be deleted, force deleting any that
+//     remain orphaned after the HCP clusters are already gone
+//  3. delete the resource group
 func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, resourceGroupName string, timeout time.Duration) error {
 	startTime := time.Now()
 	defer func() {
@@ -571,10 +572,27 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, 
 			"resourceGroup", resourceGroupName, "managedResourceGroups", managedResourceGroups)
 		managedResourceGroups, err = tc.waitForManagedResourceGroupsDeletion(ctx, resourceGroupName, 10*time.Minute)
 		if err != nil {
-			if len(managedResourceGroups) > 0 {
-				return fmt.Errorf("found %d managed resource groups left behind HCP clusters in %s: %v: %w", len(managedResourceGroups), resourceGroupName, managedResourceGroups, err)
+			if len(managedResourceGroups) == 0 {
+				return fmt.Errorf("failed waiting for managed resource group deletion in %s: %w", resourceGroupName, err)
 			}
-			return fmt.Errorf("failed waiting for managed resource group deletion in %s: %w", resourceGroupName, err)
+			// The HCP clusters in this resource group were already deleted above, yet
+			// one or more managed resource groups still reference a now non-existent
+			// cluster via ManagedBy and were never cleaned up by the RP. These are
+			// orphaned: nothing else will ever delete them, so continuing to wait
+			// would leak both the managed and the parent resource group forever.
+			// Force delete them directly (mirroring the no-RP workflow) so the parent
+			// resource group can be reclaimed.
+			ginkgo.GinkgoLogr.Info("managed resource groups still present after wait, force deleting orphaned managed resource groups",
+				"resourceGroup", resourceGroupName, "managedResourceGroups", managedResourceGroups)
+			for _, managedRG := range managedResourceGroups {
+				if err := DeleteResourceGroup(ctx, resourceClientFactory.NewResourceGroupsClient(), networkClientFactory, managedRG, true, timeout); err != nil {
+					if isIgnorableResourceGroupCleanupError(err) {
+						ginkgo.GinkgoLogr.Info("ignoring not found managed resource group", "resourceGroup", managedRG)
+					} else {
+						return fmt.Errorf("failed to cleanup orphaned managed resource group %q for %q: %w", managedRG, resourceGroupName, err)
+					}
+				}
+			}
 		}
 	} else {
 		ginkgo.GinkgoLogr.Info("no left behind managed resource groups found", "resourceGroup", resourceGroupName)


### PR DESCRIPTION
<!-- Link to Jira issue -->
Jira: [AROSLSRE-1591](https://redhat.atlassian.net/browse/AROSLSRE-1591)

### What

Make the standard e2e resource-group cleanup workflow force-delete an *orphaned* managed resource group instead of waiting for it forever. `cleanupResourceGroup` (`test/util/framework/per_test_framework.go`) already deletes HCP clusters via the RP and then waits up to 10 minutes for any managed RG to disappear. If that wait times out but the HCP clusters are already gone, the remaining managed RGs are now deleted directly (with `force`, mirroring the `no-rp` workflow) and cleanup proceeds to delete the parent RG.

### Why

When an HCP cluster is deleted but its managed RG lingers (its `managedBy` still references the now-deleted cluster), nothing ever deletes that managed RG. The 10-minute wait always times out and the reaper returns an error, so the parent customer RG is **never** deleted — both the parent and the managed RG leak forever.

This is live on INT (`64f0619f`): six overdue `idms-*` RGs (`deleteAfter` = 2026-03-21, ~4 months overdue) are stuck exactly this way, each with an orphaned `*-managed` RG still holding a DNS zone, load balancer, 10 public IPs and a storage account.

```text
DeleteAllHCPClusters            -> none (cluster already gone)
findManagedResourceGroups       -> idms-*-managed (managedBy -> deleted cluster)
waitForManagedResourceGroupsDeletion(10m) -> never deleted -> timeout -> error
=> parent RG never deleted (deadlock, repeats every reaper run)
```

### Testing

`go build ./...` and `go vet ./util/framework/...` pass in `test/`. The in-progress-deletion path is preserved: managed RGs that are genuinely mid-delete are still waited on first; only RGs that remain after the timeout (clusters already gone) are force-deleted.

### Special notes for your reviewer

The force-delete loop reuses the exact pattern already present in `cleanupResourceGroupNoRP` (`DeleteResourceGroup(..., force=true, ...)` guarded by `isIgnorableResourceGroupCleanupError`). Out of scope: the separate "stuck cluster resource still present" failure mode (INT `arm64-vm-cluster-*`, `cni-cilium-*`) where the RP delete itself hangs.

### PR Checklist

- [x] Changes build and vet cleanly
- [x] Linked Jira issue
- [x] Preserves existing in-progress-deletion behavior
