### PR TITLE
fix(templatize): handle int64 config values in BuildStampList

### DIFF
--- a/tooling/templatize/cmd/entrypoint/entrypointutils/stamps.go
+++ b/tooling/templatize/cmd/entrypoint/entrypointutils/stamps.go
@@ -35,7 +35,11 @@ func BuildStampList(stamp, stampCountConfigRef string, cfg configtypes.Configura
 		var stampCount int
 		switch v := rawCount.(type) {
 		case int:
+			// it would only fire if someone constructed a Configuration manually in Go code with a literal int value
 			stampCount = v
+		case int64:
+			// it fires when a config is read from a YAML and ARO-Tools unmarshals a json.Number into an int64 or float64
+			stampCount = int(v)
 		case float64:
 			if v != float64(int(v)) {
 				return nil, fmt.Errorf("stamp count at %q must be an integer, got %v", stampCountConfigRef, v)


### PR DESCRIPTION
[ARO-27909](https://redhat.atlassian.net/browse/ARO-27909)

### What

Add `case int64:` to the `BuildStampList` type switch in `stamps.go`.

### Why

ARO-Tools is getting a fix ([ARO-27909](https://redhat.atlassian.net/browse/ARO-27909)) that changes `yaml.Unmarshal` to produce `int64` instead of `float64` for whole numbers. This prevents integers >= 1M from rendering as scientific notation (`2e+06`) in Go templates for bicepparam files.

Today, `BuildStampList` reads the stamp count from config via `GetByPath()`, which returns `float64` for all numbers. The type switch handles `int` and `float64` but not `int64`. When Dependabot bumps the ARO-Tools dependency, stamp counts will arrive as `int64`, hit the `default` branch, and fail with `"stamp count is int64, expected int"`.

This PR adds the `int64` branch preemptively so the dep bump is safe whenever it lands.

### Testing

No tests added. The `int64` branch is dead code until the ARO-Tools dep is bumped — it cannot fire with the current dependency version. The change is a two-line addition to an existing type switch with a comment explaining why it exists.

### Special notes for your reviewer

- This is a preparatory change — the `case int64:` branch does not fire today
- The corresponding ARO-Tools fix is tracked under the same Jira ticket
- Dependabot runs weekly `gomod` updates for `tooling/templatize/` and could bump ARO-Tools at any time, so this should land first

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
