### PR TITLE
feat(observability): add Scratchpad folder for user dashboards

### DIFF
--- a/observability/observability.yaml
+++ b/observability/observability.yaml
@@ -34,5 +34,5 @@ grafana-dashboards:
   - name: SRE Cluster Health
     path: ./grafana-dashboards/sre/cluster-health
   scratchFolders:
-  - name: Scratchpad (regularly autodeleted)
+  - name: Scratchpad (all dashboards get deleted regularly)
     maxAge: 168h

--- a/observability/observability.yaml
+++ b/observability/observability.yaml
@@ -33,3 +33,6 @@ grafana-dashboards:
     path: ./grafana-dashboards/sre/user-journey
   - name: SRE Cluster Health
     path: ./grafana-dashboards/sre/cluster-health
+  scratchFolders:
+  - name: Scratchpad (regularly autodeleted)
+    maxAge: 168h


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1631

## Summary

- Adds a "Scratchpad (regularly autodeleted)" scratch folder to the Grafana observability config
- Viewers can create, save, and delete dashboards in this folder
- Dashboards are auto-deleted after 7 days (based on creation time)

Depends on https://github.com/Azure/ARO-Tools/pull/276 (grafanactl scratch folder support).

After the ARO-Tools PR merges, this PR needs a grafanactl dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)