### PR TITLE
test: add some not-ready pods to known issues

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
@@ -19,3 +19,12 @@ knownIssues:
   reason: "Orphaned MRG cleanup is newly deployed and expected to fire while existing orphans are processed."
 - name: "BackendAsyncOperation.*Stuck"
   reason: "Newly added stuck-async-operation alerts (https://github.com/Azure/ARO-HCP/pull/5952) surface a pre-existing problem: Azure Monitor Workspace ingestion latency (metrics can take ~10min to ingest) makes async operations look stuck and latches onto E2E runs even when the tests pass. Observed blocking green E2E runs (per https://cihealth.tools.hcpsvc.osadev.cloud/run-log?q=BackendAsync): BackendAsyncOperationClusterDeleteStuck, BackendAsyncOperationExternalAuthDeleteStuck, BackendAsyncOperationClusterCreateStuck, BackendAsyncOperationNodePoolDeleteStuck, BackendAsyncOperationNodePoolCreateStuck, BackendAsyncOperationStuck. Owner @stevekuznetsov; durable fix is the AMW auto-scaler (https://github.com/Azure/ARO-HCP/pull/6036). Marked known so it stops blocking the merge queue until that lands."
+- name: "KubePodNotReady"
+  labels:
+    namespace: "klusterlet-.*"
+  reason: "Klusterlet addon pods take a while to start when clusters are slow to provision, so this is a downstream issue and just noise."
+- name: "KubePodNotReady"
+  labels:
+    namespace: "ocm-.*"
+    pod: "(packageserver|olm-operator|catalog-operator)-.*"
+  reason: "OLM pods in hosted control plane namespaces are simply uninteresting to us."


### PR DESCRIPTION
Looking at the last week, we see a few of these alerts firing even when the tests pass, and we do not want this to block CI. `klusterlet-` pods are started before their secrets exist, so if it takes more than 5min for the cluster to come up after the `klusterlet-` pods are down, then we see this fire. OLM pods are simply unreliable and entirely uninteresting to our service. Not even clear why we run them by default, but if they take a while to start it's not a big deal.

---

