### PR TITLE
observability: drop nodepool retry hotloop alert, add traffic floor to access-cluster (ARO-28637)

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -230,7 +230,7 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
           summary: '{{ $labels.cluster }}: Credential controller workqueue {{ $labels.name }} retry hot loop'
           title: '{{ $labels.cluster }}: Credential controller workqueue {{ $labels.name }} retry hot loop'
         }
-        expression: '(sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_retries_total{name=~".*(RequestCredential|RevokeCredentials).*",namespace="aro-hcp"}[10m]))) / sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_adds_total{name=~".*(RequestCredential|RevokeCredentials).*",namespace="aro-hcp"}[10m])))) > 0.5'
+        expression: '(sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_retries_total{name=~".*(RequestCredential|RevokeCredentials).*",namespace="aro-hcp"}[10m]))) / sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_adds_total{name=~".*(RequestCredential|RevokeCredentials).*",namespace="aro-hcp"}[10m])))) > 0.5 and sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_adds_total{name=~".*(RequestCredential|RevokeCredentials).*",namespace="aro-hcp"}[10m]))) > 0.008'
         for: 'PT10M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
@@ -569,34 +569,6 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
         }
         expression: 'max by (name, cluster) (max without (prometheus_replica) (workqueue_depth{name=~".*NodePool.*",namespace="aro-hcp"})) > 10'
         for: 'PT5M'
-        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'UJNodePoolSaturationRetryHotLoop'
-        enabled: true
-        labels: {
-          component: 'slo'
-          severity: 'info'
-        }
-        annotations: {
-          correlationId: 'UJNodePoolSaturationRetryHotLoop/{{ $labels.cluster }}/{{ $labels.name }}'
-          description: 'Node pool controller workqueue {{ $labels.name }} has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work.'
-          info: 'Node pool controller workqueue {{ $labels.name }} has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work.'
-          runbook_url: 'https://aka.ms/arohcp-runbook-nodepool'
-          summary: '{{ $labels.cluster }}: Node Pool controller workqueue {{ $labels.name }} retry hot loop'
-          title: '{{ $labels.cluster }}: Node Pool controller workqueue {{ $labels.name }} retry hot loop'
-        }
-        expression: '(sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_retries_total{name=~".*NodePool.*",namespace="aro-hcp"}[10m]))) / sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_adds_total{name=~".*NodePool.*",namespace="aro-hcp"}[10m])))) > 0.5'
-        for: 'PT10M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
     ]

--- a/observability/alerts/access-cluster-slo-prometheusRule.yaml
+++ b/observability/alerts/access-cluster-slo-prometheusRule.yaml
@@ -169,6 +169,12 @@ spec:
             )
           )
         ) > 0.5
+        and
+        sum by (name, cluster) (
+          max without(prometheus_replica) (
+            rate(workqueue_adds_total{namespace="aro-hcp", name=~".*(RequestCredential|RevokeCredentials).*"}[10m])
+          )
+        ) > 0.008
       for: 10m
       labels:
         severity: "4"

--- a/observability/alerts/access-cluster-slo-prometheusRule_test.yaml
+++ b/observability/alerts/access-cluster-slo-prometheusRule_test.yaml
@@ -306,6 +306,21 @@ tests:
   - eval_time: 22m
     alertname: userJourneyAccessClusterSaturationRetryHotLoop
 # ========================================
+# Test 10b: Retry hot loop — high ratio but below traffic floor, no alert
+# ========================================
+# Incrementing counters at 0.08 retries/min and 0.12 adds/min.
+# ratio = 0.08/0.12 = 67% (above 50% threshold),
+# but rate(adds) = ~0.002/s which is below the 0.008/s floor.
+- interval: 1m
+  input_series:
+  - series: 'workqueue_retries_total{namespace="aro-hcp", name="OperationRequestCredential", cluster="mgmt-1"}'
+    values: "0+0.08x25"
+  - series: 'workqueue_adds_total{namespace="aro-hcp", name="OperationRequestCredential", cluster="mgmt-1"}'
+    values: "0+0.12x25"
+  alert_rule_test:
+  - eval_time: 22m
+    alertname: userJourneyAccessClusterSaturationRetryHotLoop
+# ========================================
 # Test 11: Mixed operation types — requestcredential and revokecredentials both tracked
 # ========================================
 # Verifies both operation types are captured by the regex filter.

--- a/observability/alerts/nodepool-slo-prometheusRule.yaml
+++ b/observability/alerts/nodepool-slo-prometheusRule.yaml
@@ -198,7 +198,7 @@ spec:
   # ========================================
   # Node Pool User Journey Alerts — Saturation
   # ========================================
-  # Queue depth and retry rates impact node pool operations directly,
+  # Queue depth impacts node pool operations directly,
   # making these user journey signals per ADR. Sev 4 (precursor).
   - name: arohcp_nodepool_saturation_alerts
     labels:
