### PR TITLE
feat(observability): add HCP cluster provisioning failure-rate SLO alert (AROSLSRE-1595)

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -234,6 +234,136 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
   }
 }
 
+resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_cluster_provision_slo_error_alerts'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'UJClusterProvisionErrors1h5m'
+        enabled: true
+        labels: {
+          long_window: '1h'
+          severity: '3'
+          short_window: '5m'
+          slo: 'cluster-provision-errors'
+        }
+        annotations: {
+          correlationId: 'UJClusterProvisionErrors1h5m/{{ $labels.cluster }}'
+          description: 'More than 72% of cluster create (install) operations are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours. A regional install failure of this magnitude typically points at a shared dependency (e.g. registry, DNS, or ARM) rather than individual clusters.'
+          info: 'More than 72% of cluster create (install) operations are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours. A regional install failure of this magnitude typically points at a shared dependency (e.g. registry, DNS, or ARM) rather than individual clusters.'
+          runbook_url: 'https://aka.ms/arohcp-runbook-cluster-provision'
+          summary: '{{ $labels.cluster }}: Cluster provisioning error rate critically high (>72%)'
+          title: '{{ $labels.cluster }}: Cluster provisioning error rate critically high (>72%)'
+        }
+        expression: 'errors:backend_cluster_provision:error_rate > 0.72'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'UJClusterProvisionErrors6h30m'
+        enabled: true
+        labels: {
+          long_window: '6h'
+          severity: '3'
+          short_window: '30m'
+          slo: 'cluster-provision-errors'
+        }
+        annotations: {
+          correlationId: 'UJClusterProvisionErrors6h30m/{{ $labels.cluster }}'
+          description: 'More than 30% of cluster create (install) operations are in failed state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours.'
+          info: 'More than 30% of cluster create (install) operations are in failed state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours.'
+          runbook_url: 'https://aka.ms/arohcp-runbook-cluster-provision'
+          summary: '{{ $labels.cluster }}: Cluster provisioning error rate elevated (>30%) for 30+ minutes'
+          title: '{{ $labels.cluster }}: Cluster provisioning error rate elevated (>30%) for 30+ minutes'
+        }
+        expression: 'errors:backend_cluster_provision:error_rate > 0.3'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'UJClusterProvisionErrors3d'
+        enabled: true
+        labels: {
+          long_window: '3d'
+          severity: '4'
+          slo: 'cluster-provision-errors'
+        }
+        annotations: {
+          correlationId: 'UJClusterProvisionErrors3d/{{ $labels.cluster }}'
+          description: 'More than 5% of cluster create (install) operations are in failed state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days.'
+          info: 'More than 5% of cluster create (install) operations are in failed state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days.'
+          runbook_url: 'https://aka.ms/arohcp-runbook-cluster-provision'
+          summary: '{{ $labels.cluster }}: Cluster provisioning error rate exceeds SLO target (>5%) for 6+ hours'
+          title: '{{ $labels.cluster }}: Cluster provisioning error rate exceeds SLO target (>5%) for 6+ hours'
+        }
+        expression: 'errors:backend_cluster_provision:error_rate > 0.05'
+        for: 'PT6H'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'UJClusterProvisionErrorsDegradation'
+        enabled: true
+        labels: {
+          severity: '4'
+          slo: 'cluster-provision-errors'
+        }
+        annotations: {
+          correlationId: 'UJClusterProvisionErrorsDegradation/{{ $labels.cluster }}'
+          description: 'The cluster create (install) failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire.'
+          info: 'The cluster create (install) failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire.'
+          runbook_url: 'https://aka.ms/arohcp-runbook-cluster-provision'
+          summary: '{{ $labels.cluster }}: Cluster provisioning failure rate exceeds 15% for 30 minutes'
+          title: '{{ $labels.cluster }}: Cluster provisioning failure rate exceeds 15% for 30 minutes'
+        }
+        expression: 'errors:backend_cluster_provision:error_rate > 0.15'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
 resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
   name: 'arohcp_nodepool_slo_error_alerts'
   location: location

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -27,3 +27,29 @@ resource arohcpAccessClusterSloRecordingRules 'Microsoft.AlertsManagement/promet
     ]
   }
 }
