### PR TITLE
fix: make ExpiringWatcher send cancellation-safe

### DIFF
--- a/backend/pkg/controllers/controllerutils/util.go
+++ b/backend/pkg/controllers/controllerutils/util.go
@@ -291,10 +291,12 @@ func getOrCreateControllerDocument(
 		if len(secondAttempt) >= 1 && secondAttempt[0] {
 			return nil, utils.TrackError(fmt.Errorf("second NotFound, Conflict, NotFound error: %w", err))
 		}
+		timer := time.NewTimer((database.SoftDeleteTTLSeconds + 1) * time.Second)
+		defer timer.Stop()
 		select {
 		case <-ctx.Done():
 			return nil, utils.TrackError(ctx.Err())
-		case <-time.After((database.SoftDeleteTTLSeconds + 1) * time.Second):
+		case <-timer.C:
 			// This can happen when the soft-delete marks an item, the GET will return 404, the create will 409, the second get will 404.
 			// By waiting longer than the cosmos TTL, we can re-enter the loop and try again later.  This is a rare case and will
 			// only happen when the parent item exists and the controller was deleted.

--- a/backend/pkg/informers/expiring_watcher.go
+++ b/backend/pkg/informers/expiring_watcher.go
@@ -22,6 +22,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 // expiringWatcher implements watch.Interface and sends an expired error after
@@ -43,9 +45,11 @@ func NewExpiringWatcher(ctx context.Context, expiry time.Duration) watch.Interfa
 	}
 	go func() {
 		defer utilruntime.HandleCrash()
+		logger := utils.LoggerFromContext(ctx)
 		select {
 		case <-time.After(expiry):
-			w.result <- watch.Event{
+			select {
+			case w.result <- watch.Event{
 				Type: watch.Error,
 				Object: &metav1.Status{
 					Status:  metav1.StatusFailure,
@@ -53,9 +57,17 @@ func NewExpiringWatcher(ctx context.Context, expiry time.Duration) watch.Interfa
 					Reason:  metav1.StatusReasonExpired,
 					Message: "watch expired",
 				},
+			}:
+				logger.V(4).Info("expiring watcher expired; sent Gone/Expired event to trigger relist", "expiry", expiry.String())
+			case <-w.done:
+				logger.V(4).Info("expiring watcher stopped while delivering the expired event")
+			case <-ctx.Done():
+				logger.V(4).Info("expiring watcher context canceled while delivering the expired event")
 			}
 		case <-w.done:
+			logger.V(4).Info("expiring watcher stopped before expiry")
 		case <-ctx.Done():
+			logger.V(4).Info("expiring watcher context canceled before expiry")
 		}
 		close(w.result)
 	}()

--- a/backend/pkg/informers/expiring_watcher.go
+++ b/backend/pkg/informers/expiring_watcher.go
@@ -46,8 +46,10 @@ func NewExpiringWatcher(ctx context.Context, expiry time.Duration) watch.Interfa
 	go func() {
 		defer utilruntime.HandleCrash()
 		logger := utils.LoggerFromContext(ctx)
+		timer := time.NewTimer(expiry)
+		defer timer.Stop()
 		select {
-		case <-time.After(expiry):
+		case <-timer.C:
 			select {
 			case w.result <- watch.Event{
 				Type: watch.Error,

--- a/backend/pkg/informers/expiring_watcher_test.go
+++ b/backend/pkg/informers/expiring_watcher_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package informers
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+func TestExpiringWatcher_SendsExpiredEvent(t *testing.T) {
+	ctx := context.Background()
+	w := NewExpiringWatcher(ctx, 50*time.Millisecond)
+	defer w.Stop()
+
+	select {
+	case evt, ok := <-w.ResultChan():
+		if !ok {
+			t.Fatal("ResultChan closed without sending an event")
+		}
+		if evt.Type != watch.Error {
+			t.Fatalf("expected Error event type, got %v", evt.Type)
+		}
+		status, ok := evt.Object.(*metav1.Status)
+		if !ok {
+			t.Fatalf("expected *metav1.Status, got %T", evt.Object)
+		}
+		if status.Code != http.StatusGone {
+			t.Fatalf("expected status code %d, got %d", http.StatusGone, status.Code)
+		}
+		if status.Reason != metav1.StatusReasonExpired {
+			t.Fatalf("expected reason %q, got %q", metav1.StatusReasonExpired, status.Reason)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for expired event")
+	}
+}
+
+func TestExpiringWatcher_ContextCancelDuringDelivery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Use a short expiry so the timer fires quickly, but never read from
+	// ResultChan — this simulates the prior hang where the goroutine blocked
+	// forever trying to send the expired event.
+	w := NewExpiringWatcher(ctx, 10*time.Millisecond)
+
+	// Wait for the timer to fire and the goroutine to block on send.
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel the context — the goroutine should unblock and close ResultChan.
+	cancel()
+
+	select {
+	case _, ok := <-w.ResultChan():
+		if ok {
+			t.Fatal("expected ResultChan to be closed, but received an event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit after context cancellation — ResultChan never closed")
+	}
+}
+
+func TestExpiringWatcher_StopBeforeExpiry(t *testing.T) {
+	ctx := context.Background()
+	w := NewExpiringWatcher(ctx, 10*time.Minute)
+
+	// Stop immediately — the goroutine should exit and close ResultChan.
+	w.Stop()
+
+	select {
+	case _, ok := <-w.ResultChan():
+		if ok {
+			t.Fatal("expected ResultChan to be closed, but received an event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit after Stop — ResultChan never closed")
+	}
+}
+
+func TestExpiringWatcher_ContextCancelBeforeExpiry(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	w := NewExpiringWatcher(ctx, 10*time.Minute)
+
+	cancel()
+
+	select {
+	case _, ok := <-w.ResultChan():
+		if ok {
+			t.Fatal("expected ResultChan to be closed, but received an event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit after context cancellation — ResultChan never closed")
+	}
+}
+
+func TestExpiringWatcher_StopDuringDelivery(t *testing.T) {
+	ctx := context.Background()
+
+	// Short expiry, never read from ResultChan.
+	w := NewExpiringWatcher(ctx, 10*time.Millisecond)
+
+	// Wait for timer to fire and goroutine to block on send.
+	time.Sleep(50 * time.Millisecond)
+
+	// Stop should unblock the goroutine.
+	w.Stop()
+
+	select {
+	case _, ok := <-w.ResultChan():
+		if ok {
+			t.Fatal("expected ResultChan to be closed, but received an event")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not exit after Stop — ResultChan never closed")
+	}
+}

--- a/internal/database/service_provider_cluster.go
+++ b/internal/database/service_provider_cluster.go
@@ -87,10 +87,12 @@ func GetOrCreateServiceProviderCluster(
 		if len(secondAttempt) >= 1 && secondAttempt[0] {
 			return nil, utils.TrackError(fmt.Errorf("second NotFound, Conflict, NotFound error: %w", err))
 		}
+		timer := time.NewTimer((SoftDeleteTTLSeconds + 1) * time.Second)
+		defer timer.Stop()
 		select {
 		case <-ctx.Done():
 			return nil, utils.TrackError(ctx.Err())
-		case <-time.After((SoftDeleteTTLSeconds + 1) * time.Second):
+		case <-timer.C:
 			// This can happen when the soft-delete marks an item, the GET will return 404, the create will 409, the second get will 404.
 			// By waiting longer than the cosmos TTL, we can re-enter the loop and try again later.  This is a rare case and will
 			// only happen when the parent item exists and the controller was deleted.

--- a/internal/database/service_provider_nodepool.go
+++ b/internal/database/service_provider_nodepool.go
@@ -88,10 +88,12 @@ func GetOrCreateServiceProviderNodePool(
 		if len(secondAttempt) >= 1 && secondAttempt[0] {
 			return nil, utils.TrackError(fmt.Errorf("second NotFound, Conflict, NotFound error: %w", err))
 		}
+		timer := time.NewTimer((SoftDeleteTTLSeconds + 1) * time.Second)
+		defer timer.Stop()
 		select {
 		case <-ctx.Done():
 			return nil, utils.TrackError(ctx.Err())
-		case <-time.After((SoftDeleteTTLSeconds + 1) * time.Second):
+		case <-timer.C:
 			// This can happen when the soft-delete marks an item, the GET will return 404, the create will 409, the second get will 404.
 			// By waiting longer than the cosmos TTL, we can re-enter the loop and try again later.  This is a rare case and will
 			// only happen when the parent item exists and the controller was deleted.

--- a/tooling/hcpctl/pkg/breakglass/execute.go
+++ b/tooling/hcpctl/pkg/breakglass/execute.go
@@ -406,13 +406,15 @@ func setupPortForwarding(ctx context.Context, params *ExecutionParams, localPort
 	}()
 
 	// Wait for port forwarding to be ready
+	timer := time.NewTimer(PortForwardTimeout)
+	defer timer.Stop()
 	select {
 	case <-readyCh:
 		logger.V(1).Info("Port forwarding established", "service", kasServiceName, "localPort", localPort, "remotePort", KubeAPIServerPort, "namespace", params.Namespace)
 	case <-ctx.Done():
 		stopOnce.Do(func() { close(stopCh) })
 		return nil, nil, fmt.Errorf("context cancelled while waiting for port forwarding")
-	case <-time.After(PortForwardTimeout):
+	case <-timer.C:
 		stopOnce.Do(func() { close(stopCh) })
 		return nil, nil, fmt.Errorf("timeout waiting for port forwarding setup")
 	}

--- a/tooling/hcpctl/pkg/snapshot/gatherer.go
+++ b/tooling/hcpctl/pkg/snapshot/gatherer.go
@@ -1143,10 +1143,12 @@ func (g *Gatherer) executeKQL(ctx context.Context, kqlStr, database string, time
 		if attempt > 0 {
 			backoff := time.Duration(1<<(attempt-1)) * time.Second
 			logger.Info("Retrying query after transient error", "attempt", attempt+1, "backoff", backoff, "error", lastErr)
+			backoffTimer := time.NewTimer(backoff)
 			select {
 			case <-ctx.Done():
+				backoffTimer.Stop()
 				return nil, ctx.Err()
-			case <-time.After(backoff):
+			case <-backoffTimer.C:
 			}
 		}
 		rows, err := g.executeKQLOnce(ctx, kqlStr, database, timeout)

--- a/tooling/templatize/pkg/aks/admin.go
+++ b/tooling/templatize/pkg/aks/admin.go
@@ -77,7 +77,8 @@ func EnsureClusterAdmin(ctx context.Context, kubeconfigPath, subscriptionID, res
 
 	// Wait for role assignment to be effective
 	fmt.Println("Wait for role assignment to be effective")
-	timeout := time.After(options.Timeout)
+	timeoutTimer := time.NewTimer(options.Timeout)
+	defer timeoutTimer.Stop()
 	ticker := time.NewTicker(options.CheckFrequency)
 	defer ticker.Stop()
 
@@ -85,7 +86,7 @@ func EnsureClusterAdmin(ctx context.Context, kubeconfigPath, subscriptionID, res
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-timeout:
+		case <-timeoutTimer.C:
 			return fmt.Errorf("timed out waiting for role assignment to be effective")
 		case <-ticker.C:
 			err = CheckClusterAdminPermissions(ctx, kubeconfigPath)


### PR DESCRIPTION
Guard the channel send in ExpiringWatcher with a select on ctx.Done() to prevent goroutine leaks when the watcher's context is cancelled before the expiration timer fires.
