### PR TITLE
feat(hcpctl): support rehearsal PR jobs for snapshot analyze

### DIFF
--- a/tooling/hcpctl/pkg/snapshot/prow.go
+++ b/tooling/hcpctl/pkg/snapshot/prow.go
@@ -44,10 +44,17 @@ import (
 
 const (
 	gcsBucket          = "test-platform-results"
-	prConfigPath       = "aro-hcp-provision-environment/artifacts/config.yaml"
 	testStepPersistent = "aro-hcp-test-persistent"
 	testStepLocal      = "aro-hcp-test-local"
 )
+
+// prConfigPaths lists the known GCS step artifact paths where config.yaml
+// may be found. The first match wins. Rehearsal jobs for openshift/hypershift
+// use aro-hcp-hypershift-deploy instead of aro-hcp-provision-environment.
+var prConfigPaths = []string{
+	"aro-hcp-provision-environment/artifacts/config.yaml",
+	"aro-hcp-hypershift-deploy/artifacts/config.yaml",
+}
 
 // ProwJobInfo holds the parsed information from a Prow job URL.
 type ProwJobInfo struct {
@@ -60,7 +67,13 @@ type ProwJobInfo struct {
 // IsPullRequest reports whether the job is a pull-ci (PR) job,
 // determined by the job name prefix.
 func (p *ProwJobInfo) IsPullRequest() bool {
-	return strings.HasPrefix(p.JobName, "pull-ci")
+	return strings.HasPrefix(p.JobName, "pull-ci") || p.IsRehearsalPullRequest()
+}
+
+// IsRehearsalPullRequest reports whether the job is a Prow rehearsal of a
+// pull-ci job (rehearse-NNN-pull-ci-...).
+func (p *ProwJobInfo) IsRehearsalPullRequest() bool {
+	return strings.HasPrefix(p.JobName, "rehearse") && strings.Contains(p.JobName, "pull-ci")
 }
 
 // ProwJobConfig holds the Kusto connection info extracted from a Prow job's config.yaml.
@@ -243,8 +256,9 @@ func FetchProwJobConfig(ctx context.Context, info *ProwJobInfo, sdpPipelinesDir 
 	return fetchNonPRJobConfig(ctx, info, sdpPipelinesDir, logger)
 }
 
-// fetchPRJobConfig downloads the config.yaml from the aro-hcp-provision-environment
-// GCS artifact for a PR job and parses the Kusto connection info.
+// fetchPRJobConfig downloads config.yaml from a PR job's GCS artifacts and
+// parses the Kusto connection info. It searches prConfigPaths in order,
+// returning the first one found.
 func fetchPRJobConfig(ctx context.Context, info *ProwJobInfo, logger logr.Logger) (*ProwJobConfig, error) {
 	gcsClient, err := storage.NewClient(ctx, option.WithoutAuthentication())
 	if err != nil {
@@ -258,10 +272,17 @@ func fetchPRJobConfig(ctx context.Context, info *ProwJobInfo, logger logr.Logger
 	}
 	logger.V(1).Info("Found artifact directory", "dir", artifactDir)
 
-	configGCSPath := fmt.Sprintf("%s/artifacts/%s/%s", info.GCSPrefix, artifactDir, prConfigPath)
-	configData, err := downloadObject(ctx, gcsClient, configGCSPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download config.yaml from provision-environment: %w", err)
+	var configData []byte
+	for _, configPath := range prConfigPaths {
+		configGCSPath := fmt.Sprintf("%s/artifacts/%s/%s", info.GCSPrefix, artifactDir, configPath)
+		configData, err = downloadObject(ctx, gcsClient, configGCSPath)
+		if err == nil {
+			logger.V(1).Info("Found config.yaml", "path", configPath)
+			break
+		}
+	}
+	if configData == nil {
+		return nil, fmt.Errorf("failed to find config.yaml in any known step artifact path: %v", prConfigPaths)
 	}
 
 	jobConfig, err := ParseConfig(configData)

--- a/tooling/hcpctl/pkg/snapshot/prow_test.go
+++ b/tooling/hcpctl/pkg/snapshot/prow_test.go
@@ -60,6 +60,17 @@ func TestParseProwURL(t *testing.T) {
 			wantIsPR: true,
 		},
 		{
+			name:   "rehearsal PR job",
+			rawURL: "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/82457/rehearse-82457-pull-ci-openshift-hypershift-main-e2e-aro-hcp/2081917423216234496",
+			wantInfo: &ProwJobInfo{
+				URL:       "https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/82457/rehearse-82457-pull-ci-openshift-hypershift-main-e2e-aro-hcp/2081917423216234496",
+				JobName:   "rehearse-82457-pull-ci-openshift-hypershift-main-e2e-aro-hcp",
+				ProwID:    "2081917423216234496",
+				GCSPrefix: "pr-logs/pull/openshift_release/82457/rehearse-82457-pull-ci-openshift-hypershift-main-e2e-aro-hcp/2081917423216234496",
+			},
+			wantIsPR: true,
+		},
+		{
 			name:    "no logs segment",
 			rawURL:  "https://prow.ci.openshift.org/view/gs/test-platform-results/something-else",
 			wantErr: true,


### PR DESCRIPTION

### What

Support rehearsal PR jobs for snapshot analyze tooling

### Why

`hcpctl snapshot` can't analyze rehearsal PR jobs without this change.  Also supports config values from hypershift's provision aro-hcp step rather than just the aro one from ci-operator in openshift/release.  

### Testing

Unit tests updated, running `hcpctl snapshot` tooling against a rehearsal job here: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/9070/pull-ci-openshift-hypershift-main-e2e-aro-hcp/2080304732210991104

### Special notes for your reviewer

