### PR TITLE
fix(frontend): return 429 instead of 500 for transaction precondition failures

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -51,8 +51,8 @@ func isResponseError(err error, statusCode int) bool {
 	if errors.As(err, &responseError) && responseError.StatusCode == statusCode {
 		return true
 	}
-	var stepError *transactionStepError
-	return errors.As(err, &stepError) && stepError.httpStatusCode == statusCode
+	var stepError *TransactionStepError
+	return errors.As(err, &stepError) && stepError.HTTPStatusCode == statusCode
 }
 
 // IsNotFoundError returns true if err represents an HTTP 404 Not Found response.

--- a/internal/database/errors.go
+++ b/internal/database/errors.go
@@ -21,32 +21,37 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
-// transactionStepError is returned when a Cosmos DB transactional batch step fails
+// TransactionStepError is returned when a Cosmos DB transactional batch step fails
 // with a non-424 status code. It carries the HTTP status so helpers like
 // IsPreconditionFailedError can recognize it via errors.As.
-type transactionStepError struct {
-	// step is the 1-based index of the failed operation within the batch.
-	step int
-	// totalSteps is the number of operations in the batch.
-	totalSteps int
-	// httpStatusCode is the HTTP status returned for the failed step (e.g. 412).
-	httpStatusCode int
+type TransactionStepError struct {
+	// Step is the 1-based index of the failed operation within the batch.
+	Step int
+	// TotalSteps is the number of operations in the batch.
+	TotalSteps int
+	// HTTPStatusCode is the HTTP status returned for the failed step (e.g. 412).
+	HTTPStatusCode int
+	// StepDetails describes the failed operation (action type, resource ID, etag, etc.).
+	StepDetails CosmosDBTransactionStepDetails
 }
 
 // NewTransactionStepError returns an error that indicates that a step in a Cosmos
 // DB transaction failed with the given HTTP status code.
-func NewTransactionStepError(step, totalSteps, httpStatusCode int) error {
-	return &transactionStepError{
-		step:           step,
-		totalSteps:     totalSteps,
-		httpStatusCode: httpStatusCode,
+func NewTransactionStepError(step, totalSteps, httpStatusCode int, details CosmosDBTransactionStepDetails) error {
+	return &TransactionStepError{
+		Step:           step,
+		TotalSteps:     totalSteps,
+		HTTPStatusCode: httpStatusCode,
+		StepDetails:    details,
 	}
 }
 
-func (e *transactionStepError) Error() string {
+func (e *TransactionStepError) Error() string {
 	return fmt.Sprintf(
-		"transaction step %d of %d failed with %d %s",
-		e.step, e.totalSteps, e.httpStatusCode, http.StatusText(e.httpStatusCode),
+		"transaction step %d of %d (%s %s on %s, etag %q) failed with %d %s",
+		e.Step, e.TotalSteps,
+		e.StepDetails.ActionType, e.StepDetails.GoType, e.StepDetails.ResourceID, string(e.StepDetails.Etag),
+		e.HTTPStatusCode, http.StatusText(e.HTTPStatusCode),
 	)
 }
 

--- a/internal/database/errors_test.go
+++ b/internal/database/errors_test.go
@@ -46,14 +46,20 @@ func TestIsResponseError(t *testing.T) {
 		wantHTTPStatus int // 0 means the error should not match any checker
 	}{
 		{
-			name:           "transaction step error",
-			err:            NewTransactionStepError(1, 2, http.StatusPreconditionFailed),
-			wantMessage:    "transaction step 1 of 2 failed with 412 Precondition Failed",
+			name: "transaction step error",
+			err: NewTransactionStepError(1, 2, http.StatusPreconditionFailed, CosmosDBTransactionStepDetails{
+				ActionType: "Replace",
+				CosmosID:   "cosmos-uid-1",
+				ResourceID: "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster1",
+				GoType:     "HCPOpenShiftCluster",
+				Etag:       azcore.ETag("etag-1"),
+			}),
+			wantMessage:    `transaction step 1 of 2 (Replace HCPOpenShiftCluster on /subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster1, etag "etag-1") failed with 412 Precondition Failed`,
 			wantHTTPStatus: http.StatusPreconditionFailed,
 		},
 		{
 			name:           "transaction step error through TrackError",
-			err:            utils.TrackError(NewTransactionStepError(1, 1, http.StatusPreconditionFailed)),
+			err:            utils.TrackError(NewTransactionStepError(1, 1, http.StatusPreconditionFailed, CosmosDBTransactionStepDetails{})),
 			wantHTTPStatus: http.StatusPreconditionFailed,
 		},
 		{

--- a/internal/database/transaction.go
+++ b/internal/database/transaction.go
@@ -115,7 +115,14 @@ func (t *cosmosDBTransaction) Execute(ctx context.Context, o *azcosmos.Transacti
 		if !response.Success {
 			for step, result := range response.OperationResults {
 				if result.StatusCode != http.StatusFailedDependency {
-					return nil, NewTransactionStepError(step+1, len(response.OperationResults), int(result.StatusCode))
+					logger.Error(nil, "transaction step failed",
+						"step", step+1,
+						"totalSteps", len(response.OperationResults),
+						"statusCode", result.StatusCode,
+						"resourceBody", string(result.ResourceBody),
+						"transaction", t.ToJSONStructRendering(),
+					)
+					return nil, NewTransactionStepError(step+1, len(response.OperationResults), int(result.StatusCode), t.stepsDetails[step])
 				}
 			}
 		}

--- a/internal/databasetesting/mock_resources_db_client.go
+++ b/internal/databasetesting/mock_resources_db_client.go
@@ -383,7 +383,7 @@ func (t *mockTransaction) Execute(ctx context.Context, o *azcosmos.Transactional
 		if err != nil {
 			var responseErr *azcore.ResponseError
 			if errors.As(err, &responseErr) {
-				return nil, database.NewTransactionStepError(step+1, len(t.steps), responseErr.StatusCode)
+				return nil, database.NewTransactionStepError(step+1, len(t.steps), responseErr.StatusCode, s.details)
 			}
 			return nil, err
 		}

--- a/internal/errorutils/error.go
+++ b/internal/errorutils/error.go
@@ -89,6 +89,18 @@ func writeError(ctx context.Context, w http.ResponseWriter, err error) error {
 		return nil
 	}
 
+	var stepError *database.TransactionStepError
+	if errors.As(err, &stepError) && stepError.HTTPStatusCode == http.StatusPreconditionFailed {
+		w.Header().Set("Retry-After", "1")
+		arm.WriteCloudError(w, arm.NewCloudError(
+			http.StatusTooManyRequests,
+			arm.CloudErrorCodeConflict, "",
+			"The resource was modified by another request. Please retry. (transaction step %d of %d)",
+			stepError.Step, stepError.TotalSteps,
+		))
+		return nil
+	}
+
 	arm.WriteInternalServerError(w)
 	return nil
 }
@@ -110,6 +122,11 @@ func predictedResponseStatus(err error) int {
 
 	if database.IsNotFoundError(err) {
 		return http.StatusNotFound
+	}
+
+	var stepError *database.TransactionStepError
+	if errors.As(err, &stepError) && stepError.HTTPStatusCode == http.StatusPreconditionFailed {
+		return http.StatusTooManyRequests
 	}
 
 	return http.StatusInternalServerError

--- a/internal/errorutils/error_test.go
+++ b/internal/errorutils/error_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errorutils
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func TestWriteError_TransactionPreconditionFailedBecomes429(t *testing.T) {
+	innerErr := database.NewTransactionStepError(6, 6, http.StatusPreconditionFailed, database.CosmosDBTransactionStepDetails{
+		ActionType: "Replace",
+		CosmosID:   "cosmos-uid-abc123",
+		ResourceID: "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster1",
+		GoType:     "HCPOpenShiftCluster",
+		Etag:       azcore.ETag("etag-old-value"),
+	})
+	wrappedErr := utils.TrackError(innerErr)
+
+	t.Logf("error message: %s", wrappedErr)
+	t.Logf("IsPreconditionFailedError: %v", database.IsPreconditionFailedError(wrappedErr))
+
+	var stepError *database.TransactionStepError
+	if !errors.As(wrappedErr, &stepError) {
+		t.Fatal("expected errors.As to find TransactionStepError through LineTrackingError wrapper")
+	}
+	t.Logf("cast succeeded: step=%d, totalSteps=%d, httpStatusCode=%d, action=%s, resourceID=%s",
+		stepError.Step, stepError.TotalSteps, stepError.HTTPStatusCode,
+		stepError.StepDetails.ActionType, stepError.StepDetails.ResourceID)
+
+	ctx := utils.ContextWithLogger(t.Context(), testr.New(t))
+	recorder := httptest.NewRecorder()
+
+	handler := ReportError(func(w http.ResponseWriter, r *http.Request) error {
+		return wrappedErr
+	})
+
+	req := httptest.NewRequest(http.MethodDelete, "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster1", nil)
+	req = req.WithContext(ctx)
+	handler.ServeHTTP(recorder, req)
+
+	resp := recorder.Result()
+	t.Logf("response status code: %d", resp.StatusCode)
+
+	var cloudErr arm.CloudError
+	if err := json.NewDecoder(resp.Body).Decode(&cloudErr); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	t.Logf("response body code: %s, message: %s", cloudErr.Code, cloudErr.Message)
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("expected status %d (429 Too Many Requests), got %d", http.StatusTooManyRequests, resp.StatusCode)
+	}
+
+	retryAfter := resp.Header.Get("Retry-After")
+	if retryAfter != "1" {
+		t.Errorf("expected Retry-After header to be %q, got %q", "1", retryAfter)
+	}
+}


### PR DESCRIPTION
When a Cosmos DB transactional batch step fails with 412 Precondition Failed (etag mismatch), the error was falling through to the default case in writeError() and being reported as a 500 Internal Server Error. This changes the mapping to return 429 Too Many Requests with Retry-After: 1s so callers know the operation is retryable.

Also exports TransactionStepError so callers can errors.As into it, includes CosmosDBTransactionStepDetails in the error message for debuggability, and logs the failing step's ResourceBody at error level before returning.
