### PR TITLE
chore: bump maestro image (AROSLSRE-1633)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1014,7 +1014,7 @@ defaults:
     image:
       registry: quay.io
       repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
-      digest: sha256:777e24018ea07093f8d79b6fe8694f3c332be4978bded0aea11566d936f08802 # e9c8bd7ccaa09b33f1708f21748f127d4542aaf5 (2026-07-22 18:32)
+      digest: sha256:ce18b280552cf120b48a1727c2941a519629fdf6eee8819d0e53654e52d41b9d # a6f773d61d5be43bae49438c855cb0a0a48306cd (2026-07-28 21:53)
   # ACM
   acm:
     operator:

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -564,7 +564,7 @@ maestro:
     name: arohcp-ci00-maestro-j7654321
     private: false
   image:
-    digest: sha256:777e24018ea07093f8d79b6fe8694f3c332be4978bded0aea11566d936f08802
+    digest: sha256:ce18b280552cf120b48a1727c2941a519629fdf6eee8819d0e53654e52d41b9d
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -564,7 +564,7 @@ maestro:
     name: arohcp-ci01-maestro-j7654321
     private: false
   image:
-    digest: sha256:777e24018ea07093f8d79b6fe8694f3c332be4978bded0aea11566d936f08802
+    digest: sha256:ce18b280552cf120b48a1727c2941a519629fdf6eee8819d0e53654e52d41b9d
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -564,7 +564,7 @@ maestro:
     name: arohcp-cspr-maestro-usw3
     private: false
   image:
-    digest: sha256:777e24018ea07093f8d79b6fe8694f3c332be4978bded0aea11566d936f08802
+    digest: sha256:ce18b280552cf120b48a1727c2941a519629fdf6eee8819d0e53654e52d41b9d
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -564,7 +564,7 @@ maestro:
     name: arohcp-dev-maestro-usw3
     private: false
   image:
-    digest: sha256:777e24018ea07093f8d79b6fe8694f3c332be4978bded0aea11566d936f08802
+    digest: sha256:ce18b280552cf120b48a1727c2941a519629fdf6eee8819d0e53654e52d41b9d
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -564,7 +564,7 @@ maestro:
     name: arohcp-perf-maestro-usw3ptest
     private: false
   image:
-    digest: sha256:777e24018ea07093f8d79b6fe8694f3c332be4978bded0aea11566d936f08802
+    digest: sha256:ce18b280552cf120b48a1727c2941a519629fdf6eee8819d0e53654e52d41b9d
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -564,7 +564,7 @@ maestro:
     name: arohcp-pers-maestro-usw3test
     private: false
   image:
-    digest: sha256:777e24018ea07093f8d79b6fe8694f3c332be4978bded0aea11566d936f08802
+    digest: sha256:ce18b280552cf120b48a1727c2941a519629fdf6eee8819d0e53654e52d41b9d
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:


### PR DESCRIPTION
[AROSLSRE-1633](https://redhat.atlassian.net/browse/AROSLSRE-1633)

### What

Bumps the Maestro image digest to `sha256:ce18b280` (built from [a6f773d](https://github.com/openshift-online/maestro/commit/a6f773d61d5be43bae49438c855cb0a0a48306cd)).

| Name | Old Digest | New Digest | Tag | Date | Status |
| --- | --- | --- | --- | --- | --- |
| maestro | 777e24018ea0… | ce18b280552c… | a6f773d61d5be43bae49438c855cb0a0a48306cd | 2026-07-28 21:53 | updated |

### Why

This pulls in [openshift-online/maestro#567](https://github.com/openshift-online/maestro/pull/567), which adds the `DeletedAt` guard to `OnUpdate` in both transports so Maestro no longer re-creates a ManifestWork whose delete it already processed. The current pinned build (`777e2401` / `e9c8bd7`) is the exact one that caused the stg/int node-pool e2e failures: a deleted inner ManifestWork got re-applied dozens to hundreds of times and the bundle delete never completed, so the server re-sent `delete_request` for hours. Full root cause and evidence are in [AROSLSRE-1633](https://redhat.atlassian.net/browse/AROSLSRE-1633).

### Testing

- Unit tests: added upstream in [#567](https://github.com/openshift-online/maestro/pull/567) covering the skip-when-deleting behavior on both the MQTT and gRPC transports.
- Verified the new image's source commit `a6f773d` is on maestro `main` and carries the `OnUpdate` guard in both `pkg/client/cloudevents/source_client.go` and `cmd/maestro/server/grpc_broker.go`.
- `cd config && make materialize` re-rendered the dev configs, included in this PR.

### Special notes for your reviewer

Digest-only bump plus its rendered configs, no source changes in this repo.
