### PR TITLE
Skip KubePodNotReady

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
@@ -20,11 +20,4 @@ knownIssues:
 - name: "BackendAsyncOperation.*Stuck"
   reason: "Newly added stuck-async-operation alerts (https://github.com/Azure/ARO-HCP/pull/5952) surface a pre-existing problem: Azure Monitor Workspace ingestion latency (metrics can take ~10min to ingest) makes async operations look stuck and latches onto E2E runs even when the tests pass. Observed blocking green E2E runs (per https://cihealth.tools.hcpsvc.osadev.cloud/run-log?q=BackendAsync): BackendAsyncOperationClusterDeleteStuck, BackendAsyncOperationExternalAuthDeleteStuck, BackendAsyncOperationClusterCreateStuck, BackendAsyncOperationNodePoolDeleteStuck, BackendAsyncOperationNodePoolCreateStuck, BackendAsyncOperationStuck. Owner @stevekuznetsov; durable fix is the AMW auto-scaler (https://github.com/Azure/ARO-HCP/pull/6036). Marked known so it stops blocking the merge queue until that lands."
 - name: "KubePodNotReady"
-  labels:
-    namespace: "klusterlet-.*"
-  reason: "Klusterlet addon pods take a while to start when clusters are slow to provision, so this is a downstream issue and just noise."
-- name: "KubePodNotReady"
-  labels:
-    namespace: "ocm-.*"
-    pod: "(packageserver|olm-operator|catalog-operator)-.*"
-  reason: "OLM pods in hosted control plane namespaces are simply uninteresting to us."
+  reason: "If a pod is not not, e2e should fail. If it takes more than a couple minutes, but tests pass, fine. This error makes sense in standing environments, not in CI."


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What/Why
If an important pod is not not, e2e test fail. If it takes more than a couple minutes, but tests pass, fine. This error makes sense in standing environments, not in CI.

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
