### PR TITLE
feat: surface Cluster and NodePool ServiceProvider validations as RequirementsValid

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -623,6 +623,12 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		unionKubeApplierInformers,
 		b.clock,
 	)
+	clusterRequirementsValidAggregatorController := statuscontrollers.NewClusterRequirementsValidAggregatorController(
+		b.options.ResourcesDBClient,
+		clusterLister,
+		serviceProviderClusterLister,
+		backendInformers,
+	)
 	nodePoolDegradedAggregatorController := statuscontrollers.NewNodePoolDegradedAggregatorController(
 		b.options.ResourcesDBClient,
 		nodePoolLister,
@@ -630,6 +636,12 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		backendInformers,
 		unionKubeApplierInformers,
 		b.clock,
+	)
+	nodePoolRequirementsValidAggregatorController := statuscontrollers.NewNodePoolRequirementsValidAggregatorController(
+		b.options.ResourcesDBClient,
+		nodePoolLister,
+		serviceProviderNodePoolLister,
+		backendInformers,
 	)
 	externalAuthDegradedAggregatorController := statuscontrollers.NewExternalAuthDegradedAggregatorController(
 		b.options.ResourcesDBClient,
@@ -896,7 +908,9 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go clusterPropertiesSyncController.Run(ctx, 20)
 				go identityMigrationController.Run(ctx, 20)
 				go clusterDegradedAggregatorController.Run(ctx, 20)
+				go clusterRequirementsValidAggregatorController.Run(ctx, 20)
 				go nodePoolDegradedAggregatorController.Run(ctx, 20)
+				go nodePoolRequirementsValidAggregatorController.Run(ctx, 20)
 				go externalAuthDegradedAggregatorController.Run(ctx, 20)
 				go desiredControlPlaneSizeController.Run(ctx, 20)
 				go serviceProviderClusterPropertiesSyncController.Run(ctx, 20)

--- a/backend/pkg/controllers/statuscontrollers/cluster_requirements_valid_aggregator.go
+++ b/backend/pkg/controllers/statuscontrollers/cluster_requirements_valid_aggregator.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	// clusterRequirementsValidAggregatorControllerName is the controller name used for
+	// metrics labels, ctx values, log fields, and the Controller document name.
+	clusterRequirementsValidAggregatorControllerName = "ClusterRequirementsValidAggregator"
+)
+
+// clusterRequirementsValidAggregator surfaces ServiceProviderCluster.Status.Validations
+// up onto HCPOpenShiftCluster.Status.UserFacingConditions as a single
+// RequirementsValid condition.
+//
+// Failed or Unknown validations drive RequirementsValid=False/Degraded, with
+// messages aggregated in the same "Source: message" form used by the Degraded
+// aggregator. When every validation is True (or none exist) the condition is True/Valid.
+type clusterRequirementsValidAggregator struct {
+	clusterLister                listers.ClusterLister
+	serviceProviderClusterLister listers.ServiceProviderClusterLister
+	resourcesDBClient            database.ResourcesDBClient
+}
+
+var _ controllerutils.ClusterSyncer = (*clusterRequirementsValidAggregator)(nil)
+
+// NewClusterRequirementsValidAggregatorController creates a controller that
+// aggregates ServiceProviderCluster validations onto the cluster's
+// Status.UserFacingConditions as RequirementsValid.
+func NewClusterRequirementsValidAggregatorController(
+	resourcesDBClient database.ResourcesDBClient,
+	clusterLister listers.ClusterLister,
+	serviceProviderClusterLister listers.ServiceProviderClusterLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	syncer := &clusterRequirementsValidAggregator{
+		clusterLister:                clusterLister,
+		serviceProviderClusterLister: serviceProviderClusterLister,
+		resourcesDBClient:            resourcesDBClient,
+	}
+	return controllerutils.NewClusterWatchingController(
+		clusterRequirementsValidAggregatorControllerName,
+		resourcesDBClient,
+		informers,
+		nil,
+		1*time.Minute,
+		syncer,
+	)
+}
+
+func (c *clusterRequirementsValidAggregator) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
+	existing, err := c.clusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get Cluster from cache: %w", err))
+	}
+	if !c.needsWork(existing) {
+		return nil
+	}
+
+	serviceProviderCluster, err := c.serviceProviderClusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if database.IsNotFoundError(err) {
+		// CreateServiceProviderCluster will populate it. We'll be re-enqueued via the ServiceProviderCluster informer.
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster from cache: %w", err))
+	}
+
+	aggregated := aggregateRequirementsValidCondition(serviceProviderCluster.Status.Validations)
+
+	replacement := existing.DeepCopy()
+	apimeta.SetStatusCondition(&replacement.Status.UserFacingConditions, aggregated)
+	if equality.Semantic.DeepEqual(existing.Status.UserFacingConditions, replacement.Status.UserFacingConditions) {
+		return nil
+	}
+
+	clusterCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName)
+	_, err = clusterCRUD.Replace(ctx, replacement, nil)
+	if database.IsPreconditionFailedError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to replace Cluster: %w", err))
+	}
+	return nil
+}
+
+// needsWork reports whether this aggregator should update UserFacingConditions
+// for the given cluster. Deleting clusters are skipped.
+func (c *clusterRequirementsValidAggregator) needsWork(cluster *api.HCPOpenShiftCluster) bool {
+	return cluster.ServiceProviderProperties.DeletionTimestamp == nil
+}

--- a/backend/pkg/controllers/statuscontrollers/cluster_requirements_valid_aggregator_test.go
+++ b/backend/pkg/controllers/statuscontrollers/cluster_requirements_valid_aggregator_test.go
@@ -1,0 +1,195 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+)
+
+func newTestServiceProviderClusterForAggregator(opts ...func(*api.ServiceProviderCluster)) *api.ServiceProviderCluster {
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/serviceProviderClusters/" + api.ServiceProviderClusterResourceName,
+	))
+	spc := &api.ServiceProviderCluster{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+		},
+	}
+	for _, opt := range opts {
+		opt(spc)
+	}
+	return spc
+}
+
+func TestClusterRequirementsValidAggregator_SyncOnce(t *testing.T) {
+	failedValidation := newTestValidationCondition("AValidation", metav1.ConditionFalse, "Failed", "Validation failed: boom")
+	degradedCondition := metav1.Condition{
+		Type:    requirementsValidConditionType,
+		Status:  metav1.ConditionFalse,
+		Reason:  requirementsValidConditionReasonDegraded,
+		Message: "AValidation: Validation failed: boom",
+	}
+	validCondition := metav1.Condition{
+		Type:    requirementsValidConditionType,
+		Status:  metav1.ConditionTrue,
+		Reason:  requirementsValidConditionReasonValid,
+		Message: "",
+	}
+
+	testCases := []struct {
+		name                           string
+		existingCluster                *api.HCPOpenShiftCluster
+		existingServiceProviderCluster *api.ServiceProviderCluster
+		// wantCondition is the expected RequirementsValid condition after SyncOnce.
+		// nil means the condition must remain absent. Only Type/Status/Reason/Message
+		// are asserted; LastTransitionTime is not considered.
+		wantCondition *metav1.Condition
+	}{
+		{
+			name:                           "no validations writes True/Valid",
+			existingCluster:                newTestClusterForAggregator(),
+			existingServiceProviderCluster: newTestServiceProviderClusterForAggregator(),
+			wantCondition:                  &validCondition,
+		},
+		{
+			name:            "failed validation writes False/Degraded",
+			existingCluster: newTestClusterForAggregator(),
+			existingServiceProviderCluster: newTestServiceProviderClusterForAggregator(func(spc *api.ServiceProviderCluster) {
+				spc.Status.Validations = []metav1.Condition{failedValidation}
+			}),
+			wantCondition: &degradedCondition,
+		},
+		{
+			name: "no-op when UserFacingConditions already match",
+			existingCluster: newTestClusterForAggregator(func(c *api.HCPOpenShiftCluster) {
+				c.Status.UserFacingConditions = []metav1.Condition{degradedCondition}
+			}),
+			existingServiceProviderCluster: newTestServiceProviderClusterForAggregator(func(spc *api.ServiceProviderCluster) {
+				spc.Status.Validations = []metav1.Condition{failedValidation}
+			}),
+			wantCondition: &degradedCondition,
+		},
+		{
+			name:                           "missing ServiceProviderCluster skips write",
+			existingCluster:                newTestClusterForAggregator(),
+			existingServiceProviderCluster: nil,
+			wantCondition:                  nil,
+		},
+		{
+			name: "deleting cluster skips write",
+			existingCluster: newTestClusterForAggregator(func(c *api.HCPOpenShiftCluster) {
+				now := metav1.Now()
+				c.ServiceProviderProperties.DeletionTimestamp = &now
+			}),
+			existingServiceProviderCluster: newTestServiceProviderClusterForAggregator(func(spc *api.ServiceProviderCluster) {
+				spc.Status.Validations = []metav1.Condition{failedValidation}
+			}),
+			wantCondition: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			seed := []any{}
+			if tc.existingCluster != nil {
+				seed = append(seed, tc.existingCluster)
+			}
+			if tc.existingServiceProviderCluster != nil {
+				seed = append(seed, tc.existingServiceProviderCluster)
+			}
+
+			mockDB, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, seed)
+			require.NoError(t, err)
+
+			syncer := &clusterRequirementsValidAggregator{
+				clusterLister:                &listertesting.DBClusterLister{ResourcesDBClient: mockDB},
+				serviceProviderClusterLister: &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockDB},
+				resourcesDBClient:            mockDB,
+			}
+
+			err = syncer.SyncOnce(ctx, controllerutils.HCPClusterKey{
+				SubscriptionID:    testSubscriptionID,
+				ResourceGroupName: testResourceGroupName,
+				HCPClusterName:    testClusterName,
+			})
+			require.NoError(t, err)
+
+			updated, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroupName).Get(ctx, testClusterName)
+			require.NoError(t, err)
+
+			cond := apimeta.FindStatusCondition(updated.Status.UserFacingConditions, requirementsValidConditionType)
+			if tc.wantCondition == nil {
+				assert.Nil(t, cond, "RequirementsValid must remain absent")
+				return
+			}
+			require.NotNil(t, cond, "RequirementsValid must be set")
+			assert.Equal(t, tc.wantCondition.Status, cond.Status, "status")
+			assert.Equal(t, tc.wantCondition.Reason, cond.Reason, "reason")
+			assert.Equal(t, tc.wantCondition.Message, cond.Message, "message")
+		})
+	}
+}
+
+func TestClusterRequirementsValidAggregator_NeedsWork(t *testing.T) {
+	now := metav1.Now()
+
+	tests := []struct {
+		name    string
+		cluster *api.HCPOpenShiftCluster
+		want    bool
+	}{
+		{
+			name:    "proceed when not deleting",
+			cluster: newTestClusterForAggregator(),
+			want:    true,
+		},
+		{
+			name: "skip when deletion timestamp is set",
+			cluster: newTestClusterForAggregator(func(c *api.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.DeletionTimestamp = &now
+			}),
+			want: false,
+		},
+	}
+
+	syncer := &clusterRequirementsValidAggregator{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, syncer.needsWork(tc.cluster))
+		})
+	}
+}

--- a/backend/pkg/controllers/statuscontrollers/nodepool_requirements_valid_aggregator.go
+++ b/backend/pkg/controllers/statuscontrollers/nodepool_requirements_valid_aggregator.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/informers"
+	"github.com/Azure/ARO-HCP/backend/pkg/listers"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	// nodePoolRequirementsValidAggregatorControllerName is the controller name used for
+	// metrics labels, ctx values, log fields, and the Controller document name.
+	nodePoolRequirementsValidAggregatorControllerName = "NodePoolRequirementsValidAggregator"
+)
+
+// nodePoolRequirementsValidAggregator surfaces ServiceProviderNodePool.Status.Validations
+// up onto HCPOpenShiftClusterNodePool.Status.UserFacingConditions as a single
+// RequirementsValid condition.
+//
+// Failed or Unknown validations drive RequirementsValid=False/Degraded, with
+// messages aggregated in the same "Source: message" form used by the Degraded
+// aggregator. When every validation is True (or none exist) the condition is True/Valid.
+type nodePoolRequirementsValidAggregator struct {
+	nodePoolLister                listers.NodePoolLister
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister
+	resourcesDBClient             database.ResourcesDBClient
+}
+
+var _ controllerutils.NodePoolSyncer = (*nodePoolRequirementsValidAggregator)(nil)
+
+// NewNodePoolRequirementsValidAggregatorController creates a controller that
+// aggregates ServiceProviderNodePool validations onto the node pool's
+// Status.UserFacingConditions as RequirementsValid.
+func NewNodePoolRequirementsValidAggregatorController(
+	resourcesDBClient database.ResourcesDBClient,
+	nodePoolLister listers.NodePoolLister,
+	serviceProviderNodePoolLister listers.ServiceProviderNodePoolLister,
+	informers informers.BackendInformers,
+) controllerutils.Controller {
+	syncer := &nodePoolRequirementsValidAggregator{
+		nodePoolLister:                nodePoolLister,
+		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
+		resourcesDBClient:             resourcesDBClient,
+	}
+	return controllerutils.NewNodePoolWatchingController(
+		nodePoolRequirementsValidAggregatorControllerName,
+		resourcesDBClient,
+		informers,
+		nil,
+		1*time.Minute,
+		syncer,
+	)
+}
+
+func (c *nodePoolRequirementsValidAggregator) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {
+	existing, err := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get NodePool from cache: %w", err))
+	}
+	if !c.needsWork(existing) {
+		return nil
+	}
+
+	serviceProviderNodePool, err := c.serviceProviderNodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if database.IsNotFoundError(err) {
+		// CreateServiceProviderNodePool will populate it. We'll be re-enqueued via the ServiceProviderNodePool informer.
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderNodePool from cache: %w", err))
+	}
+
+	aggregated := aggregateRequirementsValidCondition(serviceProviderNodePool.Status.Validations)
+
+	replacement := existing.DeepCopy()
+	apimeta.SetStatusCondition(&replacement.Status.UserFacingConditions, aggregated)
+	if equality.Semantic.DeepEqual(existing.Status.UserFacingConditions, replacement.Status.UserFacingConditions) {
+		return nil
+	}
+
+	nodePoolCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).NodePools(key.HCPClusterName)
+	_, err = nodePoolCRUD.Replace(ctx, replacement, nil)
+	if database.IsPreconditionFailedError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to replace NodePool: %w", err))
+	}
+	return nil
+}
+
+func (c *nodePoolRequirementsValidAggregator) needsWork(nodePool *api.HCPOpenShiftClusterNodePool) bool {
+	return nodePool.ServiceProviderProperties.DeletionTimestamp == nil
+}

--- a/backend/pkg/controllers/statuscontrollers/nodepool_requirements_valid_aggregator_test.go
+++ b/backend/pkg/controllers/statuscontrollers/nodepool_requirements_valid_aggregator_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controllerutils"
+	"github.com/Azure/ARO-HCP/backend/pkg/listertesting"
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+)
+
+func newTestServiceProviderNodePoolForAggregator(opts ...func(*api.ServiceProviderNodePool)) *api.ServiceProviderNodePool {
+	resourceID := api.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/nodePools/" + testNodePoolName +
+			"/serviceProviderNodePools/" + api.ServiceProviderNodePoolResourceName,
+	))
+	spnp := &api.ServiceProviderNodePool{
+		CosmosMetadata: arm.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+		},
+	}
+	for _, opt := range opts {
+		opt(spnp)
+	}
+	return spnp
+}
+
+func TestNodePoolRequirementsValidAggregator_SyncOnce(t *testing.T) {
+	failedValidation := newTestValidationCondition("AValidation", metav1.ConditionFalse, "Failed", "Validation failed: boom")
+	degradedCondition := metav1.Condition{
+		Type:    requirementsValidConditionType,
+		Status:  metav1.ConditionFalse,
+		Reason:  requirementsValidConditionReasonDegraded,
+		Message: "AValidation: Validation failed: boom",
+	}
+	validCondition := metav1.Condition{
+		Type:    requirementsValidConditionType,
+		Status:  metav1.ConditionTrue,
+		Reason:  requirementsValidConditionReasonValid,
+		Message: "",
+	}
+
+	testCases := []struct {
+		name                            string
+		existingNodePool                *api.HCPOpenShiftClusterNodePool
+		existingServiceProviderNodePool *api.ServiceProviderNodePool
+		// wantCondition is the expected RequirementsValid condition after SyncOnce.
+		// nil means the condition must remain absent. Only Type/Status/Reason/Message
+		// are asserted; LastTransitionTime is not considered.
+		wantCondition *metav1.Condition
+	}{
+		{
+			name:                            "no validations writes True/Valid",
+			existingNodePool:                newTestNodePoolForAggregator(),
+			existingServiceProviderNodePool: newTestServiceProviderNodePoolForAggregator(),
+			wantCondition:                   &validCondition,
+		},
+		{
+			name:             "failed validation writes False/Degraded",
+			existingNodePool: newTestNodePoolForAggregator(),
+			existingServiceProviderNodePool: newTestServiceProviderNodePoolForAggregator(func(spnp *api.ServiceProviderNodePool) {
+				spnp.Status.Validations = []metav1.Condition{failedValidation}
+			}),
+			wantCondition: &degradedCondition,
+		},
+		{
+			name: "no-op when UserFacingConditions already match",
+			existingNodePool: newTestNodePoolForAggregator(func(np *api.HCPOpenShiftClusterNodePool) {
+				np.Status.UserFacingConditions = []metav1.Condition{degradedCondition}
+			}),
+			existingServiceProviderNodePool: newTestServiceProviderNodePoolForAggregator(func(spnp *api.ServiceProviderNodePool) {
+				spnp.Status.Validations = []metav1.Condition{failedValidation}
+			}),
+			wantCondition: &degradedCondition,
+		},
+		{
+			name:                            "missing ServiceProviderNodePool skips write",
+			existingNodePool:                newTestNodePoolForAggregator(),
+			existingServiceProviderNodePool: nil,
+			wantCondition:                   nil,
+		},
+		{
+			name: "deleting node pool skips write",
+			existingNodePool: newTestNodePoolForAggregator(func(np *api.HCPOpenShiftClusterNodePool) {
+				now := metav1.Now()
+				np.ServiceProviderProperties.DeletionTimestamp = &now
+			}),
+			existingServiceProviderNodePool: newTestServiceProviderNodePoolForAggregator(func(spnp *api.ServiceProviderNodePool) {
+				spnp.Status.Validations = []metav1.Condition{failedValidation}
+			}),
+			wantCondition: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			seed := []any{newTestClusterForAggregator()}
+			if tc.existingNodePool != nil {
+				seed = append(seed, tc.existingNodePool)
+			}
+			if tc.existingServiceProviderNodePool != nil {
+				seed = append(seed, tc.existingServiceProviderNodePool)
+			}
+
+			mockDB, err := databasetesting.NewMockResourcesDBClientWithResources(ctx, seed)
+			require.NoError(t, err)
+
+			syncer := &nodePoolRequirementsValidAggregator{
+				nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockDB},
+				serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockDB},
+				resourcesDBClient:             mockDB,
+			}
+
+			err = syncer.SyncOnce(ctx, controllerutils.HCPNodePoolKey{
+				SubscriptionID:    testSubscriptionID,
+				ResourceGroupName: testResourceGroupName,
+				HCPClusterName:    testClusterName,
+				HCPNodePoolName:   testNodePoolName,
+			})
+			require.NoError(t, err)
+
+			updated, err := mockDB.HCPClusters(testSubscriptionID, testResourceGroupName).NodePools(testClusterName).Get(ctx, testNodePoolName)
+			require.NoError(t, err)
+
+			cond := apimeta.FindStatusCondition(updated.Status.UserFacingConditions, requirementsValidConditionType)
+			if tc.wantCondition == nil {
+				assert.Nil(t, cond, "RequirementsValid must remain absent")
+				return
+			}
+			require.NotNil(t, cond, "RequirementsValid must be set")
+			assert.Equal(t, tc.wantCondition.Status, cond.Status, "status")
+			assert.Equal(t, tc.wantCondition.Reason, cond.Reason, "reason")
+			assert.Equal(t, tc.wantCondition.Message, cond.Message, "message")
+		})
+	}
+}
+
+func TestNodePoolRequirementsValidAggregator_NeedsWork(t *testing.T) {
+	now := metav1.Now()
+
+	tests := []struct {
+		name     string
+		nodePool *api.HCPOpenShiftClusterNodePool
+		want     bool
+	}{
+		{
+			name:     "proceed when not deleting",
+			nodePool: newTestNodePoolForAggregator(),
+			want:     true,
+		},
+		{
+			name: "skip when deletion timestamp is set",
+			nodePool: newTestNodePoolForAggregator(func(np *api.HCPOpenShiftClusterNodePool) {
+				np.ServiceProviderProperties.DeletionTimestamp = &now
+			}),
+			want: false,
+		},
+	}
+
+	syncer := &nodePoolRequirementsValidAggregator{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, syncer.needsWork(tc.nodePool))
+		})
+	}
+}

--- a/backend/pkg/controllers/statuscontrollers/requirements_valid.go
+++ b/backend/pkg/controllers/statuscontrollers/requirements_valid.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// requirementsValidConditionType is the user-facing condition type that
+	// aggregates ServiceProvider* Status.Validations onto the parent resource's
+	// Status.UserFacingConditions.
+	requirementsValidConditionType = "RequirementsValid"
+
+	// requirementsValidConditionReasonValid is set when every known validation
+	// has Status=True (or there are no validations yet). Paired with
+	// Status=True and an empty Message.
+	requirementsValidConditionReasonValid = "Valid"
+	// requirementsValidConditionReasonDegraded is set when at least one
+	// validation has Status False or Unknown. Paired with Status=False and a
+	// Message that enumerates those non-True validations.
+	requirementsValidConditionReasonDegraded = "Degraded"
+)
+
+// aggregateRequirementsValidCondition builds the single RequirementsValid
+// condition that RequirementsValid aggregators write onto
+// status.userFacingConditions.
+//
+// Input is the ServiceProvider* Status.Validations slice.
+//
+// Result:
+//   - Type is always RequirementsValid.
+//   - When every validation has Status=True (or the slice is empty):
+//     Status=True, Reason=Valid, Message empty.
+//   - When at least one validation has Status False or Unknown: Status=False,
+//     Reason=Degraded, Message lists only those non-True validations, sorted
+//     by Type and formatted by joinNamedMessages as "ValidationName: <line>"
+//     (one line per unique message line), joined with newlines.
+func aggregateRequirementsValidCondition(validations []metav1.Condition) metav1.Condition {
+	failed := make([]namedMessage, 0, len(validations))
+	for _, validation := range validations {
+		if validation.Status == metav1.ConditionTrue {
+			continue
+		}
+		failed = append(failed, namedMessage{
+			name:    validation.Type,
+			message: validation.Message,
+		})
+	}
+	sort.Slice(failed, func(i, j int) bool {
+		return failed[i].name < failed[j].name
+	})
+
+	if len(failed) == 0 {
+		return metav1.Condition{
+			Type:    requirementsValidConditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  requirementsValidConditionReasonValid,
+			Message: "",
+		}
+	}
+
+	return metav1.Condition{
+		Type:    requirementsValidConditionType,
+		Status:  metav1.ConditionFalse,
+		Reason:  requirementsValidConditionReasonDegraded,
+		Message: joinNamedMessages(failed),
+	}
+}

