### PR TITLE
feat: add UserFacingConditions to Cluster, NodePool, and ExternalAuth status

### DIFF
--- a/internal/api/types_cluster.go
+++ b/internal/api/types_cluster.go
@@ -51,6 +51,21 @@ type HCPOpenShiftClusterStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+
+	// UserFacingConditions is a list of conditions that tracks user-facing cluster
+	// conditions. Each Condition Type should be unique among all conditions.
+	// The conditions here are exposed to the ARM API. This means that UserFacingConditions
+	// must not contain any internal details. This also means the Type and Reason
+	// values become part of the public API.
+	// Addition of new conditions here should be done only when strictly necessary, sparingly and only done
+	// when there is a clear benefit to doing so. We expect the number of conditions at this
+	// level to be kept to a minimum.
+	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
+	UserFacingConditions []metav1.Condition `json:"userFacingConditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 var _ arm.CosmosPersistable = &HCPOpenShiftCluster{}

--- a/internal/api/types_externalauth.go
+++ b/internal/api/types_externalauth.go
@@ -49,6 +49,21 @@ type HCPOpenShiftClusterExternalAuthStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+
+	// UserFacingConditions is a list of conditions that tracks user-facing external auth
+	// conditions. Each Condition Type should be unique among all conditions.
+	// The conditions here are exposed to the ARM API. This means that UserFacingConditions
+	// must not contain any internal details. This also means the Type and Reason
+	// values become part of the public API.
+	// Addition of new conditions here should be done only when strictly necessary, sparingly and only done
+	// when there is a clear benefit to doing so. We expect the number of conditions at this
+	// level to be kept to a minimum.
+	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
+	UserFacingConditions []metav1.Condition `json:"userFacingConditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 // EnsureDefaults fills in default values for fields that may be absent in

