### PR TITLE
fix: increate timeBombDeadline for new e2e tests

### DIFF
--- a/test/e2e/cluster_create_private_ingress.go
+++ b/test/e2e/cluster_create_private_ingress.go
@@ -39,7 +39,7 @@ import (
 // credentials, and cluster health — to avoid creating multiple clusters in CI.
 var _ = Describe("Customer", func() {
 	// Deadline for v20260630preview API deployment in non-dev environments
-	timeBombDeadline := framework.Must(time.Parse(time.RFC3339, "2026-07-31T00:00:00Z"))
+	timeBombDeadline := framework.Must(time.Parse(time.RFC3339, "2026-08-07T00:00:00Z"))
 
 	It("should create a cluster with private ingress using v20260630preview and verify the ingress is internal",
 		labels.RequireNothing,

--- a/test/e2e/kms_key_rotation.go
+++ b/test/e2e/kms_key_rotation.go
@@ -35,7 +35,7 @@ const HCPClusterReencryptionUpgradeTimeout = 18 * time.Minute
 
 var _ = Describe("Customer", func() {
 	// Deadline for v20260630preview API deployment in non-dev environments
-	timeBombDeadline := framework.Must(time.Parse(time.RFC3339, "2026-07-31T00:00:00Z"))
+	timeBombDeadline := framework.Must(time.Parse(time.RFC3339, "2026-08-07T00:00:00Z"))
 
 	It("should be able to rotate KMS key for a cluster with version >= 4.22",
 		labels.RequireNothing, labels.High, labels.Positive, labels.AroRpApiCompatible, labels.Slow,


### PR DESCRIPTION
Increase the timeBombDeadline to 7th August to prevent release failures.

<!-- Link to Jira issue -->

### What

Increase the timeBombDeadline for private ingress and kms key rotation e2e tests.

### Why

The API was delayed to the 7th of August. Thus, to prevent test failures we increase the timeBomb beforehand.

### Testing

No tests needed

### Special notes for your reviewer

https://redhat-external.slack.com/archives/C075PHEFZKQ/p1784854622550329

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

