### PR TITLE
Bump CIHealth to include https://github.com/roivaz/ARO-HCP-CIHealth/pull/8

### DIFF
--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -129,7 +129,7 @@ clouds:
           image:
             registry: "quay.io"
             repository: "roivaz/cihealth"
-            tag: "0c8550b"
+            tag: "c402cb7"
           disableRuntimeWorkloads: false
           app:
             replicas: 2


### PR DESCRIPTION
Bumps the CIHealth dev-ci image to \`c402cb7\`, built from https://github.com/roivaz/ARO-HCP-CIHealth/actions/runs/30370566003/job/90313013898 after https://github.com/roivaz/ARO-HCP-CIHealth/pull/8 merged.

Image: `quay.io/roivaz/cihealth:c402cb7` (`sha256:e6ce1b0bdf29bfbb77781968c785ce9c1403fdbb9d708bf6f0706d4d57782683`)

That PR fixes several failure-pattern extraction defects (overmerged/undermerged canonicals, dropped ClusterService `<no_message>` detail, truncated RP error messages with embedded escaped quotes) and adds a rule to always surface inner error detail for the `Microsoft.RedHatOpenShift` provider.