### PR TITLE
chore(openshift-ci): add script to manage MSI mock pool app owners

### DIFF
--- a/dev-infrastructure/openshift-ci/add-msi-mock-pool-owners.sh
+++ b/dev-infrastructure/openshift-ci/add-msi-mock-pool-owners.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+MSI_MOCK_POOL_SIZE="${MSI_MOCK_POOL_SIZE:-20}"
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <owner-email-or-object-id> [<owner-email-or-object-id> ...]"
+    echo ""
+    echo "Adds one or more owners to all aro-dev-msi-mock-pool-* app registrations."
+    echo ""
+    echo "Examples:"
+    echo "  $0 user@redhat.com"
+    echo "  $0 user1@redhat.com user2@redhat.com"
+    echo "  $0 00000000-0000-0000-0000-000000000000"
+    exit 1
+fi
+
+OWNER_OBJECT_IDS=()
+for OWNER_ARG in "$@"; do
+    if [[ "$OWNER_ARG" == *"@"* ]]; then
+        echo "Resolving ${OWNER_ARG} to object ID..."
+        OID=$(az ad user show --id "$OWNER_ARG" --query id -o tsv)
+        if [ -z "$OID" ]; then
+            echo "ERROR: Could not resolve user '${OWNER_ARG}'"
+            exit 1
+        fi
+        echo "  -> ${OID}"
+        OWNER_OBJECT_IDS+=("$OID")
+    else
+        OWNER_OBJECT_IDS+=("$OWNER_ARG")
+    fi
+done
+
+for i in $(seq 0 $((MSI_MOCK_POOL_SIZE - 1))); do
+    APP_NAME="aro-dev-msi-mock-pool-${i}"
+    APP_OBJECT_ID=$(az ad app list --filter "displayName eq '${APP_NAME}'" --query '[0].id' -o tsv)
+
+    if [ -z "$APP_OBJECT_ID" ]; then
+        echo "WARN: App '${APP_NAME}' not found, skipping"
+        continue
+    fi
+
+    for OID in "${OWNER_OBJECT_IDS[@]}"; do
+        echo "Adding owner ${OID} to ${APP_NAME}..."
+        if ! OUTPUT=$(az ad app owner add --id "$APP_OBJECT_ID" --owner-object-id "$OID" 2>&1); then
+            echo "  WARN: Failed to add owner to ${APP_NAME}: ${OUTPUT}"
+        fi
+    done
+done
+
+echo "Done."


### PR DESCRIPTION
## What

Adds `dev-infrastructure/openshift-ci/add-msi-mock-pool-owners.sh` which:
- Accepts one or more email addresses or object IDs as arguments
- Resolves emails to Azure AD object IDs automatically
- Iterates over all MSI mock pool app registrations and adds the specified owners
- Reports actual error messages on failure rather than silently swallowing them

## Why

There's currently no easy way to bulk-add owners to the `aro-dev-msi-mock-pool-*`
app registrations in Azure AD. When onboarding team members or rotating ownership,
this has to be done manually for each of the 20 apps.

## Usage

```bash
./dev-infrastructure/openshift-ci/add-msi-mock-pool-owners.sh user@redhat.com
```

### Testing

Tested locally by adding user @roivaz.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