+
+resource arohcpClusterProvisionSloRecordingRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_cluster_provision_slo_recording_rules'
+  location: location
+  properties: {
+    scopes: [
+      azureMonitoring
+    ]
+    enabled: true
+    interval: 'PT1M'
+    rules: [
+      {
+        record: 'errors:backend_cluster_provision:succeeded_total'
+        expression: 'count by (cluster) (backend_resource_operation_phase_info{operation_type="create",phase="succeeded",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"})'
+      }
+      {
+        record: 'errors:backend_cluster_provision:terminal_total'
+        expression: 'count by (cluster) (backend_resource_operation_phase_info{operation_type="create",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"})'
+      }
+      {
+        record: 'errors:backend_cluster_provision:error_rate'
+        expression: '(count by (cluster) (backend_resource_operation_phase_info{operation_type="create",phase="failed",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}) or 0 * count by (cluster) (backend_resource_operation_phase_info{operation_type="create",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"})) / clamp_min(count by (cluster) (backend_resource_operation_phase_info{operation_type="create",phase=~"succeeded|failed|canceled",resource_type="microsoft.redhatopenshift/hcpopenshiftclusters"}), 1)'
+      }
+    ]
+  }
+}

--- a/observability/alerts-rp-services.yaml
+++ b/observability/alerts-rp-services.yaml
@@ -1,6 +1,7 @@
 prometheusRules:
   rulesFolders:
   - alerts/access-cluster-slo-prometheusRule.yaml
+  - alerts/cluster-provision-slo-prometheusRule.yaml
   - alerts/nodepool-slo-prometheusRule.yaml
   untestedRules: []
   testDependencies:

--- a/observability/alerts/cluster-provision-slo-prometheusRule.yaml
+++ b/observability/alerts/cluster-provision-slo-prometheusRule.yaml
@@ -1,0 +1,106 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: k8s
+    role: alert-rules
+  name: cluster-provision-slo-rules
+  namespace: monitoring
+spec:
+  groups:
+  # ========================================
+  # Cluster Provisioning SLO Alerts — Errors
+  # ========================================
+  # Recording rules feeding these alerts (errors:backend_cluster_provision:*)
+  # live in recording-rules/cluster-provision-slo-recordingRule.yaml.
+  # Multi-window burn-rate-style alerting adapted for gauge metrics.
+  # Naming convention: {Scope}{Subject}{Metric}{BurnRateTier} per ADR-001.
+  #
+  # Burn rate thresholds calculated from 95% SLO (5% error budget):
+  #   Fast (14.4x): 14.4 * 0.05 = 0.72 → 72% error rate
+  #   Medium (6x):  6 * 0.05 = 0.30 → 30% error rate
+  #   Slow (1x):    1 * 0.05 = 0.05 → 5% error rate
+  #
+  # The 'for' duration enforces sustained observation, approximating the
+  # short window of multi-window burn rate alerting. For gauge metrics
+  # (point-in-time state rather than event rates), this provides equivalent
+  # protection against transient spikes.
+  #
+  # Severity: cluster provisioning is the primary customer-facing RP-lane user
+  # journey, so fast/medium burn page at IcM Sev 3 and slow/degradation raise a
+  # Sev 4 ticket, mirroring the access-cluster SLO severity model.
+  - name: arohcp_cluster_provision_slo_error_alerts
+    rules:
+    # ----------------------------------------
+    # Fast Burn Alert (IcM Sev 3 — RP lane / customer-facing UJ)
+    # ----------------------------------------
+    # 14.4x burn rate → >72% failure rate sustained for 5 minutes
+    # Would exhaust 7-day error budget in ~12 hours
+    - alert: UJClusterProvisionErrors1h5m
+      expr: |
+        errors:backend_cluster_provision:error_rate > 0.72
+      for: 5m
+      labels:
+        severity: "3"
+        slo: cluster-provision-errors
+        long_window: 1h
+        short_window: 5m
+      annotations:
+        summary: "{{ $labels.cluster }}: Cluster provisioning error rate critically high (>72%)"
+        description: "More than 72% of cluster create (install) operations are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours. A regional install failure of this magnitude typically points at a shared dependency (e.g. registry, DNS, or ARM) rather than individual clusters."
+        runbook_url: "https://aka.ms/arohcp-runbook-cluster-provision"
+    # ----------------------------------------
+    # Medium Burn Alert (IcM Sev 3)
+    # ----------------------------------------
+    # 6x burn rate → >30% failure rate sustained for 30 minutes
+    # Would exhaust 7-day error budget in ~28 hours
+    - alert: UJClusterProvisionErrors6h30m
+      expr: |
+        errors:backend_cluster_provision:error_rate > 0.30
+      for: 30m
+      labels:
+        severity: "3"
+        slo: cluster-provision-errors
+        long_window: 6h
+        short_window: 30m
+      annotations:
+        summary: "{{ $labels.cluster }}: Cluster provisioning error rate elevated (>30%) for 30+ minutes"
+        description: "More than 30% of cluster create (install) operations are in failed state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours."
+        runbook_url: "https://aka.ms/arohcp-runbook-cluster-provision"
+    # ----------------------------------------
+    # Slow Burn Alert (IcM Sev 4 — ticket)
+    # ----------------------------------------
+    # Per ADR: slow burn alerts generate a ticket, not a page.
+    # 1x burn rate → >5% failure rate sustained for 6 hours
+    # Would exhaust 7-day error budget in ~7 days
+    - alert: UJClusterProvisionErrors3d
+      expr: |
+        errors:backend_cluster_provision:error_rate > 0.05
+      for: 6h
+      labels:
+        severity: "4"
+        slo: cluster-provision-errors
+        long_window: 3d
+      annotations:
+        summary: "{{ $labels.cluster }}: Cluster provisioning error rate exceeds SLO target (>5%) for 6+ hours"
+        description: "More than 5% of cluster create (install) operations are in failed state sustained over 6 hours, indicating persistent degradation at the 95% SLO boundary that would exhaust the error budget in ~7 days."
+        runbook_url: "https://aka.ms/arohcp-runbook-cluster-provision"
+    # ----------------------------------------
+    # Degradation Alert (IcM Sev 4 — ticket)
+    # ----------------------------------------
+    # With a 95% SLO, the fast-burn threshold only fires at ~72% failure rate.
+    # This provides early warning at 15% failure rate before burn-rate alerts fire.
+    # Precursor signal → Sev 4 per ADR.
+    - alert: UJClusterProvisionErrorsDegradation
+      expr: |
+        errors:backend_cluster_provision:error_rate > 0.15
+      for: 30m
+      labels:
+        severity: "4"
+        slo: cluster-provision-errors
+      annotations:
+        summary: "{{ $labels.cluster }}: Cluster provisioning failure rate exceeds 15% for 30 minutes"
+        description: "The cluster create (install) failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire."
+        runbook_url: "https://aka.ms/arohcp-runbook-cluster-provision"

