### PR TITLE
feat(kusto): add entity-groups pipeline step and retain deployer Admin

### DIFF
--- a/dev-infrastructure/geography-pipeline-stg.yaml
+++ b/dev-infrastructure/geography-pipeline-stg.yaml
@@ -60,6 +60,9 @@ resourceGroups:
     template: templates/kusto.bicep
     parameters: configurations/kusto-stg.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    dependsOn:
+    - resourceGroup: global
+      step: output
     automatedRetry:
       errorContainsAny:
       - "InternalServerError"
@@ -153,3 +156,25 @@ resourceGroups:
       step: action-groups
     - resourceGroup: kusto-infra
       step: detach-legacy-monitoring-stack
+  - name: entity-groups
+    action: KustoEntityGroups
+    entityGroups:
+    - "AllServiceLogs:ServiceLogs"
+    - "AllHostedControlPlaneLogs:HostedControlPlaneLogs"
+    - "AllMonitoringEvents:MonitoringEvents"
+    timeout: "10m"
+    identityFrom:
+      resourceGroup: global
+      step: output
+      name: globalMSIId
+    automatedRetry:
+      errorContainsAny:
+      - "InternalServerError"
+      - "Internal server error"
+      - "connection refused"
+      - "context deadline exceeded"
+      maximumRetryCount: 3
+      durationBetweenRetries: 2m
+    dependsOn:
+    - resourceGroup: kusto-infra
+      step: deploy

--- a/dev-infrastructure/geography-pipeline.yaml
+++ b/dev-infrastructure/geography-pipeline.yaml
@@ -89,6 +89,9 @@ resourceGroups:
     template: templates/kusto.bicep
     parameters: configurations/kusto.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    dependsOn:
+    - resourceGroup: global
+      step: output
     automatedRetry:
       errorContainsAny:
       - "InternalServerError"
@@ -182,3 +185,25 @@ resourceGroups:
       step: action-groups
     - resourceGroup: kusto-infra
       step: detach-legacy-monitoring-stack
+  - name: entity-groups
+    action: KustoEntityGroups
+    entityGroups:
+    - "AllServiceLogs:ServiceLogs"
+    - "AllHostedControlPlaneLogs:HostedControlPlaneLogs"
+    - "AllMonitoringEvents:MonitoringEvents"
+    timeout: "10m"
+    identityFrom:
+      resourceGroup: global
+      step: output
+      name: globalMSIId
+    automatedRetry:
+      errorContainsAny:
+      - "InternalServerError"
+      - "Internal server error"
+      - "connection refused"
+      - "context deadline exceeded"
+      maximumRetryCount: 3
+      durationBetweenRetries: 2m
+    dependsOn:
+    - resourceGroup: kusto-infra
+      step: deploy

--- a/dev-infrastructure/geography-pipeline.yaml
+++ b/dev-infrastructure/geography-pipeline.yaml
@@ -87,6 +87,9 @@ resourceGroups:
     template: templates/kusto.bicep
     parameters: configurations/kusto.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    dependsOn:
+    - resourceGroup: global
+      step: output
     automatedRetry:
       errorContainsAny:
       - "InternalServerError"
@@ -180,3 +183,25 @@ resourceGroups:
       step: action-groups
     - resourceGroup: kusto-infra
       step: detach-legacy-monitoring-stack
+  - name: entity-groups
+    action: KustoEntityGroups
+    entityGroups:
+    - "AllServiceLogs:ServiceLogs"
+    - "AllHostedControlPlaneLogs:HostedControlPlaneLogs"
+    - "AllMonitoringEvents:MonitoringEvents"
+    timeout: "10m"
+    identityFrom:
+      resourceGroup: global
+      step: output
+      name: globalMSIId
+    automatedRetry:
+      errorContainsAny:
+      - "InternalServerError"
+      - "Internal server error"
+      - "connection refused"
+      - "context deadline exceeded"
+      maximumRetryCount: 3
+      durationBetweenRetries: 2m
+    dependsOn:
+    - resourceGroup: kusto-infra
+      step: deploy

--- a/dev-infrastructure/modules/logs/kusto/cluster.bicep
+++ b/dev-infrastructure/modules/logs/kusto/cluster.bicep
@@ -66,6 +66,9 @@ resource kusto 'Microsoft.Kusto/clusters@2024-04-13' = {
     name: sku
     tier: tier
   }
+  tags: {
+    aroHCPPurpose: 'logs'
+  }
   identity: {
     type: 'SystemAssigned'
   }

