### PR TITLE
fix: push v20260630preview timebomb deadlines to 2026-08-07

### DIFF
--- a/test/e2e/cluster_create_private_ingress.go
+++ b/test/e2e/cluster_create_private_ingress.go
@@ -38,9 +38,6 @@ import (
 // v2026-06-30-preview API version smoke test — verifying cluster creation,
 // credentials, and cluster health — to avoid creating multiple clusters in CI.
 var _ = Describe("Customer", func() {
-	// Deadline for v20260630preview API deployment in non-dev environments
-	timeBombDeadline := framework.Must(time.Parse(time.RFC3339, "2026-07-31T00:00:00Z"))
-
 	It("should create a cluster with private ingress using v20260630preview and verify the ingress is internal",
 		labels.RequireNothing,
 		labels.Critical,
@@ -89,10 +86,10 @@ var _ = Describe("Customer", func() {
 				framework.ClusterCreationTimeout,
 			)
 			if isAPINotDeployedError(err) {
-				if time.Now().Before(timeBombDeadline) {
-					Skip(fmt.Sprintf("v20260630preview API not yet deployed; skipping until %s", timeBombDeadline.Format(time.RFC3339)))
+				if time.Now().Before(framework.V20260630PreviewDeploymentDeadline) {
+					Skip(fmt.Sprintf("v20260630preview API not yet deployed; skipping until %s", framework.V20260630PreviewDeploymentDeadline.Format(time.RFC3339)))
 				}
-				Fail(fmt.Sprintf("v20260630preview API still not deployed as of %s deadline", timeBombDeadline.Format(time.RFC3339)))
+				Fail(fmt.Sprintf("v20260630preview API still not deployed as of %s deadline", framework.V20260630PreviewDeploymentDeadline.Format(time.RFC3339)))
 			}
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with private ingress", customerClusterName)
 

--- a/test/e2e/cluster_fips_mode.go
+++ b/test/e2e/cluster_fips_mode.go
@@ -69,8 +69,8 @@ var _ = Describe("FIPS Mode Support", func() {
 						}
 					}
 					if !available {
-						if time.Now().After(framework.Must(time.Parse(time.RFC3339, "2026-08-07T00:00:00Z"))) {
-							Fail(fmt.Sprintf("API version %s should be available for Microsoft.RedHatOpenShift/hcpOpenShiftClusters by 2026-08-07 00:00 UTC", apiVersion))
+						if time.Now().After(framework.V20260630PreviewDeploymentDeadline) {
+							Fail(fmt.Sprintf("API version %s should be available for Microsoft.RedHatOpenShift/hcpOpenShiftClusters by %s", apiVersion, framework.V20260630PreviewDeploymentDeadline.Format(time.RFC3339)))
 						}
 						Skip(fmt.Sprintf("API version %s is not available for Microsoft.RedHatOpenShift/hcpOpenShiftClusters in this environment", apiVersion))
 					}

--- a/test/e2e/kms_key_rotation.go
+++ b/test/e2e/kms_key_rotation.go
@@ -34,9 +34,6 @@ import (
 const HCPClusterReencryptionUpgradeTimeout = 18 * time.Minute
 
 var _ = Describe("Customer", func() {
-	// Deadline for v20260630preview API deployment in non-dev environments
-	timeBombDeadline := framework.Must(time.Parse(time.RFC3339, "2026-07-31T00:00:00Z"))
-
 	It("should be able to rotate KMS key for a cluster with version >= 4.22",
 		labels.RequireNothing, labels.High, labels.Positive, labels.AroRpApiCompatible, labels.Slow,
 		func(ctx context.Context) {
@@ -83,10 +80,10 @@ var _ = Describe("Customer", func() {
 				framework.ClusterCreationTimeout,
 			)
 			if isAPINotDeployedError(err) {
-				if time.Now().Before(timeBombDeadline) {
-					Skip(fmt.Sprintf("v20260630preview API not yet deployed; skipping until %s", timeBombDeadline.Format(time.RFC3339)))
+				if time.Now().Before(framework.V20260630PreviewDeploymentDeadline) {
+					Skip(fmt.Sprintf("v20260630preview API not yet deployed; skipping until %s", framework.V20260630PreviewDeploymentDeadline.Format(time.RFC3339)))
 				}
-				Fail(fmt.Sprintf("v20260630preview API still not deployed as of %s deadline", timeBombDeadline.Format(time.RFC3339)))
+				Fail(fmt.Sprintf("v20260630preview API still not deployed as of %s deadline", framework.V20260630PreviewDeploymentDeadline.Format(time.RFC3339)))
 			}
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster for KMS key rotation test")
 

--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -45,3 +45,6 @@ const (
 const (
 	IdentityContainerAssignmentRetryInterval = 60 * time.Second
 )
+
+// API version deployment deadlines (timebombs)
+var V20260630PreviewDeploymentDeadline = Must(time.Parse(time.RFC3339, "2026-08-07T00:00:00Z"))


### PR DESCRIPTION
## Summary
- Extends the v20260630preview API deployment timebomb deadlines from 2026-07-31 to 2026-08-07 in two E2E tests (`cluster_create_private_ingress` and `kms_key_rotation`) to match the updated API rollout timeline.

## Test plan
- [ ] Verify CI passes with updated deadlines
- [ ] Confirm alignment with `cluster_fips_mode.go` which already uses the 2026-08-07 deadline

🤖 Generated with [Claude Code](https://claude.com/claude-code)