--- a/observability/alerts/cluster-provision-slo-prometheusRule_test.yaml
+++ b/observability/alerts/cluster-provision-slo-prometheusRule_test.yaml
@@ -1,0 +1,248 @@
+rule_files:
+- cluster-provision-slo-prometheusRule.yaml
+- cluster-provision-slo-recordingRule.yaml
+evaluation_interval: 1m
+tests:
+# ========================================
+# Test 1: Normal operation — all installs succeeded, no alerts
+# ========================================
+# 10 cluster create operations in "succeeded" phase, 0 in "failed".
+# Error rate = 0%, well below 95% SLO. No alerts should fire.
+- interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/a", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/b", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/c", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/d", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/e", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/f", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/g", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/h", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/i", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/j", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x70"
+  promql_expr_test:
+  - expr: errors:backend_cluster_provision:succeeded_total
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_cluster_provision:succeeded_total{cluster="mgmt-1"}'
+      value: 10
+  - expr: errors:backend_cluster_provision:terminal_total
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_cluster_provision:terminal_total{cluster="mgmt-1"}'
+      value: 10
+  - expr: errors:backend_cluster_provision:error_rate
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_cluster_provision:error_rate{cluster="mgmt-1"}'
+      value: 0
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: UJClusterProvisionErrors1h5m
+  - eval_time: 10m
+    alertname: UJClusterProvisionErrors6h30m
+  - eval_time: 10m
+    alertname: UJClusterProvisionErrors3d
+  - eval_time: 10m
+    alertname: UJClusterProvisionErrorsDegradation
+# ========================================
+# Test 2: Fast burn — 80% failure rate, fast + degradation fire
+# ========================================
+# 2 succeeded, 8 failed → error rate = 80% > 72% threshold (14.4x burn).
+- interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/a", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/b", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/c", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/d", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/e", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/f", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/g", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/h", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/i", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/j", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  promql_expr_test:
+  - expr: errors:backend_cluster_provision:error_rate
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_cluster_provision:error_rate{cluster="mgmt-1"}'
+      value: 0.8
+  alert_rule_test:
+  # Fast burn fires after 5m 'for' duration
+  - eval_time: 7m
+    alertname: UJClusterProvisionErrors1h5m
+    exp_alerts:
+    - exp_labels:
+        cluster: "mgmt-1"
+        severity: "3"
+        slo: cluster-provision-errors
+        long_window: 1h
+        short_window: 5m
+      exp_annotations:
+        summary: "mgmt-1: Cluster provisioning error rate critically high (>72%)"
+        description: "More than 72% of cluster create (install) operations are in failed state, indicating a fast error budget burn (14.4x) that would exhaust the 95% SLO budget in ~12 hours. A regional install failure of this magnitude typically points at a shared dependency (e.g. registry, DNS, or ARM) rather than individual clusters."
+        runbook_url: "https://aka.ms/arohcp-runbook-cluster-provision"
+  # Degradation also fires (15% threshold met at 80%)
+  - eval_time: 35m
+    alertname: UJClusterProvisionErrorsDegradation
+    exp_alerts:
+    - exp_labels:
+        cluster: "mgmt-1"
+        severity: "4"
+        slo: cluster-provision-errors
+      exp_annotations:
+        summary: "mgmt-1: Cluster provisioning failure rate exceeds 15% for 30 minutes"
+        description: "The cluster create (install) failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire."
+        runbook_url: "https://aka.ms/arohcp-runbook-cluster-provision"
+# ========================================
+# Test 3: Degradation — 20% failure rate, only degradation fires
+# ========================================
+# 8 succeeded, 2 failed → error rate = 20% (> 15% degradation, < 30% medium).
+- interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/a", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/b", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/c", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/d", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/e", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/f", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/g", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/h", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/i", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/2/cluster/j", subscription_id="sub-2", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  promql_expr_test:
+  - expr: errors:backend_cluster_provision:error_rate
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_cluster_provision:error_rate{cluster="mgmt-1"}'
+      value: 0.2
+  alert_rule_test:
+  # Degradation fires at 20%
+  - eval_time: 35m
+    alertname: UJClusterProvisionErrorsDegradation
+    exp_alerts:
+    - exp_labels:
+        cluster: "mgmt-1"
+        severity: "4"
+        slo: cluster-provision-errors
+      exp_annotations:
+        summary: "mgmt-1: Cluster provisioning failure rate exceeds 15% for 30 minutes"
+        description: "The cluster create (install) failure rate has been above 15% for 30 minutes. This provides early warning of degradation before SLO-based burn rate alerts fire."
+        runbook_url: "https://aka.ms/arohcp-runbook-cluster-provision"
+  # Fast and medium burn must NOT fire at 20%
+  - eval_time: 35m
+    alertname: UJClusterProvisionErrors1h5m
+  - eval_time: 35m
+    alertname: UJClusterProvisionErrors6h30m
+# ========================================
+# Test 4: Medium burn — 40% failure rate, medium + degradation fire, fast does not
+# ========================================
+# 6 succeeded, 4 failed → error rate = 40% (> 30% medium, < 72% fast).
+- interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/3/cluster/a", subscription_id="sub-3", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/3/cluster/b", subscription_id="sub-3", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/3/cluster/c", subscription_id="sub-3", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/3/cluster/d", subscription_id="sub-3", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/3/cluster/e", subscription_id="sub-3", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/3/cluster/f", subscription_id="sub-3", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/3/cluster/g", subscription_id="sub-3", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/3/cluster/h", subscription_id="sub-3", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/3/cluster/i", subscription_id="sub-3", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/3/cluster/j", subscription_id="sub-3", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  promql_expr_test:
+  - expr: errors:backend_cluster_provision:error_rate
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_cluster_provision:error_rate{cluster="mgmt-1"}'
+      value: 0.4
+  alert_rule_test:
+  # Medium burn fires after 30m 'for' duration
+  - eval_time: 35m
+    alertname: UJClusterProvisionErrors6h30m
+    exp_alerts:
+    - exp_labels:
+        cluster: "mgmt-1"
+        severity: "3"
+        slo: cluster-provision-errors
+        long_window: 6h
+        short_window: 30m
+      exp_annotations:
+        summary: "mgmt-1: Cluster provisioning error rate elevated (>30%) for 30+ minutes"
+        description: "More than 30% of cluster create (install) operations are in failed state sustained over 30 minutes, indicating a medium error budget burn (6x) that would exhaust the 95% SLO budget in ~28 hours."
+        runbook_url: "https://aka.ms/arohcp-runbook-cluster-provision"
+  # Fast burn must NOT fire at 40%
+  - eval_time: 35m
+    alertname: UJClusterProvisionErrors1h5m
+# ========================================
+# Test 5: Isolation — node pool and in-flight (non-terminal) ops are excluded
+# ========================================
+# Only 1 failed cluster create is terminal. The node pool create and the
+# in-flight (provisioning) cluster create must NOT contribute to the SLI, so the
+# error rate is 100% (1 failed / 1 terminal), proving the selectors are scoped
+# to terminal hcpOpenShiftCluster create operations only.
+- interval: 1m
+  input_series:
+  # terminal cluster create failure (counts)
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/4/cluster/a", subscription_id="sub-4", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  # in-flight cluster create (must NOT count — non-terminal)
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/4/cluster/b", subscription_id="sub-4", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="provisioning", cluster="mgmt-1"}'
+    values: "1+0x40"
+  # node pool create failure (must NOT count — different resource_type)
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/4/np/a", subscription_id="sub-4", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  # cluster update failure (must NOT count — different operation_type)
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/4/cluster/c", subscription_id="sub-4", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="update", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x40"
+  promql_expr_test:
+  - expr: errors:backend_cluster_provision:terminal_total
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_cluster_provision:terminal_total{cluster="mgmt-1"}'
+      value: 1
+  - expr: errors:backend_cluster_provision:error_rate
+    eval_time: 10m
+    exp_samples:
+    - labels: 'errors:backend_cluster_provision:error_rate{cluster="mgmt-1"}'
+      value: 1