--- a/dev-infrastructure/modules/logs/kusto/main.bicep
+++ b/dev-infrastructure/modules/logs/kusto/main.bicep
@@ -48,8 +48,6 @@ var db = {
 
 var databases = [db.serviceLogs, db.hostedControlPlaneLogs, db.monitoringEvents]
 
-var dummyScript = '.create-or-alter function with (docstring = \'dummy function to run last and to remove permission\') dummyFunction() {print \'dummy\'}'
-
 var allServiceLogsTablesKQL = {
   backendLogs: loadTextContent('tables/backendLogs.kql')
   containerlogs: loadTextContent('tables/containerLogs.kql')
@@ -188,27 +186,12 @@ module databaseUserScripts 'database-users.bicep' = [
   }
 ]
 
-// 5. Remove the caller principal
-// THIS MUST BE THE LAST SCRIPT TO RUN
-module removePermission 'script.bicep' = [
-  for (database, i) in databases: {
-    name: '${database}-removePermission-${i}'
-    params: {
-      kustoName: kustoName
-      databaseName: databases[i]
-      scriptName: 'removePermissionScript'
-      scriptContent: dummyScript
-      principalPermissionsAction: 'RemovePermissionOnScriptCompletion'
-      continueOnErrors: false
-    }
-    dependsOn: [
-      databaseUserScripts
-      serviceLogsTables
-      hostedControlPlaneLogsTables
-      monitoringEventsTables
-    ]
-  }
-]
+// The deploying identity (global MSI) retains Database Admin on all databases
+// from RetainPermissionOnScriptCompletion used by table-creation scripts above.
+// Database Admin is the minimum role for `.create-or-alter entity_group` (Kusto
+// docs). Do not scope down to a lesser role; the entity-groups pipeline step
+// (kustoctl) requires it to sync cross-cluster entity groups on all three
+// databases (ServiceLogs, HostedControlPlaneLogs, MonitoringEvents).
 
 // Outputs mirror original contract
 output id string = cluster.outputs.id

--- a/internal/database/informers/informerutils/changefeed_list_watch.go
+++ b/internal/database/informers/informerutils/changefeed_list_watch.go
@@ -288,7 +288,7 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 	if err != nil {
 		retErr := utils.TrackError(err)
 		utilruntime.HandleError(retErr)
-		c.Stop()
+		c.signalStop()
 		cancel(retErr)
 		return
 	}
@@ -331,7 +331,7 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 			case <-c.done:
 			case <-ctx.Done():
 			}
-			c.Stop()
+			c.signalStop()
 			return
 		}
 	}(ctx)
@@ -469,6 +469,11 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 }
 
 func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPIType]) Stop() {
+	c.signalStop()
+	<-c.finished
+}
+
+func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPIType]) signalStop() {
 	c.stopOnce.Do(func() {
 		close(c.done)
 	})
@@ -480,7 +485,7 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 
 // Finished returns a channel that is closed once Run and all of its child
 // goroutines have fully exited. It is safe to call before, during, or after
-// Run, and Stop must be invoked separately to actually trigger shutdown.
+// Run. Stop triggers shutdown and waits for this channel to close.
 func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPIType]) Finished() <-chan struct{} {
 	return c.finished
 }

--- a/internal/database/informers/informerutils/changefeed_list_watch.go
+++ b/internal/database/informers/informerutils/changefeed_list_watch.go
@@ -89,6 +89,11 @@ func waitForWatcher[InternalAPIType any, InternalAPITypePointer coreapi.CosmosMe
 	}
 }
 
+func stopAndWaitForWatcher[InternalAPIType any, InternalAPITypePointer coreapi.CosmosMetadataAccessorPtr[InternalAPIType], CosmosAPIType any](ctx context.Context, clock utilsclock.Clock, watcher *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPIType]) error {
+	watcher.signalStop()
+	return waitForWatcher(ctx, clock, watcher)
+}
+
 func (c *ChangeFeedListWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPIType]) List(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -108,8 +113,7 @@ func (c *ChangeFeedListWatcher[InternalAPIType, InternalAPITypePointer, CosmosAP
 	prevFeedWatcher := c.currentWatcher
 	c.currentWatcher = nil
 	if prevFeedWatcher != nil {
-		prevFeedWatcher.Stop()
-		if err := waitForWatcher(ctx, c.clock, prevFeedWatcher); err != nil {
+		if err := stopAndWaitForWatcher(ctx, c.clock, prevFeedWatcher); err != nil {
 			logger.Error(err, "failed to wait for previous watcher to stop, continuing")
 		}
 	}
@@ -121,8 +125,7 @@ func (c *ChangeFeedListWatcher[InternalAPIType, InternalAPITypePointer, CosmosAP
 
 	iter, err := c.globalLister.List(ctx, nil)
 	if err != nil {
-		c.currentWatcher.Stop()
-		if err := waitForWatcher(ctx, c.clock, c.currentWatcher); err != nil {
+		if err := stopAndWaitForWatcher(ctx, c.clock, c.currentWatcher); err != nil {
 			logger.Error(err, "failed to wait for current watcher to stop, continuing")
 		}
 		c.currentWatcher = nil
@@ -146,8 +149,7 @@ func (c *ChangeFeedListWatcher[InternalAPIType, InternalAPITypePointer, CosmosAP
 			})
 	}
 	if err := iter.GetError(); err != nil {
-		c.currentWatcher.Stop()
-		if err := waitForWatcher(ctx, c.clock, c.currentWatcher); err != nil {
+		if err := stopAndWaitForWatcher(ctx, c.clock, c.currentWatcher); err != nil {
 			logger.Error(err, "failed to wait for current watcher to stop, continuing")
 		}
 		c.currentWatcher = nil

--- a/internal/database/informers/informerutils/changefeed_list_watch_test.go
+++ b/internal/database/informers/informerutils/changefeed_list_watch_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package informerutils
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	utilsclock "k8s.io/utils/clock"
+
+	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+)
+
+func TestStopAndWaitForWatcherRespectsContext(t *testing.T) {
+	watcher := &ChangeFeedWatcher[coreapi.HCPOpenShiftCluster, *coreapi.HCPOpenShiftCluster, struct{}]{
+		done:     make(chan struct{}),
+		finished: make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := stopAndWaitForWatcher(ctx, utilsclock.RealClock{}, watcher)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("stopAndWaitForWatcher() error = %v, want context.Canceled", err)
+	}
+
+	select {
+	case <-watcher.done:
+	default:
+		t.Fatal("stopAndWaitForWatcher() did not signal the watcher to stop")
+	}
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -77,6 +77,7 @@ require (
 	github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260807054659-4a463f5d83c7 // indirect
 	github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260807054659-4a463f5d83c7 // indirect
 	github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260807054659-4a463f5d83c7 // indirect
+	github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707 // indirect
 	github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260807054659-4a463f5d83c7 // indirect
 	github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260807054659-4a463f5d83c7 // indirect
 	github.com/Azure/ARO-Tools/tools/yamlwrap v0.0.0-20260807054659-4a463f5d83c7 // indirect

--- a/test/go.mod
+++ b/test/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260729121920-58ceb447fbb3 // indirect
 	github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260729121920-58ceb447fbb3 // indirect
 	github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260729121920-58ceb447fbb3 // indirect
+	github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707 // indirect
 	github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260729121920-58ceb447fbb3 // indirect
 	github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260729121920-58ceb447fbb3 // indirect
 	github.com/Azure/ARO-Tools/tools/yamlwrap v0.0.0-20260729121920-58ceb447fbb3 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -77,6 +77,8 @@ github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260807054659-4a463f5d83c7 h
 github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260807054659-4a463f5d83c7/go.mod h1:bV7DKmaQCbO+GOg5lppT8Ap3wdyuB091So5DA/mjcrg=
 github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260807054659-4a463f5d83c7 h1:+KO62xH5VO61fMAFHTOm+2ZKmOKbnZns/lZRskpGDt0=
 github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260807054659-4a463f5d83c7/go.mod h1:VuBG3k3KZmuryie88Ym3PYR0/83Tf1Ooei3KMDw0Fzk=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707 h1:9PebQsjEluc2PlP70Joug0e9KJ7POK28/IB/V72fgB0=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707/go.mod h1:6eOFGWnLVSTCxOPAzY0/21bf/WppxEVhemxiz3m7gdw=
 github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260807054659-4a463f5d83c7 h1:lvyut6Z7rCLAnsB3kGfvmPDcR9AoQHaDjF3BuWLpOxI=
 github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260807054659-4a463f5d83c7/go.mod h1:RvEBh8gN0NxaZH+Lb+k3v4sWdJwBcbEgVSMmvX2Yzhs=
 github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260807054659-4a463f5d83c7 h1:oO4rgGV5iLtIXplTCmlT8nYc0i7ouw0CGfE9PGgxajE=

--- a/test/go.sum
+++ b/test/go.sum
@@ -79,6 +79,8 @@ github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260729121920-58ceb447fbb3 h
 github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260729121920-58ceb447fbb3/go.mod h1:RB+puZDEhnuT9tfjDrvvf1GfxhpYhNzA1GfuIzFH1VI=
 github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260729121920-58ceb447fbb3 h1:Zv9HawhuBiS6V3tK4Hkt4OBinp60528/nEJXhdICCGY=
 github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260729121920-58ceb447fbb3/go.mod h1:+30fbUVQyCLC5R790NoYfZgKdOHPdSaXzMPJHc6SZGU=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707 h1:9PebQsjEluc2PlP70Joug0e9KJ7POK28/IB/V72fgB0=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707/go.mod h1:6eOFGWnLVSTCxOPAzY0/21bf/WppxEVhemxiz3m7gdw=
 github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260729121920-58ceb447fbb3 h1:TyQYbNhNGAccA57PNR6N+Tcob4s0ow8shWr5NrgA1I8=
 github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260729121920-58ceb447fbb3/go.mod h1:pRJ0Qa8BaixSoIyS6Dw2icSSZ4zbAT2bPUURD9SsHH4=
 github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260729121920-58ceb447fbb3 h1:wFiQy3C6O0sUEPQYUZxvSLCYoTrGOnxjtt7dHC1LOMU=

--- a/tooling/kustoctl/go.mod
+++ b/tooling/kustoctl/go.mod
@@ -3,6 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/kustoctl
 go 1.25.5
 
 require (
+	github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707
 	github.com/Azure/azure-kusto-go/azkustodata v1.2.1
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
@@ -10,18 +11,18 @@ require (
 )
 
 require (
+	github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260807054659-4a463f5d83c7 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.10.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/samber/lo v1.53.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
@@ -29,4 +30,5 @@ require (
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
+	k8s.io/apimachinery v0.35.3 // indirect
 )

--- a/tooling/kustoctl/go.mod
+++ b/tooling/kustoctl/go.mod
@@ -3,6 +3,7 @@ module github.com/Azure/ARO-HCP/tooling/kustoctl
 go 1.25.5
 
 require (
+	github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707
 	github.com/Azure/azure-kusto-go/azkustodata v1.2.1
 	github.com/dusted-go/logging v1.3.0
 	github.com/go-logr/logr v1.4.3
@@ -10,18 +11,18 @@ require (
 )
 
 require (
+	github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260729121920-58ceb447fbb3 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.10.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/samber/lo v1.53.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
@@ -29,4 +30,5 @@ require (
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
+	k8s.io/apimachinery v0.35.3 // indirect
 )

--- a/tooling/kustoctl/go.sum
+++ b/tooling/kustoctl/go.sum
@@ -1,3 +1,6 @@
+github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260807054659-4a463f5d83c7 h1:clcrDVg+wk/7YbeoeMvAvFcNf0pxoG+UkRvDVbMPQ1c=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707 h1:9PebQsjEluc2PlP70Joug0e9KJ7POK28/IB/V72fgB0=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707/go.mod h1:6eOFGWnLVSTCxOPAzY0/21bf/WppxEVhemxiz3m7gdw=
 github.com/Azure/azure-kusto-go/azkustodata v1.2.1 h1:De25JIENJVLYUMB4Z9LfAFzbgjGz1ozYJiL2zprs1KA=
 github.com/Azure/azure-kusto-go/azkustodata v1.2.1/go.mod h1:pYbM6A7z4XDU+3S0+OgoyUOuCOWPUe/hyEfnOCT6Gok=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 h1:jHb/wfvRikGdxMXYV3QG/SzUOPYN9KEUUuC0Yd0/vC0=
@@ -8,6 +11,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 h1:xFaZZ+IubdftrDH
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0/go.mod h1:mCBhUhlMjLLJKr5aqw2TNS/VqJOie8MzWq3DAMJeKso=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.10.0 h1:+1fJwTilk/X7inNqwREnYEOgFCdg8ut7GULxARDbu34=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.10.0/go.mod h1:EGwSLlGqrrfYQhtCi9JcIkPQKl9WxsL6ZPJd+63Vy1A=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=
@@ -60,3 +65,5 @@ golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+k8s.io/apimachinery v0.35.3 h1:MeaUwQCV3tjKP4bcwWGgZ/cp/vpsRnQzqO6J6tJyoF8=
+k8s.io/apimachinery v0.35.3/go.mod h1:jQCgFZFR1F4Ik7hvr2g84RTJSZegBc8yHgFWKn//hns=

--- a/tooling/kustoctl/go.sum
+++ b/tooling/kustoctl/go.sum
@@ -1,4 +1,5 @@
 github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260807054659-4a463f5d83c7 h1:clcrDVg+wk/7YbeoeMvAvFcNf0pxoG+UkRvDVbMPQ1c=
+github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260807054659-4a463f5d83c7/go.mod h1:EX/FGO15pK78gOYzb6rYUuIG1jZCYfwSsw1OntQy+dI=
 github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707 h1:9PebQsjEluc2PlP70Joug0e9KJ7POK28/IB/V72fgB0=
 github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707/go.mod h1:6eOFGWnLVSTCxOPAzY0/21bf/WppxEVhemxiz3m7gdw=
 github.com/Azure/azure-kusto-go/azkustodata v1.2.1 h1:De25JIENJVLYUMB4Z9LfAFzbgjGz1ozYJiL2zprs1KA=

--- a/tooling/kustoctl/go.sum
+++ b/tooling/kustoctl/go.sum
@@ -1,3 +1,7 @@
+github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260729121920-58ceb447fbb3 h1:NxN0mw3luqyfHBCf/+FeLAaaJ+zXIwwk2CqCazxiwx4=
+github.com/Azure/ARO-Tools/tools/cmdutils v0.0.0-20260729121920-58ceb447fbb3/go.mod h1:m3Q8TZE7LOKeIu3L3LIP+H51fJvx8m2Dob6sw7A3S1s=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707 h1:9PebQsjEluc2PlP70Joug0e9KJ7POK28/IB/V72fgB0=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707/go.mod h1:6eOFGWnLVSTCxOPAzY0/21bf/WppxEVhemxiz3m7gdw=
 github.com/Azure/azure-kusto-go/azkustodata v1.2.1 h1:De25JIENJVLYUMB4Z9LfAFzbgjGz1ozYJiL2zprs1KA=
 github.com/Azure/azure-kusto-go/azkustodata v1.2.1/go.mod h1:pYbM6A7z4XDU+3S0+OgoyUOuCOWPUe/hyEfnOCT6Gok=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 h1:jHb/wfvRikGdxMXYV3QG/SzUOPYN9KEUUuC0Yd0/vC0=
@@ -8,6 +12,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 h1:xFaZZ+IubdftrDH
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0/go.mod h1:mCBhUhlMjLLJKr5aqw2TNS/VqJOie8MzWq3DAMJeKso=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.10.0 h1:+1fJwTilk/X7inNqwREnYEOgFCdg8ut7GULxARDbu34=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.10.0/go.mod h1:EGwSLlGqrrfYQhtCi9JcIkPQKl9WxsL6ZPJd+63Vy1A=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=
@@ -60,3 +66,5 @@ golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+k8s.io/apimachinery v0.35.3 h1:MeaUwQCV3tjKP4bcwWGgZ/cp/vpsRnQzqO6J6tJyoF8=
+k8s.io/apimachinery v0.35.3/go.mod h1:jQCgFZFR1F4Ik7hvr2g84RTJSZegBc8yHgFWKn//hns=

--- a/tooling/kustoctl/main.go
+++ b/tooling/kustoctl/main.go
@@ -25,6 +25,8 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 
+	"github.com/Azure/ARO-Tools/tools/kustoctl/cmd/entitygroups"
+
 	"github.com/Azure/ARO-HCP/tooling/kustoctl/cmd/validate"
 )
 
@@ -63,6 +65,13 @@ Kusto-related operational tasks.`,
 		os.Exit(1)
 	}
 	cmd.AddCommand(validateCmd)
+
+	entityGroupsCmd, err := entitygroups.NewEntityGroupsCommand()
+	if err != nil {
+		logger.Error(err, "failed to create entity-groups command")
+		os.Exit(1)
+	}
+	cmd.AddCommand(entityGroupsCmd)
 
 	cmd.SetHelpCommand(&cobra.Command{Hidden: true})
 

--- a/tooling/templatize/go.mod
+++ b/tooling/templatize/go.mod
@@ -41,6 +41,7 @@ require (
 )
 
 require (
+	github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0
 	k8s.io/api v0.35.3
 )
@@ -56,6 +57,7 @@ require (
 	cloud.google.com/go/storage v1.62.1 // indirect
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/ARO-Tools/tools/yamlwrap v0.0.0-20260807054659-4a463f5d83c7 // indirect
+	github.com/Azure/azure-kusto-go/azkustodata v1.2.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dashboard/armdashboard/v2 v2.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0 // indirect
@@ -229,6 +231,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rubenv/sql-migrate v1.8.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/samber/lo v1.53.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/tooling/templatize/go.mod
+++ b/tooling/templatize/go.mod
@@ -41,6 +41,7 @@ require (
 )
 
 require (
+	github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0
 	k8s.io/api v0.35.3
 )
@@ -56,6 +57,7 @@ require (
 	cloud.google.com/go/storage v1.62.1 // indirect
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/ARO-Tools/tools/yamlwrap v0.0.0-20260729121920-58ceb447fbb3 // indirect
+	github.com/Azure/azure-kusto-go/azkustodata v1.2.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dashboard/armdashboard/v2 v2.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0 // indirect
@@ -229,6 +231,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rubenv/sql-migrate v1.8.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/samber/lo v1.53.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/tooling/templatize/go.sum
+++ b/tooling/templatize/go.sum
@@ -79,6 +79,8 @@ github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260807054659-4a463f5d83c7 h
 github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260807054659-4a463f5d83c7/go.mod h1:bV7DKmaQCbO+GOg5lppT8Ap3wdyuB091So5DA/mjcrg=
 github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260807054659-4a463f5d83c7 h1:+KO62xH5VO61fMAFHTOm+2ZKmOKbnZns/lZRskpGDt0=
 github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260807054659-4a463f5d83c7/go.mod h1:VuBG3k3KZmuryie88Ym3PYR0/83Tf1Ooei3KMDw0Fzk=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707 h1:9PebQsjEluc2PlP70Joug0e9KJ7POK28/IB/V72fgB0=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707/go.mod h1:6eOFGWnLVSTCxOPAzY0/21bf/WppxEVhemxiz3m7gdw=
 github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260807054659-4a463f5d83c7 h1:lvyut6Z7rCLAnsB3kGfvmPDcR9AoQHaDjF3BuWLpOxI=
 github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260807054659-4a463f5d83c7/go.mod h1:RvEBh8gN0NxaZH+Lb+k3v4sWdJwBcbEgVSMmvX2Yzhs=
 github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260807054659-4a463f5d83c7 h1:oO4rgGV5iLtIXplTCmlT8nYc0i7ouw0CGfE9PGgxajE=
@@ -87,6 +89,8 @@ github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260807054659-4a463f5d83c7 
 github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260807054659-4a463f5d83c7/go.mod h1:kDlrhNzGuT5kCoASmooN6zmpg+goCiM+Fanv0fVAsRQ=
 github.com/Azure/ARO-Tools/tools/yamlwrap v0.0.0-20260807054659-4a463f5d83c7 h1:pSC+svaXYZbS5ezuZ/7tJHTGvUjvee5yGQKFKns015I=
 github.com/Azure/ARO-Tools/tools/yamlwrap v0.0.0-20260807054659-4a463f5d83c7/go.mod h1:vBqaNrQUd9dAmedrRoqI2jVlVbNrFnIFXUu2hFqdct0=
+github.com/Azure/azure-kusto-go/azkustodata v1.2.1 h1:De25JIENJVLYUMB4Z9LfAFzbgjGz1ozYJiL2zprs1KA=
+github.com/Azure/azure-kusto-go/azkustodata v1.2.1/go.mod h1:pYbM6A7z4XDU+3S0+OgoyUOuCOWPUe/hyEfnOCT6Gok=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 h1:jHb/wfvRikGdxMXYV3QG/SzUOPYN9KEUUuC0Yd0/vC0=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1/go.mod h1:pzBXCYn05zvYIrwLgtK8Ap8QcjRg+0i76tMQdWN6wOk=
@@ -775,6 +779,8 @@ github.com/rubenv/sql-migrate v1.8.1/go.mod h1:BTIKBORjzyxZDS6dzoiw6eAFYJ1iNlGAt
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
+github.com/samber/lo v1.53.0 h1:t975lj2py4kJPQ6haz1QMgtId2gtmfktACxIXArw3HM=
+github.com/samber/lo v1.53.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
@@ -833,6 +839,8 @@ github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 h1:ZF+QBjOI+tILZ
 github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834/go.mod h1:m9ymHTgNSEjuxvw8E7WWe4Pl4hZQHXONY8wE6dMLaRk=
 github.com/tetratelabs/wazero v1.11.0 h1:+gKemEuKCTevU4d7ZTzlsvgd1uaToIDtlQlmNbwqYhA=
 github.com/tetratelabs/wazero v1.11.0/go.mod h1:eV28rsN8Q+xwjogd7f4/Pp4xFxO7uOGbLcD/LzB1wiU=
+github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
+github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=
 github.com/trivago/tgo v1.0.7 h1:uaWH/XIy9aWYWpjm2CU3RpcqZXmX2ysQ9/Go+d9gyrM=
 github.com/trivago/tgo v1.0.7/go.mod h1:w4dpD+3tzNIIiIfkWWa85w5/B77tlvdZckQ+6PkFnhc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/tooling/templatize/go.sum
+++ b/tooling/templatize/go.sum
@@ -79,6 +79,8 @@ github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260729121920-58ceb447fbb3 h
 github.com/Azure/ARO-Tools/tools/grafanactl v0.0.0-20260729121920-58ceb447fbb3/go.mod h1:RB+puZDEhnuT9tfjDrvvf1GfxhpYhNzA1GfuIzFH1VI=
 github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260729121920-58ceb447fbb3 h1:Zv9HawhuBiS6V3tK4Hkt4OBinp60528/nEJXhdICCGY=
 github.com/Azure/ARO-Tools/tools/helm v0.0.0-20260729121920-58ceb447fbb3/go.mod h1:+30fbUVQyCLC5R790NoYfZgKdOHPdSaXzMPJHc6SZGU=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707 h1:9PebQsjEluc2PlP70Joug0e9KJ7POK28/IB/V72fgB0=
+github.com/Azure/ARO-Tools/tools/kustoctl v0.0.0-20260720175808-ca2cea2cb707/go.mod h1:6eOFGWnLVSTCxOPAzY0/21bf/WppxEVhemxiz3m7gdw=
 github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260729121920-58ceb447fbb3 h1:TyQYbNhNGAccA57PNR6N+Tcob4s0ow8shWr5NrgA1I8=
 github.com/Azure/ARO-Tools/tools/prow-job-executor v0.0.0-20260729121920-58ceb447fbb3/go.mod h1:pRJ0Qa8BaixSoIyS6Dw2icSSZ4zbAT2bPUURD9SsHH4=
 github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260729121920-58ceb447fbb3 h1:wFiQy3C6O0sUEPQYUZxvSLCYoTrGOnxjtt7dHC1LOMU=
@@ -87,6 +89,8 @@ github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260729121920-58ceb447fbb3 
 github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260729121920-58ceb447fbb3/go.mod h1:E91qmRNxrV2BU5wKywha4gDgue41NmOYYZ0+sZ83YYs=
 github.com/Azure/ARO-Tools/tools/yamlwrap v0.0.0-20260729121920-58ceb447fbb3 h1:FmXgMquZB2nzwv+ILJYoPwxnlmDBgEH9srDayDqsHSw=
 github.com/Azure/ARO-Tools/tools/yamlwrap v0.0.0-20260729121920-58ceb447fbb3/go.mod h1:vBqaNrQUd9dAmedrRoqI2jVlVbNrFnIFXUu2hFqdct0=
+github.com/Azure/azure-kusto-go/azkustodata v1.2.1 h1:De25JIENJVLYUMB4Z9LfAFzbgjGz1ozYJiL2zprs1KA=
+github.com/Azure/azure-kusto-go/azkustodata v1.2.1/go.mod h1:pYbM6A7z4XDU+3S0+OgoyUOuCOWPUe/hyEfnOCT6Gok=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 h1:jHb/wfvRikGdxMXYV3QG/SzUOPYN9KEUUuC0Yd0/vC0=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1/go.mod h1:pzBXCYn05zvYIrwLgtK8Ap8QcjRg+0i76tMQdWN6wOk=
@@ -785,6 +789,8 @@ github.com/rubenv/sql-migrate v1.8.1/go.mod h1:BTIKBORjzyxZDS6dzoiw6eAFYJ1iNlGAt
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
+github.com/samber/lo v1.53.0 h1:t975lj2py4kJPQ6haz1QMgtId2gtmfktACxIXArw3HM=
+github.com/samber/lo v1.53.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
@@ -843,6 +849,8 @@ github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834 h1:ZF+QBjOI+tILZ
 github.com/tetratelabs/wabin v0.0.0-20230304001439-f6f874872834/go.mod h1:m9ymHTgNSEjuxvw8E7WWe4Pl4hZQHXONY8wE6dMLaRk=
 github.com/tetratelabs/wazero v1.11.0 h1:+gKemEuKCTevU4d7ZTzlsvgd1uaToIDtlQlmNbwqYhA=
 github.com/tetratelabs/wazero v1.11.0/go.mod h1:eV28rsN8Q+xwjogd7f4/Pp4xFxO7uOGbLcD/LzB1wiU=
+github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
+github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=
 github.com/trivago/tgo v1.0.7 h1:uaWH/XIy9aWYWpjm2CU3RpcqZXmX2ysQ9/Go+d9gyrM=
 github.com/trivago/tgo v1.0.7/go.mod h1:w4dpD+3tzNIIiIfkWWa85w5/B77tlvdZckQ+6PkFnhc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/tooling/templatize/pkg/pipeline/kusto_entity_groups.go
+++ b/tooling/templatize/pkg/pipeline/kusto_entity_groups.go
@@ -1,0 +1,40 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/ARO-Tools/pipelines/graph"
+	"github.com/Azure/ARO-Tools/pipelines/types"
+	"github.com/Azure/ARO-Tools/tools/kustoctl/cmd/entitygroups"
+)
+
+func runKustoEntityGroupsStep(_ graph.Identifier, step *types.KustoEntityGroupsStep, ctx context.Context) error {
+	opts := entitygroups.DefaultSyncOptions()
+	opts.EntityGroups = step.EntityGroups
+
+	if step.Timeout != "" {
+		d, err := time.ParseDuration(step.Timeout)
+		if err != nil {
+			return fmt.Errorf("failed to parse timeout %q: %w", step.Timeout, err)
+		}
+		opts.Timeout = d
+	}
+
+	return opts.Run(ctx)
+}

--- a/tooling/templatize/pkg/pipeline/kusto_entity_groups.go
+++ b/tooling/templatize/pkg/pipeline/kusto_entity_groups.go
@@ -25,16 +25,25 @@ import (
 )
 
 func runKustoEntityGroupsStep(_ graph.Identifier, step *types.KustoEntityGroupsStep, ctx context.Context) error {
+	opts, err := kustoEntityGroupsOptions(step)
+	if err != nil {
+		return err
+	}
+
+	return opts.Run(ctx)
+}
+
+func kustoEntityGroupsOptions(step *types.KustoEntityGroupsStep) (*entitygroups.RawSyncOptions, error) {
 	opts := entitygroups.DefaultSyncOptions()
 	opts.EntityGroups = step.EntityGroups
 
 	if step.Timeout != "" {
 		d, err := time.ParseDuration(step.Timeout)
 		if err != nil {
-			return fmt.Errorf("failed to parse timeout %q: %w", step.Timeout, err)
+			return nil, fmt.Errorf("failed to parse timeout %q: %w", step.Timeout, err)
 		}
 		opts.Timeout = d
 	}
 
-	return opts.Run(ctx)
+	return opts, nil
 }

--- a/tooling/templatize/pkg/pipeline/kusto_entity_groups_test.go
+++ b/tooling/templatize/pkg/pipeline/kusto_entity_groups_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Azure/ARO-Tools/pipelines/graph"
+	"github.com/Azure/ARO-Tools/pipelines/types"
+)
+
+func TestRunKustoEntityGroupsStep_TimeoutParse(t *testing.T) {
+	tests := []struct {
+		name      string
+		timeout   string
+		wantError bool
+		errorMsg  string
+	}{
+		{
+			name:      "valid timeout",
+			timeout:   "10m",
+			wantError: false,
+		},
+		{
+			name:      "valid timeout seconds",
+			timeout:   "30s",
+			wantError: false,
+		},
+		{
+			name:      "empty timeout uses default",
+			timeout:   "",
+			wantError: false,
+		},
+		{
+			name:      "invalid timeout",
+			timeout:   "notaduration",
+			wantError: true,
+			errorMsg:  "failed to parse timeout",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step := &types.KustoEntityGroupsStep{
+				EntityGroups: []string{"TestEG:TestDB"},
+				Timeout:      tt.timeout,
+			}
+
+			// runKustoEntityGroupsStep will fail at opts.Run (no Azure creds)
+			// but we're testing the timeout parse path before that
+			err := runKustoEntityGroupsStep(graph.Identifier{}, step, context.Background())
+
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errorMsg)
+				}
+				if tt.errorMsg != "" && !containsStr(err.Error(), tt.errorMsg) {
+					t.Fatalf("expected error containing %q, got %q", tt.errorMsg, err.Error())
+				}
+			}
+			// For valid timeouts, the function will fail later (no Azure creds),
+			// which is fine - we only care that it didn't fail on timeout parse
+			if !tt.wantError && err != nil && containsStr(err.Error(), "failed to parse timeout") {
+				t.Fatalf("unexpected timeout parse error: %v", err)
+			}
+		})
+	}
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && findSubstr(s, substr))
+}
+
+func findSubstr(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/tooling/templatize/pkg/pipeline/kusto_entity_groups_test.go
+++ b/tooling/templatize/pkg/pipeline/kusto_entity_groups_test.go
@@ -16,39 +16,41 @@ package pipeline
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/Azure/ARO-Tools/pipelines/graph"
 	"github.com/Azure/ARO-Tools/pipelines/types"
+	"github.com/Azure/ARO-Tools/tools/kustoctl/cmd/entitygroups"
 )
 
-func TestRunKustoEntityGroupsStep_TimeoutParse(t *testing.T) {
+func TestKustoEntityGroupsOptions(t *testing.T) {
+	defaultTimeout := entitygroups.DefaultSyncOptions().Timeout
 	tests := []struct {
-		name      string
-		timeout   string
-		wantError bool
-		errorMsg  string
+		name        string
+		timeout     string
+		wantTimeout time.Duration
+		wantError   string
 	}{
 		{
-			name:      "valid timeout",
-			timeout:   "10m",
-			wantError: false,
+			name:        "valid timeout",
+			timeout:     "10m",
+			wantTimeout: 10 * time.Minute,
 		},
 		{
-			name:      "valid timeout seconds",
-			timeout:   "30s",
-			wantError: false,
+			name:        "valid timeout seconds",
+			timeout:     "30s",
+			wantTimeout: 30 * time.Second,
 		},
 		{
-			name:      "empty timeout uses default",
-			timeout:   "",
-			wantError: false,
+			name:        "empty timeout uses default",
+			wantTimeout: defaultTimeout,
 		},
 		{
 			name:      "invalid timeout",
 			timeout:   "notaduration",
-			wantError: true,
-			errorMsg:  "failed to parse timeout",
+			wantError: "failed to parse timeout",
 		},
 	}
 
@@ -59,36 +61,33 @@ func TestRunKustoEntityGroupsStep_TimeoutParse(t *testing.T) {
 				Timeout:      tt.timeout,
 			}
 
-			// runKustoEntityGroupsStep will fail at opts.Run (no Azure creds)
-			// but we're testing the timeout parse path before that
-			err := runKustoEntityGroupsStep(graph.Identifier{}, step, context.Background())
-
-			if tt.wantError {
-				if err == nil {
-					t.Fatalf("expected error containing %q, got nil", tt.errorMsg)
+			opts, err := kustoEntityGroupsOptions(step)
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+					t.Fatalf("kustoEntityGroupsOptions() error = %v, want error containing %q", err, tt.wantError)
 				}
-				if tt.errorMsg != "" && !containsStr(err.Error(), tt.errorMsg) {
-					t.Fatalf("expected error containing %q, got %q", tt.errorMsg, err.Error())
-				}
+				return
 			}
-			// For valid timeouts, the function will fail later (no Azure creds),
-			// which is fine - we only care that it didn't fail on timeout parse
-			if !tt.wantError && err != nil && containsStr(err.Error(), "failed to parse timeout") {
-				t.Fatalf("unexpected timeout parse error: %v", err)
+			if err != nil {
+				t.Fatalf("kustoEntityGroupsOptions() error = %v", err)
+			}
+			if opts.Timeout != tt.wantTimeout {
+				t.Errorf("kustoEntityGroupsOptions() timeout = %v, want %v", opts.Timeout, tt.wantTimeout)
+			}
+			if len(opts.EntityGroups) != 1 || opts.EntityGroups[0] != "TestEG:TestDB" {
+				t.Errorf("kustoEntityGroupsOptions() entity groups = %v, want [TestEG:TestDB]", opts.EntityGroups)
 			}
 		})
 	}
 }
 
-func containsStr(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && findSubstr(s, substr))
-}
-
-func findSubstr(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
+func TestRunStepDispatchesKustoEntityGroupsStep(t *testing.T) {
+	step := &types.KustoEntityGroupsStep{
+		Timeout: "notaduration",
 	}
-	return false
+
+	_, _, err := RunStep(graph.Identifier{}, step, context.Background(), nil, nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "error running Kusto Entity Groups Step: failed to parse timeout") {
+		t.Fatalf("RunStep() error = %v, want KustoEntityGroupsStep timeout parse error", err)
+	}
 }

--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -964,6 +964,11 @@ func RunStep(id graph.Identifier, s types.Step, ctx context.Context, executionTa
 			return nil, nil, fmt.Errorf("error running Grafana Manage Step: %w", err)
 		}
 		return nil, nil, nil
+	case *types.KustoEntityGroupsStep:
+		if err := runKustoEntityGroupsStep(id, step, ctx); err != nil {
+			return nil, nil, fmt.Errorf("error running Kusto Entity Groups Step: %w", err)
+		}
+		return nil, nil, nil
 	case *types.ARMStep:
 		a, err := newArmClient(executionTarget.GetSubscriptionID(), executionTarget.GetRegion(), options.BicepClient)
 		if err != nil {


### PR DESCRIPTION
Replaces #6150 (reverted in #6258) and #6229.

### What

Adds the Kusto entity-groups pipeline step to the geography pipeline, enabling cross-cluster entity group sync on all three databases:
- `AllServiceLogs:ServiceLogs`
- `AllHostedControlPlaneLogs:HostedControlPlaneLogs`
- `AllMonitoringEvents:MonitoringEvents`

This enables `entity_group` KQL queries across all regional Kusto clusters without manually listing each cluster URI.

### Why

\#6150 failed in INT because explicit PrincipalAssignment resources (hardcoded name `globalMSI-admin`) conflicted with existing auto-named assignments created by the Kusto script deployment flow (`RetainPermissionOnScriptCompletion`). This v3 takes a different approach: instead of adding PrincipalAssignment resources, remove the `removePermission` module so the deploying identity retains Database Admin after table-creation scripts complete.

### Permission model

The global MSI retains Database Admin on all three databases (ServiceLogs, HostedControlPlaneLogs, MonitoringEvents). Previously this was revoked after each deploy. The retained privilege is required for the entity-groups pipeline step and is lesser than the ARM Contributor the global MSI already holds on the Kusto cluster.

### Changes

- Remove `removePermission` module from `kusto/main.bicep` (retain Admin for entity-groups on all DBs)
- Remove `globalMSIId` parameter wiring (no longer needed)
- Remove PrincipalAssignment resources (no longer needed)
- Add `aroHCPPurpose: 'logs'` tag to Kusto cluster (kustoctl discovery)
- Add `entity-groups` pipeline step to `geography-pipeline.yaml` and `geography-pipeline-stg.yaml` (all 3 databases)
- Add `KustoEntityGroups` runner in templatize (`kusto_entity_groups.go` + `run.go` case)
- Register `entity-groups` subcommand in `tooling/kustoctl`

### Dependencies

- [sdp-pipelines PR 16614060](https://dev.azure.com/msazure/AzureRedHatOpenShift/_git/sdp-pipelines/pullrequest/16614060): KustoEntityGroupsStep EV2RA adapter (merged)
- [ARO-Tools #267](https://github.com/Azure/ARO-Tools/pull/267) (merged): kustoctl entity-groups sync command

Jira: [ARO-27830](https://redhat.atlassian.net/browse/ARO-27830)
Closes #6229