--- a/backend/pkg/controllers/statuscontrollers/requirements_valid_test.go
+++ b/backend/pkg/controllers/statuscontrollers/requirements_valid_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statuscontrollers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newTestValidationCondition(name string, status metav1.ConditionStatus, reason, message string) metav1.Condition {
+	return metav1.Condition{
+		Type:               name,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.NewTime(fixedNow.Add(-time.Minute)),
+	}
+}
+
+func TestAggregateRequirementsValidCondition(t *testing.T) {
+	validCondition := metav1.Condition{
+		Type:    requirementsValidConditionType,
+		Status:  metav1.ConditionTrue,
+		Reason:  requirementsValidConditionReasonValid,
+		Message: "",
+	}
+
+	testCases := []struct {
+		name          string
+		validations   []metav1.Condition
+		wantCondition metav1.Condition
+	}{
+		{
+			name:          "no validations writes True/Valid with empty message",
+			validations:   nil,
+			wantCondition: validCondition,
+		},
+		{
+			name: "all validations succeeded writes True/Valid",
+			validations: []metav1.Condition{
+				newTestValidationCondition("AValidation", metav1.ConditionTrue, "Succeeded", "Validation succeeded"),
+				newTestValidationCondition("BValidation", metav1.ConditionTrue, "Succeeded", "Validation succeeded"),
+			},
+			wantCondition: validCondition,
+		},
+		{
+			name: "one failed validation writes False/Degraded with that message",
+			validations: []metav1.Condition{
+				newTestValidationCondition("AValidation", metav1.ConditionTrue, "Succeeded", "Validation succeeded"),
+				newTestValidationCondition("BValidation", metav1.ConditionFalse, "Failed", "Validation failed: boom"),
+			},
+			wantCondition: metav1.Condition{
+				Type:    requirementsValidConditionType,
+				Status:  metav1.ConditionFalse,
+				Reason:  requirementsValidConditionReasonDegraded,
+				Message: "BValidation: Validation failed: boom",
+			},
+		},
+		{
+			name: "multiple failed validations are sorted and joined like UnionCondition",
+			validations: []metav1.Condition{
+				newTestValidationCondition("ZValidation", metav1.ConditionFalse, "Failed", "Validation failed: zed"),
+				newTestValidationCondition("AValidation", metav1.ConditionFalse, "Failed", "Validation failed: aye"),
+				newTestValidationCondition("MValidation", metav1.ConditionTrue, "Succeeded", "Validation succeeded"),
+			},
+			wantCondition: metav1.Condition{
+				Type:    requirementsValidConditionType,
+				Status:  metav1.ConditionFalse,
+				Reason:  requirementsValidConditionReasonDegraded,
+				Message: "AValidation: Validation failed: aye\nZValidation: Validation failed: zed",
+			},
+		},
+		{
+			name: "multi-line failed messages are expanded per line with source prefix",
+			validations: []metav1.Condition{
+				newTestValidationCondition("AValidation", metav1.ConditionFalse, "Failed", "line one\nline two"),
+			},
+			wantCondition: metav1.Condition{
+				Type:    requirementsValidConditionType,
+				Status:  metav1.ConditionFalse,
+				Reason:  requirementsValidConditionReasonDegraded,
+				Message: "AValidation: line one\nAValidation: line two",
+			},
+		},
+		{
+			name: "Unknown validations count as Degraded",
+			validations: []metav1.Condition{
+				newTestValidationCondition("AValidation", metav1.ConditionUnknown, "Pending", "still running"),
+			},
+			wantCondition: metav1.Condition{
+				Type:    requirementsValidConditionType,
+				Status:  metav1.ConditionFalse,
+				Reason:  requirementsValidConditionReasonDegraded,
+				Message: "AValidation: still running",
+			},
+		},
+		{
+			name: "False and Unknown validations are both included in the message",
+			validations: []metav1.Condition{
+				newTestValidationCondition("AValidation", metav1.ConditionTrue, "Succeeded", "Validation succeeded"),
+				newTestValidationCondition("BValidation", metav1.ConditionUnknown, "Pending", "still running"),
+				newTestValidationCondition("CValidation", metav1.ConditionFalse, "Failed", "Validation failed: boom"),
+			},
+			wantCondition: metav1.Condition{
+				Type:    requirementsValidConditionType,
+				Status:  metav1.ConditionFalse,
+				Reason:  requirementsValidConditionReasonDegraded,
+				Message: "BValidation: still running\nCValidation: Validation failed: boom",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := aggregateRequirementsValidCondition(tc.validations)
+			// Only Type/Status/Reason/Message are asserted; LastTransitionTime is not considered.
+			require.Equal(t, tc.wantCondition.Type, got.Type, "type")
+			assert.Equal(t, tc.wantCondition.Status, got.Status, "status")
+			assert.Equal(t, tc.wantCondition.Reason, got.Reason, "reason")
+			assert.Equal(t, tc.wantCondition.Message, got.Message, "message")
+		})
+	}
+}