--- a/observability/recording-rules-services.yaml
+++ b/observability/recording-rules-services.yaml
@@ -1,5 +1,6 @@
 prometheusRules:
   rulesFolders:
   - recording-rules/access-cluster-slo-recordingRule.yaml
+  - recording-rules/cluster-provision-slo-recordingRule.yaml
   untestedRules: []
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep

--- a/observability/recording-rules/cluster-provision-slo-recordingRule.yaml
+++ b/observability/recording-rules/cluster-provision-slo-recordingRule.yaml
@@ -1,0 +1,74 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: k8s
+    role: recording-rules
+  name: cluster-provision-slo-recording-rules
+  namespace: monitoring
+spec:
+  groups:
+  # ========================================
+  # Cluster Provisioning SLO Recording Rules
+  # ========================================
+  # These rules track the Errors SLO for HCP cluster provisioning (install).
+  # SLO: 95% of cluster create operations should succeed (not reach "failed"
+  # terminal phase). Error Budget: 5% (1 - 0.95).
+  #
+  # Metrics are gauge-based (backend_resource_operation_phase_info) from Cosmos DB,
+  # so we use count() aggregations rather than rate() on counters.
+  #
+  # Scope: covers create operations on hcpOpenShiftClusters (the cluster install
+  # user journey). Update/delete are covered by the async-operations stuck alert;
+  # node pool operations have their own SLO (nodepool-slo-prometheusRule.yaml).
+  #
+  # Grouping is by the `cluster` label (the management cluster serving the
+  # request), which is a per-region proxy: a regional install failure (e.g. the
+  # ACR canary-replica endpoint outage in AROSLSRE-1592 that failed ~100% of
+  # eastus2 installs) surfaces as a spike in the per-management-cluster error rate.
+  - name: arohcp_cluster_provision_slo_recording_rules
+    interval: 1m
+    rules:
+    # Instantaneous count of succeeded cluster create operations per cluster
+    - record: errors:backend_cluster_provision:succeeded_total
+      expr: |
+        count by (cluster) (backend_resource_operation_phase_info{
+          resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+          operation_type="create",
+          phase="succeeded"
+        })
+    # Instantaneous count of all terminal cluster create operations per cluster
+    - record: errors:backend_cluster_provision:terminal_total
+      expr: |
+        count by (cluster) (backend_resource_operation_phase_info{
+          resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+          operation_type="create",
+          phase=~"succeeded|failed|canceled"
+        })
+    # Instantaneous error rate per cluster: fraction of terminal operations that failed
+    - record: errors:backend_cluster_provision:error_rate
+      expr: |
+        (
+          count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="create",
+            phase="failed"
+          })
+          or
+          0 * count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="create",
+            phase=~"succeeded|failed|canceled"
+          })
+        )
+        /
+        clamp_min(
+          count by (cluster) (backend_resource_operation_phase_info{
+            resource_type="microsoft.redhatopenshift/hcpopenshiftclusters",
+            operation_type="create",
+            phase=~"succeeded|failed|canceled"
+          }),
+          1
+        )

