### PR TITLE
chore: zero the diff between upstream azure-rest-api-specs-pr and ARO-HCP

### DIFF
--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2026-06-30-preview/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/examples/2026-06-30-preview/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
@@ -107,7 +107,8 @@
           "nodeDrainTimeoutMinutes": 20,
           "clusterImageRegistry": {
             "state": "Enabled"
-          }
+          },
+          "cryptoRestrictions": "None"
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
@@ -305,7 +305,7 @@ model IngressProfile {
   type?: IngressType = IngressType.Public;
 }
 
-/** The internet visibility of the OpenShift API server. */
+/** The internet visibility of the OpenShift API server */
 union Visibility {
   string,
 
@@ -908,10 +908,18 @@ model NodePoolPlatformProfile {
 
 /** The settings and configuration options for OSDisk */
 model OsDiskProfile {
+  /** The OS disk size in GiB */
+  @removed(Versions.v2026_06_30_preview)
+  @renamedFrom(Versions.v2026_06_30_preview, "sizeGiB")
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  @minValue(64)
+  noMaxSizeGiB?: int32 = 64;
+
   /** The OS disk size in GiB. Maximum is 4095 GiB for Managed disks. For Ephemeral disks,
    * the maximum is 2040 GiB; Azure may enforce a lower effective limit based on the
    * selected VM size's local cache, temp, or NVMe capacity.
    */
+  @added(Versions.v2026_06_30_preview)
   @visibility(Lifecycle.Read, Lifecycle.Create)
   @minValue(64)
   @maxValue(4095)

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
@@ -3067,10 +3067,9 @@
         "sizeGiB": {
           "type": "integer",
           "format": "int32",
-          "description": "The OS disk size in GiB. Maximum is 4095 GiB for Managed disks. For Ephemeral disks,\nthe maximum is 2040 GiB; Azure may enforce a lower effective limit based on the\nselected VM size's local cache, temp, or NVMe capacity.",
+          "description": "The OS disk size in GiB",
           "default": 64,
           "minimum": 64,
-          "maximum": 4095,
           "x-ms-mutability": [
             "read",
             "create"

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
@@ -3192,10 +3192,9 @@
         "sizeGiB": {
           "type": "integer",
           "format": "int32",
-          "description": "The OS disk size in GiB. Maximum is 4095 GiB for Managed disks. For Ephemeral disks,\nthe maximum is 2040 GiB; Azure may enforce a lower effective limit based on the\nselected VM size's local cache, temp, or NVMe capacity.",
+          "description": "The OS disk size in GiB",
           "default": 64,
           "minimum": 64,
-          "maximum": 4095,
           "x-ms-mutability": [
             "read",
             "create"

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/examples/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/examples/HcpOpenShiftClusters_Update_MaximumSet_Gen.json
@@ -107,7 +107,8 @@
           "nodeDrainTimeoutMinutes": 20,
           "clusterImageRegistry": {
             "state": "Enabled"
-          }
+          },
+          "cryptoRestrictions": "None"
         },
         "identity": {
           "principalId": "e5867472-f0ed-4fc1-80e1-59b4c0256adb",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/readme.md
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/readme.md
@@ -114,7 +114,6 @@ suppressions:
   - code: PreviewVersionOverOneYear
     from: openapi.json
     reason: API version will be deprecated when 2025-12-23-preview is deployed to Azure regions.
-
 ```
 
 

--- a/internal/api/v20240610preview/generated/constants.go
+++ b/internal/api/v20240610preview/generated/constants.go
@@ -338,7 +338,7 @@ func PossibleProvisioningStateValues() []ProvisioningState {
 	}
 }
 
-// StatusType - Representation of the possible values of a external auths condition status.
+// StatusType - Representation of the possible values of a condition status.
 type StatusType string
 
 const (

--- a/internal/api/v20240610preview/generated/models.go
+++ b/internal/api/v20240610preview/generated/models.go
@@ -821,9 +821,7 @@ type OsDiskProfile struct {
 	// Details on how to create a Disk Encryption Set can be found here: https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-customer-managed-keys-portal#set-up-your-disk-encryption-set
 	EncryptionSetID *string
 
-	// The OS disk size in GiB. Maximum is 4095 GiB for Managed disks. For Ephemeral disks, the maximum is 2040 GiB; Azure may
-	// enforce a lower effective limit based on the selected VM size's local cache,
-	// temp, or NVMe capacity.
+	// The OS disk size in GiB
 	SizeGiB *int32
 }
 

--- a/internal/api/v20251223preview/generated/constants.go
+++ b/internal/api/v20251223preview/generated/constants.go
@@ -378,7 +378,7 @@ func PossibleProvisioningStateValues() []ProvisioningState {
 	}
 }
 
-// StatusType - Representation of the possible values of a external auths condition status.
+// StatusType - Representation of the possible values of a condition status.
 type StatusType string
 
 const (

--- a/internal/api/v20251223preview/generated/models.go
+++ b/internal/api/v20251223preview/generated/models.go
@@ -882,9 +882,7 @@ type OsDiskProfile struct {
 	// Details on how to create a Disk Encryption Set can be found here: https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-customer-managed-keys-portal#set-up-your-disk-encryption-set
 	EncryptionSetID *string
 
-	// The OS disk size in GiB. Maximum is 4095 GiB for Managed disks. For Ephemeral disks, the maximum is 2040 GiB; Azure may
-	// enforce a lower effective limit based on the selected VM size's local cache,
-	// temp, or NVMe capacity.
+	// The OS disk size in GiB
 	SizeGiB *int32
 }
 


### PR DESCRIPTION
no jira

### What

Brings in diffs from upstream azure-rest-api-specs-pr back to ARO-HCP so there is zero diff between the two repositories

### Why

to keep the api specs aligned

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
