### PR TITLE
fix: wait for cs-keyvault SecretProviderClass before mounting CSI volume

### DIFF
--- a/cluster-service/deploy/templates/cs-keyvault.rbac.yaml
+++ b/cluster-service/deploy/templates/cs-keyvault.rbac.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cs-keyvault-spc-reader
+  namespace: '{{ .Release.Namespace }}'
+  labels:
+    app: clusters-service
+rules:
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cs-keyvault-spc-reader
+  namespace: '{{ .Release.Namespace }}'
+  labels:
+    app: clusters-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cs-keyvault-spc-reader
+subjects:
+- kind: ServiceAccount
+  name: '{{ .Values.serviceAccountName }}'
+  namespace: '{{ .Release.Namespace }}'

--- a/cluster-service/deploy/templates/deployment.yaml
+++ b/cluster-service/deploy/templates/deployment.yaml
@@ -97,6 +97,41 @@ spec:
           volumeAttributes:
             secretProviderClass: cs-keyvault
       initContainers:
+      - name: wait-for-keyvault-spc
+        # Waits for the "cs-keyvault" SecretProviderClass to exist before the
+        # next init container mounts the CSI-backed "keyvault" volume that
+        # depends on it. Helm has no ordering guarantee between this
+        # Deployment and the SecretProviderClass resource (it's an
+        # unrecognized Kind to Helm's installer, so it can land before or
+        # after the Deployment on any given install/upgrade), so on a fresh
+        # cluster bring-up the Deployment's pods can be scheduled before the
+        # SecretProviderClass object exists, causing FailedMount/CrashLoop on
+        # clusters-service-init until it shows up. This container does not
+        # mount the "keyvault" volume itself, so kubelet can start it
+        # immediately regardless of CSI/SecretProviderClass state. On
+        # upgrades, where the SecretProviderClass already exists from a
+        # prior install, this is a fast no-op.
+        image: '{{ .Values.waitForKeyvaultSpcImage }}'
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - |
+          until kubectl get secretproviderclass cs-keyvault -n "${POD_NAMESPACE}" >/dev/null 2>&1; do
+            echo "waiting for secretproviderclass cs-keyvault to exist"
+            sleep 2
+          done
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          requests:
+            memory: "16Mi"
+            cpu: "10m"
+          limits:
+            memory: "32Mi"
       - name: clusters-service-init
         image: '{{ .Values.imageRegistry }}/{{ .Values.imageRepository }}@{{ .Values.imageDigest }}'
         imagePullPolicy: IfNotPresent

--- a/cluster-service/deploy/values.yaml
+++ b/cluster-service/deploy/values.yaml
@@ -9,6 +9,7 @@ replicas: 1
 imageRegistry: "localhost"
 imageRepository: "clusters-service"
 imageDigest: "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+waitForKeyvaultSpcImage: "localhost/aks-command-runtime:latest"
 logLevel: 4
 runtimeMode: "aro-hcp"
 defaultExpiration: "0"

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
@@ -7807,6 +7807,40 @@ data:
           version_constraints:
             min_version: 4.11.0
 ---
+# Source: clusters-service/templates/cs-keyvault.rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cs-keyvault-spc-reader
+  namespace: 'clusters-service'
+  labels:
+    app: clusters-service
+rules:
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses
+  verbs:
+  - get
+  - list
+---
+# Source: clusters-service/templates/cs-keyvault.rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cs-keyvault-spc-reader
+  namespace: 'clusters-service'
+  labels:
+    app: clusters-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cs-keyvault-spc-reader
+subjects:
+- kind: ServiceAccount
+  name: 'clusters-service'
+  namespace: 'clusters-service'
+---
 # Source: clusters-service/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -7966,6 +8000,41 @@ spec:
           volumeAttributes:
             secretProviderClass: cs-keyvault
       initContainers:
+      - name: wait-for-keyvault-spc
+        # Waits for the "cs-keyvault" SecretProviderClass to exist before the
+        # next init container mounts the CSI-backed "keyvault" volume that
+        # depends on it. Helm has no ordering guarantee between this
+        # Deployment and the SecretProviderClass resource (it's an
+        # unrecognized Kind to Helm's installer, so it can land before or
+        # after the Deployment on any given install/upgrade), so on a fresh
+        # cluster bring-up the Deployment's pods can be scheduled before the
+        # SecretProviderClass object exists, causing FailedMount/CrashLoop on
+        # clusters-service-init until it shows up. This container does not
+        # mount the "keyvault" volume itself, so kubelet can start it
+        # immediately regardless of CSI/SecretProviderClass state. On
+        # upgrades, where the SecretProviderClass already exists from a
+        # prior install, this is a fast no-op.
+        image: 'mcr.microsoft.com/aks/command/runtime@sha256:1234567890'
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - |
+          until kubectl get secretproviderclass cs-keyvault -n "${POD_NAMESPACE}" >/dev/null 2>&1; do
+            echo "waiting for secretproviderclass cs-keyvault to exist"
+            sleep 2
+          done
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          requests:
+            memory: "16Mi"
+            cpu: "10m"
+          limits:
+            memory: "32Mi"
       - name: clusters-service-init
         image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
         imagePullPolicy: IfNotPresent

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
@@ -7820,6 +7820,40 @@ spec:
     requests:
       storage: '512Mi'
 ---
+# Source: clusters-service/templates/cs-keyvault.rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cs-keyvault-spc-reader
+  namespace: 'clusters-service'
+  labels:
+    app: clusters-service
+rules:
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses
+  verbs:
+  - get
+  - list
+---
+# Source: clusters-service/templates/cs-keyvault.rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cs-keyvault-spc-reader
+  namespace: 'clusters-service'
+  labels:
+    app: clusters-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cs-keyvault-spc-reader
+subjects:
+- kind: ServiceAccount
+  name: 'clusters-service'
+  namespace: 'clusters-service'
+---
 # Source: clusters-service/templates/database.service.yaml
 apiVersion: v1
 kind: Service
@@ -8067,6 +8101,41 @@ spec:
           volumeAttributes:
             secretProviderClass: cs-keyvault
       initContainers:
+      - name: wait-for-keyvault-spc
+        # Waits for the "cs-keyvault" SecretProviderClass to exist before the
+        # next init container mounts the CSI-backed "keyvault" volume that
+        # depends on it. Helm has no ordering guarantee between this
+        # Deployment and the SecretProviderClass resource (it's an
+        # unrecognized Kind to Helm's installer, so it can land before or
+        # after the Deployment on any given install/upgrade), so on a fresh
+        # cluster bring-up the Deployment's pods can be scheduled before the
+        # SecretProviderClass object exists, causing FailedMount/CrashLoop on
+        # clusters-service-init until it shows up. This container does not
+        # mount the "keyvault" volume itself, so kubelet can start it
+        # immediately regardless of CSI/SecretProviderClass state. On
+        # upgrades, where the SecretProviderClass already exists from a
+        # prior install, this is a fast no-op.
+        image: 'mcr.microsoft.com/aks/command/runtime@sha256:1234567890'
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - |
+          until kubectl get secretproviderclass cs-keyvault -n "${POD_NAMESPACE}" >/dev/null 2>&1; do
+            echo "waiting for secretproviderclass cs-keyvault to exist"
+            sleep 2
+          done
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          requests:
+            memory: "16Mi"
+            cpu: "10m"
+          limits:
+            memory: "32Mi"
       - name: clusters-service-init
         image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
         imagePullPolicy: IfNotPresent

--- a/cluster-service/values.yaml
+++ b/cluster-service/values.yaml
@@ -21,6 +21,10 @@ imageRegistry: "{{ .acr.svc.name }}.azurecr.io"
 imageRepository: "{{ .clustersService.image.repository }}"
 # Image Digest
 imageDigest: "{{ .clustersService.image.digest }}"
+# Image used by the wait-for-keyvault-spc init container to poll for the
+# cs-keyvault SecretProviderClass via kubectl before mounting the keyvault
+# CSI volume.
+waitForKeyvaultSpcImage: "{{ .aksCommandRuntime.image.registry }}/{{ .aksCommandRuntime.image.repository }}@{{ .aksCommandRuntime.image.digest }}"
 # log verbosity level. It is a go-logr/logr verbosity level.
 logLevel: 4
 # Number of replicas of the service to run.

--- a/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
+++ b/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
@@ -7807,6 +7807,40 @@ data:
           version_constraints:
             min_version: 4.11.0
 ---
