### PR TITLE
refactor(dev-infra): share constrained RBAC-Admin ABAC condition

### DIFF
--- a/dev-infrastructure/modules/common.bicep
+++ b/dev-infrastructure/modules/common.bicep
@@ -456,3 +456,18 @@ func safeTake(input string, maxLength int) string =>
     ))
     ? take(take(input, maxLength), length(take(input, maxLength)) - 1)
     : take(input, maxLength)
+
+// Highly privileged built-in role definition IDs that must never be sub-assigned
+// by a constrained RBAC Administrator (Owner, User Access Administrator, RBAC Administrator).
+var _ownerRoleDefinitionId = '8e3af657-a8ff-443c-a75c-2fe8c4bcb635'
+var _userAccessAdminRoleDefinitionId = '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
+var _rbacAdminRoleDefinitionId = 'f58310d9-a9f6-439a-9e8d-f62e7b41a168'
+
+// ABAC condition (v2.0) restricting a role assignment so the grantee can create/delete
+// role assignments for any role EXCEPT the three privileged roles above. Shared verbatim
+// by every constrained RBAC-Administrator grant so the guarded role set stays in sync.
+@export()
+var restrictedRoleAssignmentCondition = '((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/write\'})) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {${_ownerRoleDefinitionId}, ${_userAccessAdminRoleDefinitionId}, ${_rbacAdminRoleDefinitionId}})) AND ((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/delete\'})) OR (@Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {${_ownerRoleDefinitionId}, ${_userAccessAdminRoleDefinitionId}, ${_rbacAdminRoleDefinitionId}}))'
+
+@export()
+var restrictedRoleAssignmentConditionVersion = '2.0'

--- a/dev-infrastructure/templates/ci-bot-rbac-subscription.bicep
+++ b/dev-infrastructure/templates/ci-bot-rbac-subscription.bicep
@@ -1,5 +1,7 @@
 targetScope = 'subscription'
 
+import { restrictedRoleAssignmentCondition, restrictedRoleAssignmentConditionVersion } from '../modules/common.bicep'
+
 @description('Principal ID of the CI bot service principal')
 param botPrincipalId string
 
@@ -12,9 +14,6 @@ param grantAksRbac bool = false
 var contributorRole = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
 var rbacAdminRole = 'f58310d9-a9f6-439a-9e8d-f62e7b41a168'
 var aksRbacClusterAdminRole = 'b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b'
-
-var ownerRole = '8e3af657-a8ff-443c-a75c-2fe8c4bcb635'
-var userAccessAdminRole = '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
 
 var keyVaultAdminRole = '00482a5a-887f-4fb3-b363-3b7fe8e74483'
 var grafanaAdminRole = '22926164-76b3-42b3-bc55-97df8dab3e41'
@@ -36,8 +35,8 @@ resource rbacAdminAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01
     principalId: botPrincipalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', rbacAdminRole)
-    condition: '((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/write\'})) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {${ownerRole}, ${userAccessAdminRole}, ${rbacAdminRole}})) AND ((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/delete\'})) OR (@Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {${ownerRole}, ${userAccessAdminRole}, ${rbacAdminRole}}))'
-    conditionVersion: '2.0'
+    condition: restrictedRoleAssignmentCondition
+    conditionVersion: restrictedRoleAssignmentConditionVersion
     description: 'CI bot: assign all roles except Owner, UAA, RBAC Administrator'
   }
 }

--- a/dev-infrastructure/templates/prow-permissions.bicep
+++ b/dev-infrastructure/templates/prow-permissions.bicep
@@ -1,14 +1,12 @@
 targetScope = 'subscription'
 
+import { restrictedRoleAssignmentCondition, restrictedRoleAssignmentConditionVersion } from '../modules/common.bicep'
+
 @description('The principal ID of the Prow OpenShift Release Bot')
 param prowPrincipalId string
 
 var contributorRole = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
 var userAccessAdminRole = '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
-
-// Privileged roles that must never be assigned
-var ownerRole = '8e3af657-a8ff-443c-a75c-2fe8c4bcb635'
-var rbacAdminRole = 'f58310d9-a9f6-439a-9e8d-f62e7b41a168'
 
 resource contributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(subscription().id, prowPrincipalId, contributorRole)
@@ -27,7 +25,7 @@ resource userAccessAdminRoleAssignment 'Microsoft.Authorization/roleAssignments@
     principalId: prowPrincipalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', userAccessAdminRole)
-    condition: '((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/write\'})) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {${ownerRole}, ${userAccessAdminRole}, ${rbacAdminRole}})) AND ((!(ActionMatches{\'Microsoft.Authorization/roleAssignments/delete\'})) OR (@Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAllValues:GuidNotEquals {${ownerRole}, ${userAccessAdminRole}, ${rbacAdminRole}}))'
-    conditionVersion: '2.0'
+    condition: restrictedRoleAssignmentCondition
+    conditionVersion: restrictedRoleAssignmentConditionVersion
   }
 }


### PR DESCRIPTION
## Why

The constrained "RBAC Administrator" ABAC condition — the one that forbids assigning or removing the privilege-escalation roles (Owner, User Access Administrator, RBAC Administrator) — is duplicated verbatim across `dev-infrastructure` bicep templates, each carrying its own copies of the three privileged role-definition GUIDs. Keeping the guarded role set correct means editing every copy in lockstep, which is error-prone.

## What

- **`modules/common.bicep`**: add an `@export()` `restrictedRoleAssignmentCondition` var (built from local privileged-role GUID vars) plus `restrictedRoleAssignmentConditionVersion`, so the condition and its guarded role set live in one place.
- **`templates/ci-bot-rbac-subscription.bicep`** and **`templates/prow-permissions.bicep`**: import the shared vars and drop their now-unused local `ownerRole` / `userAccessAdminRole` / `rbacAdminRole` copies and the inline condition string.

Pure code-quality cleanup, no functional change: the emitted ARM condition resolves to the same string (same GUIDs, same `format()` output).

## Testing

- `bicep build` compiles clean for `modules/common.bicep`, `ci-bot-rbac-subscription.bicep`, and `prow-permissions.bicep`.
- Verified the compiled condition variable resolves to the exact same string as the previous inline literal (same three privileged role GUIDs in the same positions).

## Jira

[AROSLSRE-1622](https://redhat.atlassian.net/browse/AROSLSRE-1622)
