### PR TITLE
deduplicate stuck nodepool alert across metric replicas

### DIFF
--- a/observability/alerts/nodepool-slo-prometheusRule.yaml
+++ b/observability/alerts/nodepool-slo-prometheusRule.yaml
@@ -192,7 +192,7 @@ spec:
           max_over_time(
             (
               (
-                (time() - backend_resource_operation_start_time_seconds{resource_type=~".*nodepools", subscription_id!~"974ebd46-8ad3-41e3-afef-7ef25fd5c371|e8c5a115-842d-4d7e-98ad-cfb2c50b209e|e627aa70-36a3-40b0-8e68-975269e39d7b|6ed122d1-7e03-4a01-baae-9020abf350d4|64f0619f-ebc2-4156-9d91-c4c781de7e54|dee2f1be-a999-4e19-b027-221e7adaf7d3|8d696692-794f-4cdb-ba25-9250c9e9ec4c|ec435068-e722-475f-8504-c91b72a5dc51|  403d9de9-132b-4974-94a5-5b78bdfa191e"})
+                (time() - backend_resource_operation_start_time_seconds{resource_type=~".*nodepools", subscription_id!~"974ebd46-8ad3-41e3-afef-7ef25fd5c371|e8c5a115-842d-4d7e-98ad-cfb2c50b209e|e627aa70-36a3-40b0-8e68-975269e39d7b|6ed122d1-7e03-4a01-baae-9020abf350d4|64f0619f-ebc2-4156-9d91-c4c781de7e54|dee2f1be-a999-4e19-b027-221e7adaf7d3|8d696692-794f-4cdb-ba25-9250c9e9ec4c|ec435068-e722-475f-8504-c91b72a5dc51|403d9de9-132b-4974-94a5-5b78bdfa191e"})
                 and
                 backend_resource_operation_phase_info{resource_type=~".*nodepools", phase=~"updating|deleting"} == 1
               ) > 7200

--- a/observability/alerts/nodepool-slo-prometheusRule.yaml
+++ b/observability/alerts/nodepool-slo-prometheusRule.yaml
@@ -179,14 +179,25 @@ spec:
     # distinct stuck episodes more than 6h apart still get their own incident.
     - alert: UJNodePoolStuckOperation
       expr: |
-        max_over_time(
-          (
+        max by (
+          cluster,
+          environment,
+          region,
+          subscription_id,
+          resource_id,
+          resource_type,
+          operation_type,
+          phase
+        ) (
+          max_over_time(
             (
-              (time() - backend_resource_operation_start_time_seconds{resource_type=~".*nodepools", subscription_id!~"974ebd46-8ad3-41e3-afef-7ef25fd5c371|e8c5a115-842d-4d7e-98ad-cfb2c50b209e|e627aa70-36a3-40b0-8e68-975269e39d7b|6ed122d1-7e03-4a01-baae-9020abf350d4|64f0619f-ebc2-4156-9d91-c4c781de7e54|dee2f1be-a999-4e19-b027-221e7adaf7d3|8d696692-794f-4cdb-ba25-9250c9e9ec4c|ec435068-e722-475f-8504-c91b72a5dc51|403d9de9-132b-4974-94a5-5b78bdfa191e"})
-              and
-              backend_resource_operation_phase_info{resource_type=~".*nodepools", phase=~"updating|deleting"} == 1
-            ) > 7200
-          )[6h:5m]
+              (
+                (time() - backend_resource_operation_start_time_seconds{resource_type=~".*nodepools", subscription_id!~"974ebd46-8ad3-41e3-afef-7ef25fd5c371|e8c5a115-842d-4d7e-98ad-cfb2c50b209e|e627aa70-36a3-40b0-8e68-975269e39d7b|6ed122d1-7e03-4a01-baae-9020abf350d4|64f0619f-ebc2-4156-9d91-c4c781de7e54|dee2f1be-a999-4e19-b027-221e7adaf7d3|8d696692-794f-4cdb-ba25-9250c9e9ec4c|ec435068-e722-475f-8504-c91b72a5dc51|  403d9de9-132b-4974-94a5-5b78bdfa191e"})
+                and
+                backend_resource_operation_phase_info{resource_type=~".*nodepools", phase=~"updating|deleting"} == 1
+              ) > 7200
+            )[6h:5m]
+          )
         )
       for: 15m
       labels:


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Grouping the metrics using only stable labels such as the resourceid and operation phase. This makes all copies of the same stuck operation produce on alert.

### Why

The existing  expression preserved volatile labels such as pod/instance/prometheus_replica. 
When a new rollout of Prometheus instances were made, would create new alert instances for the same continuous operation.

### Testing

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
