### PR TITLE
feat: provision dev-ci storage account for Chai-bot batch analysis output

### DIFF
--- a/config/config-dev-ci.schema.json
+++ b/config/config-dev-ci.schema.json
@@ -334,6 +334,38 @@
                   }
                 }
               }
+            },
+            "batchAnalysis": {
+              "type": "object",
+              "description": "Configuration for the Chai-bot Tide-batch analysis output storage",
+              "properties": {
+                "storageAccount": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Globally-unique storage account name that holds Chai-bot batch-analysis artifacts"
+                    },
+                    "location": {
+                      "type": "string",
+                      "description": "Azure region for the storage account"
+                    },
+                    "containerName": {
+                      "type": "string",
+                      "description": "Blob container that receives analysis artifacts"
+                    }
+                  }
+                },
+                "chaiBot": {
+                  "type": "object",
+                  "properties": {
+                    "principalId": {
+                      "type": "string",
+                      "description": "Object (principal) ID of the Chai-bot service principal granted read/write on the storage account"
+                    }
+                  }
+                }
+              }
             }
           }
         },

--- a/config/config-dev-ci.schema.json
+++ b/config/config-dev-ci.schema.json
@@ -354,7 +354,8 @@
                       "type": "string",
                       "description": "Blob container that receives analysis artifacts"
                     }
-                  }
+                  },
+                  "required": ["name", "location", "containerName"]
                 },
                 "chaiBot": {
                   "type": "object",
@@ -363,7 +364,8 @@
                       "type": "string",
                       "description": "Object (principal) ID of the Chai-bot service principal granted read/write on the storage account"
                     }
-                  }
+                  },
+                  "required": ["principalId"]
                 }
               }
             }

--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -144,6 +144,15 @@ clouds:
             gatewayNamespace: "aks-istio-ingress"
             sectionName: "tools-https"
             blockReviewPath: true
+        batchAnalysis:
+          storageAccount:
+            name: "arohcpdevcibatch{{ .ctx.regionShort }}"
+            location: "{{ .ctx.region }}"
+            containerName: "analyses"
+          chaiBot:
+            # app registration associated with chai-bot (same principal used as
+            # the shared Kusto viewerIdentity)
+            principalId: "5990dc26-1b73-4547-9bba-9a5bd64a0165"
         alerting:
           email: "aro-hcp-service-lifecycle-team@redhat.com"
           enabled: true

--- a/dev-infrastructure/configurations/dev-ci-batch-analysis-storage.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/dev-ci-batch-analysis-storage.tmpl.bicepparam
@@ -1,0 +1,6 @@
+using '../templates/dev-ci-batch-analysis-storage.bicep'
+
+param location = '{{ .opstool.batchAnalysis.storageAccount.location }}'
+param storageAccountName = '{{ .opstool.batchAnalysis.storageAccount.name }}'
+param containerName = '{{ .opstool.batchAnalysis.storageAccount.containerName }}'
+param chaiPrincipalId = '{{ .opstool.batchAnalysis.chaiBot.principalId }}'

--- a/dev-infrastructure/dev-ci/batch-analysis/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/batch-analysis/pipeline.yaml
@@ -1,0 +1,13 @@
+$schema: "pipeline.schema.v1"
+serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.BatchAnalysis
+rolloutName: Dev CI Batch Analysis Storage Rollout
+resourceGroups:
+- name: opstool
+  resourceGroup: '{{ .svc.rg }}'
+  subscription: '{{ .svc.subscription.key }}'
+  steps:
+  - name: storage
+    action: ARM
+    template: ../../templates/dev-ci-batch-analysis-storage.bicep
+    parameters: ../../configurations/dev-ci-batch-analysis-storage.tmpl.bicepparam
+    deploymentLevel: ResourceGroup

--- a/dev-infrastructure/templates/dev-ci-batch-analysis-storage.bicep
+++ b/dev-infrastructure/templates/dev-ci-batch-analysis-storage.bicep
@@ -17,7 +17,7 @@ param chaiPrincipalId string
 var storageBlobDataContributorRole = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
