### PR TITLE
fix(dev): stop transient stg-global V2 racing the shared rollout for Entra apps

### DIFF
--- a/dev-infrastructure/configurations/geneva-identities-stg.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/geneva-identities-stg.tmpl.bicepparam
@@ -5,6 +5,14 @@ using '../templates/geneva-identities.bicep'
 
 param genevaActionsCertificateDomain = '{{ .geneva.actions.certificate.san }}'
 param genevaActionApplicationUseSNI = {{ .geneva.actions.application.useSNI }}
-param genevaActionApplicationManage = {{ .geneva.actions.application.manage }}
+// Coexistence: the Geneva Actions Entra app is environment-scoped (arohcp-ga-stg)
+// and is managed by both the canonical stg global rollout and this transient V2
+// rollout. Both set the same fixed entraAppOwnerIds, so app ownership races between
+// them: whichever ran last owns it, and the other rollout's deploy identity (which
+// only holds Application.ReadWrite.OwnedBy) then fails to manage it with
+// Authorization_RequestDenied. This regressed the V2 rollout after a run where it
+// had briefly owned the app. The V2 global rollout does not consume this app, so
+// skip managing it here to end the tug-of-war. Revisit at decommission.
+param genevaActionApplicationManage = false
 param genevaActionApplicationName = '{{ .geneva.actions.application.name }}'
 param entraAppOwnerIds = '{{ .entraAppOwnerIds }}'

--- a/dev-infrastructure/configurations/mise-identity-stg.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mise-identity-stg.tmpl.bicepparam
@@ -1,0 +1,15 @@
+// TRANSIENT: STG-global "V2" copy of mise-identity.tmpl.bicepparam. Removed at decommission.
+//
+// Coexistence: the MISE Entra app is environment-scoped (arohcp-mise-stg) and is
+// managed by both the canonical stg global rollout and this transient V2 rollout.
+// Both set the same fixed entraAppOwnerIds, so app ownership races between them:
+// whichever ran last owns it, and the other rollout's deploy identity (which only
+// holds Application.ReadWrite.OwnedBy) then fails to manage it with
+// Authorization_RequestDenied. The V2 global rollout does not consume this app
+// (the stg svc rollout looks it up independently), so skip deploying it here to end
+// the tug-of-war. Revisit at decommission.
+using '../templates/mise-identity.bicep'
+
+param miseApplicationName = '{{ .mise.applicationName }}'
+param entraAppOwnerIds = '{{ .entraAppOwnerIds }}'
+param miseApplicationDeploy = false

--- a/dev-infrastructure/global-pipeline-stg.yaml
+++ b/dev-infrastructure/global-pipeline-stg.yaml
@@ -279,7 +279,7 @@ resourceGroups:
   - name: mise-identity
     action: ARM
     template: templates/mise-identity.bicep
-    parameters: configurations/mise-identity.tmpl.bicepparam
+    parameters: configurations/mise-identity-stg.tmpl.bicepparam
     deploymentLevel: ResourceGroup
   - name: housekeeping
     action: Shell


### PR DESCRIPTION
Jira: [AROSLSRE-1653](https://redhat.atlassian.net/browse/AROSLSRE-1653)

## What

Stop the transient stg-global "V2" rollout (serviceGroup `Microsoft.Azure.ARO.HCP.Global.StgGlobal`) from managing the environment-scoped Entra apps that the canonical stg global rollout also manages:

- `configurations/geneva-identities-stg.tmpl.bicepparam`: hardcode `genevaActionApplicationManage = false` (this bicepparam is V2-only).
- `configurations/mise-identity-stg.tmpl.bicepparam`: new V2-only bicepparam with `miseApplicationDeploy = false` (the original `mise-identity.tmpl.bicepparam` is shared with the canonical `global-pipeline.yaml`, so it cannot be edited in place).
- `global-pipeline-stg.yaml`: point the `mise-identity` step at the new `-stg` bicepparam.

## Why

Both the canonical stg global rollout and this transient V2 rollout run the `geneva-identities` and `mise-identity` ARM steps, which manage the same env-scoped Entra apps `arohcp-ga-stg` and `arohcp-mise-stg` (created via the Microsoft Graph bicep extension) with the same fixed `entraAppOwnerIds`. So app ownership races between the two rollouts: whichever runs last owns the app, and the other rollout's deploy identity (which only holds `Application.ReadWrite.OwnedBy`) then fails to manage it with `Authorization_RequestDenied: Insufficient privileges ... Target: /resources/entraApp`.

This is a regression, not a permanent permission gap. The V2 rollout ran these two steps successfully on 2026-07-23 (rollout `c4ef4d6d`) while it owned the apps, then failed on 2026-07-29 (rollout `2b50cb98`) once ownership had moved to the canonical rollout.

The V2 global rollout does not consume either app: no step declares `dependsOn` on them and neither bicep template has outputs. The only MISE consumer is the regular stg svc rollout, which looks up `arohcp-mise-stg` independently. So the V2 rollout has no reason to manage these apps. With the params off, both ARM steps become empty no-op deployments that succeed, ending the tug-of-war without any tenant-admin Graph grant. This mirrors the coexistence handling already used for `grafana-group-roles`.

Revisit (app ownership / cleanup) when `arohcp-stg` is decommissioned.

## Testing

`make validate-changed-config-pipelines` passes (validates the changed `global-pipeline-stg.yaml` and its bicepparam references). Confirmed the new mise bicepparam matches all params declared in `templates/mise-identity.bicep`.