Using [this tool](https://github.com/stevekuznetsov/ARO-HCP/tree/skuznets/prow-result-cli-poc) we can get a list of Prow jobs in the last week that failed, but ran e2e and had no e2e failures. Any alerts that fired for those are spurious.

Using [this query](https://dataexplorer.azure.com/clusters/hcp-dev-us-2.eastus2/databases/MonitoringEvents?query=H4sIAAAAAAAAA3VYTW%2FkNgy991f4lgToLCTqg1LQ9LJtf0FOe5ud8W5dZDyAx9l%2BoD%2B%2B9EjqQiSdSwaETUmPj49PPr6Ny%2Frrt3Febz%2F8O%2Fz5%2B7iMw5dpGc%2B%2FHNfxdbqMw8%2FDmX6u9PMRDMSDwQPYVwPPFp8BPz0Nx%2FnMXvlJeQVfAZ5DeDbw6en%2FlY7b6h%2Bv8zr%2BtX54O34e324fTm%2Fvt3VchmkeHh9Ok7GHP4JzwcZ0uHy9rAf78ONQ4xgjgjGH27fT92CEGCN48XCy6LxnDwfILlDmLmgi5JR2gjxtRGs9LdenrRvugg4wORf5BqI1gQUTRBcTP5cP1iD0wewxZAUZWh5jjiJuwMcAbGPZhpgzyxwSWGdZ0CfrfZTYYnaU2fBTJAt2fw%2BiQBkRxKltMuhkEhc9eqUcKcEdOvE8ZIgcvZAwCP4gHTA5UDLEbEFmNjaD5ZDSQSjMAakMlBmS2fDncZv8tqSIE2cQlXiuJRPxEFLmpbQpBHAs2HbSbzvQn3ZwjGB52hYUbVLr2HdEdk5wLJoYglLx7MCgkdwjlEyUfR0wJ0UEKsfE9hya7OXzremkmLhMNGGLep%2B3RbsgJExayzhqD68StdCsR9URKJEFvfPO8INnyipwNqQxXqF0O3V%2FCuOIYCxocw5ZAb%2FpDMtARxZtZdELEmIileQkDDYEjd7oLcl15Bk2DLhoIICAq3WB6KZEAh4UmSJt3cRBHjl4jSrEbwzakPKBaq1oZpUI2d2Fuj3%2BJseN%2FKyFiz6oYs7TAtpoOSaNGD1jrbkP0B5nRzApu23jb0%2BHWYNQVXixLPVSVMjZNiz6PRNtkdOgbq8%2FiCHp4qAZS%2FOWSxxN0aBxoA1iHr8PMH4QR7PRKRBlbZK2bYjMBlwyQlgKboKKGYN4uPGNeY8y%2FpRRcrcfUlRLUfokgSSHZ27MFMTYolxGmgjsTfO%2BfJhzVPwDiYMRPqpZwb0uVjMz3Iq87PFNZKZaBzG86qmlCBRTwfzApkme9y%2BJstJQTdgFdOiyNp2bJdvbtshf11U7SGqm7jTa7O4ZAjRSlCTNTKriz6yvB6FIbSQxR1fEXJ0ye%2B0jISrTVihSFUbFCCEqE6HNwb1J0de92pteJejWkbjNaN5DpK0%2BTTXhqu%2BVXZ%2B3FEwbcwpJkQgyb0H0bHN0ghj1UqaOaWmBykVpz2kLqlcPIPEvTkYes1hfOdmLvok81dftWTiOQNAuJo0kfSGqlInWqPOI3SkQHK9vcyN90TMhxZ1Ss4t7AqL2LJvUhR7SJJf2lCoRVClrrN5z8pLYsJkJcXFGIRRtekqvVaDbyyzHYvksIESyXrfZlcdZAWDrGlXw9%2BzEHoCqzVD3IO87hQlCyuqtZEvy%2FXPM5TpP63X5eJ3P0zpd5%2BHlZXj4bfu080DP3N4vl%2BMy%2FTMOp%2Bv7vA4v5f%2Fj0%2FD57%2FIl52W93tZlmr8%2Bah927rH5eBm3Ba%2FLeVy2F0uu83g7%2FQcH2%2B6EixIAAA%3D%3D) we can see what alerts fired for them:

| alert | count |
| - | - |
| KubePodNotReady | 608 |
| CPUThrottlingHigh | 275 |
| OrphanedMRGDetected | 75 |
| MiseEnvoyScrapeDown | 72 |
| PrometheusOperatorRejectedResources | 42 |
| BackendControllerQueueDepthHigh | 16 |
| UJNodePoolSaturationQueueDepth | 6 |
| KustoLogsDataStale | 4 |
| BackendAsyncOperationClusterCreateStuck | 3 |
| KubeContainerOOMKilled | 2 |
| BackendAsyncOperationExternalAuthDeleteStuck | 1 |
| FluentBitIngestionPaused | 1 |
| KubePodCrashLooping | 1 |
| BackendAsyncOperationCredentialRevokeStuck | 1 |

Using [this query](https://dataexplorer.azure.com/clusters/hcp-dev-us-2.eastus2/databases/MonitoringEvents?query=H4sIAAAAAAAAA41Y227bRhB991cQRgFLjejs%2FWIkQYCmTwWCoslTmjZgxLWlVhINkk6ctPn3DrXcyJxZJvWLpfHu7MzsmTNnXe1C2%2F%2F8IRz67uzf4uMmtKG43rahflH14fV2H4pnRQ0fe%2Fi4EEyYktlS8NdMXHF7JeybZVEdarTlSWaLfS3EldZXTLxZfj2pGk7%2FqTn04b6%2F3FXvw667XO%2Fuuj60xfZQLC7WW8bLv7SUmhtX7m%2F2fckvVsVot8ZYwVjZfVifjEYYY4Qiix23Uim0WAsvNXieGJkR3rkZI3ZrLOcKjpu6HQOeGKWwTkqDAzCcaWR0wkjjcF5Kc2bF1OiV1T5TGTjeGm%2BInQlltECBea6N98izdoJLjozKcaUMra31EjwznIXjgs%2FHQC7IWytI1twxK6kTaZRVmetwThxLR9YLLwyunnZWE%2FxYSNBJkfFgPBfUM%2BNecFxSSATMuCAjAqkHx4b6Yzt3ajiS2AEz1mbsfrwyYtfaeXyV3GktJDKmSKZha%2FjJJW6N4NhtMpI2Ge9x2hFeSoIxw4zWmRv3UjDLKPagSszQvtbWuwwJjBgj4UnLvKLrU9NRMpEeYIIOVcoPh06MwlmXaxkJ7aGyQI0wm1ZVQlEMMiqpJMOJe%2FBK6syAY1QG0inraRZMAsCQkXuvfab4iWeQB0iZtBW3ioDQOmBJDELNtc7B2yoOdG2wh6EGmDSsEKRcqQtINzkgcJ2hKeDWgRxoylrloAL4tjo3pJSGu85w5kgRtLsjdKf1Z94M4EctHPkhS%2BbYrbDccFyTBIwpYjk7DtBpnSWUKRNtGn9zPIwaBG4FXxaHXjIZcKaASb97gK3FMBjDmybCgLpw0RiHeYspDqaozmEgDWJsPw4wnIiE2SgzJfK5SZrCIJ6ZkI4RYol1I1D0VpPFCW9Ie8TxlxklR%2FlBSTVeytSJBsrBnhMyCTAGK6aRRAJz03x6fdZ7k9EPQA6M6KgkBee6OOsZ1S3SyxzeiGe4a02G15g1JYEoKpAeGDhJ4f4FUs40VCJ2UjorfW46J0k2FzbxP56b7SDKmXmlkWb3FCECRkrGSRKTWfJH0lcJwkhpJCFFF8k8O2Xm2oeWKE5bwkgjMWaEkLWZiZDm4NykmN77KG%2BmLAGvDodlRtIexO2o07IiPKt7adf7wQXiRu%2B0y1AEiDdNejYpOgKM8VGWHdNUAsWH0pzSJlAfNQCtf1QyNM0ofelkj%2FxG%2FIy6bk7C4Qro3MMkgWR6ESOVkdYY5xF6U1gh8f0mNTK9dA%2BVwkopycU5Asn2LJrUER5UJMf2pCyhs1SWUD2n5CmwxSAmyMPZEqJI05NqrVi6Oc90LMZ%2FCxCSHJ%2Fb6MkjOSlg6pos4c%2FJibkCZmVGNgb63olIIFQ2vkoGJ9%2F%2Bd8zRdqj2oXj6tLj45e59%2BLWpXzb9b6GqP13AVlgbDnUxLOluqzWsK%2Fqm69vt4WaRc%2Fh14fK0%2Bbapv7cNlizPHj8uXjbtvtptP4fTiQ%2BCSH%2Bs3z2MZ111YXFWwM%2FJ2vVV23cft%2F2mOG%2FW%2B7Jqm8369nz18Fv54%2FnqG9v%2Bjv%2Bp2oW%2BHPY9%2BEr2naHYIZurYsj2tqjD7a75tA%2BH%2FnELH7dDsH3R3V1fb%2B9DVyzKJ5uq2zwbfy2Lph2C6MP13e60cFjWtPX2UO2eLbP1iCU%2BVQLCefH15OK26iH0w9Ux4vLJKZByPBy2x4%2FFIlzeXBbXTVNar9f1tXHruvzs3eZ%2BeXQ8HLSv%2BvUGgm%2FDTbgvnp%2F%2Fubh8tCx%2Fr8rPrPR%2F%2FONWnH05fdVffoD6DWdCpd4d9yzAy%2Bp%2Fbnx%2B%2FpZ%2FM%2BTz5Sql%2FGqs3KtAck7le5Ag%2B15Gb%2BtH3wl9XBFjTEekgGDl2XBb3d1%2BX7UDLtbNHdzG0%2Fh7sSzef8pieoVuFnyA79AO66OLOnTr%2FwComBWc3BUAAA%3D%3D) we can see what pods are failing:

| normalized_namespace | normalized_pod | count |
| - | - | - |
| klusterlet-\* | `klusterlet-addon-workmgr-<replicaset-hash>-<pod-hash>` | 240 |
| klusterlet-\* | `governance-policy-framework-<replicaset-hash>-<pod-hash>` | 222 |
| klusterlet-\* | `config-policy-controller-<replicaset-hash>-<pod-hash>` | 222 |
| ocm-arohcp-\* | `packageserver-<replicaset-hash>-<pod-hash>` | 208 |
| clusters-service | `clusters-service-<replicaset-hash>-<pod-hash>` | 74 |
| ocm-arohcp-\* | `olm-operator-<replicaset-hash>-<pod-hash>` | 72 |
| ocm-arohcp-\* | `catalog-operator-<replicaset-hash>-<pod-hash>` | 70 |
| ocm-arohcp-\* | `hosted-cluster-config-operator-<replicaset-hash>-<pod-hash>` | 70 |
| ocm-arohcp-\* | `capi-provider-<replicaset-hash>-<pod-hash>` | 12 |
| maestro | `maestro-<replicaset-hash>-<pod-hash>` | 8 |
| ocm-arohcp-\* | `router-<replicaset-hash>-<pod-hash>` | 6 |
| open-cluster-management-agent-addon | `klusterlet-addon-workmgr-<replicaset-hash>-<pod-hash>` | 3 |
| ocm-arohcp-\* | `kube-apiserver-<replicaset-hash>-<pod-hash>` | 2 |
| klusterlet-\* | `config-policy-controller-f74956-cnj44` | 2 |
| klusterlet-\* | `governance-policy-framework-94bbdb-dlz2c` | 2 |