-  name: storageAccountName
+  name: toLower(storageAccountName)
   location: location
   kind: 'StorageV2'
   sku: {

--- a/dev-infrastructure/templates/dev-ci-batch-analysis-storage.bicep
+++ b/dev-infrastructure/templates/dev-ci-batch-analysis-storage.bicep
@@ -1,0 +1,62 @@
+@description('Location for the storage account')
+param location string
+
+@minLength(3)
+@maxLength(24)
+@description('Globally-unique name of the storage account that holds Chai-bot Tide-batch analysis output')
+param storageAccountName string
+
+@description('Name of the blob container that receives analysis artifacts')
+param containerName string
+
+@description('Object (principal) ID of the Chai-bot service principal that reads/writes analysis artifacts')
+param chaiPrincipalId string
+
+// Storage Blob Data Contributor: read/write/delete access to blob containers and data (no account-key access).
+// https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor
+var storageBlobDataContributorRole = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageAccountName
+  location: location
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_ZRS'
+  }
+  properties: {
+    accessTier: 'Hot'
+    supportsHttpsTrafficOnly: true
+    allowBlobPublicAccess: false
+    allowSharedKeyAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    // Chai runs outside our network, so it reaches the account over the public
+    // endpoint and authenticates with its Entra identity (no shared keys).
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+  name: 'default'
+  parent: storageAccount
+}
+
+resource analysisContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01' = {
+  name: containerName
+  parent: blobService
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+resource chaiBlobContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, chaiPrincipalId, storageBlobDataContributorRole)
+  scope: storageAccount
+  properties: {
+    principalId: chaiPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributorRole)
+  }
+}
+
+output storageAccountName string = storageAccount.name
+output blobEndpoint string = storageAccount.properties.primaryEndpoints.blob

--- a/topology-dev-ci.yaml
+++ b/topology-dev-ci.yaml
@@ -29,6 +29,9 @@ services:
   - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.CIHealth
     pipelinePath: dev-infrastructure/dev-ci/cihealth/pipeline.yaml
     purpose: Deploy the CIHealth runtime on cihealth.tools.hcpsvc.osadev.cloud.
+  - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.BatchAnalysis
+    pipelinePath: dev-infrastructure/dev-ci/batch-analysis/pipeline.yaml
+    purpose: Provision the storage account for Chai-bot Tide-batch analysis output and grant the bot read/write access.
 - serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.Privileged
   pipelinePath: dev-infrastructure/dev-ci/privileged/pipeline.yaml
   purpose: No-op grouping root for the on-demand privileged entrypoint. Owner-only; run manually by an OWNERS-group member.


### PR DESCRIPTION
## What

Adds a new `DevCI.BatchAnalysis` service group under the unattended `DevCI.Unprivileged` dev-ci entrypoint that provisions a storage account on the opstool footprint and grants the **chai-bot** service principal read/write access to it.

New files:
- `dev-infrastructure/templates/dev-ci-batch-analysis-storage.bicep` — StorageV2 / `Standard_ZRS`, `allowSharedKeyAccess:false`, `publicNetworkAccess:Enabled` (Chai reaches it off-network and authenticates with its Entra identity), an `analyses` blob container, and a **Storage Blob Data Contributor** role assignment to the chai-bot principal.
- `dev-infrastructure/configurations/dev-ci-batch-analysis-storage.tmpl.bicepparam`
- `dev-infrastructure/dev-ci/batch-analysis/pipeline.yaml`

Config:
- `config/config-dev-ci.yaml` + `config-dev-ci.schema.json` — new `opstool.batchAnalysis` block (`storageAccount.{name,location,containerName}`, `chaiBot.principalId`).
- `topology-dev-ci.yaml` — new child under `DevCI.Unprivileged`.

## Why

Part of epic [ARO-28327](https://redhat.atlassian.net/browse/ARO-28327). The OpenShift CI team's **Chai bot** can run `hcpctl snapshot analyze` as a scheduled task over failed **Tide batch** runs and publish the root-cause analyses somewhere durable — a zero-code alternative to running our own discovery/analysis controller. This provisions the storage account it will write to and wires the grant, so the bot can upload artifacts with its existing identity.

The chai-bot principal (`5990dc26-…`) is the same app registration already used as the shared Kusto `viewerIdentity`.

## Unprivileged placement

The role assignment grants **Storage Blob Data Contributor** (`ba92f5b4-…`), which is **not** in the ABAC-restricted set (Owner / User Access Administrator / RBAC Administrator) on the CI bot's *Role Based Access Control Administrator* grant. So the unattended postsubmit identity can create it — no privileged entrypoint required.

## Testing

- `config-dev-ci.schema.json` parses; `az bicep build` clean; `cd config && make materialize` passes; `make yamlfmt` clean.
- bicepparam renders for `dev-ci`: `location=westus3`, `storageAccountName=arohcpdevcibatchusw3` (20 chars, valid), `containerName=analyses`, principal resolved.
- Pre-existing local `templatize pipeline validate` failures on unrelated pipelines (`mock-identity-rbac*`) reproduce on pristine `main` and are unrelated to this change.