--- a/backend/pkg/controllers/statuscontrollers/union_condition.go
+++ b/backend/pkg/controllers/statuscontrollers/union_condition.go
@@ -125,13 +125,34 @@ func UnionCondition(
 // line, prefixed with the source controller name so the aggregated message
 // remains attributable.
 func unionMessage(sources []SourcedCondition) string {
+	named := make([]namedMessage, 0, len(sources))
+	for _, src := range sources {
+		named = append(named, namedMessage{
+			name:    src.ControllerName,
+			message: src.Condition.Message,
+		})
+	}
+	return joinNamedMessages(named)
+}
+
+// namedMessage is a source name paired with a free-form message. Used by
+// joinNamedMessages so Degraded aggregation (controller name) and
+// RequirementsValid aggregation (validation type) share one formatter.
+type namedMessage struct {
+	name    string
+	message string
+}
+
+// joinNamedMessages formats messages as "name: line" for each unique line of
+// each message, then joins with newlines. Empty messages are skipped.
+func joinNamedMessages(sources []namedMessage) string {
 	lines := []string{}
 	for _, src := range sources {
-		if len(src.Condition.Message) == 0 {
+		if len(src.message) == 0 {
 			continue
 		}
-		for _, line := range uniq(strings.Split(src.Condition.Message, "\n")) {
-			lines = append(lines, fmt.Sprintf("%s: %s", src.ControllerName, line))
+		for _, line := range uniq(strings.Split(src.message, "\n")) {
+			lines = append(lines, fmt.Sprintf("%s: %s", src.name, line))
 		}
 	}
 	return strings.Join(lines, "\n")

--- a/docs/cosmos-data-flow.md
+++ b/docs/cosmos-data-flow.md
@@ -1035,6 +1035,34 @@ No Cosmos writes. Posts `NodePoolUpgradePolicy` to Cluster Service.
 | **Write** | **`HCPOpenShiftClusterNodePool`** | <ul><li>**`Status.Conditions[Degraded]`** = aggregated union</li></ul> |
 | **Write** | **`HCPOpenShiftClusterExternalAuth`** | <ul><li>**`Status.Conditions[Degraded]`** = aggregated union</li></ul> |
 
+#### ClusterRequirementsValidAggregator
+
+**File:** [cluster_requirements_valid_aggregator.go](../backend/pkg/controllers/statuscontrollers/cluster_requirements_valid_aggregator.go)
+**Trigger:** Cluster / ServiceProviderCluster informer, 1-minute resync
+**Gate (SyncOnce preconditions):**
+- `Cluster.ServiceProviderProperties.DeletionTimestamp` == nil
+- `ServiceProviderCluster` exists
+
+| | Object | Fields |
+|---|--------|--------|
+| Read | `HCPOpenShiftCluster` | <ul><li>`ServiceProviderProperties.DeletionTimestamp` (SyncOnce: must be nil)</li><li>`Status.UserFacingConditions` (skip write when unchanged)</li></ul> |
+| Read | `ServiceProviderCluster` | <ul><li>`Status.Validations` (non-True = Status False or Unknown)</li></ul> |
+| **Write** | **`HCPOpenShiftCluster`** | <ul><li>**`Status.UserFacingConditions[RequirementsValid]`** = True/Valid when no failures; False/Degraded with unioned failed validation messages otherwise</li></ul> |
+
+#### NodePoolRequirementsValidAggregator
+
+**File:** [nodepool_requirements_valid_aggregator.go](../backend/pkg/controllers/statuscontrollers/nodepool_requirements_valid_aggregator.go)
+**Trigger:** NodePool / ServiceProviderNodePool informer, 1-minute resync
+**Gate (SyncOnce preconditions):**
+- `NodePool.ServiceProviderProperties.DeletionTimestamp` == nil
+- `ServiceProviderNodePool` exists
+
+| | Object | Fields |
+|---|--------|--------|
+| Read | `HCPOpenShiftClusterNodePool` | <ul><li>`ServiceProviderProperties.DeletionTimestamp` (SyncOnce: must be nil)</li><li>`Status.UserFacingConditions` (skip write when unchanged)</li></ul> |
+| Read | `ServiceProviderNodePool` | <ul><li>`Status.Validations` (non-True = Status False or Unknown)</li></ul> |
+| **Write** | **`HCPOpenShiftClusterNodePool`** | <ul><li>**`Status.UserFacingConditions[RequirementsValid]`** = True/Valid when no failures; False/Degraded with unioned failed validation messages otherwise</li></ul> |
+
 #### CreateClusterScopedReadDesires / CreateNodePoolScopedReadDesires
 
 **File:** [create_cluster_scoped_read_desires_controller.go](../backend/pkg/controllers/create_cluster_scoped_read_desires_controller.go), [create_nodepool_scoped_read_desires_controller.go](../backend/pkg/controllers/create_nodepool_scoped_read_desires_controller.go)
@@ -1293,6 +1321,22 @@ Single writer, but gates billing lifecycle.
 | [ClusterDegradedAggregator](#degradedaggregators-cluster--nodepool--externalauth) | Aggregated `Degraded` condition from all controller status docs |
 
 Single writer.
+
+### `HCPOpenShiftCluster.Status.UserFacingConditions`
+
+| Actor | When |
+|-------|------|
+| [ClusterRequirementsValidAggregator](#clusterrequirementsvalidaggregator) | Aggregated `RequirementsValid` condition from `ServiceProviderCluster.Status.Validations` |
+
+Single writer today (`RequirementsValid` only).
+
+### `HCPOpenShiftClusterNodePool.Status.UserFacingConditions`
+
+| Actor | When |
+|-------|------|
+| [NodePoolRequirementsValidAggregator](#nodepoolrequirementsvalidaggregator) | Aggregated `RequirementsValid` condition from `ServiceProviderNodePool.Status.Validations` |
+
+Single writer today (`RequirementsValid` only).
 
 ### `HCPOpenShiftClusterNodePool.Properties.ProvisioningState`
 

--- a/internal/api/types_cluster.go
+++ b/internal/api/types_cluster.go
@@ -36,7 +36,7 @@ type HCPOpenShiftCluster struct {
 	ServiceProviderProperties HCPOpenShiftClusterServiceProviderProperties `json:"serviceProviderProperties,omitempty"`
 	// Written by: Frontend PUT/PATCH Cluster (Create/Update), IdentityMigration
 	Identity *arm.ManagedServiceIdentity `json:"identity,omitempty"`
-	// Written by: ClusterDegradedAggregator
+	// Written by: ClusterDegradedAggregator, ClusterRequirementsValidAggregator
 	Status HCPOpenShiftClusterStatus `json:"status"`
 }
 
@@ -60,6 +60,7 @@ type HCPOpenShiftClusterStatus struct {
 	// Addition of new conditions here should be done only when strictly necessary, sparingly and only done
 	// when there is a clear benefit to doing so. We expect the number of conditions at this
 	// level to be kept to a minimum.
+	// Written by: ClusterRequirementsValidAggregator
 	// +optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge

--- a/internal/api/types_nodepool.go
+++ b/internal/api/types_nodepool.go
@@ -39,7 +39,7 @@ type HCPOpenShiftClusterNodePool struct {
 	// Written by: Frontend PUT/PATCH/DELETE NodePool, OperationNodePool* controllers, NodePoolClusterServiceCreate, NodePoolDeletion* controllers
 	ServiceProviderProperties HCPOpenShiftClusterNodePoolServiceProviderProperties `json:"serviceProviderProperties,omitempty"`
 	Identity                  *arm.ManagedServiceIdentity                          `json:"identity,omitempty"`
-	// Written by: NodePoolDegradedAggregator
+	// Written by: NodePoolDegradedAggregator, NodePoolRequirementsValidAggregator
 	Status HCPOpenShiftClusterNodePoolStatus `json:"status"`
 }
 
@@ -63,6 +63,7 @@ type HCPOpenShiftClusterNodePoolStatus struct {
 	// Addition of new conditions here should be done only when strictly necessary, sparingly and only done
 	// when there is a clear benefit to doing so. We expect the number of conditions at this
 	// level to be kept to a minimum.
+	// Written by: NodePoolRequirementsValidAggregator
 	// +optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge


### PR DESCRIPTION
Builds on top of https://github.com/Azure/ARO-HCP/pull/6308.

Add Cluster and NodePool controllers that roll ServiceProviderCluster
and ServiceProviderNodePool Status.Validations respectively up onto
their corresponding Status.UserFacingConditions as a single
RequirementsValid condition, which ends up exposed via the ARM API.

Aggregation rules:
- Type is always RequirementsValid.
- When all validations are True then Status is set to True with
  Reason=Valid
- When there's at least one validation that is False or Uknown then
  Status is set to False with Reason=Degraded. In that case, messages
  of both false or unknown validations are aggregated in the shared
  Degraded-style format