### PR TITLE
fix(e2e): correct client factory cache checks and lock misuse

### DIFF
--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -949,7 +949,7 @@ func (tc *perItOrDescribeTestContext) Get20240610ClientFactoryOrDie(ctx context.
 
 func (tc *perItOrDescribeTestContext) GetARMSubscriptionsClientFactory() (*armsubscriptions.ClientFactory, error) {
 	tc.contextLock.RLock()
-	if tc.clientFactory20240610 != nil {
+	if tc.armSubscriptionsClientFactory != nil {
 		defer tc.contextLock.RUnlock()
 		return tc.armSubscriptionsClientFactory, nil
 	}
@@ -962,7 +962,7 @@ func (tc *perItOrDescribeTestContext) GetARMSubscriptionsClientFactory() (*armsu
 }
 
 func (tc *perItOrDescribeTestContext) getARMSubscriptionsClientFactoryUnlocked() (*armsubscriptions.ClientFactory, error) {
-	if tc.armResourcesClientFactory != nil {
+	if tc.armSubscriptionsClientFactory != nil {
 		return tc.armSubscriptionsClientFactory, nil
 	}
 
@@ -1278,12 +1278,12 @@ func (tc *perItOrDescribeTestContext) AvailableZones(ctx context.Context, vmSize
 }
 
 func (tc *perItOrDescribeTestContext) SubscriptionID(ctx context.Context) (string, error) {
-	tc.contextLock.Lock()
+	tc.contextLock.RLock()
 	if len(tc.subscriptionID) > 0 {
 		defer tc.contextLock.RUnlock()
 		return tc.subscriptionID, nil
 	}
-	tc.contextLock.Unlock()
+	tc.contextLock.RUnlock()
 
 	tc.contextLock.Lock()
 	defer tc.contextLock.Unlock()


### PR DESCRIPTION
### What

Fixes three errors in the cached accessors on `perItOrDescribeTestContext` in `test/util/framework/per_test_framework.go`:

| Location | Before | After |
|---|---|---|
| `GetARMSubscriptionsClientFactory` | fast path gated on `clientFactory20240610` | gated on `armSubscriptionsClientFactory` |
| `getARMSubscriptionsClientFactoryUnlocked` | gated on `armResourcesClientFactory` | gated on `armSubscriptionsClientFactory` |
| `SubscriptionID` | `contextLock.Lock()` released with `RUnlock()` | `RLock()` / `RUnlock()` |

All three now follow the `RLock` → check → `RUnlock` → `Lock` → `*Unlocked()`
shape used by every other accessor in the file.

### Why

**Both subscriptions-factory accessors gate on the wrong field.** They check one
cache field but return and cache a different one, so either can return
`(nil, nil)` — leaving callers to nil-deref on `clientFactory.NewClient()`.

**`SubscriptionID` mixes read and write lock modes.** `sync.RWMutex` keeps the
reader count and the writer flag separate, so releasing a write lock with
`RUnlock()` is wrong twice over:

1. The writer flag is never cleared — `contextLock` stays exclusively held, and
   every subsequent accessor (`GetARMResourcesClientFactory`, `RecordTestStep`,
   `commitTimingMetadata`, …) blocks until Ginkgo's node timeout.
2. With zero active readers the counter goes negative and Go hits
   `fatal("sync: RUnlock of unlocked RWMutex")` in `rUnlockSlow`. `fatal()` is a
   runtime throw, **not** a panic — neither `recover()` nor the
   `utilruntime.HandleCrash` guards the framework relies on can catch it. The
   whole test binary dies, skipping cleanup and leaking Azure resource groups.

That branch is currently unreachable because the per-test `subscriptionID` field
is never assigned (only `perBinaryInvocationTestContext.subscriptionID` is), but
any future `tc.subscriptionID = …` — a natural-looking one-line change — arms it.

### Testing

No new tests. 

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge