### PR TITLE
fix(acr): keep eastus2euap canary replica endpoint disabled across rollouts (AROSLSRE-1593)

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -394,7 +394,7 @@
         },
         "regionEndpointDisabledRegions": {
           "type": "string",
-          "description": "Space-separated list of replication regions whose regional data endpoint must be kept disabled (--region-endpoint-enabled false), e.g. the eastus2euap canary replica. Optional; defaults to none."
+          "description": "Space-separated list of replication regions whose regional data endpoint must be kept disabled by disabling global endpoint routing, e.g. the eastus2euap canary replica. Optional; defaults to none."
         }
       },
       "additionalProperties": false,

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -394,7 +394,7 @@
         },
         "regionEndpointDisabledRegions": {
           "type": "string",
-          "description": "Space-separated list of replication regions whose regional data endpoint must be kept disabled by disabling global endpoint routing, e.g. the eastus2euap canary replica. Optional; defaults to none."
+          "description": "Space-separated list of replication regions whose regional data endpoint must be kept disabled, e.g. the eastus2euap canary replica. Optional; defaults to none."
         }
       },
       "additionalProperties": false,

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -391,6 +391,10 @@
             "days"
           ],
           "additionalProperties": false
+        },
+        "regionEndpointDisabledRegions": {
+          "type": "string",
+          "description": "Space-separated list of replication regions whose regional data endpoint must be kept disabled (--region-endpoint-enabled false), e.g. the eastus2euap canary replica. Optional; defaults to none."
         }
       },
       "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -102,7 +102,7 @@ defaults:
         enabled: true
         days: 90
       # Space-separated list of replication regions whose regional data endpoint
-      # must stay disabled (--region-endpoint-enabled false). The eastus2euap
+      # must stay disabled (disable global endpoint routing). The eastus2euap
       # (canary/EUAP) replica participates in ACR global routing and can serve
       # co-located prod eastus2 pulls; a degraded euap replica endpoint caused a
       # ~100% HCP install outage (AROSLSRE-1592). Keeping its regional endpoint

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -101,6 +101,14 @@ defaults:
       untaggedImagesRetention:
         enabled: true
         days: 90
+      # Space-separated list of replication regions whose regional data endpoint
+      # must stay disabled (--region-endpoint-enabled false). The eastus2euap
+      # (canary/EUAP) replica participates in ACR global routing and can serve
+      # co-located prod eastus2 pulls; a degraded euap replica endpoint caused a
+      # ~100% HCP install outage (AROSLSRE-1592). Keeping its regional endpoint
+      # disabled prevents the canary replica from serving global traffic and
+      # ensures the manual mitigation persists across rollouts.
+      regionEndpointDisabledRegions: 'eastus2euap'
   # TRANSIENT — STG-global "V2" migration scaffolding. Every pipeline (including
   # the stg-only V2 copies) is preprocessed by helmtest against the dev render
   # and by EV2 manifest generation for all public envs, and the renderer uses

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -102,12 +102,11 @@ defaults:
         enabled: true
         days: 90
       # Space-separated list of replication regions whose regional data endpoint
-      # must stay disabled (disable global endpoint routing). The eastus2euap
-      # (canary/EUAP) replica participates in ACR global routing and can serve
-      # co-located prod eastus2 pulls; a degraded euap replica endpoint caused a
-      # ~100% HCP install outage (AROSLSRE-1592). Keeping its regional endpoint
-      # disabled prevents the canary replica from serving global traffic and
-      # ensures the manual mitigation persists across rollouts.
+      # must stay disabled. A canary/EUAP replica (e.g. eastus2euap) can otherwise
+      # serve co-located prod pulls; a degraded such replica caused a ~100% HCP
+      # install outage (AROSLSRE-1592). Keeping its regional endpoint disabled
+      # stops the replica from serving neighbouring-region traffic and ensures the
+      # manual mitigation persists across rollouts.
       regionEndpointDisabledRegions: 'eastus2euap'
   # TRANSIENT — STG-global "V2" migration scaffolding. Every pipeline (including
   # the stg-only V2 copies) is preprocessed by helmtest against the dev render

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -12,6 +12,7 @@ acm:
 acr:
   ocp:
     name: arohcpocpdev
+    regionEndpointDisabledRegions: eastus2euap
     untaggedImagesRetention:
       days: 90
       enabled: true

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -12,6 +12,7 @@ acm:
 acr:
   ocp:
     name: arohcpocpdev
+    regionEndpointDisabledRegions: eastus2euap
     untaggedImagesRetention:
       days: 90
       enabled: true

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -12,6 +12,7 @@ acm:
 acr:
   ocp:
     name: arohcpocpdev
+    regionEndpointDisabledRegions: eastus2euap
     untaggedImagesRetention:
       days: 90
       enabled: true

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -12,6 +12,7 @@ acm:
 acr:
   ocp:
     name: arohcpocpdev
+    regionEndpointDisabledRegions: eastus2euap
     untaggedImagesRetention:
       days: 90
       enabled: true

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -12,6 +12,7 @@ acm:
 acr:
   ocp:
     name: arohcpocpdev
+    regionEndpointDisabledRegions: eastus2euap
     untaggedImagesRetention:
       days: 90
       enabled: true

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -12,6 +12,7 @@ acm:
 acr:
   ocp:
     name: arohcpocpdev
+    regionEndpointDisabledRegions: eastus2euap
     untaggedImagesRetention:
       days: 90
       enabled: true

--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -32,6 +32,8 @@ resourceGroups:
       configRef: acr.ocp.name
     - name: REPLICATION_REGION
       configRef: region
+    - name: ENDPOINT_DISABLED_REGIONS
+      configRef: acr.ocp.regionEndpointDisabledRegions
     shellIdentity:
       input:
         resourceGroup: global

--- a/dev-infrastructure/scripts/manage-acr-replication.sh
+++ b/dev-infrastructure/scripts/manage-acr-replication.sh
@@ -129,7 +129,7 @@ REPLICATION_INFO=$(az resource list \
     --output json
 )
 
-if [ -n "$REPLICATION_INFO" ]; then
+if [ -n "$REPLICATION_INFO" ] && [ "$REPLICATION_INFO" != "null" ]; then
     REPLICATION_RESOURCE_ID=$(echo "$REPLICATION_INFO" | jq -r '.id')
     REPLICATION_NAME=$(echo "$REPLICATION_INFO" | jq -r '.name' | cut -f 2 -d "/")
     # we need to query the replication state from the replica resource id and not from the list operation or the ACR
@@ -154,9 +154,12 @@ if [ -n "$REPLICATION_INFO" ]; then
 
         # After deleting failed replication, create a new one
         create_replication
-    else
+    elif [ "$REPLICATION_STATE" = "Succeeded" ]; then
         echo "Replication already exists and is in good state: $REPLICATION_NAME (state: $REPLICATION_STATE)"
         reconcile_replication_endpoint "$REPLICATION_NAME" "$REPLICATION_ENDPOINT_ENABLED"
+        exit 0
+    else
+        echo "Replication already exists but is not ready for endpoint reconciliation: $REPLICATION_NAME (state: $REPLICATION_STATE)"
         exit 0
     fi
 else

--- a/dev-infrastructure/scripts/manage-acr-replication.sh
+++ b/dev-infrastructure/scripts/manage-acr-replication.sh
@@ -156,7 +156,11 @@ if [ -n "$REPLICATION_INFO" ] && [ "$REPLICATION_INFO" != "null" ]; then
         create_replication
     elif [ "$REPLICATION_STATE" = "Succeeded" ]; then
         echo "Replication already exists and is in good state: $REPLICATION_NAME (state: $REPLICATION_STATE)"
-        reconcile_replication_endpoint "$REPLICATION_NAME" "$REPLICATION_ENDPOINT_ENABLED"
+        if [ "$DESIRED_ENDPOINT_ENABLED" = "false" ]; then
+            reconcile_replication_endpoint "$REPLICATION_NAME" "$REPLICATION_ENDPOINT_ENABLED"
+        else
+            echo "Endpoint reconciliation not requested for $REPLICATION_NAME; leaving existing enabled=$REPLICATION_ENDPOINT_ENABLED state unchanged"
+        fi
         exit 0
     else
         echo "Replication already exists but is not ready for endpoint reconciliation: $REPLICATION_NAME (state: $REPLICATION_STATE)"

--- a/dev-infrastructure/scripts/manage-acr-replication.sh
+++ b/dev-infrastructure/scripts/manage-acr-replication.sh
@@ -134,8 +134,14 @@ if [ -n "$REPLICATION_INFO" ]; then
     REPLICATION_NAME=$(echo "$REPLICATION_INFO" | jq -r '.name' | cut -f 2 -d "/")
     # we need to query the replication state from the replica resource id and not from the list operation or the ACR
     # there are bugs flying around that report the wrong replication state on the list operation
-    REPLICATION_STATE=$(az resource show --ids "$REPLICATION_RESOURCE_ID" --query "properties.provisioningState" -o tsv)
-    echo "Found existing replication $REPLICATION_NAME ($REPLICATION_RESOURCE_ID) in state $REPLICATION_STATE"
+    REPLICATION_DETAILS=$(az resource show \
+        --ids "$REPLICATION_RESOURCE_ID" \
+        --query "{provisioningState:properties.provisioningState, regionEndpointEnabled:properties.regionEndpointEnabled}" \
+        --output json
+    )
+    REPLICATION_STATE=$(echo "$REPLICATION_DETAILS" | jq -r '.provisioningState')
+    REPLICATION_ENDPOINT_ENABLED=$(echo "$REPLICATION_DETAILS" | jq -r '.regionEndpointEnabled')
+    echo "Found existing replication $REPLICATION_NAME ($REPLICATION_RESOURCE_ID) in state $REPLICATION_STATE with endpoint enabled=$REPLICATION_ENDPOINT_ENABLED"
 
     # Only check for failed replications if one exists
     if [ "$REPLICATION_STATE" = "Failed" ]; then
@@ -150,6 +156,7 @@ if [ -n "$REPLICATION_INFO" ]; then
         create_replication
     else
         echo "Replication already exists and is in good state: $REPLICATION_NAME (state: $REPLICATION_STATE)"
+        reconcile_replication_endpoint "$REPLICATION_NAME" "$REPLICATION_ENDPOINT_ENABLED"
         exit 0
     fi
 else

--- a/dev-infrastructure/scripts/manage-acr-replication.sh
+++ b/dev-infrastructure/scripts/manage-acr-replication.sh
@@ -60,17 +60,47 @@ else
     ENDPOINT_ROUTING_FLAG="--region-endpoint-enabled"
 fi
 
+# Determine the desired regional data-endpoint state for this replica. Regions
+# listed (space-separated) in ENDPOINT_DISABLED_REGIONS must keep their regional
+# endpoint disabled so a co-located canary replica (e.g. eastus2euap) never
+# serves ACR global routing for a neighbouring prod region. Defaults to enabled.
+DESIRED_ENDPOINT_ENABLED=true
+for disabled_region in ${ENDPOINT_DISABLED_REGIONS:-}; do
+    if [ "$disabled_region" = "$REPLICATION_REGION" ]; then
+        DESIRED_ENDPOINT_ENABLED=false
+        break
+    fi
+done
+echo "Desired regional endpoint for $REPLICATION_REGION: enabled=$DESIRED_ENDPOINT_ENABLED"
+
 # Function to create a new replication
 create_replication() {
-    echo "Creating replication $REPLICATION_REGION for ACR $ACR_NAME in region $REPLICATION_REGION..."
+    echo "Creating replication $REPLICATION_REGION for ACR $ACR_NAME in region $REPLICATION_REGION (endpoint enabled=$DESIRED_ENDPOINT_ENABLED)..."
     execute az acr replication create \
         --registry "$ACR_NAME" \
         --resource-group "$RESOURCE_GROUP" \
         --location "$REPLICATION_REGION" \
         --name "$REPLICATION_REGION" \
-        "$ENDPOINT_ROUTING_FLAG" true
+        "$ENDPOINT_ROUTING_FLAG" "$DESIRED_ENDPOINT_ENABLED"
 
     echo "Successfully created replication $REPLICATION_REGION for ACR $ACR_NAME in region $REPLICATION_REGION"
+}
+
+# Function to reconcile an existing replica's regional endpoint to the desired state
+reconcile_replication_endpoint() {
+    local replica_name="$1"
+    local current_enabled="$2"
+    if [ "$current_enabled" = "$DESIRED_ENDPOINT_ENABLED" ]; then
+        echo "Replica $replica_name regional endpoint already at desired state (enabled=$DESIRED_ENDPOINT_ENABLED)"
+        return 0
+    fi
+    echo "Reconciling replica $replica_name regional endpoint: $current_enabled -> $DESIRED_ENDPOINT_ENABLED"
+    execute az acr replication update \
+        --registry "$ACR_NAME" \
+        --resource-group "$RESOURCE_GROUP" \
+        --name "$replica_name" \
+        "$ENDPOINT_ROUTING_FLAG" "$DESIRED_ENDPOINT_ENABLED"
+    echo "Successfully reconciled replica $replica_name regional endpoint to enabled=$DESIRED_ENDPOINT_ENABLED"
 }
 
 echo "Managing ACR replication for $ACR_NAME in region $REPLICATION_REGION..."


### PR DESCRIPTION
Jira: [AROSLSRE-1593](https://redhat.atlassian.net/browse/AROSLSRE-1593) (parent incident [AROSLSRE-1592](https://redhat.atlassian.net/browse/AROSLSRE-1592))

### What

Add config that keeps the **eastus2euap (canary/EUAP)** regional replica of the OCP ACR (`arohcpocpprod`) with its regional data endpoint **disabled**, and make the region rollout enforce it.

- `config/config.yaml` — new `acr.ocp.regionEndpointDisabledRegions: 'eastus2euap'` (space-separated, EV2-dunder-safe scalar).
- `config/config.schema.json` — optional `regionEndpointDisabledRegions` string on the shared `acr` definition.
- `dev-infrastructure/region-pipeline.yaml` — thread `ENDPOINT_DISABLED_REGIONS` into the `ocp-acr-replication` step.
- `dev-infrastructure/scripts/manage-acr-replication.sh` — honor the desired endpoint state on `create`, and **reconcile** existing replicas via `az acr replication update` when the current state drifts.
- `config/rendered/**` — regenerated.

### Why

The eastus2euap replica participates in ACR global routing and can serve co-located prod **East US 2** pulls. On 2026-07-22 its regional endpoint degraded, driving HyperShift `control-plane-operator` release-image lookups into their 15s timeout → **~100% HCP install failures** in East US 2 ([AROSLSRE-1592](https://redhat.atlassian.net/browse/AROSLSRE-1592)).

The incident was mitigated by disabling that replica's regional endpoint. But the `ocp-acr-replication` step recreates a `Failed` replica with the endpoint hardcoded **enabled**, so a future rollout could silently revert the fix. This change pins the desired state declaratively.

```text
config: acr.ocp.regionEndpointDisabledRegions='eastus2euap'
  -> region-pipeline ocp-acr-replication (ENDPOINT_DISABLED_REGIONS)
  -> manage-acr-replication.sh: desired endpoint=false for eastus2euap
     - create: az acr replication create ... --region-endpoint-enabled false
     - existing & drifted: az acr replication update ... --region-endpoint-enabled false
```

In steady state the reconcile adds **zero** extra `az` calls (it only acts when current != desired).

### Testing

- `make -C config validate` — passes.
- `make -C config materialize` — regenerated; rendered dev shows `regionEndpointDisabledRegions: eastus2euap`.
- `bash -n dev-infrastructure/scripts/manage-acr-replication.sh` — syntax OK.

No unit/integration tests exist for these shell/config plumbing paths; change is config + an idempotent reconcile guarded by a drift check.

### Special notes for your reviewer

Scoped to the OCP ACR only (the incident registry); the `svc-acr-replication` step is intentionally left unchanged. The field is optional in the schema, so `acr.svc` is unaffected.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
