### PR TITLE
observability: add per-subscription correlationId to stuck operation alerts

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -149,7 +149,7 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
           severity: '4'
         }
         annotations: {
-          correlationId: 'userJourneyAccessClusterStuckOperation/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.phase }}'
+          correlationId: 'userJourneyAccessClusterStuckOperation/{{ $labels.cluster }}/{{ $labels.subscription_id }}'
           description: 'Credential operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation.'
           info: 'Credential operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation.'
           runbook_url: 'aka.ms/arohcp-runbook-access-cluster'
@@ -373,7 +373,7 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
           severity: 'info'
         }
         annotations: {
-          correlationId: 'UJNodePoolStuckOperation/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.phase }}'
+          correlationId: 'UJNodePoolStuckOperation/{{ $labels.cluster }}/{{ $labels.subscription_id }}'
           description: 'Node pool operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation.'
           info: 'Node pool operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation.'
           runbook_url: 'https://aka.ms/arohcp-runbook-nodepool'

--- a/observability/alerts/access-cluster-slo-prometheusRule.yaml
+++ b/observability/alerts/access-cluster-slo-prometheusRule.yaml
@@ -127,6 +127,7 @@ spec:
         summary: "{{ $labels.cluster }}: Credential operation stuck in {{ $labels.phase }} for over 1 hour"
         description: "Credential operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."
         runbook_url: "aka.ms/arohcp-runbook-access-cluster"
+        correlationId: "userJourneyAccessClusterStuckOperation/{{ $labels.cluster }}/{{ $labels.subscription_id }}"
   # ========================================
   # Access the Cluster Alerts — Saturation
   # ========================================

--- a/observability/alerts/access-cluster-slo-prometheusRule_test.yaml
+++ b/observability/alerts/access-cluster-slo-prometheusRule_test.yaml
@@ -199,6 +199,7 @@ tests:
         summary: "mgmt-1: Credential operation stuck in accepted for over 1 hour"
         description: "Credential operation for /sub/3/cluster/stuck has been in accepted phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."
         runbook_url: "aka.ms/arohcp-runbook-access-cluster"
+        correlationId: "userJourneyAccessClusterStuckOperation/mgmt-1/sub-3"
 # ========================================
 # Test 5: No stuck operation — requestcredential in "provisioning" for < 1 hour
 # ========================================
@@ -392,6 +393,7 @@ tests:
         summary: "mgmt-1: Credential operation stuck in deleting for over 1 hour"
         description: "Credential operation for /sub/7/cluster/stuck-revoke has been in deleting phase for over 1 hour. Stuck operations are invisible to success/failure SLIs and require investigation."
         runbook_url: "aka.ms/arohcp-runbook-access-cluster"
+        correlationId: "userJourneyAccessClusterStuckOperation/mgmt-1/sub-7"
 # ========================================
 # Test 13: Stuck operation does not fire for e2e subscription
 # ========================================

--- a/observability/alerts/nodepool-slo-prometheusRule.yaml
+++ b/observability/alerts/nodepool-slo-prometheusRule.yaml
@@ -193,6 +193,7 @@ spec:
         summary: "{{ $labels.cluster }}: Node Pool operation stuck in {{ $labels.phase }} for over 2 hours"
         description: "Node pool operation for {{ $labels.resource_id }} has been in {{ $labels.phase }} phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
         runbook_url: "https://aka.ms/arohcp-runbook-nodepool"
+        correlationId: "UJNodePoolStuckOperation/{{ $labels.cluster }}/{{ $labels.subscription_id }}"
   # ========================================
   # Node Pool User Journey Alerts — Saturation
   # ========================================

--- a/observability/alerts/nodepool-slo-prometheusRule_test.yaml
+++ b/observability/alerts/nodepool-slo-prometheusRule_test.yaml
@@ -197,6 +197,7 @@ tests:
         summary: "mgmt-1: Node Pool operation stuck in updating for over 2 hours"
         description: "Node pool operation for /sub/3/np/stuck has been in updating phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
         runbook_url: "https://aka.ms/arohcp-runbook-nodepool"
+        correlationId: "UJNodePoolStuckOperation/mgmt-1/sub-3"
 # ========================================
 # Test 5: No stuck operation — operation in "updating" for < 2 hours
 # ========================================
@@ -389,6 +390,7 @@ tests:
         summary: "mgmt-1: Node Pool operation stuck in deleting for over 2 hours"
         description: "Node pool operation for /sub/7/np/stuck-del has been in deleting phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
         runbook_url: "https://aka.ms/arohcp-runbook-nodepool"
+        correlationId: "UJNodePoolStuckOperation/mgmt-1/sub-7"
 # ========================================
 # Test 13: Stuck delete that flaps (backend retry resets start_time)
 # ========================================
@@ -425,6 +427,7 @@ tests:
         summary: "mgmt-1: Node Pool operation stuck in deleting for over 2 hours"
         description: "Node pool operation for /sub/8/np/flap-del has been in deleting phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
         runbook_url: "https://aka.ms/arohcp-runbook-nodepool"
+        correlationId: "UJNodePoolStuckOperation/mgmt-1/sub-8"
   # Raw condition FALSE here (start_time reset → age < 7200s) but the resource is
   # still wedged. The 6h hold keeps the same alert firing → no resolve, no duplicate.
   - eval_time: 300m
@@ -442,6 +445,7 @@ tests:
         summary: "mgmt-1: Node Pool operation stuck in deleting for over 2 hours"
         description: "Node pool operation for /sub/8/np/flap-del has been in deleting phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
         runbook_url: "https://aka.ms/arohcp-runbook-nodepool"
+        correlationId: "UJNodePoolStuckOperation/mgmt-1/sub-8"
   # Raw condition true again after re-crossing 7200s — still one continuous alert.
   - eval_time: 470m
     alertname: UJNodePoolStuckOperation
@@ -458,6 +462,7 @@ tests:
         summary: "mgmt-1: Node Pool operation stuck in deleting for over 2 hours"
         description: "Node pool operation for /sub/8/np/flap-del has been in deleting phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
         runbook_url: "https://aka.ms/arohcp-runbook-nodepool"
+        correlationId: "UJNodePoolStuckOperation/mgmt-1/sub-8"
 # ========================================
 # Test 14: Stuck delete completes — alert clears after the 6h hold
 # ========================================
@@ -488,6 +493,7 @@ tests:
         summary: "mgmt-1: Node Pool operation stuck in deleting for over 2 hours"
         description: "Node pool operation for /sub/9/np/done-del has been in deleting phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
         runbook_url: "https://aka.ms/arohcp-runbook-nodepool"
+        correlationId: "UJNodePoolStuckOperation/mgmt-1/sub-9"
   # 6h after the last stuck sample (150m + 360m = 510m) the hold expires → resolved.
   - eval_time: 520m
     alertname: UJNodePoolStuckOperation


### PR DESCRIPTION
[ARO-28631](https://redhat.atlassian.net/browse/ARO-28631)


## Problem

The default correlationId (`<AlertName>/<cluster>`) groups all firings of the same alert on the same management cluster into one IcM incident. For stuck operation alerts that fire per-resource, suppressing one customer's incident (e.g. quota tagged `hcp-suppress`) also suppresses unrelated incidents for other customers on the same cluster.

## Fix

Add explicit `correlationId` annotation to `UJNodePoolStuckOperation` and `userJourneyAccessClusterStuckOperation` using `subscription_id`:

```
correlationId: '<AlertName>/{{ $labels.cluster }}/{{ $labels.subscription_id }}'
```

This gives per-subscription-per-cluster IcM incidents so that:
- Suppressing one customer's quota issue does not suppress another customer's drain bug
- The same customer hitting the same problem across multiple resources stays grouped (less noise)

## ADR update

The ADR (openshift-online/architecture PR #79) will be updated to document the correlationId granularity guidance: per-cluster for infra alerts, per-subscription for customer-facing stuck operation alerts.

## Testing

Alert rule structure only (annotation addition). No PromQL changes. Existing unit tests pass.