--- a/internal/api/types_nodepool.go
+++ b/internal/api/types_nodepool.go
@@ -54,6 +54,21 @@ type HCPOpenShiftClusterNodePoolStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
+
+	// UserFacingConditions is a list of conditions that tracks user-facing node pool
+	// conditions. Each Condition Type should be unique among all conditions.
+	// The conditions here are exposed to the ARM API. This means that UserFacingConditions
+	// must not contain any internal details. This also means the Type and Reason
+	// values become part of the public API.
+	// Addition of new conditions here should be done only when strictly necessary, sparingly and only done
+	// when there is a clear benefit to doing so. We expect the number of conditions at this
+	// level to be kept to a minimum.
+	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=type
+	UserFacingConditions []metav1.Condition `json:"userFacingConditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 var _ arm.CosmosPersistable = &HCPOpenShiftClusterNodePool{}

--- a/internal/api/v20260630preview/external_auth_methods.go
+++ b/internal/api/v20260630preview/external_auth_methods.go
@@ -304,7 +304,7 @@ func (v version) NewHCPOpenShiftClusterExternalAuth(from *api.HCPOpenShiftCluste
 			SystemData: api.PtrOrNil(newSystemData(from.SystemData)),
 			Properties: &generated.ExternalAuthProperties{
 				ProvisioningState: api.PtrOrNil(generated.ExternalAuthProvisioningState(from.Properties.ProvisioningState)),
-				Status:            newResourceStatus(from.Status.Conditions),
+				Status:            api.PtrOrNil(newExternalAuthResourceStatus(&from.Status)),
 				Issuer:            api.PtrOrNil(newTokenIssuerProfile(&from.Properties.Issuer)),
 				Claim:             api.PtrOrNil(newExternalAuthClaimProfile(&from.Properties.Claim)),
 			},
@@ -320,4 +320,13 @@ func (v version) NewHCPOpenShiftClusterExternalAuth(from *api.HCPOpenShiftCluste
 		})
 	}
 	return out
+}
+
+func newExternalAuthResourceStatus(from *api.HCPOpenShiftClusterExternalAuthStatus) generated.ResourceStatus {
+	if from == nil {
+		return generated.ResourceStatus{}
+	}
+	return generated.ResourceStatus{
+		Conditions: newConditions(from.UserFacingConditions),
+	}
 }

--- a/internal/api/v20260630preview/hcpopenshiftclusters_methods.go
+++ b/internal/api/v20260630preview/hcpopenshiftclusters_methods.go
@@ -261,14 +261,35 @@ func newKmsKey(from *api.KmsKey) generated.KmsKey {
 }
 
 func newConditions(from []metav1.Condition) []*generated.Condition {
-	// TODO (bvesel): propose a method for how we want to translate our internal metav1.Conditions type to this external
-	// type.  Until then, we'll plumb it with empty data.
-	return []*generated.Condition{}
+	if from == nil {
+		return nil
+	}
+
+	out := make([]*generated.Condition, 0, len(from))
+	for i := range from {
+		c := from[i]
+		cond := &generated.Condition{
+			Type:    api.Ptr(generated.ConditionType(c.Type)),
+			Status:  api.Ptr(generated.StatusType(c.Status)),
+			Reason:  api.Ptr(c.Reason),
+			Message: api.Ptr(c.Message),
+		}
+		if !c.LastTransitionTime.IsZero() {
+			t := c.LastTransitionTime.Time
+			cond.LastTransitionTime = &t
+		}
+		out = append(out, cond)
+	}
+
+	return out
 }
 
-func newResourceStatus(from []metav1.Condition) *generated.ResourceStatus {
-	return &generated.ResourceStatus{
-		Conditions: newConditions(from),
+func newClusterResourceStatus(from *api.HCPOpenShiftClusterStatus) generated.ResourceStatus {
+	if from == nil {
+		return generated.ResourceStatus{}
+	}
+	return generated.ResourceStatus{
+		Conditions: newConditions(from.UserFacingConditions),
 	}
 }
 
@@ -379,7 +400,7 @@ func (v version) NewHCPOpenShiftCluster(from *api.HCPOpenShiftCluster) api.Versi
 				ClusterImageRegistry:    api.PtrOrNil(newClusterImageRegistryProfile(&from.CustomerProperties.ClusterImageRegistry)),
 				Etcd:                    api.PtrOrNil(newEtcdProfile(&from.CustomerProperties.Etcd)),
 				ImageDigestMirrors:      newImageDigestMirrors(from.CustomerProperties.ImageDigestMirrors),
-				Status:                  newResourceStatus(from.Status.Conditions),
+				Status:                  api.PtrOrNil(newClusterResourceStatus(&from.Status)),
 				CryptoRestrictions:      api.PtrOrNil(generated.CryptoRestrictions(from.CustomerProperties.CryptoRestrictions)),
 			},
 			Identity: newManagedServiceIdentity(from.Identity),

--- a/internal/api/v20260630preview/nodepools_methods.go
+++ b/internal/api/v20260630preview/nodepools_methods.go
@@ -325,7 +325,7 @@ func (v version) NewHCPOpenShiftClusterNodePool(from *api.HCPOpenShiftClusterNod
 				// Use Ptr (not PtrOrNil) to ensure int32 zero value is preserved in JSON response.
 				Replicas:                api.Ptr(from.Properties.Replicas),
 				NodeDrainTimeoutMinutes: from.Properties.NodeDrainTimeoutMinutes,
-				Status:                  newResourceStatus(from.Status.Conditions),
+				Status:                  api.PtrOrNil(newNodePoolResourceStatus(&from.Status)),
 			},
 			Identity: newManagedServiceIdentity(from.Identity),
 		},
@@ -353,4 +353,13 @@ func (v version) NewHCPOpenShiftClusterNodePool(from *api.HCPOpenShiftClusterNod
 	}
 
 	return out
+}
+
+func newNodePoolResourceStatus(from *api.HCPOpenShiftClusterNodePoolStatus) generated.ResourceStatus {
+	if from == nil {
+		return generated.ResourceStatus{}
+	}
+	return generated.ResourceStatus{
+		Conditions: newConditions(from.UserFacingConditions),
+	}
 }

--- a/internal/api/zz_generated.deepcopy.go
+++ b/internal/api/zz_generated.deepcopy.go
@@ -717,6 +717,13 @@ func (in *HCPOpenShiftClusterExternalAuthStatus) DeepCopyInto(out *HCPOpenShiftC
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.UserFacingConditions != nil {
+		in, out := &in.UserFacingConditions, &out.UserFacingConditions
+		*out = make([]v1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 
@@ -913,6 +920,13 @@ func (in *HCPOpenShiftClusterNodePoolStatus) DeepCopyInto(out *HCPOpenShiftClust
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.UserFacingConditions != nil {
+		in, out := &in.UserFacingConditions, &out.UserFacingConditions
+		*out = make([]v1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 
@@ -974,6 +988,13 @@ func (in *HCPOpenShiftClusterStatus) DeepCopyInto(out *HCPOpenShiftClusterStatus
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
+		*out = make([]v1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.UserFacingConditions != nil {
+		in, out := &in.UserFacingConditions, &out.UserFacingConditions
 		*out = make([]v1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])

--- a/test-integration/frontend/artifacts/VersionCompliance/Cluster/basic-cluster/expected/get/2026-06-30-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/Cluster/basic-cluster/expected/get/2026-06-30-preview.json
@@ -52,9 +52,6 @@
 			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
 		},
 		"provisioningState": "Succeeded",
-		"status": {
-			"conditions": []
-		},
 		"version": {
 			"channelGroup": "stable",
 			"id": "4.20"

--- a/test-integration/frontend/artifacts/VersionCompliance/Cluster/basic-cluster/expected/list/2026-06-30-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/Cluster/basic-cluster/expected/list/2026-06-30-preview.json
@@ -52,9 +52,6 @@
 			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
 		},
 		"provisioningState": "Succeeded",
-		"status": {
-			"conditions": []
-		},
 		"version": {
 			"channelGroup": "stable",
 			"id": "4.20"

--- a/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/expected/get/2026-06-30-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/expected/get/2026-06-30-preview.json
@@ -20,9 +20,6 @@
 		},
 		"provisioningState": "Succeeded",
 		"replicas": 0,
-		"status": {
-			"conditions": []
-		},
 		"version": {
 			"channelGroup": "stable",
 			"id": "4.20.8"

--- a/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/expected/list/2026-06-30-preview.json
+++ b/test-integration/frontend/artifacts/VersionCompliance/NodePool/basic-nodepool/expected/list/2026-06-30-preview.json
@@ -20,9 +20,6 @@
 		},
 		"provisioningState": "Succeeded",
 		"replicas": 0,
-		"status": {
-			"conditions": []
-		},
 		"version": {
 			"channelGroup": "stable",
 			"id": "4.20.8"


### PR DESCRIPTION
Add a status.userFacingConditions field ([]metav1.Condition) on the internal Cluster, NodePool, and ExternalAuth documents.

These conditions are intended for ARM-facing status and must not include internal details. This also means that Type and Reason become part of the public API.	Addition of new conditions here should be done only when strictly necessary, sparingly and only done when there is a clear benefit to doing so. We expect the number of conditions at this level to be kept to a minimum.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