+# Source: clusters-service/templates/cs-keyvault.rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cs-keyvault-spc-reader
+  namespace: 'clusters-service'
+  labels:
+    app: clusters-service
+rules:
+- apiGroups:
+  - secrets-store.csi.x-k8s.io
+  resources:
+  - secretproviderclasses
+  verbs:
+  - get
+  - list
+---
+# Source: clusters-service/templates/cs-keyvault.rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cs-keyvault-spc-reader
+  namespace: 'clusters-service'
+  labels:
+    app: clusters-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cs-keyvault-spc-reader
+subjects:
+- kind: ServiceAccount
+  name: 'clusters-service'
+  namespace: 'clusters-service'
+---
 # Source: clusters-service/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -7966,6 +8000,41 @@ spec:
           volumeAttributes:
             secretProviderClass: cs-keyvault
       initContainers:
+      - name: wait-for-keyvault-spc
+        # Waits for the "cs-keyvault" SecretProviderClass to exist before the
+        # next init container mounts the CSI-backed "keyvault" volume that
+        # depends on it. Helm has no ordering guarantee between this
+        # Deployment and the SecretProviderClass resource (it's an
+        # unrecognized Kind to Helm's installer, so it can land before or
+        # after the Deployment on any given install/upgrade), so on a fresh
+        # cluster bring-up the Deployment's pods can be scheduled before the
+        # SecretProviderClass object exists, causing FailedMount/CrashLoop on
+        # clusters-service-init until it shows up. This container does not
+        # mount the "keyvault" volume itself, so kubelet can start it
+        # immediately regardless of CSI/SecretProviderClass state. On
+        # upgrades, where the SecretProviderClass already exists from a
+        # prior install, this is a fast no-op.
+        image: 'mcr.microsoft.com/aks/command/runtime@sha256:1234567890'
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - |
+          until kubectl get secretproviderclass cs-keyvault -n "${POD_NAMESPACE}" >/dev/null 2>&1; do
+            echo "waiting for secretproviderclass cs-keyvault to exist"
+            sleep 2
+          done
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          requests:
+            memory: "16Mi"
+            cpu: "10m"
+          limits:
+            memory: "32Mi"
       - name: clusters-service-init
         image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Helm's kind sorter always installs unrecognized CRD kinds (such as
SecretProviderClass) after Deployment, with no ordering guarantee
relative to it. On fresh cluster bring-up this means clusters-service
pods can be scheduled before the cs-keyvault SecretProviderClass
exists, so the CSI-backed "keyvault" volume fails to mount and the
clusters-service-init container is stuck until the CR shows up. This
is the dominant, deterministic root cause behind the KubePodNotReady
alerts firing for clusters-service during e2e presubmit provisioning.

Helm hooks were considered but rejected: hooks only ever Create() the
resource, so a pre-upgrade hook would delete and recreate the
SecretProviderClass on every helm upgrade, disrupting already-running
pods' CSI mounts in persistent (INT/STG/PROD) environments. Splitting
the SecretProviderClass into a separate chart/release was also
rejected, since migrating ownership of an existing resource between
Helm releases is a painful, multi-rollout process for already-running
persistent clusters.

Instead, add a lightweight wait-for-keyvault-spc init container ahead
of clusters-service-init in the same chart/release. It does not
reference the CSI-backed volume, so kubelet can start it immediately
regardless of CR/CSI state, and it simply polls with kubectl until the
cs-keyvault SecretProviderClass exists before letting the pod proceed.
This sidesteps Helm's install ordering entirely without touching the
SecretProviderClass's lifecycle: it remains a completely normal,
non-hook, Helm-tracked resource that is patched in place via standard
3-way merge on every upgrade, with zero adoption/ownership risk. On
upgrades, where the CR already exists, this container is a fast no-op.

Changes:
- Add cs-keyvault.rbac.yaml: Role/RoleBinding granting the
  clusters-service ServiceAccount get/list on secretproviderclasses so
  the wait container can poll for the CR via kubectl.
- Add wait-for-keyvault-spc init container to the clusters-service
  Deployment, using the existing shared aksCommandRuntime image
  (mcr.microsoft.com/aks/command/runtime) already used elsewhere in the
  repo for similar kubectl-based utility containers.
- Wire waitForKeyvaultSpcImage through deploy/values.yaml (local
  rendering placeholder) and values.yaml (pipeline-injected value).
- Regenerate affected zz_fixture_TestHelmTemplate_*.yaml fixtures via
  `cd config && make materialize`.