### PR TITLE
fix(ci): suppress HCCO and capi-provider KubePodNotReady alerts in CI known issues

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
@@ -33,3 +33,8 @@ knownIssues:
     namespace: "ocm-.*"
     pod: "hosted-cluster-config-operator-.*"
   reason: "HCCO pods are transiently not-ready during cluster provisioning because the init container (availability-prober) blocks until the guest cluster kube-apiserver and 18+ CRDs are bootstrapped, which routinely exceeds the 5-minute KubePodNotReady threshold."
+- name: "KubePodNotReady"
+  labels:
+    namespace: "ocm-.*"
+    pod: "capi-provider-.*"
+  reason: "capi-provider pods are transiently not-ready during HCP provisioning due to a deliberate bootstrap dependency cycle: the pod mounts the service-network-admin-kubeconfig secret (created by the KAS component), but capi-provider is intentionally excluded from the KAS dependency gate in HyperShift (componentsExcludedFromKubeAPIServerDependency) because node provisioning cannot wait for KAS to fully roll out. The pod sits in ContainerCreating with FailedMount errors until KAS reconciles and creates the secret, then the availability-prober init container gates on KAS /livez before starting the main container. This is by design and consistently exceeds the 5-minute KubePodNotReady threshold during provisioning (~56 alerts/day across 32 pods)."

--- a/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
@@ -28,3 +28,8 @@ knownIssues:
     namespace: "ocm-.*"
     pod: "(packageserver|olm-operator|catalog-operator)-.*"
   reason: "OLM pods in hosted control plane namespaces are simply uninteresting to us."
+- name: "KubePodNotReady"
+  labels:
+    namespace: "ocm-.*"
+    pod: "hosted-cluster-config-operator-.*"
+  reason: "HCCO pods are transiently not-ready during cluster provisioning because the init container (availability-prober) blocks until the guest cluster kube-apiserver and 18+ CRDs are bootstrapped, which routinely exceeds the 5-minute KubePodNotReady threshold."


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What/Why

Suppresses two transient KubePodNotReady alerts that fire during every HCP cluster provisioning in CI:

**HCCO (hosted-cluster-config-operator):** The init container (availability-prober) blocks until the guest cluster's kube-apiserver is healthy and 18+ CRDs are registered by CVO. This bootstrap sequence takes ~7 minutes on average (median from 40k+ pods over 3 days), exceeding the 5-minute alert threshold every time. Kusto data confirms 100% of these alerts are transient (5-8 min duration) and resolve once bootstrapping completes.

**capi-provider:** The pod mounts the service-network-admin-kubeconfig secret (created by KAS), but capi-provider is intentionally excluded from the KAS dependency gate in HyperShift (`componentsExcludedFromKubeAPIServerDependency`) because node provisioning cannot wait for KAS to fully roll out. The pod sits in ContainerCreating with FailedMount errors until KAS creates the secret, then the availability-prober init container gates on KAS /livez. This is by design and consistently exceeds the 5-minute threshold (~56 alerts/day across 32 pods).

Both are expected behavior during cluster bootstrap, not service issues.

### Testing

No new tests — this change only adds entries to the known-issues YAML used by the observability gatherer to suppress expected alerts.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Self-reviewed the diff
- [x] Commit history is clean (rebased/squashed)