### PR TITLE
chore(config): bump clusters-service image digest

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1032,7 +1032,7 @@ defaults:
     image:
       registry: quay.io
       repository: app-sre/aro-hcp-clusters-service
-      digest: sha256:1ca0a2b39872d87b89505fc1ed549110b4cf09a7c79b9dd6351f0d8efab2d5e4 # ed6a71e9b466739c9edd6ba69b2c35ee9587a6bc (2026-07-22 08:06)
+      digest: sha256:55bcc0e8e5f1e455e18369f757fa750984f653ea17bac5e9b2ca6f402934165c # ed6a71e9b466739c9edd6ba69b2c35ee9587a6bc (2026-07-27 08:21)
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci00
   image:
-    digest: sha256:1ca0a2b39872d87b89505fc1ed549110b4cf09a7c79b9dd6351f0d8efab2d5e4
+    digest: sha256:55bcc0e8e5f1e455e18369f757fa750984f653ea17bac5e9b2ca6f402934165c
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci01
   image:
-    digest: sha256:1ca0a2b39872d87b89505fc1ed549110b4cf09a7c79b9dd6351f0d8efab2d5e4
+    digest: sha256:55bcc0e8e5f1e455e18369f757fa750984f653ea17bac5e9b2ca6f402934165c
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:1ca0a2b39872d87b89505fc1ed549110b4cf09a7c79b9dd6351f0d8efab2d5e4
+    digest: sha256:55bcc0e8e5f1e455e18369f757fa750984f653ea17bac5e9b2ca6f402934165c
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:1ca0a2b39872d87b89505fc1ed549110b4cf09a7c79b9dd6351f0d8efab2d5e4
+    digest: sha256:55bcc0e8e5f1e455e18369f757fa750984f653ea17bac5e9b2ca6f402934165c
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:1ca0a2b39872d87b89505fc1ed549110b4cf09a7c79b9dd6351f0d8efab2d5e4
+    digest: sha256:55bcc0e8e5f1e455e18369f757fa750984f653ea17bac5e9b2ca6f402934165c
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:1ca0a2b39872d87b89505fc1ed549110b4cf09a7c79b9dd6351f0d8efab2d5e4
+    digest: sha256:55bcc0e8e5f1e455e18369f757fa750984f653ea17bac5e9b2ca6f402934165c
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:


### PR DESCRIPTION
## What

Bumps the pinned `clustersService` image digest from `sha256:1ca0a2b3…` (2026-07-22) to the current `latest` `sha256:55bcc0e8…` (2026-07-27), plus the regenerated dev rendered configs.

## Why

The old digest has been garbage-collected from `quay.io/app-sre/aro-hcp-clusters-service`. Every `e2e-parallel` run mirrors that image in the `aro-hcp-provision-environment` pre-step and dies fleet-wide with:

```
Error response from registry: failed to resolve sha256:1ca0a2b3…:
quay.io/app-sre/aro-hcp-clusters-service@sha256:1ca0a2b3…: not found
```

Confirmed on multiple open PRs (#6277, #6272, #6271) with the identical signature, so it is not a flake. The automated digest-updater PR (#6272) did not pick CS up. The new digest has the same source commit (`ed6a71e9`); it is just a fresh rebuild republished under `latest`.

## How

```
AZURE_TOKEN_CREDENTIALS=dev ./image-updater update --config config.yaml --tags --groups cs
make -C config materialize
```

## Testing

- `make -C config materialize` regenerated the 6 dev rendered configs; helmtest passed.
- Diff is the CS digest line only (config.yaml + 6 rendered files).