@@ -219,26 +219,7 @@ spec:
         summary: "{{ $labels.cluster }}: Node Pool controller workqueue {{ $labels.name }} depth is high"
         description: "Node pool controller workqueue {{ $labels.name }} has had a depth > 10 for more than 5 minutes, indicating work is accumulating faster than it can be processed."
         runbook_url: "https://aka.ms/arohcp-runbook-nodepool"
-    # Retry hot loop: high retry ratio on node pool workqueue
-    - alert: UJNodePoolSaturationRetryHotLoop
-      expr: |
-        (
-          sum by (name, cluster) (
-            max without(prometheus_replica) (
-              rate(workqueue_retries_total{namespace="aro-hcp", name=~".*NodePool.*"}[10m])
-            )
-          )
-          /
-          sum by (name, cluster) (
-            max without(prometheus_replica) (
-              rate(workqueue_adds_total{namespace="aro-hcp", name=~".*NodePool.*"}[10m])
-            )
-          )
-        ) > 0.5
-      for: 10m
-      labels:
-        severity: info
-      annotations:
-        summary: "{{ $labels.cluster }}: Node Pool controller workqueue {{ $labels.name }} retry hot loop"
-        description: "Node pool controller workqueue {{ $labels.name }} has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work."
-        runbook_url: "https://aka.ms/arohcp-runbook-nodepool"
+    # Retry hot loop alert removed (ARO-28637): the workqueue retry ratio
+    # encodes backend implementation detail (polling requeues count as retries),
+    # fires without customer impact, and is not actionable. The stuck operation
+    # alert covers the customer-visible outcome.

--- a/observability/alerts/nodepool-slo-prometheusRule_test.yaml
+++ b/observability/alerts/nodepool-slo-prometheusRule_test.yaml
@@ -270,40 +270,6 @@ tests:
   - eval_time: 7m
     alertname: UJNodePoolSaturationQueueDepth
 # ========================================
-# Test 9: Retry hot loop — retry ratio > 50%
-# ========================================
-- interval: 1m
-  input_series:
-  - series: 'workqueue_retries_total{namespace="aro-hcp", name="OperationNodePoolUpdate", cluster="mgmt-1"}'
-    values: "0+80x25"
-  - series: 'workqueue_adds_total{namespace="aro-hcp", name="OperationNodePoolUpdate", cluster="mgmt-1"}'
-    values: "0+100x25"
-  alert_rule_test:
-  - eval_time: 22m
-    alertname: UJNodePoolSaturationRetryHotLoop
-    exp_alerts:
-    - exp_labels:
-        cluster: "mgmt-1"
-        component: slo
-        name: "OperationNodePoolUpdate"
-        severity: info
-      exp_annotations:
-        summary: "mgmt-1: Node Pool controller workqueue OperationNodePoolUpdate retry hot loop"
-        description: "Node pool controller workqueue OperationNodePoolUpdate has a retry ratio > 50% sustained over 10 minutes, indicating most queue activity is failed retries rather than fresh work."
-        runbook_url: "https://aka.ms/arohcp-runbook-nodepool"
-# ========================================
-# Test 10: Retry hot loop — low retry ratio, no alert
-# ========================================
-- interval: 1m
-  input_series:
-  - series: 'workqueue_retries_total{namespace="aro-hcp", name="OperationNodePoolUpdate", cluster="mgmt-1"}'
-    values: "0+10x25"
-  - series: 'workqueue_adds_total{namespace="aro-hcp", name="OperationNodePoolUpdate", cluster="mgmt-1"}'
-    values: "0+100x25"
-  alert_rule_test:
-  - eval_time: 22m
-    alertname: UJNodePoolSaturationRetryHotLoop
-# ========================================
 # Test 11: Mixed operation types — update and delete both tracked
 # ========================================
 # Verifies both update and delete operations are captured by the regex filter.


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-28637

## Summary

**Drop `UJNodePoolSaturationRetryHotLoop`**: The workqueue retry ratio fires on internal backend polling behavior (requeues during async op completion count as retries), not customer-visible failures. It fires during normal operation while node pool creates succeed at 99-100%. Per the ADR, user-journey alerts must be symptom-oriented, tied to customer impact, and actionable. The stuck operation alert (`UJNodePoolStuckOperation`) covers the customer-visible outcome.

**Add traffic floor to `userJourneyAccessClusterSaturationRetryHotLoop`**: Credential operations are short-lived one-shot calls (1 retry in ~4,165 ops across the fleet in 24h), so a sustained retry hotloop genuinely indicates a problem. However, the ratio had no minimum traffic guard, meaning 1 retry / 1 add = 100% would fire. Added `and rate(adds) > 0.008` (~5 ops per 10m window) so the ratio only evaluates when there is meaningful traffic.

## Changes

- Removed `UJNodePoolSaturationRetryHotLoop` alert + tests from `nodepool-slo-prometheusRule.yaml`
- Added traffic floor clause to `userJourneyAccessClusterSaturationRetryHotLoop` in `access-cluster-slo-prometheusRule.yaml`
- Added test 10b: high ratio below traffic floor does not fire
- Regenerated `generatedRPPrometheusAlertingRules.bicep`

## Testing

`make -C observability alerts` passes (promtool tests + bicep regeneration).