--- a/observability/recording-rules/cluster-provision-slo-recordingRule_test.yaml
+++ b/observability/recording-rules/cluster-provision-slo-recordingRule_test.yaml
@@ -1,0 +1,51 @@
+rule_files:
+- cluster-provision-slo-recordingRule.yaml
+evaluation_interval: 1m
+tests:
+# Verify recording rules produce expected output from input series.
+# 6 succeeded, 4 failed cluster create operations → error rate = 40%.
+- interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/a", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/b", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/c", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/d", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/e", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/f", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="succeeded", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/g", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/h", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/i", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/j", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x15"
+  # In-flight (non-terminal) and other resource/operation types must be ignored
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/k", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="create", phase="provisioning", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/np/a", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="create", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x15"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/1/cluster/l", subscription_id="sub-1", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters", operation_type="update", phase="failed", cluster="mgmt-1"}'
+    values: "1+0x15"
+  promql_expr_test:
+  - expr: "errors:backend_cluster_provision:succeeded_total"
+    eval_time: 5m
+    exp_samples:
+    - labels: 'errors:backend_cluster_provision:succeeded_total{cluster="mgmt-1"}'
+      value: 6
+  - expr: "errors:backend_cluster_provision:terminal_total"
+    eval_time: 5m
+    exp_samples:
+    - labels: 'errors:backend_cluster_provision:terminal_total{cluster="mgmt-1"}'
+      value: 10
+  - expr: "errors:backend_cluster_provision:error_rate"
+    eval_time: 5m
+    exp_samples:
+    - labels: 'errors:backend_cluster_provision:error_rate{cluster="mgmt-1"}'
+      value: 0.4


