### PR TITLE
fix(test): stop reaper abandoning deletable RGs behind deny-locked managed RGs (AROSLSRE-1545)

### DIFF
--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -45,6 +45,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	armauthorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
@@ -522,6 +523,69 @@ func (tc *perItOrDescribeTestContext) waitForManagedResourceGroupsDeletion(ctx c
 	}
 }
 
+// partitionDenyAssignmentLockedResourceGroups splits managed resource groups into those blocked
+// by a system-protected deny assignment (locked: the reaper can never delete them, they need
+// RP-side remediation) and the rest. A probe failure is treated as "not locked" so the caller
+// falls back to the existing wait-and-report behaviour rather than skipping a group that might
+// still be deletable.
+func (tc *perItOrDescribeTestContext) partitionDenyAssignmentLockedResourceGroups(ctx context.Context, resourceGroupNames []string) (locked, pending []string) {
+	for _, resourceGroupName := range resourceGroupNames {
+		isLocked, err := tc.resourceGroupHasSystemProtectedDenyAssignment(ctx, resourceGroupName)
+		if err != nil {
+			ginkgo.GinkgoLogr.Error(err, "failed to check for a system-protected deny assignment, treating resource group as not locked",
+				"resourceGroup", resourceGroupName)
+			pending = append(pending, resourceGroupName)
+			continue
+		}
+		if isLocked {
+			locked = append(locked, resourceGroupName)
+		} else {
+			pending = append(pending, resourceGroupName)
+		}
+	}
+	return locked, pending
+}
+
+// resourceGroupHasSystemProtectedDenyAssignment reports whether the resource group carries a
+// system-protected deny assignment. The RP creates such a deny assignment on the managed
+// resource group holding customer infrastructure (isSystemProtected=true), which blocks
+// resourceGroups/delete for every principal except the RP first-party service principals. Once
+// the parent HCP cluster is gone, the managed resource group is orphaned and the reaper can
+// never delete it, so there is no point waiting for it to disappear.
+func (tc *perItOrDescribeTestContext) resourceGroupHasSystemProtectedDenyAssignment(ctx context.Context, resourceGroupName string) (bool, error) {
+	creds, err := tc.perBinaryInvocationTestContext.getAzureCredentials()
+	if err != nil {
+		return false, err
+	}
+	subscriptionID, err := tc.SubscriptionID(ctx)
+	if err != nil {
+		return false, err
+	}
+	denyAssignmentsClient, err := armauthorization.NewDenyAssignmentsClient(subscriptionID, creds, tc.perBinaryInvocationTestContext.getClientFactoryOptions())
+	if err != nil {
+		return false, err
+	}
+
+	pager := denyAssignmentsClient.NewListForResourceGroupPager(resourceGroupName, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			if isResourceGroupNotFoundError(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed listing deny assignments for resource group %q: %w", resourceGroupName, err)
+		}
+		for _, denyAssignment := range page.Value {
+			if denyAssignment.Properties != nil &&
+				denyAssignment.Properties.IsSystemProtected != nil &&
+				*denyAssignment.Properties.IsSystemProtected {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
 // cleanupResourceGroup is the standard resourcegroup cleanup.  It attempts to
 // 1. delete all HCP clusters via the RP and wait for success
 // 2. wait for any managed resource groups to be deleted
@@ -567,14 +631,33 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, 
 	}
 
 	if len(managedResourceGroups) > 0 {
-		ginkgo.GinkgoLogr.Info("managed resource groups still present, waiting for deletion",
-			"resourceGroup", resourceGroupName, "managedResourceGroups", managedResourceGroups)
-		managedResourceGroups, err = tc.waitForManagedResourceGroupsDeletion(ctx, resourceGroupName, 10*time.Minute)
-		if err != nil {
-			if len(managedResourceGroups) > 0 {
-				return fmt.Errorf("found %d managed resource groups left behind HCP clusters in %s: %v: %w", len(managedResourceGroups), resourceGroupName, managedResourceGroups, err)
+		// A managed resource group carrying a system-protected deny assignment (created by the
+		// RP to guard customer infrastructure) cannot be deleted by cleanup once its parent HCP
+		// cluster is gone: the deny assignment blocks resourceGroups/delete for every principal
+		// except the RP first-party service principals. Waiting for such an orphaned group to
+		// disappear only burns the timeout on every reaper run and then abandons the deletable
+		// parent resource group. Skip the wait for those, record them for RP-side remediation
+		// (AROSLSRE-1591), and still delete the parent below to shrink the leak surface.
+		lockedManagedResourceGroups, pendingManagedResourceGroups := tc.partitionDenyAssignmentLockedResourceGroups(ctx, managedResourceGroups)
+
+		if len(lockedManagedResourceGroups) > 0 {
+			ginkgo.GinkgoLogr.Info("leaving behind managed resource groups locked by a system-protected deny assignment; they cannot be deleted by cleanup and require RP-side remediation (AROSLSRE-1591)",
+				"resourceGroup", resourceGroupName, "lockedManagedResourceGroups", lockedManagedResourceGroups)
+		}
+
+		if len(pendingManagedResourceGroups) > 0 {
+			ginkgo.GinkgoLogr.Info("managed resource groups still present, waiting for deletion",
+				"resourceGroup", resourceGroupName, "managedResourceGroups", pendingManagedResourceGroups)
+			remainingManagedResourceGroups, waitErr := tc.waitForManagedResourceGroupsDeletion(ctx, resourceGroupName, 10*time.Minute)
+			if waitErr != nil {
+				// waitForManagedResourceGroupsDeletion re-lists every managed group for the parent,
+				// so the deny-assignment-locked ones always remain and are expected here. Only fail
+				// when a group without a deny assignment is left behind, which is a genuine anomaly.
+				_, stillPendingManagedResourceGroups := tc.partitionDenyAssignmentLockedResourceGroups(ctx, remainingManagedResourceGroups)
+				if len(stillPendingManagedResourceGroups) > 0 {
+					return fmt.Errorf("found %d managed resource groups left behind HCP clusters in %s: %v: %w", len(stillPendingManagedResourceGroups), resourceGroupName, stillPendingManagedResourceGroups, waitErr)
+				}
 			}
-			return fmt.Errorf("failed waiting for managed resource group deletion in %s: %w", resourceGroupName, err)
 		}
 	} else {
 		ginkgo.GinkgoLogr.Info("no left behind managed resource groups found", "resourceGroup", resourceGroupName)

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -492,18 +493,24 @@ func (tc *perItOrDescribeTestContext) findManagedResourceGroups(ctx context.Cont
 	return managedResourceGroups, nil
 }
 
-// waitForManagedResourceGroupsDeletion polls findManagedResourceGroups until no managed resource groups remain for the given parent resource group
-// This handles the case where managed RGs are still being deleted (e.g. because the HCP cluster was already in a deleting state prior to cleanup)
-// Returns the remaining managed resource groups (empty if all were deleted)
+// waitForManagedResourceGroupsDeletion polls findManagedResourceGroups until no deletable managed
+// resource groups remain for the given parent resource group. This handles the case where managed
+// RGs are still being deleted (e.g. because the HCP cluster was already in a deleting state prior
+// to cleanup). Managed groups locked by a system-protected deny assignment are re-checked on every
+// poll and never counted as pending: they can never be deleted from our side, so waiting for them
+// would only burn the timeout even after the deletable groups are gone. Returns the deletable
+// (non-locked) managed resource groups still present (empty if all deletable ones were deleted).
 func (tc *perItOrDescribeTestContext) waitForManagedResourceGroupsDeletion(ctx context.Context, resourceGroupName string, timeout time.Duration) ([]string, error) {
 	ctx, cancel := context.WithTimeoutCause(ctx, timeout, fmt.Errorf("timeout '%f' minutes exceeded waiting for managed resource groups in %s to be deleted", timeout.Minutes(), resourceGroupName))
 	defer cancel()
 
+	var previousPending []string
 	for {
 		select {
 		case <-ctx.Done():
 			remaining, _ := tc.findManagedResourceGroups(context.Background(), resourceGroupName)
-			return remaining, fmt.Errorf("timed out waiting for managed resource groups in %q to be deleted, caused by: %w, error: %w", resourceGroupName, context.Cause(ctx), ctx.Err())
+			_, pending := tc.partitionDenyAssignmentLockedResourceGroups(context.Background(), remaining)
+			return pending, fmt.Errorf("timed out waiting for managed resource groups in %q to be deleted, caused by: %w, error: %w", resourceGroupName, context.Cause(ctx), ctx.Err())
 		case <-time.After(StandardPollInterval):
 		}
 
@@ -512,14 +519,19 @@ func (tc *perItOrDescribeTestContext) waitForManagedResourceGroupsDeletion(ctx c
 			return nil, fmt.Errorf("failed to search for managed resource groups while waiting for deletion: %w", err)
 		}
 
-		if len(managedResourceGroups) == 0 {
-			ginkgo.GinkgoLogr.Info("all managed resource groups deleted",
+		_, pendingManagedResourceGroups := tc.partitionDenyAssignmentLockedResourceGroups(ctx, managedResourceGroups)
+		if len(pendingManagedResourceGroups) == 0 {
+			ginkgo.GinkgoLogr.Info("all deletable managed resource groups deleted",
 				"resourceGroup", resourceGroupName)
 			return nil, nil
 		}
 
-		ginkgo.GinkgoLogr.Info("waiting for managed resource group deletion",
-			"resourceGroup", resourceGroupName, "remaining", managedResourceGroups)
+		// delta-only logging: only emit when the set of pending groups changes between polls
+		if !slices.Equal(pendingManagedResourceGroups, previousPending) {
+			ginkgo.GinkgoLogr.Info("waiting for managed resource group deletion",
+				"resourceGroup", resourceGroupName, "remaining", pendingManagedResourceGroups)
+			previousPending = pendingManagedResourceGroups
+		}
 	}
 }
 
@@ -576,8 +588,10 @@ func (tc *perItOrDescribeTestContext) resourceGroupHasSystemProtectedDenyAssignm
 			return false, fmt.Errorf("failed listing deny assignments for resource group %q: %w", resourceGroupName, err)
 		}
 		for _, denyAssignment := range page.Value {
-			if denyAssignment.Properties != nil &&
-				denyAssignment.Properties.IsSystemProtected != nil &&
+			if denyAssignment == nil || denyAssignment.Properties == nil {
+				continue
+			}
+			if denyAssignment.Properties.IsSystemProtected != nil &&
 				*denyAssignment.Properties.IsSystemProtected {
 				return true, nil
 			}
@@ -648,15 +662,12 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroup(ctx context.Context, 
 		if len(pendingManagedResourceGroups) > 0 {
 			ginkgo.GinkgoLogr.Info("managed resource groups still present, waiting for deletion",
 				"resourceGroup", resourceGroupName, "managedResourceGroups", pendingManagedResourceGroups)
-			remainingManagedResourceGroups, waitErr := tc.waitForManagedResourceGroupsDeletion(ctx, resourceGroupName, 10*time.Minute)
-			if waitErr != nil {
-				// waitForManagedResourceGroupsDeletion re-lists every managed group for the parent,
-				// so the deny-assignment-locked ones always remain and are expected here. Only fail
-				// when a group without a deny assignment is left behind, which is a genuine anomaly.
-				_, stillPendingManagedResourceGroups := tc.partitionDenyAssignmentLockedResourceGroups(ctx, remainingManagedResourceGroups)
-				if len(stillPendingManagedResourceGroups) > 0 {
-					return fmt.Errorf("found %d managed resource groups left behind HCP clusters in %s: %v: %w", len(stillPendingManagedResourceGroups), resourceGroupName, stillPendingManagedResourceGroups, waitErr)
-				}
+			// waitForManagedResourceGroupsDeletion re-checks deny assignments on every poll and
+			// returns only the deletable (non-locked) groups still present, so the deny-locked
+			// ones never block the wait. A deletable group still present here is a genuine anomaly.
+			stillPendingManagedResourceGroups, waitErr := tc.waitForManagedResourceGroupsDeletion(ctx, resourceGroupName, 10*time.Minute)
+			if waitErr != nil && len(stillPendingManagedResourceGroups) > 0 {
+				return fmt.Errorf("found %d managed resource groups left behind HCP clusters in %s: %v: %w", len(stillPendingManagedResourceGroups), resourceGroupName, stillPendingManagedResourceGroups, waitErr)
 			}
 		}
 	} else {


### PR DESCRIPTION
Jira: [AROSLSRE-1545](https://redhat.atlassian.net/browse/AROSLSRE-1545)

### What

Make the expired-resource-group reaper stop abandoning deletable parent resource groups when their `-managed` sibling is locked by a system-protected deny assignment.

The standard cleanup path (`cleanupResourceGroup`) now, when managed resource groups are still present:

- Checks each managed group for a system-protected deny assignment (`isSystemProtected=true`) via the `DenyAssignments` API.
- Skips the 10-minute deletion wait for the deny-locked ones (nothing will ever delete them from our side), logs them for RP-side remediation ([AROSLSRE-1591](https://redhat.atlassian.net/browse/AROSLSRE-1591)), and still deletes the deletable parent resource group.
- Keeps the existing wait + hard-fail behaviour for a managed group that has no deny assignment and is genuinely still around after the wait (a real anomaly).
- Treats a deny-assignment probe failure as "not locked", so it falls back to the current wait-and-report behaviour rather than skipping a group that might still be deletable.

### Why

For orphaned INT `idms-*` groups the HCP cluster is already gone, but the `-managed` sibling carries an RP-created system-protected deny assignment that blocks `resourceGroups/delete` for every principal except the RP first-party service principals. The reaper deletes the (already-absent) cluster, then waits up to 10 minutes for that managed group to vanish. It never does, so the wait times out every run and the deletable parent `idms-*` group is left behind, accumulating overdue leaked resource groups (6 in INT at time of writing, ~4 months overdue).

We cannot delete the deny-locked managed group ourselves (force-deleting it was tried and rejected because the deny assignment blocks it, see the closed #6247), so the expensive infra it holds needs RP/HyperShift-side remediation tracked in [AROSLSRE-1591](https://redhat.atlassian.net/browse/AROSLSRE-1591). What the reaper *can* do is stop burning the timeout and stop abandoning the cheap, deletable parent, which shrinks the leak surface and keeps the reaper green.

### Testing

- Unit tests: the change is exercised through live Azure APIs (`DenyAssignments` listing + resource-group deletion). Consistent with the sibling helpers (`findManagedResourceGroups`, `waitForManagedResourceGroupsDeletion`, `DeleteResourceGroup`), which have no unit coverage because they require Azure, this fix does not add a unit test; the existing framework unit tests cover the pure error-classification helpers only.
- Validated locally with `go build ./util/framework/...`, `go vet ./util/framework/`, and `golangci-lint run --build-tags E2Etests ./util/framework/` (0 issues).
- Behaviour confirmed against the real INT subscription: the 6 overdue `idms-*` parents have zero deny assignments (deletable) while their `-managed` siblings each carry a system-protected deny assignment, which is exactly the case this change now handles.
