### PR TITLE
[WIP] Add new DeploymentWatcher to the management cluster agent

### DIFF
--- a/mgmt-agent/cmd/options.go
+++ b/mgmt-agent/cmd/options.go
@@ -99,6 +99,7 @@ type completedControllerOptions struct {
 	ksmCtrl                  *ksmhcp.KSMHCPController
 	resourceWatcher          *controller.ResourceWatcher
 	podWatcher               *controller.PodWatcher
+	deploymentWatcher        *controller.DeploymentWatcher
 	configMapWatcher         *controller.ConfigMapWatcher
 	kubeInformers            kubeinformers.SharedInformerFactory
 	ksmKubeInformers         kubeinformers.SharedInformerFactory
@@ -178,6 +179,11 @@ func (o *ValidatedControllerOptions) Complete(ctx context.Context) (*ControllerO
 		return nil, fmt.Errorf("failed to create pod watcher: %w", err)
 	}
 
+	deploymentWatcher, err := controller.NewDeploymentWatcher(clusterWideKubeInformers.Apps().V1().Deployments())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create deployment watcher: %w", err)
+	}
+
 	cmWatcherInformers := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClientset, 0,
 		kubeinformers.WithTweakListOptions(func(opts *metav1.ListOptions) {
 			opts.FieldSelector = "metadata.name=" + controller.RouterConfigMapName
@@ -240,6 +246,7 @@ func (o *ValidatedControllerOptions) Complete(ctx context.Context) (*ControllerO
 			ksmCtrl:                  ksmCtrl,
 			resourceWatcher:          resourceWatcher,
 			podWatcher:               podWatcher,
+			deploymentWatcher:        deploymentWatcher,
 			configMapWatcher:         configMapWatcher,
 			kubeInformers:            kubeInformers,
 			ksmKubeInformers:         ksmKubeInformers,
@@ -395,6 +402,14 @@ func (o *ControllerOptions) runControllersUnderLeaderElection(ctx context.Contex
 						defer utilruntime.HandleCrash()
 						if err := o.podWatcher.Run(ctx); err != nil {
 							logger.Error(err, "pod watcher failed")
+						}
+					}()
+				}
+				if o.deploymentWatcher != nil {
+					go func() {
+						defer utilruntime.HandleCrash()
+						if err := o.deploymentWatcher.Run(ctx); err != nil {
+							logger.Error(err, "deployment watcher failed")
 						}
 					}()
 				}

--- a/mgmt-agent/pkg/controller/deploymentwatcher.go
+++ b/mgmt-agent/pkg/controller/deploymentwatcher.go
@@ -1,0 +1,111 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	appsinformers "k8s.io/client-go/informers/apps/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+const (
+	hypershiftNamespace      = "hypershift"
+	hostedClusterNSPrefix    = "ocm-"
+)
+
+// DeploymentWatcher watches Deployment resources using a typed informer and
+// logs create, update, and delete events via structured logging. Only
+// Deployments in the hypershift namespace or hosted cluster namespaces
+// (ocm-* prefix) are logged.
+type DeploymentWatcher struct {
+	deploymentSynced cache.InformerSynced
+}
+
+// NewDeploymentWatcher creates a new DeploymentWatcher. It registers event
+// handlers on the given Deployment informer to log Deployment lifecycle events.
+func NewDeploymentWatcher(deploymentInformer appsinformers.DeploymentInformer) (*DeploymentWatcher, error) {
+	w := &DeploymentWatcher{
+		deploymentSynced: deploymentInformer.Informer().HasSynced,
+	}
+
+	if _, err := deploymentInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			deploy, ok := obj.(*appsv1.Deployment)
+			if !ok || !isWatchedNamespace(deploy.Namespace) {
+				return
+			}
+			logDeploymentEvent("Add", deploy)
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			deploy, ok := newObj.(*appsv1.Deployment)
+			if !ok || !isWatchedNamespace(deploy.Namespace) {
+				return
+			}
+			logDeploymentEvent("Update", deploy)
+		},
+		DeleteFunc: func(obj interface{}) {
+			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = tombstone.Obj
+			}
+			deploy, ok := obj.(*appsv1.Deployment)
+			if !ok || !isWatchedNamespace(deploy.Namespace) {
+				return
+			}
+			logDeploymentEvent("Delete", deploy)
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("failed to add event handler: %w", err)
+	}
+
+	return w, nil
+}
+
+// Run waits for the Deployment informer cache to sync and blocks until the
+// context is cancelled.
+func (w *DeploymentWatcher) Run(ctx context.Context) error {
+	logger := klog.FromContext(ctx)
+	logger.Info("Starting deployment watcher")
+
+	logger.Info("Waiting for deployment informer cache to sync")
+	if ok := cache.WaitForCacheSync(ctx.Done(), w.deploymentSynced); !ok {
+		return fmt.Errorf("failed to wait for deployment informer cache to sync")
+	}
+
+	logger.Info("Deployment watcher informer synced and running")
+	<-ctx.Done()
+	logger.Info("Shutting down deployment watcher")
+	return nil
+}
+
+func isWatchedNamespace(ns string) bool {
+	return ns == hypershiftNamespace || strings.HasPrefix(ns, hostedClusterNSPrefix)
+}
+
+func logDeploymentEvent(eventType string, deploy *appsv1.Deployment) {
+	deployCopy := *deploy
+	deployCopy.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
+	klog.InfoS("deployment event",
+		"snapshotType", "kubernetes",
+		"event", eventType,
+		"namespace", deployCopy.Namespace,
+		"name", deployCopy.Name,
+		"object", &deployCopy,
+	)
+}