### PR DESCRIPTION
[AROSLSRE-1595](https://redhat.atlassian.net/browse/AROSLSRE-1595)

### What

Adds an HCP **cluster-provisioning (install) Errors SLO** — burn-rate alerts plus
their backing recording rules — mirroring the existing access-cluster and
node-pool SLOs.

- `observability/recording-rules/cluster-provision-slo-recordingRule.yaml` —
  `errors:backend_cluster_provision:{succeeded_total,terminal_total,error_rate}`,
  scoped to `operation_type="create"` on hcpOpenShiftClusters, grouped by `cluster`.
- `observability/alerts/cluster-provision-slo-prometheusRule.yaml` — four burn-rate
  tiers: `UJClusterProvisionErrors1h5m` (Sev 3), `…6h30m` (Sev 3), `…3d` (Sev 4),
  `…Degradation` (Sev 4).
- Registered in the RP-services bundles; regenerated Bicep.

### Why

Follow-up from incident [AROSLSRE-1592](https://redhat.atlassian.net/browse/AROSLSRE-1592):
a regional dependency failure broke **~100% of HCP installs in eastus2 for ~2h**, but
the only cluster-create signal was the per-cluster *stuck* alert
(`BackendAsyncOperationClusterCreateStuck`, 20m). There was no regional install
**failure-rate** alert — node-pool and access-cluster had Errors SLOs, cluster
`create` (the primary provisioning user journey) did not. Grouping by `cluster`
(management cluster ≈ region) makes a shared-dependency regional spike page fast
instead of being diluted fleet-wide.

### Testing

- Unit tests: promtool tests for the recording rules and each burn-rate tier
  (normal / fast / medium / degradation, plus isolation of node-pool, in-flight,
  and non-create ops), run via the `prometheus-rules` generator. All pass; Bicep
  regenerated and `bicep format`-clean.

### Special notes for your reviewer

- **No companion sdp-pipelines PR required** — only Prometheus rule YAML + regenerated
  Bicep under existing bundles/entrypoints (no new step, service group, or registration).
- Recording rules live in a dedicated `recordingRule.yaml` (not inline in the alerts
  file) because the alerting generator emits only `alert:` rules — the access-cluster
  split pattern — so the recorded series actually deploys.
- Severity follows the access-cluster SLO (customer-facing RP-lane UJ): Sev 3 page on
  fast/medium burn, Sev 4 ticket on slow/degradation.
