### PR TITLE
fix: increase kms key rotation timeout

### DIFF
--- a/test/e2e/kms_key_rotation.go
+++ b/test/e2e/kms_key_rotation.go
@@ -31,7 +31,9 @@ import (
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
 )
 
-const HCPClusterReencryptionUpgradeTimeout = 18 * time.Minute
+// UpdateTimeout of a cluster + the etcd re-encryption timeout
+// To check the p99 in the future and adjust times
+const HCPClusterReencryptionUpgradeTimeout = framework.UpdateHCPClusterTimeout + 20*time.Minute
 
 var _ = Describe("Customer", func() {
 	It("should be able to rotate KMS key for a cluster with version >= 4.22",


### PR DESCRIPTION
### What

Increase the re-encryption timeout from 18 to 20 minutes.

### Why

Several e2e are failing because of KAS not being healthy in due time. To complete an update operation it is required that the cluster-autoscaler component is available, this component depends on KAS. 

From logs we can see that KAS was available and health just before the timeout.

Also this aligns with openshift documentation of re-encryption expectations. 
https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/etcd/etcd-encrypt#disabling-etcd-encryption_etcd-encrypt

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer
Related discussion
https://redhat-external.slack.com/archives/C075PHEFZKQ/p1785349422015949

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
