### PR TITLE
feat(config): cut over stg global to hcp-stg-global sub (AROSLSRE-529)

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -76,9 +76,44 @@ clouds:
         defaults:
           # This must be defined here, so our ci jobs can know this
           kusto:
-            kustoName: "hcp-stg-uk-2"
-          # Transient STG-global "V2" names for the parallel infra in the dedicated
-          # hcp-stg-global sub during coexistence. Removed at decommission.
+            # STG-global cutover (AROSLSRE-529): live stg moves to the new
+            # dedicated Kusto cluster (was hcp-stg-uk-2).
+            kustoName: "hcp-{{ .ctx.environment }}-uk-3"
+          # STG-global cutover (AROSLSRE-529): flip live stg off the shared
+          # hcp-global subscription onto the dedicated hcp-stg-global sub, and
+          # point the canonical resource names at the dedicated "…2" infra the V2
+          # rollout already stood up. These are the same resources the stgGlobalV2
+          # block below feeds to the transient V2 pipelines, now promoted to their
+          # canonical paths so the live pipelines deploy them. int/prod untouched.
+          global:
+            subscription:
+              key: hcp-stg-global
+            keyVault:
+              name: "arohcp{{ .ctx.environment }}2-global"
+          acr:
+            svc:
+              name: "arohcpsvc{{ .ctx.environment }}2"
+            ocp:
+              name: "arohcpocp{{ .ctx.environment }}2"
+          geneva:
+            actions:
+              keyVault:
+                name: "arohcp{{ .ctx.environment }}2-geneva-kv"
+          oidc:
+            storageAccount:
+              name: "arohcp{{ .ctx.environment }}2oidc{{ .ctx.regionShort }}"
+            frontdoor:
+              name: "arohcp{{ .ctx.environment }}2"
+              keyVault:
+                name: "ah-{{ .ctx.environment }}2-afd"
+          monitoring:
+            grafanaName: "arohcp-{{ .ctx.environment }}2"
+          # TRANSIENT — STG-global "V2" migration: real globally-unique names +
+          # dedicated DNS zones for the parallel infra deployed into the dedicated
+          # STG-global subscription during coexistence. Overrides the public.defaults
+          # empty-sentinel; only stg gets real values. "2" suffix is the only literal
+          # vs the canonical names. Live stg.defaults names (acr.svc.name etc.) are
+          # untouched until cutover. Removed at decommission.
           stgGlobalV2:
             acrSvcName: "arohcpsvc{{ .ctx.environment }}2"
             acrOcpName: "arohcpocp{{ .ctx.environment }}2"

--- a/dev-infrastructure/openshift-ci/renew-prow-token.sh
+++ b/dev-infrastructure/openshift-ci/renew-prow-token.sh
@@ -28,7 +28,9 @@ OPENSHIFT_CI_NAMESPACE="aro-hcp-prow-ci"
 OPENSHIFT_CI_SECRET="api-token-secret"
 OPENSHIFT_CI_CONSOLE="https://console-openshift-console.apps.ci.l2s4.p1.openshiftapps.com/"
 
