### PR TITLE
feat(cleanup-sweeper): allow a dedicated Graph credential for directory reads (AROSLSRE-1544)

### DIFF
--- a/tooling/cleanup-sweeper/cmd/root/options.go
+++ b/tooling/cleanup-sweeper/cmd/root/options.go
@@ -180,9 +180,16 @@ func (o *ValidatedOptions) Complete(_ context.Context) (*Options, error) {
 		return nil, fmt.Errorf("failed to create Azure credential: %w", err)
 	}
 
-	graphCred, err := newGraphCredential(cred)
-	if err != nil {
-		return nil, err
+	// Only the shared-leftovers workflow performs Microsoft Graph directory
+	// reads, so resolve the (optionally dedicated) Graph credential only then.
+	// This keeps a partial GRAPH_AZURE_* configuration from failing workflows
+	// that never touch Graph (for example, rg-ordered).
+	var graphCred azcore.TokenCredential = cred
+	if o.workflow == WorkflowSharedLeftovers {
+		graphCred, err = newGraphCredential(cred)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &Options{

--- a/tooling/cleanup-sweeper/cmd/root/options.go
+++ b/tooling/cleanup-sweeper/cmd/root/options.go
@@ -267,7 +267,7 @@ func (o *Options) Run(ctx context.Context) error {
 func newGraphCredential(fallback azcore.TokenCredential) (azcore.TokenCredential, error) {
 	tenantID := strings.TrimSpace(os.Getenv("GRAPH_AZURE_TENANT_ID"))
 	clientID := strings.TrimSpace(os.Getenv("GRAPH_AZURE_CLIENT_ID"))
-	clientSecret := os.Getenv("GRAPH_AZURE_CLIENT_SECRET")
+	clientSecret := strings.TrimSpace(os.Getenv("GRAPH_AZURE_CLIENT_SECRET"))
 
 	if tenantID == "" && clientID == "" && clientSecret == "" {
 		return fallback, nil

--- a/tooling/cleanup-sweeper/cmd/root/options.go
+++ b/tooling/cleanup-sweeper/cmd/root/options.go
@@ -17,6 +17,7 @@ package root
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -95,6 +96,11 @@ type ValidatedOptions struct {
 
 type completedOptions struct {
 	AzureCredential azcore.TokenCredential
+	// GraphCredential is used exclusively for Microsoft Graph directory reads
+	// by the shared-leftovers workflow. It defaults to AzureCredential unless a
+	// dedicated Graph identity is supplied via the GRAPH_AZURE_* environment
+	// variables.
+	GraphCredential azcore.TokenCredential
 	Policy          *policy.Policy
 
 	Workflow WorkflowMode
@@ -174,9 +180,15 @@ func (o *ValidatedOptions) Complete(_ context.Context) (*Options, error) {
 		return nil, fmt.Errorf("failed to create Azure credential: %w", err)
 	}
 
+	graphCred, err := newGraphCredential(cred)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Options{
 		completedOptions: &completedOptions{
 			AzureCredential: cred,
+			GraphCredential: graphCred,
 			Policy:          o.policy,
 			Workflow:        o.workflow,
 			SubscriptionID:  subscriptionID,
@@ -223,6 +235,7 @@ func (o *Options) Run(ctx context.Context) error {
 		err := sharedworkflow.Run(ctx, sharedworkflow.RunOptions{
 			SubscriptionID:  o.SubscriptionID,
 			AzureCredential: o.AzureCredential,
+			GraphCredential: o.GraphCredential,
 			DryRun:          o.DryRun,
 			Wait:            o.Wait,
 			Parallelism:     o.Parallelism,
@@ -236,6 +249,31 @@ func (o *Options) Run(ctx context.Context) error {
 
 	logger.Info("Completed cleanup-sweeper")
 	return nil
+}
+
+// newGraphCredential returns the credential used for Microsoft Graph directory
+// reads. When the GRAPH_AZURE_TENANT_ID, GRAPH_AZURE_CLIENT_ID and
+// GRAPH_AZURE_CLIENT_SECRET environment variables are all set, a dedicated
+// client-secret credential is built for that identity (allowing directory read
+// permissions to be supplied by a different service principal than the one used
+// for ARM). Otherwise it falls back to the provided ARM credential.
+func newGraphCredential(fallback azcore.TokenCredential) (azcore.TokenCredential, error) {
+	tenantID := strings.TrimSpace(os.Getenv("GRAPH_AZURE_TENANT_ID"))
+	clientID := strings.TrimSpace(os.Getenv("GRAPH_AZURE_CLIENT_ID"))
+	clientSecret := os.Getenv("GRAPH_AZURE_CLIENT_SECRET")
+
+	if tenantID == "" && clientID == "" && clientSecret == "" {
+		return fallback, nil
+	}
+	if tenantID == "" || clientID == "" || clientSecret == "" {
+		return nil, fmt.Errorf("GRAPH_AZURE_TENANT_ID, GRAPH_AZURE_CLIENT_ID and GRAPH_AZURE_CLIENT_SECRET must all be set to use a dedicated Graph credential")
+	}
+
+	cred, err := azidentity.NewClientSecretCredential(tenantID, clientID, clientSecret, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dedicated Graph credential: %w", err)
+	}
+	return cred, nil
 }
 
 func parseWorkflowMode(raw string) (WorkflowMode, error) {

--- a/tooling/cleanup-sweeper/cmd/root/options_test.go
+++ b/tooling/cleanup-sweeper/cmd/root/options_test.go
@@ -20,6 +20,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azpolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
 const testPolicyYAML = `
@@ -120,4 +123,59 @@ func writePolicyFile(t *testing.T) string {
 		t.Fatalf("failed to write policy file: %v", err)
 	}
 	return path
+}
+
+type fakeTokenCredential struct{}
+
+func (fakeTokenCredential) GetToken(context.Context, azpolicy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{}, nil
+}
+
+func TestNewGraphCredential(t *testing.T) {
+	fallback := fakeTokenCredential{}
+
+	t.Run("falls back when no GRAPH_AZURE_* variables are set", func(t *testing.T) {
+		t.Setenv("GRAPH_AZURE_TENANT_ID", "")
+		t.Setenv("GRAPH_AZURE_CLIENT_ID", "")
+		t.Setenv("GRAPH_AZURE_CLIENT_SECRET", "")
+
+		got, err := newGraphCredential(fallback)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if got != fallback {
+			t.Fatalf("expected fallback credential to be returned")
+		}
+	})
+
+	t.Run("errors when GRAPH_AZURE_* variables are partially set", func(t *testing.T) {
+		t.Setenv("GRAPH_AZURE_TENANT_ID", "00000000-0000-0000-0000-000000000000")
+		t.Setenv("GRAPH_AZURE_CLIENT_ID", "")
+		t.Setenv("GRAPH_AZURE_CLIENT_SECRET", "secret")
+
+		_, err := newGraphCredential(fallback)
+		if err == nil {
+			t.Fatalf("expected error for partial configuration")
+		}
+		if !strings.Contains(err.Error(), "must all be set") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("builds a dedicated credential when all GRAPH_AZURE_* variables are set", func(t *testing.T) {
+		t.Setenv("GRAPH_AZURE_TENANT_ID", "00000000-0000-0000-0000-000000000000")
+		t.Setenv("GRAPH_AZURE_CLIENT_ID", "11111111-1111-1111-1111-111111111111")
+		t.Setenv("GRAPH_AZURE_CLIENT_SECRET", "secret")
+
+		got, err := newGraphCredential(fallback)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if got == nil {
+			t.Fatalf("expected a credential")
+		}
+		if got == azcore.TokenCredential(fallback) {
+			t.Fatalf("expected a dedicated credential, not the fallback")
+		}
+	})
 }

--- a/tooling/cleanup-sweeper/cmd/workflow/shared/run.go
+++ b/tooling/cleanup-sweeper/cmd/workflow/shared/run.go
@@ -29,6 +29,9 @@ import (
 type RunOptions struct {
 	SubscriptionID  string
 	AzureCredential azcore.TokenCredential
+	// GraphCredential is used exclusively for Microsoft Graph directory reads.
+	// When nil it defaults to AzureCredential.
+	GraphCredential azcore.TokenCredential
 
 	DryRun      bool
 	Wait        bool
@@ -47,6 +50,7 @@ func Run(ctx context.Context, opts RunOptions) error {
 		ctx,
 		opts.SubscriptionID,
 		opts.AzureCredential,
+		opts.GraphCredential,
 		cleanupengine.WorkflowOptions{
 			DryRun:      opts.DryRun,
 			Wait:        opts.Wait,

--- a/tooling/cleanup-sweeper/pkg/engine/role_assignments_sweeper.go
+++ b/tooling/cleanup-sweeper/pkg/engine/role_assignments_sweeper.go
@@ -35,10 +35,16 @@ const (
 )
 
 // RoleAssignmentsSweeperWorkflow builds the shared-leftovers cleanup workflow.
+//
+// credential backs the ARM clients (role assignments, key vaults, resource
+// groups). graphCredential is used exclusively for the Microsoft Graph
+// directory reads performed by the orphaned role-assignment step; when nil it
+// defaults to credential, preserving single-identity behavior.
 func RoleAssignmentsSweeperWorkflow(
 	_ context.Context,
 	subscriptionID string,
 	credential azcore.TokenCredential,
+	graphCredential azcore.TokenCredential,
 	opts WorkflowOptions,
 ) (*runner.Engine, error) {
 	if strings.TrimSpace(subscriptionID) == "" {
@@ -46,6 +52,9 @@ func RoleAssignmentsSweeperWorkflow(
 	}
 	if credential == nil {
 		return nil, fmt.Errorf("azure credential is required")
+	}
+	if graphCredential == nil {
+		graphCredential = credential
 	}
 
 	clientOptions := normalizeARMClientOptions(opts.ClientOptions)
@@ -78,7 +87,7 @@ func RoleAssignmentsSweeperWorkflow(
 		Steps: []runner.Step{
 			roleassignmentsteps.MustNewDeleteOrphanedStep(roleassignmentsteps.DeleteOrphanedStepConfig{
 				RoleAssignmentsClient:       roleAssignmentsClient,
-				AzureCredential:             credential,
+				GraphCredential:             graphCredential,
 				SubscriptionID:              subscriptionID,
 				Name:                        "Delete orphaned role assignments",
 				Retries:                     orphanedRoleAssignmentStepRetries,

--- a/tooling/cleanup-sweeper/pkg/engine/role_assignments_sweeper.go
+++ b/tooling/cleanup-sweeper/pkg/engine/role_assignments_sweeper.go
@@ -59,6 +59,11 @@ func RoleAssignmentsSweeperWorkflow(
 
 	clientOptions := normalizeARMClientOptions(opts.ClientOptions)
 
+	graphClient, err := roleassignmentsteps.NewGraphClient(graphCredential)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create graph client: %w", err)
+	}
+
 	roleAssignmentsClient, err := armauthorization.NewRoleAssignmentsClient(subscriptionID, credential, clientOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create role assignments client: %w", err)
@@ -87,7 +92,7 @@ func RoleAssignmentsSweeperWorkflow(
 		Steps: []runner.Step{
 			roleassignmentsteps.MustNewDeleteOrphanedStep(roleassignmentsteps.DeleteOrphanedStepConfig{
 				RoleAssignmentsClient:       roleAssignmentsClient,
-				GraphCredential:             graphCredential,
+				GraphClient:                 graphClient,
 				SubscriptionID:              subscriptionID,
 				Name:                        "Delete orphaned role assignments",
 				Retries:                     orphanedRoleAssignmentStepRetries,

--- a/tooling/cleanup-sweeper/pkg/engine/steps/roleassignments/delete.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/roleassignments/delete.go
@@ -49,8 +49,12 @@ const (
 // DeleteOrphanedStepConfig configures orphaned role-assignment cleanup.
 type DeleteOrphanedStepConfig struct {
 	RoleAssignmentsClient *armauthorization.RoleAssignmentsClient
-	AzureCredential       azcore.TokenCredential
-	SubscriptionID        string
+	// GraphCredential is used exclusively for Microsoft Graph directory reads
+	// (the orphaned-principal preflight and getByIds resolution). It may differ
+	// from the credential backing RoleAssignmentsClient so that directory read
+	// permissions (Directory.Read.All) can be supplied by a separate identity.
+	GraphCredential azcore.TokenCredential
+	SubscriptionID  string
 
 	Name                        string
 	Retries                     int
@@ -73,8 +77,8 @@ func NewDeleteOrphanedStep(cfg DeleteOrphanedStepConfig) (runner.Step, error) {
 	if cfg.RoleAssignmentsClient == nil {
 		return nil, fmt.Errorf("role assignments client is required")
 	}
-	if cfg.AzureCredential == nil {
-		return nil, fmt.Errorf("azure credential is required")
+	if cfg.GraphCredential == nil {
+		return nil, fmt.Errorf("graph credential is required")
 	}
 	if strings.TrimSpace(cfg.SubscriptionID) == "" {
 		return nil, fmt.Errorf("subscription ID is required")
@@ -129,7 +133,7 @@ func (s *deleteOrphanedStep) Discover(ctx context.Context) ([]runner.Target, err
 	return discoverOrphanedRoleAssignments(
 		ctx,
 		s.cfg.RoleAssignmentsClient,
-		s.cfg.AzureCredential,
+		s.cfg.GraphCredential,
 		s.cfg.SubscriptionID,
 	)
 }
@@ -153,7 +157,7 @@ func (s *deleteOrphanedStep) Delete(ctx context.Context, target runner.Target, _
 func discoverOrphanedRoleAssignments(
 	ctx context.Context,
 	roleAssignmentsClient *armauthorization.RoleAssignmentsClient,
-	azureCredential azcore.TokenCredential,
+	graphCredential azcore.TokenCredential,
 	subscriptionID string,
 ) ([]runner.Target, error) {
 	logger, err := logr.FromContext(ctx)
@@ -166,15 +170,15 @@ func discoverOrphanedRoleAssignments(
 	if roleAssignmentsClient == nil {
 		return nil, fmt.Errorf("role assignments client is required")
 	}
-	if azureCredential == nil {
-		return nil, fmt.Errorf("azure credential is required")
+	if graphCredential == nil {
+		return nil, fmt.Errorf("graph credential is required")
 	}
 	subscriptionID = strings.TrimSpace(subscriptionID)
 	if subscriptionID == "" {
 		return nil, fmt.Errorf("subscription ID is required")
 	}
 
-	graphClient, err := newGraphClient(azureCredential)
+	graphClient, err := newGraphClient(graphCredential)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", preflightFailureMessage, err)
 	}

--- a/tooling/cleanup-sweeper/pkg/engine/steps/roleassignments/delete.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/roleassignments/delete.go
@@ -49,12 +49,13 @@ const (
 // DeleteOrphanedStepConfig configures orphaned role-assignment cleanup.
 type DeleteOrphanedStepConfig struct {
 	RoleAssignmentsClient *armauthorization.RoleAssignmentsClient
-	// GraphCredential is used exclusively for Microsoft Graph directory reads
-	// (the orphaned-principal preflight and getByIds resolution). It may differ
-	// from the credential backing RoleAssignmentsClient so that directory read
-	// permissions (Directory.Read.All) can be supplied by a separate identity.
-	GraphCredential azcore.TokenCredential
-	SubscriptionID  string
+	// GraphClient performs the Microsoft Graph directory reads (the
+	// orphaned-principal preflight and getByIds resolution). It is built from a
+	// credential that may differ from the one backing RoleAssignmentsClient, so
+	// that directory read permissions (Directory.Read.All) can be supplied by a
+	// separate identity. Build it with NewGraphClient.
+	GraphClient    *msgraphsdk.GraphServiceClient
+	SubscriptionID string
 
 	Name                        string
 	Retries                     int
@@ -77,8 +78,8 @@ func NewDeleteOrphanedStep(cfg DeleteOrphanedStepConfig) (runner.Step, error) {
 	if cfg.RoleAssignmentsClient == nil {
 		return nil, fmt.Errorf("role assignments client is required")
 	}
-	if cfg.GraphCredential == nil {
-		return nil, fmt.Errorf("graph credential is required")
+	if cfg.GraphClient == nil {
+		return nil, fmt.Errorf("graph client is required")
 	}
 	if strings.TrimSpace(cfg.SubscriptionID) == "" {
 		return nil, fmt.Errorf("subscription ID is required")
@@ -133,7 +134,7 @@ func (s *deleteOrphanedStep) Discover(ctx context.Context) ([]runner.Target, err
 	return discoverOrphanedRoleAssignments(
 		ctx,
 		s.cfg.RoleAssignmentsClient,
-		s.cfg.GraphCredential,
+		s.cfg.GraphClient,
 		s.cfg.SubscriptionID,
 	)
 }
@@ -157,7 +158,7 @@ func (s *deleteOrphanedStep) Delete(ctx context.Context, target runner.Target, _
 func discoverOrphanedRoleAssignments(
 	ctx context.Context,
 	roleAssignmentsClient *armauthorization.RoleAssignmentsClient,
-	graphCredential azcore.TokenCredential,
+	graphClient *msgraphsdk.GraphServiceClient,
 	subscriptionID string,
 ) ([]runner.Target, error) {
 	logger, err := logr.FromContext(ctx)
@@ -170,17 +171,12 @@ func discoverOrphanedRoleAssignments(
 	if roleAssignmentsClient == nil {
 		return nil, fmt.Errorf("role assignments client is required")
 	}
-	if graphCredential == nil {
-		return nil, fmt.Errorf("graph credential is required")
+	if graphClient == nil {
+		return nil, fmt.Errorf("graph client is required")
 	}
 	subscriptionID = strings.TrimSpace(subscriptionID)
 	if subscriptionID == "" {
 		return nil, fmt.Errorf("subscription ID is required")
-	}
-
-	graphClient, err := newGraphClient(graphCredential)
-	if err != nil {
-		return nil, fmt.Errorf("%s: %w", preflightFailureMessage, err)
 	}
 
 	// Mandatory and unconditional preflight. If this fails, we fail closed
@@ -243,7 +239,11 @@ func discoverOrphanedRoleAssignments(
 	return targets, nil
 }
 
-func newGraphClient(azureCredential azcore.TokenCredential) (*msgraphsdk.GraphServiceClient, error) {
+// NewGraphClient builds a Microsoft Graph client from the given credential. It
+// is used by the workflow to construct the Graph client once and pass it to the
+// orphaned role-assignment step, keeping client construction alongside the ARM
+// clients rather than inside the step.
+func NewGraphClient(azureCredential azcore.TokenCredential) (*msgraphsdk.GraphServiceClient, error) {
 	authProvider, err := kiotaauth.NewAzureIdentityAuthenticationProviderWithScopes(
 		azureCredential,
 		[]string{graphScope},

--- a/tooling/cleanup-sweeper/pkg/engine/steps/roleassignments/delete_test.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/roleassignments/delete_test.go
@@ -78,7 +78,7 @@ func TestMustNewDeleteOrphanedStep_PanicsWhenInvalid(t *testing.T) {
 	t.Parallel()
 
 	cfg := validDeleteOrphanedStepConfig()
-	cfg.AzureCredential = nil
+	cfg.GraphCredential = nil
 
 	defer func() {
 		if recover() == nil {
@@ -200,7 +200,7 @@ func strPtr(value string) *string { return &value }
 func validDeleteOrphanedStepConfig() DeleteOrphanedStepConfig {
 	return DeleteOrphanedStepConfig{
 		RoleAssignmentsClient: &armauthorization.RoleAssignmentsClient{},
-		AzureCredential:       roleAssignmentsTestCredential{},
+		GraphCredential:       roleAssignmentsTestCredential{},
 		SubscriptionID:        "00000000-0000-0000-0000-000000000000",
 	}
 }

--- a/tooling/cleanup-sweeper/pkg/engine/steps/roleassignments/delete_test.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/roleassignments/delete_test.go
@@ -15,14 +15,12 @@
 package roleassignments
 
 import (
-	"context"
 	"testing"
-	"time"
 
 	"github.com/go-logr/logr"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"
 
 	"github.com/Azure/ARO-HCP/tooling/cleanup-sweeper/pkg/engine/steps/common"
@@ -78,7 +76,7 @@ func TestMustNewDeleteOrphanedStep_PanicsWhenInvalid(t *testing.T) {
 	t.Parallel()
 
 	cfg := validDeleteOrphanedStepConfig()
-	cfg.GraphCredential = nil
+	cfg.GraphClient = nil
 
 	defer func() {
 		if recover() == nil {
@@ -200,13 +198,7 @@ func strPtr(value string) *string { return &value }
 func validDeleteOrphanedStepConfig() DeleteOrphanedStepConfig {
 	return DeleteOrphanedStepConfig{
 		RoleAssignmentsClient: &armauthorization.RoleAssignmentsClient{},
-		GraphCredential:       roleAssignmentsTestCredential{},
+		GraphClient:           &msgraphsdk.GraphServiceClient{},
 		SubscriptionID:        "00000000-0000-0000-0000-000000000000",
 	}
-}
-
-type roleAssignmentsTestCredential struct{}
-
-func (roleAssignmentsTestCredential) GetToken(context.Context, policy.TokenRequestOptions) (azcore.AccessToken, error) {
-	return azcore.AccessToken{Token: "token", ExpiresOn: time.Now().Add(time.Hour)}, nil
 }

--- a/tooling/cleanup-sweeper/pkg/engine/steps/roleassignments/delete_test.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/roleassignments/delete_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-
 	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"

--- a/tooling/cleanup-sweeper/pkg/engine/workflows_test.go
+++ b/tooling/cleanup-sweeper/pkg/engine/workflows_test.go
@@ -43,6 +43,7 @@ func TestWorkflowBuilders(t *testing.T) {
 					context.Background(),
 					"00000000-0000-0000-0000-000000000000",
 					workflowsTestCredential{},
+					workflowsTestCredential{},
 					WorkflowOptions{
 						DryRun:      true,
 						Wait:        true,

--- a/tooling/cleanup-sweeper/pkg/engine/workflows_test.go
+++ b/tooling/cleanup-sweeper/pkg/engine/workflows_test.go
@@ -69,6 +69,35 @@ func TestWorkflowBuilders(t *testing.T) {
 			},
 		},
 		{
+			name: "role assignments workflow defaults graph credential to arm credential when nil",
+			execute: func(_ *testing.T) (interface{}, error) {
+				return RoleAssignmentsSweeperWorkflow(
+					context.Background(),
+					"00000000-0000-0000-0000-000000000000",
+					workflowsTestCredential{},
+					nil,
+					WorkflowOptions{
+						DryRun:      true,
+						Wait:        true,
+						Parallelism: 7,
+					},
+				)
+			},
+			assertions: func(t *testing.T, workflow interface{}, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("expected no error while building workflow with nil graph credential, got %v", err)
+				}
+				builtWorkflow, ok := workflow.(*runner.Engine)
+				if !ok || builtWorkflow == nil {
+					t.Fatalf("expected *runner.Engine workflow")
+				}
+				if len(builtWorkflow.Steps) != 2 {
+					t.Fatalf("expected two steps, got %d", len(builtWorkflow.Steps))
+				}
+			},
+		},
+		{
 			name: "resource group ordered workflow propagates canceled context",
 			execute: func(_ *testing.T) (interface{}, error) {
 				baseCtx := logr.NewContext(context.Background(), logr.Discard())


### PR DESCRIPTION
Jira: [AROSLSRE-1544](https://redhat.atlassian.net/browse/AROSLSRE-1544)

### What

Allow the cleanup-sweeper to use a separate credential for Microsoft Graph directory reads, distinct from the credential used for ARM (Azure Resource Manager) operations.

The orphaned role-assignment step (`shared-leftovers`) resolves each assignment's principal via Microsoft Graph and fails closed unless the running identity holds directory read permissions (`Directory.Read.All`). Previously the sweeper used a single identity for both ARM and Graph, so every subscription's sweeper identity had to carry a tenant-wide Graph grant.

This change reads `GRAPH_AZURE_TENANT_ID`, `GRAPH_AZURE_CLIENT_ID` and `GRAPH_AZURE_CLIENT_SECRET`; when all three are set it builds a dedicated client-secret credential for Graph. When they are unset it falls back to the ARM credential, preserving the existing single-identity behavior.

### Why

Extending the sweeper's `shared-leftovers` workflow to the INT/STG/PROD e2e customer subscriptions requires directory reads on each. The per-environment CI bots already hold the subscription-scoped roles needed for ARM (RBAC Administrator + Contributor on their own subscriptions) but do not hold `Directory.Read.All`, and that tenant-wide grant cannot be self-served.

Splitting the credential lets each env bot keep doing ARM on its own subscription while an identity that already holds `Directory.Read.All` in the same tenant supplies only the directory reads, avoiding a new tenant-wide grant per bot.

### Testing

- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `go test ./...` passes, including a new `TestNewGraphCredential` covering: fallback to the ARM credential when `GRAPH_AZURE_*` are unset, an error on partial configuration, and a dedicated credential when all three are set.

### Special notes for your reviewer

Backward-compatible: the existing single-identity sweeper job is unaffected because both the env-var parsing and the workflow default to the ARM credential when no dedicated Graph credential is provided. The consuming openshift/release job wiring (mounting the Graph-reader secret and exporting `GRAPH_AZURE_*`) is a follow-up change in openshift/release.

### PR Checklist

- [x] Tests added/updated where appropriate
- [x] Backward compatible (no behavior change when `GRAPH_AZURE_*` is unset)