--- a/mgmt-agent/pkg/controller/deploymentwatcher.go
+++ b/mgmt-agent/pkg/controller/deploymentwatcher.go
@@ -17,17 +17,19 @@ package controller
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	appsinformers "k8s.io/client-go/informers/apps/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
 const (
-	hypershiftNamespace      = "hypershift"
-	hostedClusterNSPrefix    = "ocm-"
+	hypershiftNamespace   = "hypershift"
+	hostedClusterNSPrefix = "ocm-"
 )
 
 // DeploymentWatcher watches Deployment resources using a typed informer and
@@ -53,12 +55,18 @@ func NewDeploymentWatcher(deploymentInformer appsinformers.DeploymentInformer) (
 			}
 			logDeploymentEvent("Add", deploy)
 		},
-		UpdateFunc: func(_, newObj interface{}) {
-			deploy, ok := newObj.(*appsv1.Deployment)
-			if !ok || !isWatchedNamespace(deploy.Namespace) {
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldDeploy, ok := oldObj.(*appsv1.Deployment)
+			if !ok {
 				return
 			}
-			logDeploymentEvent("Update", deploy)
+			newDeploy, ok := newObj.(*appsv1.Deployment)
+			if !ok || !isWatchedNamespace(newDeploy.Namespace) {
+				return
+			}
+			if deploymentStateChanged(oldDeploy, newDeploy) {
+				logDeploymentEvent("Update", newDeploy)
+			}
 		},
 		DeleteFunc: func(obj interface{}) {
 			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
@@ -98,9 +106,56 @@ func isWatchedNamespace(ns string) bool {
 	return ns == hypershiftNamespace || strings.HasPrefix(ns, hostedClusterNSPrefix)
 }
 
+// deploymentStateChanged returns true if diagnostically meaningful fields
+// changed between old and new. It ignores noisy fields like condition
+// timestamps, resourceVersion, and managedFields.
+func deploymentStateChanged(oldDeploy, newDeploy *appsv1.Deployment) bool {
+	oldStatus := oldDeploy.Status
+	newStatus := newDeploy.Status
+
+	if oldStatus.ObservedGeneration != newStatus.ObservedGeneration ||
+		oldStatus.Replicas != newStatus.Replicas ||
+		oldStatus.UpdatedReplicas != newStatus.UpdatedReplicas ||
+		oldStatus.ReadyReplicas != newStatus.ReadyReplicas ||
+		oldStatus.AvailableReplicas != newStatus.AvailableReplicas ||
+		oldStatus.UnavailableReplicas != newStatus.UnavailableReplicas {
+		return true
+	}
+
+	if !conditionStatusMapEqual(oldStatus.Conditions, newStatus.Conditions) {
+		return true
+	}
+
+	if !reflect.DeepEqual(oldDeploy.Spec.Template, newDeploy.Spec.Template) {
+		return true
+	}
+
+	return false
+}
+
+// conditionStatusMapEqual returns true if both slices have the same set of
+// condition Type→Status pairs. It ignores LastUpdateTime, LastTransitionTime,
+// Reason, and Message — those change frequently without diagnostic value.
+func conditionStatusMapEqual(a, b []appsv1.DeploymentCondition) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aMap := make(map[appsv1.DeploymentConditionType]corev1.ConditionStatus, len(a))
+	for _, c := range a {
+		aMap[c.Type] = c.Status
+	}
+	for _, c := range b {
+		if aMap[c.Type] != c.Status {
+			return false
+		}
+	}
+	return true
+}
+
 func logDeploymentEvent(eventType string, deploy *appsv1.Deployment) {
 	deployCopy := *deploy
 	deployCopy.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
+	deployCopy.ManagedFields = nil
 	klog.InfoS("deployment event",
 		"snapshotType", "kubernetes",
 		"event", eventType,

--- a/mgmt-agent/pkg/controller/deploymentwatcher_test.go
+++ b/mgmt-agent/pkg/controller/deploymentwatcher_test.go
@@ -1,0 +1,109 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestLogDeploymentEvent(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		deploy    *appsv1.Deployment
+	}{
+		{
+			name:      "Add event",
+			eventType: "Add",
+			deploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "operator",
+					Namespace: "hypershift",
+				},
+			},
+		},
+		{
+			name:      "Update event",
+			eventType: "Update",
+			deploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "control-plane-operator",
+					Namespace: "ocm-hcp-test",
+				},
+			},
+		},
+		{
+			name:      "Delete event",
+			eventType: "Delete",
+			deploy: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "operator",
+					Namespace: "hypershift",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logDeploymentEvent(tt.eventType, tt.deploy)
+		})
+	}
+}
+
+func TestIsWatchedNamespace(t *testing.T) {
+	tests := []struct {
+		namespace string
+		expected  bool
+	}{
+		{"hypershift", true},
+		{"ocm-hcp-test", true},
+		{"ocm-arohcp-12345", true},
+		{"ocm-", true},
+		{"kube-system", false},
+		{"default", false},
+		{"openshift-operators", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.namespace, func(t *testing.T) {
+			if got := isWatchedNamespace(tt.namespace); got != tt.expected {
+				t.Errorf("isWatchedNamespace(%q) = %v, want %v", tt.namespace, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewDeploymentWatcher(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	factory := kubeinformers.NewSharedInformerFactory(clientset, 0)
+
+	w, err := NewDeploymentWatcher(factory.Apps().V1().Deployments())
+	if err != nil {
+		t.Fatalf("NewDeploymentWatcher() returned error: %v", err)
+	}
+	if w == nil {
+		t.Fatal("NewDeploymentWatcher() returned nil")
+	}
+	if w.deploymentSynced == nil {
+		t.Fatal("NewDeploymentWatcher() did not set deploymentSynced")
+	}
+}

--- a/mgmt-agent/pkg/controller/deploymentwatcher_test.go
+++ b/mgmt-agent/pkg/controller/deploymentwatcher_test.go
@@ -16,8 +16,10 @@ package controller
 
 import (
 	"testing"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -87,6 +89,166 @@ func TestIsWatchedNamespace(t *testing.T) {
 		t.Run(tt.namespace, func(t *testing.T) {
 			if got := isWatchedNamespace(tt.namespace); got != tt.expected {
 				t.Errorf("isWatchedNamespace(%q) = %v, want %v", tt.namespace, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDeploymentStateChanged(t *testing.T) {
+	baseConditions := []appsv1.DeploymentCondition{
+		{
+			Type:           appsv1.DeploymentAvailable,
+			Status:         corev1.ConditionTrue,
+			LastUpdateTime: metav1.NewTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+		},
+		{
+			Type:           appsv1.DeploymentProgressing,
+			Status:         corev1.ConditionTrue,
+			LastUpdateTime: metav1.NewTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+		},
+	}
+
+	baseDeploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "operator",
+			Namespace:       "hypershift",
+			ResourceVersion: "100",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "operator", Image: "quay.io/hypershift/operator:v1.0"},
+					},
+				},
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration:  1,
+			Replicas:            2,
+			UpdatedReplicas:     2,
+			ReadyReplicas:       2,
+			AvailableReplicas:   2,
+			UnavailableReplicas: 0,
+			Conditions:          baseConditions,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		modify   func(d *appsv1.Deployment)
+		expected bool
+	}{
+		{
+			name:     "no changes",
+			modify:   func(_ *appsv1.Deployment) {},
+			expected: false,
+		},
+		{
+			name: "only resourceVersion changes",
+			modify: func(d *appsv1.Deployment) {
+				d.ResourceVersion = "200"
+			},
+			expected: false,
+		},
+		{
+			name: "only managedFields changes",
+			modify: func(d *appsv1.Deployment) {
+				d.ManagedFields = []metav1.ManagedFieldsEntry{
+					{Manager: "kube-controller-manager", Operation: metav1.ManagedFieldsOperationUpdate},
+				}
+			},
+			expected: false,
+		},
+		{
+			name: "only condition timestamps change",
+			modify: func(d *appsv1.Deployment) {
+				d.Status.Conditions = []appsv1.DeploymentCondition{
+					{
+						Type:           appsv1.DeploymentAvailable,
+						Status:         corev1.ConditionTrue,
+						LastUpdateTime: metav1.NewTime(time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)),
+					},
+					{
+						Type:           appsv1.DeploymentProgressing,
+						Status:         corev1.ConditionTrue,
+						LastUpdateTime: metav1.NewTime(time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)),
+					},
+				}
+			},
+			expected: false,
+		},
+		{
+			name: "readyReplicas changes",
+			modify: func(d *appsv1.Deployment) {
+				d.Status.ReadyReplicas = 1
+			},
+			expected: true,
+		},
+		{
+			name: "availableReplicas changes",
+			modify: func(d *appsv1.Deployment) {
+				d.Status.AvailableReplicas = 1
+			},
+			expected: true,
+		},
+		{
+			name: "unavailableReplicas changes",
+			modify: func(d *appsv1.Deployment) {
+				d.Status.UnavailableReplicas = 1
+			},
+			expected: true,
+		},
+		{
+			name: "observedGeneration changes",
+			modify: func(d *appsv1.Deployment) {
+				d.Status.ObservedGeneration = 2
+			},
+			expected: true,
+		},
+		{
+			name: "condition status changes",
+			modify: func(d *appsv1.Deployment) {
+				d.Status.Conditions = []appsv1.DeploymentCondition{
+					{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionFalse},
+					{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue},
+				}
+			},
+			expected: true,
+		},
+		{
+			name: "new condition added",
+			modify: func(d *appsv1.Deployment) {
+				d.Status.Conditions = append(d.Status.Conditions,
+					appsv1.DeploymentCondition{Type: appsv1.DeploymentReplicaFailure, Status: corev1.ConditionTrue},
+				)
+			},
+			expected: true,
+		},
+		{
+			name: "spec template image changes",
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Containers[0].Image = "quay.io/hypershift/operator:v2.0"
+			},
+			expected: true,
+		},
+		{
+			name: "spec template env var added",
+			modify: func(d *appsv1.Deployment) {
+				d.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{
+					{Name: "FOO", Value: "bar"},
+				}
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			newDeploy := baseDeploy.DeepCopy()
+			tt.modify(newDeploy)
+			if got := deploymentStateChanged(baseDeploy, newDeploy); got != tt.expected {
+				t.Errorf("deploymentStateChanged() = %v, want %v", got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
Jira: [ARO-28661](https://redhat.atlassian.net/browse/ARO-28661)

**Summary**

  Adds a DeploymentWatcher to mgmt-agent that logs apps/v1 Deployment events with snapshotType=kubernetes, routing them to the kubernetesResourceSnapshots Kusto table via existing
  Fluent Bit config. This makes Deployment objects (e.g. HyperShift Operator, Control Plane Operator) available in Kusto for diagnostics. No Fluent Bit or schema changes needed.

  This is the first step toward incorporating additional management cluster data into CI artifacts and snapshot analysis — future PRs will query Kusto for these artifacts and attach
  them to e2e test runs.

**Test plan**

  - [x] Unit tests pass
  - [x] go vet and build pass
  - [ ] Verify Deployment events appear in kubernetesResourceSnapshots after deploying to dev