-VAULT_NAMES=("arohcpdev-global" "arohcpint-global" "arohcpstg-global" "arohcpprod-global")
+# STG-global cutover (AROSLSRE-529): stg's global secrets moved to the dedicated
+# hcp-stg-global key vault (arohcpstg2-global); the shared arohcpstg-global is retired for stg.
+VAULT_NAMES=("arohcpdev-global" "arohcpint-global" "arohcpstg2-global" "arohcpprod-global")
 
 cloud_for_vault() {
     case "$1" in

--- a/docs/secret-sync.md
+++ b/docs/secret-sync.md
@@ -17,7 +17,7 @@ The target key vaults (one per environment) in `encryptedsecrets.yaml` are:
 |---|---|
 | `arohcpdev-global` | dev |
 | `arohcpint-global` | int |
-| `arohcpstg-global` | stg |
+| `arohcpstg2-global` | stg |
 | `arohcpprod-global` | prod |
 
 ### Register vs Populate
@@ -152,7 +152,7 @@ Run once per target environment. The `--cloud` flag must match: `dev` for the de
     --secret-name my-new-secret
 ```
 
-Repeat for each environment you need to target (`arohcpstg-global`, `arohcpprod-global`).
+Repeat for each environment you need to target (`arohcpstg2-global`, `arohcpprod-global`).
 
 The command is idempotent — re-running with the same secret name overwrites the encrypted value. This is also how rotation works.
 

--- a/docs/sops/renew-prow-token.md
+++ b/docs/sops/renew-prow-token.md
@@ -89,7 +89,7 @@ The token only reaches Key Vault when the `decrypt-and-ingest-secrets` step in [
 | What | Where |
 |------|-------|
 | Token source (K8s) | `aro-hcp-prow-ci` namespace, `api-token-secret` secret, on OpenShift CI cluster |
-| Token storage (Azure) | 4 global Key Vaults: `arohcpdev-global`, `arohcpint-global`, `arohcpstg-global`, `arohcpprod-global` |
+| Token storage (Azure) | 4 global Key Vaults: `arohcpdev-global`, `arohcpint-global`, `arohcpstg2-global`, `arohcpprod-global` |
 | Encrypted at rest | [`dev-infrastructure/data/encryptedsecrets.yaml`](../../dev-infrastructure/data/encryptedsecrets.yaml) |
 | Renewal script | [`dev-infrastructure/openshift-ci/renew-prow-token.sh`](../../dev-infrastructure/openshift-ci/renew-prow-token.sh) |
 | Config reference | [`config/config.yaml`](../../config/config.yaml) → `e2e.prow.globalKeyVaultTokenSecret: "prow-token"` |


### PR DESCRIPTION
<!-- Link to Jira issue -->
Jira: [AROSLSRE-529](https://redhat.atlassian.net/browse/AROSLSRE-529)

### What

Cut over live STG off the shared `hcp-global` subscription onto the dedicated `hcp-stg-global` sub, and repoint the canonical resource names at the dedicated "2" infra the StgGlobal V2 rollout already stood up:

- `global.subscription.key`: `hcp-global` -> `hcp-stg-global`
- `global.keyVault.name`, `acr.svc/ocp.name`, geneva actions KV, `oidc.storageAccount/frontdoor` names + KV, `monitoring.grafanaName` -> the `...2` names
- `kusto.kustoName`: `hcp-stg-uk-2` -> `hcp-stg-uk-3`
- prow token vault + docs: `arohcpstg-global` -> `arohcpstg2-global`

The transient `stgGlobalV2` overlay block stays in place for now (it still feeds the coexistence V2 pipelines) and is removed at decommission.

### Why

STG has been running its shared global/geography path on the same `hcp-global` subscription as prod. AROSLSRE-525/529 gives STG its own dedicated global subscription so the parallel westus3 region can be born on the new sub. This is the atomic flip that re-homes the live shared path onto the resources V2 pre-staged. The DNS zones + `grafanaMajorVersion` move on the sdp-pipelines sensitive-overlay side; this PR owns the config that lives in ARO-HCP.

### Testing

- `cd config && make materialize` clean; no `rendered/dev/*` or helm-fixture drift.
- Rendered public stg/int/prod before and after with templatize: stg flips subscription to `hcp-stg-global` and every name to its `...2`/`uk-3` variant; int and prod render byte-identical.
- EV2 scope verified: the canonical `Subscriptions.Global` already constrains `stg/uksouth` and provisions `subscription: '{{ .global.subscription.key }}'`, so post-flip it provisions `hcp-stg-global` itself and the canonical `Global`/`Geography` pipelines deploy into the same key. No canonical pipeline hardcodes `hcp-global`.

### Special notes for your reviewer

Pairs with an sdp-pipelines PR that moves STG onto its dedicated DNS zones (`aro-hcp-stg.azure.com` / `aroapp-hcp-stg.azure.com`, [AROSLSRE-1204](https://redhat.atlassian.net/browse/AROSLSRE-1204)), the matching cert SANs, and `grafanaMajorVersion` 13. That side lands after this merges (it bumps `hcp/Revision.mk` to this commit). The transient StgGlobal V2 stack is retired in a follow-up once the cutover is verified healthy.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
