### PR TITLE
feat(frontend): add user_agent label for CapZ/ASO request metrics

### DIFF
--- a/frontend/pkg/frontend/client_class.go
+++ b/frontend/pkg/frontend/client_class.go
@@ -1,0 +1,44 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import "strings"
+
+// Known User-Agent product tokens emitted by ASO and CapZ when calling Azure ARM / RP APIs.
+// Examples observed in ARM HttpIncomingRequests:
+//
+//	aso-controller/v2.13.0-hcpclusters.9 cluster-api-provider-azure/v1.22.1-mce-217
+const (
+	userAgentTokenASO  = "aso-controller/"
+	userAgentTokenCAPZ = "cluster-api-provider-azure/"
+)
+
+// clientClassFromUserAgent maps a request User-Agent to a low-cardinality
+// client_class label value for Prometheus metrics.
+func clientClassFromUserAgent(ua string) string {
+	hasASO := strings.Contains(ua, userAgentTokenASO)
+	hasCAPZ := strings.Contains(ua, userAgentTokenCAPZ)
+
+	switch {
+	case hasASO && hasCAPZ:
+		return clientClassASOCAPZ
+	case hasASO:
+		return clientClassASO
+	case hasCAPZ:
+		return clientClassCAPZ
+	default:
+		return clientClassOther
+	}
+}

--- a/frontend/pkg/frontend/client_class.go
+++ b/frontend/pkg/frontend/client_class.go
@@ -25,20 +25,16 @@ const (
 	userAgentTokenCAPZ = "cluster-api-provider-azure/"
 )
 
-// clientClassFromUserAgent maps a request User-Agent to a low-cardinality
-// client_class label value for Prometheus metrics.
-func clientClassFromUserAgent(ua string) string {
-	hasASO := strings.Contains(ua, userAgentTokenASO)
-	hasCAPZ := strings.Contains(ua, userAgentTokenCAPZ)
-
-	switch {
-	case hasASO && hasCAPZ:
-		return clientClassASOCAPZ
-	case hasASO:
-		return clientClassASO
-	case hasCAPZ:
-		return clientClassCAPZ
-	default:
-		return clientClassOther
+// userAgentMetricLabel returns a Prometheus label value for the request User-Agent.
+// Known CapZ/ASO agents keep the (trimmed) User-Agent so versions remain visible;
+// everything else collapses to "other" to bound cardinality.
+func userAgentMetricLabel(ua string) string {
+	ua = strings.Join(strings.Fields(ua), " ")
+	if ua == "" {
+		return userAgentOther
 	}
+	if strings.Contains(ua, userAgentTokenASO) || strings.Contains(ua, userAgentTokenCAPZ) {
+		return ua
+	}
+	return userAgentOther
 }

--- a/frontend/pkg/frontend/client_class.go
+++ b/frontend/pkg/frontend/client_class.go
@@ -23,18 +23,29 @@ import "strings"
 const (
 	userAgentTokenASO  = "aso-controller/"
 	userAgentTokenCAPZ = "cluster-api-provider-azure/"
+
+	// Bound label size so a spoofed header cannot create huge series keys.
+	maxUserAgentLabelLen = 256
 )
 
 // userAgentMetricLabel returns a Prometheus label value for the request User-Agent.
-// Known CapZ/ASO agents keep the (trimmed) User-Agent so versions remain visible;
-// everything else collapses to "other" to bound cardinality.
+// Only known CapZ/ASO product tokens (including versions) are kept so client
+// versions remain visible without accepting arbitrary header values.
+// Everything else collapses to "other".
 func userAgentMetricLabel(ua string) string {
-	ua = strings.Join(strings.Fields(ua), " ")
-	if ua == "" {
+	var parts []string
+	for _, tok := range strings.Fields(ua) {
+		if strings.HasPrefix(tok, userAgentTokenASO) || strings.HasPrefix(tok, userAgentTokenCAPZ) {
+			parts = append(parts, tok)
+		}
+	}
+	if len(parts) == 0 {
 		return userAgentOther
 	}
-	if strings.Contains(ua, userAgentTokenASO) || strings.Contains(ua, userAgentTokenCAPZ) {
-		return ua
+
+	label := strings.Join(parts, " ")
+	if len(label) > maxUserAgentLabelLen {
+		return userAgentOther
 	}
-	return userAgentOther
+	return label
 }

--- a/frontend/pkg/frontend/client_class_test.go
+++ b/frontend/pkg/frontend/client_class_test.go
@@ -14,7 +14,10 @@
 
 package frontend
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestUserAgentMetricLabel(t *testing.T) {
 	t.Parallel()
@@ -35,28 +38,33 @@ func TestUserAgentMetricLabel(t *testing.T) {
 			want: userAgentOther,
 		},
 		{
-			name: "aso only keeps full UA",
+			name: "aso only keeps product token",
 			ua:   "aso-controller/v2.13.0-hcpclusters.9",
 			want: "aso-controller/v2.13.0-hcpclusters.9",
 		},
 		{
-			name: "capz only keeps full UA",
+			name: "capz only keeps product token",
 			ua:   "cluster-api-provider-azure/v1.22.1-mce-217",
 			want: "cluster-api-provider-azure/v1.22.1-mce-217",
 		},
 		{
-			name: "aso+capz combined keeps full UA",
-			ua:   "aso-controller/v2.13.0-hcpclusters.9 cluster-api-provider-azure/v1.22.1-mce-217",
+			name: "strips azsdk wrapper, keeps CapZ/ASO tokens with versions",
+			ua:   "azsdk-go-generic/v2.13.0-hcpclusters.9 (go1.24.13; linux) aso-controller/v2.13.0-hcpclusters.9 cluster-api-provider-azure/v1.22.1-mce-217",
 			want: "aso-controller/v2.13.0-hcpclusters.9 cluster-api-provider-azure/v1.22.1-mce-217",
-		},
-		{
-			name: "whitespace normalized for known UA",
-			ua:   "  aso-controller/v2.12.0   cluster-api-provider-azure/v1.19.0  ",
-			want: "aso-controller/v2.12.0 cluster-api-provider-azure/v1.19.0",
 		},
 		{
 			name: "does not match substring without slash",
 			ua:   "not-aso-controller-or-cluster-api-provider-azure",
+			want: userAgentOther,
+		},
+		{
+			name: "embedded token in unrelated product is ignored",
+			ua:   "evil-aso-controller/v9 not-cluster-api-provider-azure/v9",
+			want: userAgentOther,
+		},
+		{
+			name: "overlong extracted label falls back to other",
+			ua:   "aso-controller/" + strings.Repeat("x", maxUserAgentLabelLen),
 			want: userAgentOther,
 		},
 	}

--- a/frontend/pkg/frontend/client_class_test.go
+++ b/frontend/pkg/frontend/client_class_test.go
@@ -16,7 +16,7 @@ package frontend
 
 import "testing"
 
-func TestClientClassFromUserAgent(t *testing.T) {
+func TestUserAgentMetricLabel(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -27,45 +27,45 @@ func TestClientClassFromUserAgent(t *testing.T) {
 		{
 			name: "empty",
 			ua:   "",
-			want: clientClassOther,
+			want: userAgentOther,
 		},
 		{
 			name: "portal / generic",
 			ua:   "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)",
-			want: clientClassOther,
+			want: userAgentOther,
 		},
 		{
-			name: "aso only",
+			name: "aso only keeps full UA",
 			ua:   "aso-controller/v2.13.0-hcpclusters.9",
-			want: clientClassASO,
+			want: "aso-controller/v2.13.0-hcpclusters.9",
 		},
 		{
-			name: "capz only",
+			name: "capz only keeps full UA",
 			ua:   "cluster-api-provider-azure/v1.22.1-mce-217",
-			want: clientClassCAPZ,
+			want: "cluster-api-provider-azure/v1.22.1-mce-217",
 		},
 		{
-			name: "aso+capz combined (observed ARM UA)",
+			name: "aso+capz combined keeps full UA",
 			ua:   "aso-controller/v2.13.0-hcpclusters.9 cluster-api-provider-azure/v1.22.1-mce-217",
-			want: clientClassASOCAPZ,
+			want: "aso-controller/v2.13.0-hcpclusters.9 cluster-api-provider-azure/v1.22.1-mce-217",
 		},
 		{
-			name: "aso+capz with extra tokens",
-			ua:   "Go-http-client/2.0 aso-controller/v2.12.0 cluster-api-provider-azure/v1.19.0 azsdk-go-...",
-			want: clientClassASOCAPZ,
+			name: "whitespace normalized for known UA",
+			ua:   "  aso-controller/v2.12.0   cluster-api-provider-azure/v1.19.0  ",
+			want: "aso-controller/v2.12.0 cluster-api-provider-azure/v1.19.0",
 		},
 		{
 			name: "does not match substring without slash",
 			ua:   "not-aso-controller-or-cluster-api-provider-azure",
-			want: clientClassOther,
+			want: userAgentOther,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := clientClassFromUserAgent(tt.ua); got != tt.want {
-				t.Fatalf("clientClassFromUserAgent(%q) = %q, want %q", tt.ua, got, tt.want)
+			if got := userAgentMetricLabel(tt.ua); got != tt.want {
+				t.Fatalf("userAgentMetricLabel(%q) = %q, want %q", tt.ua, got, tt.want)
 			}
 		})
 	}

--- a/frontend/pkg/frontend/client_class_test.go
+++ b/frontend/pkg/frontend/client_class_test.go
@@ -1,0 +1,72 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import "testing"
+
+func TestClientClassFromUserAgent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ua   string
+		want string
+	}{
+		{
+			name: "empty",
+			ua:   "",
+			want: clientClassOther,
+		},
+		{
+			name: "portal / generic",
+			ua:   "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)",
+			want: clientClassOther,
+		},
+		{
+			name: "aso only",
+			ua:   "aso-controller/v2.13.0-hcpclusters.9",
+			want: clientClassASO,
+		},
+		{
+			name: "capz only",
+			ua:   "cluster-api-provider-azure/v1.22.1-mce-217",
+			want: clientClassCAPZ,
+		},
+		{
+			name: "aso+capz combined (observed ARM UA)",
+			ua:   "aso-controller/v2.13.0-hcpclusters.9 cluster-api-provider-azure/v1.22.1-mce-217",
+			want: clientClassASOCAPZ,
+		},
+		{
+			name: "aso+capz with extra tokens",
+			ua:   "Go-http-client/2.0 aso-controller/v2.12.0 cluster-api-provider-azure/v1.19.0 azsdk-go-...",
+			want: clientClassASOCAPZ,
+		},
+		{
+			name: "does not match substring without slash",
+			ua:   "not-aso-controller-or-cluster-api-provider-azure",
+			want: clientClassOther,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := clientClassFromUserAgent(tt.ua); got != tt.want {
+				t.Fatalf("clientClassFromUserAgent(%q) = %q, want %q", tt.ua, got, tt.want)
+			}
+		})
+	}
+}

--- a/frontend/pkg/frontend/const.go
+++ b/frontend/pkg/frontend/const.go
@@ -39,10 +39,7 @@ const (
 	noMatchRouteLabel   = "<no match>"
 	unknownVersionLabel = "<unknown>"
 
-	// client_class label values for frontend_http_requests_* metrics.
-	// Keep this set small — never use the raw User-Agent string as a label.
-	clientClassASO     = "aso"
-	clientClassCAPZ    = "capz"
-	clientClassASOCAPZ = "aso+capz"
-	clientClassOther   = "other"
+	// user_agent label fallback for frontend_http_requests_* metrics.
+	// Known CapZ/ASO User-Agents are kept verbatim; all others use this value.
+	userAgentOther = "other"
 )

--- a/frontend/pkg/frontend/const.go
+++ b/frontend/pkg/frontend/const.go
@@ -38,4 +38,11 @@ const (
 
 	noMatchRouteLabel   = "<no match>"
 	unknownVersionLabel = "<unknown>"
+
+	// client_class label values for frontend_http_requests_* metrics.
+	// Keep this set small — never use the raw User-Agent string as a label.
+	clientClassASO     = "aso"
+	clientClassCAPZ    = "capz"
+	clientClassASOCAPZ = "aso+capz"
+	clientClassOther   = "other"
 )

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -940,10 +940,10 @@ func assertHTTPMetrics(t *testing.T, r prometheus.Gatherer, subscription *arm.Su
 
 		for _, m := range mf.GetMetric() {
 			var (
-				route       string
-				apiVersion  string
-				state       string
-				clientClass string
+				route      string
+				apiVersion string
+				state      string
+				userAgent  string
 			)
 			for _, l := range m.GetLabel() {
 				switch l.GetName() {
@@ -953,8 +953,8 @@ func assertHTTPMetrics(t *testing.T, r prometheus.Gatherer, subscription *arm.Su
 					apiVersion = l.GetValue()
 				case "state":
 					state = l.GetValue()
-				case "client_class":
-					clientClass = l.GetValue()
+				case "user_agent":
+					userAgent = l.GetValue()
 				}
 			}
 
@@ -963,7 +963,7 @@ func assertHTTPMetrics(t *testing.T, r prometheus.Gatherer, subscription *arm.Su
 			assert.NotEqual(t, route, noMatchRouteLabel)
 			assert.NotEmpty(t, apiVersion)
 			assert.NotEqual(t, apiVersion, unknownVersionLabel)
-			assert.Equal(t, clientClassOther, clientClass)
+			assert.Equal(t, userAgentOther, userAgent)
 
 			if mf.GetName() == requestCounterName {
 				assert.NotEmpty(t, state)

--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -940,9 +940,10 @@ func assertHTTPMetrics(t *testing.T, r prometheus.Gatherer, subscription *arm.Su
 
 		for _, m := range mf.GetMetric() {
 			var (
-				route      string
-				apiVersion string
-				state      string
+				route       string
+				apiVersion  string
+				state       string
+				clientClass string
 			)
 			for _, l := range m.GetLabel() {
 				switch l.GetName() {
@@ -952,6 +953,8 @@ func assertHTTPMetrics(t *testing.T, r prometheus.Gatherer, subscription *arm.Su
 					apiVersion = l.GetValue()
 				case "state":
 					state = l.GetValue()
+				case "client_class":
+					clientClass = l.GetValue()
 				}
 			}
 
@@ -960,6 +963,7 @@ func assertHTTPMetrics(t *testing.T, r prometheus.Gatherer, subscription *arm.Su
 			assert.NotEqual(t, route, noMatchRouteLabel)
 			assert.NotEmpty(t, apiVersion)
 			assert.NotEqual(t, apiVersion, unknownVersionLabel)
+			assert.Equal(t, clientClassOther, clientClass)
 
 			if mf.GetName() == requestCounterName {
 				assert.NotEmpty(t, state)

--- a/frontend/pkg/frontend/metrics.go
+++ b/frontend/pkg/frontend/metrics.go
@@ -65,14 +65,14 @@ func NewMetricsMiddleware(r prometheus.Registerer, ssg SubscriptionStateGetter) 
 		requestCounter: promauto.With(r).NewCounterVec(
 			prometheus.CounterOpts{
 				Name: requestCounterName,
-				Help: "Counter for HTTP requests by method, code, route and user agent.",
+				Help: "Counter for HTTP requests by api_version, method, code, route, state, and user_agent.",
 			},
 			[]string{"api_version", "method", "code", "route", "state", "user_agent"},
 		),
 		requestDuration: promauto.With(r).NewHistogramVec(
 			prometheus.HistogramOpts{
 				Name: requestDurationName,
-				Help: "Histogram of latencies for HTTP requests by method, code, route and user agent.",
+				Help: "Histogram of latencies for HTTP requests by api_version, method, code, route, and user_agent.",
 				// Buckets are modeled after k8s.io/apiserver request latency
 				// histograms, with dense resolution around the 1s mark to
 				// enable accurate P99 calculation for the S360 Control Plane

--- a/frontend/pkg/frontend/metrics.go
+++ b/frontend/pkg/frontend/metrics.go
@@ -65,21 +65,21 @@ func NewMetricsMiddleware(r prometheus.Registerer, ssg SubscriptionStateGetter) 
 		requestCounter: promauto.With(r).NewCounterVec(
 			prometheus.CounterOpts{
 				Name: requestCounterName,
-				Help: "Counter for HTTP requests by method, code, route and client class.",
+				Help: "Counter for HTTP requests by method, code, route and user agent.",
 			},
-			[]string{"api_version", "method", "code", "route", "state", "client_class"},
+			[]string{"api_version", "method", "code", "route", "state", "user_agent"},
 		),
 		requestDuration: promauto.With(r).NewHistogramVec(
 			prometheus.HistogramOpts{
 				Name: requestDurationName,
-				Help: "Histogram of latencies for HTTP requests by method, code, route and client class.",
+				Help: "Histogram of latencies for HTTP requests by method, code, route and user agent.",
 				// Buckets are modeled after k8s.io/apiserver request latency
 				// histograms, with dense resolution around the 1s mark to
 				// enable accurate P99 calculation for the S360 Control Plane
 				// Latency KPI (synchronous responses within 1 second).
 				Buckets: []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 4, 5, 6, 8, 10, 15},
 			},
-			[]string{"api_version", "method", "code", "route", "client_class"},
+			[]string{"api_version", "method", "code", "route", "user_agent"},
 		),
 	}
 
@@ -119,23 +119,23 @@ func (mm MetricsMiddleware) Metrics() MiddlewareFunc {
 			subscriptionID = resource.SubscriptionID
 		}
 
-		clientClass := clientClassFromUserAgent(r.UserAgent())
+		userAgent := userAgentMetricLabel(r.UserAgent())
 
 		mm.requestCounter.With(prometheus.Labels{
-			"method":       r.Method,
-			"api_version":  apiVersion,
-			"code":         strconv.Itoa(lrw.statusCode),
-			"route":        route,
-			"state":        mm.ssg.GetSubscriptionState(subscriptionID),
-			"client_class": clientClass,
+			"method":      r.Method,
+			"api_version": apiVersion,
+			"code":        strconv.Itoa(lrw.statusCode),
+			"route":       route,
+			"state":       mm.ssg.GetSubscriptionState(subscriptionID),
+			"user_agent":  userAgent,
 		}).Inc()
 
 		mm.requestDuration.With(prometheus.Labels{
-			"method":       r.Method,
-			"api_version":  apiVersion,
-			"code":         strconv.Itoa(lrw.statusCode),
-			"route":        route,
-			"client_class": clientClass,
+			"method":      r.Method,
+			"api_version": apiVersion,
+			"code":        strconv.Itoa(lrw.statusCode),
+			"route":       route,
+			"user_agent":  userAgent,
 		}).Observe(time.Since(startTime).Seconds())
 	}
 }

--- a/frontend/pkg/frontend/metrics.go
+++ b/frontend/pkg/frontend/metrics.go
@@ -65,21 +65,21 @@ func NewMetricsMiddleware(r prometheus.Registerer, ssg SubscriptionStateGetter) 
 		requestCounter: promauto.With(r).NewCounterVec(
 			prometheus.CounterOpts{
 				Name: requestCounterName,
-				Help: "Counter for HTTP requests by method, code and route.",
+				Help: "Counter for HTTP requests by method, code, route and client class.",
 			},
-			[]string{"api_version", "method", "code", "route", "state"},
+			[]string{"api_version", "method", "code", "route", "state", "client_class"},
 		),
 		requestDuration: promauto.With(r).NewHistogramVec(
 			prometheus.HistogramOpts{
 				Name: requestDurationName,
-				Help: "Histogram of latencies for HTTP requests by method, code and route.",
+				Help: "Histogram of latencies for HTTP requests by method, code, route and client class.",
 				// Buckets are modeled after k8s.io/apiserver request latency
 				// histograms, with dense resolution around the 1s mark to
 				// enable accurate P99 calculation for the S360 Control Plane
 				// Latency KPI (synchronous responses within 1 second).
 				Buckets: []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3, 4, 5, 6, 8, 10, 15},
 			},
-			[]string{"api_version", "method", "code", "route"},
+			[]string{"api_version", "method", "code", "route", "client_class"},
 		),
 	}
 
@@ -119,19 +119,23 @@ func (mm MetricsMiddleware) Metrics() MiddlewareFunc {
 			subscriptionID = resource.SubscriptionID
 		}
 
+		clientClass := clientClassFromUserAgent(r.UserAgent())
+
 		mm.requestCounter.With(prometheus.Labels{
-			"method":      r.Method,
-			"api_version": apiVersion,
-			"code":        strconv.Itoa(lrw.statusCode),
-			"route":       route,
-			"state":       mm.ssg.GetSubscriptionState(subscriptionID),
+			"method":       r.Method,
+			"api_version":  apiVersion,
+			"code":         strconv.Itoa(lrw.statusCode),
+			"route":        route,
+			"state":        mm.ssg.GetSubscriptionState(subscriptionID),
+			"client_class": clientClass,
 		}).Inc()
 
 		mm.requestDuration.With(prometheus.Labels{
-			"method":      r.Method,
-			"api_version": apiVersion,
-			"code":        strconv.Itoa(lrw.statusCode),
-			"route":       route,
+			"method":       r.Method,
+			"api_version":  apiVersion,
+			"code":         strconv.Itoa(lrw.statusCode),
+			"route":        route,
+			"client_class": clientClass,
 		}).Observe(time.Since(startTime).Seconds())
 	}
 }

--- a/frontend/pkg/frontend/metrics_test.go
+++ b/frontend/pkg/frontend/metrics_test.go
@@ -45,12 +45,12 @@ func TestMetricsMiddlewareUserAgent(t *testing.T) {
 			wantLabel: userAgentOther,
 		},
 		{
-			name:      "aso+capz keeps full UA",
-			userAgent: "aso-controller/v2.13.0-hcpclusters.9 cluster-api-provider-azure/v1.22.1-mce-217",
+			name:      "aso+capz keeps product tokens with versions",
+			userAgent: "azsdk-go-generic/v2.13.0-hcpclusters.9 (go1.24.13; linux) aso-controller/v2.13.0-hcpclusters.9 cluster-api-provider-azure/v1.22.1-mce-217",
 			wantLabel: "aso-controller/v2.13.0-hcpclusters.9 cluster-api-provider-azure/v1.22.1-mce-217",
 		},
 		{
-			name:      "capz only keeps full UA",
+			name:      "capz only keeps product token",
 			userAgent: "cluster-api-provider-azure/v1.22.1-mce-217",
 			wantLabel: "cluster-api-provider-azure/v1.22.1-mce-217",
 		},

--- a/frontend/pkg/frontend/metrics_test.go
+++ b/frontend/pkg/frontend/metrics_test.go
@@ -35,9 +35,9 @@ func TestMetricsMiddlewareClientClass(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		userAgent   string
-		wantClass   string
+		name      string
+		userAgent string
+		wantClass string
 	}{
 		{
 			name:      "other when unset",

--- a/frontend/pkg/frontend/metrics_test.go
+++ b/frontend/pkg/frontend/metrics_test.go
@@ -1,0 +1,107 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type staticSubscriptionState string
+
+func (s staticSubscriptionState) GetSubscriptionState(string) string {
+	return string(s)
+}
+
+func TestMetricsMiddlewareClientClass(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		userAgent   string
+		wantClass   string
+	}{
+		{
+			name:      "other when unset",
+			userAgent: "",
+			wantClass: clientClassOther,
+		},
+		{
+			name:      "aso+capz from observed UA",
+			userAgent: "aso-controller/v2.13.0-hcpclusters.9 cluster-api-provider-azure/v1.22.1-mce-217",
+			wantClass: clientClassASOCAPZ,
+		},
+		{
+			name:      "capz only",
+			userAgent: "cluster-api-provider-azure/v1.22.1-mce-217",
+			wantClass: clientClassCAPZ,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reg := prometheus.NewRegistry()
+			mm := NewMetricsMiddleware(reg, staticSubscriptionState("Registered"))
+			middleware := mm.Metrics()
+
+			req := httptest.NewRequest(http.MethodGet, "/subscriptions/00000000-0000-0000-0000-000000000000?api-version=2024-01-01", nil)
+			if tt.userAgent != "" {
+				req.Header.Set("User-Agent", tt.userAgent)
+			}
+			rr := httptest.NewRecorder()
+			middleware(rr, req, func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			require.Equal(t, http.StatusOK, rr.Code)
+
+			metrics, err := reg.Gather()
+			require.NoError(t, err)
+
+			var sawCounter, sawDuration bool
+			for _, mf := range metrics {
+				switch mf.GetName() {
+				case requestCounterName:
+					sawCounter = true
+					assert.Equal(t, tt.wantClass, labelValue(t, mf.GetMetric()[0], "client_class"))
+				case requestDurationName:
+					sawDuration = true
+					assert.Equal(t, tt.wantClass, labelValue(t, mf.GetMetric()[0], "client_class"))
+				}
+			}
+			assert.True(t, sawCounter, "expected %s", requestCounterName)
+			assert.True(t, sawDuration, "expected %s", requestDurationName)
+		})
+	}
+}
+
+func labelValue(t *testing.T, m *dto.Metric, name string) string {
+	t.Helper()
+	for _, l := range m.GetLabel() {
+		if l.GetName() == name {
+			return l.GetValue()
+		}
+	}
+	t.Fatalf("label %q not found", name)
+	return ""
+}

--- a/frontend/pkg/frontend/metrics_test.go
+++ b/frontend/pkg/frontend/metrics_test.go
@@ -31,28 +31,28 @@ func (s staticSubscriptionState) GetSubscriptionState(string) string {
 	return string(s)
 }
 
-func TestMetricsMiddlewareClientClass(t *testing.T) {
+func TestMetricsMiddlewareUserAgent(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name      string
 		userAgent string
-		wantClass string
+		wantLabel string
 	}{
 		{
 			name:      "other when unset",
 			userAgent: "",
-			wantClass: clientClassOther,
+			wantLabel: userAgentOther,
 		},
 		{
-			name:      "aso+capz from observed UA",
+			name:      "aso+capz keeps full UA",
 			userAgent: "aso-controller/v2.13.0-hcpclusters.9 cluster-api-provider-azure/v1.22.1-mce-217",
-			wantClass: clientClassASOCAPZ,
+			wantLabel: "aso-controller/v2.13.0-hcpclusters.9 cluster-api-provider-azure/v1.22.1-mce-217",
 		},
 		{
-			name:      "capz only",
+			name:      "capz only keeps full UA",
 			userAgent: "cluster-api-provider-azure/v1.22.1-mce-217",
-			wantClass: clientClassCAPZ,
+			wantLabel: "cluster-api-provider-azure/v1.22.1-mce-217",
 		},
 	}
 
@@ -83,10 +83,10 @@ func TestMetricsMiddlewareClientClass(t *testing.T) {
 				switch mf.GetName() {
 				case requestCounterName:
 					sawCounter = true
-					assert.Equal(t, tt.wantClass, labelValue(t, mf.GetMetric()[0], "client_class"))
+					assert.Equal(t, tt.wantLabel, labelValue(t, mf.GetMetric()[0], "user_agent"))
 				case requestDurationName:
 					sawDuration = true
-					assert.Equal(t, tt.wantClass, labelValue(t, mf.GetMetric()[0], "client_class"))
+					assert.Equal(t, tt.wantLabel, labelValue(t, mf.GetMetric()[0], "user_agent"))
 				}
 			}
 			assert.True(t, sawCounter, "expected %s", requestCounterName)


### PR DESCRIPTION
## Summary
- Add a `user_agent` label on `frontend_http_requests_total` and `frontend_http_requests_duration_seconds`.
- Known CapZ/ASO agents (`aso-controller/`, `cluster-api-provider-azure/`) keep the full User-Agent so versions are visible.
- All other clients collapse to `other` to bound Prometheus cardinality.
- Motivated by CapZ observability under [ARO-25381](https://redhat.atlassian.net/browse/ARO-25381) and review feedback on needing version-aware client tracking.

## Test plan
- [ ] `GOOS=linux go test -c ./frontend/pkg/frontend` compiles successfully
- [ ] CI unit tests / verify / lint
- [ ] After deploy: confirm CapZ/ASO series show full UA (with version) and non-CapZ traffic is `other`
- [ ] Optionally: Kusto distinct CapZ/ASO UA count across regions to validate cardinality