### PR TITLE
feat(config): bring up STG westus3 in parallel on hcp-stg-global (AROSLSRE-1657)

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -42,16 +42,43 @@ clouds:
                     memory: 2Gi
       stg:
         # this is the MSFT STAGE environment
+        regions:
+          # westus3: second STG region, born on the dedicated hcp-stg-global sub with
+          # its "…2" global names (AROSLSRE-1657). uksouth stays on hcp-global.
+          westus3:
+            global:
+              subscription:
+                key: hcp-stg-global
+              keyVault:
+                name: "arohcp{{ .ctx.environment }}2-global"
+            acr:
+              svc:
+                name: "arohcpsvc{{ .ctx.environment }}2"
+              ocp:
+                name: "arohcpocp{{ .ctx.environment }}2"
+            geneva:
+              actions:
+                keyVault:
+                  name: "arohcp{{ .ctx.environment }}2-geneva-kv"
+            oidc:
+              storageAccount:
+                name: "arohcp{{ .ctx.environment }}2oidc{{ .ctx.regionShort }}"
+              frontdoor:
+                name: "arohcp{{ .ctx.environment }}2"
+                keyVault:
+                  name: "ah-{{ .ctx.environment }}2-afd"
+            monitoring:
+              grafanaName: "arohcp-{{ .ctx.environment }}2"
+            kusto:
+              # US-geography cluster (hcp-{env}-{geoShort} convention), separate from
+              # the uksouth hcp-stg-uk-* cluster.
+              kustoName: "hcp-{{ .ctx.environment }}-us-1"
         defaults:
           # This must be defined here, so our ci jobs can know this
           kusto:
             kustoName: "hcp-stg-uk-2"
-          # TRANSIENT — STG-global "V2" migration: real globally-unique names +
-          # dedicated DNS zones for the parallel infra deployed into the dedicated
-          # STG-global subscription during coexistence. Overrides the public.defaults
-          # empty-sentinel; only stg gets real values. "2" suffix is the only literal
-          # vs the canonical names. Live stg.defaults names (acr.svc.name etc.) are
-          # untouched until cutover. Removed at decommission.
+          # Transient STG-global "V2" names for the parallel infra in the dedicated
+          # hcp-stg-global sub during coexistence. Removed at decommission.
           stgGlobalV2:
             acrSvcName: "arohcpsvc{{ .ctx.environment }}2"
             acrOcpName: "arohcpocp{{ .ctx.environment }}2"
@@ -60,26 +87,17 @@ clouds:
             frontDoorName: "arohcp{{ .ctx.environment }}2"
             frontDoorKeyVaultName: "ah-{{ .ctx.environment }}2-afd"
             oidcStorageAccountName: "arohcp{{ .ctx.environment }}2oidc{{ .ctx.regionShort }}"
-            # DNS: dedicated stg zones (delegated from azure.com via SafeDNS),
-            # replacing the shared aro-hcp.azure.com / aroapp-hcp.io. Owned by the
-            # DNS track (AROSLSRE-1204) — confirm before deploy.
+            # Dedicated stg parent zones (replace the shared aro-hcp.azure.com / aroapp-hcp.io).
             svcParentZoneName: "aro-hcp-{{ .ctx.environment }}.azure.com"
             cxParentZoneName: "aroapp-hcp-{{ .ctx.environment }}.azure.com"
-            # New Kusto cluster (live stg is hcp-stg-uk-2; this is the next one).
+            # V2 stg Kusto cluster.
             kustoName: "hcp-{{ .ctx.environment }}-uk-3"
-            # New Grafana workspace (live stg is arohcp-stg; this is the V2 one).
-            # Globally unique — must differ from the live name to avoid NameNotUnique.
+            # V2 Grafana workspace (globally unique, differs from the live name).
             grafanaName: "arohcp-{{ .ctx.environment }}2"
-            # New workspace must be created on v13: Azure retired v11 for new
-            # creation on 2026-06-15, so only major versions 12/13 are accepted.
-            # The live grandfathered workspace stays on 11 (shared monitoring value).
+            # v13: Azure only accepts major 12/13 for new workspaces since 2026-06-15.
             grafanaMajorVersion: "13"
-            # Dedicated STG billing Kusto in the new hcp-stg-global sub. Distinct from
-            # the shared billing.kusto.* (which Billing.Global keeps managing for stg),
-            # so the shared cluster is never touched. The SKU is E8a_v4 because the
-            # shared billing.kusto.sku (E8ads_v5) is not offered in uksouth, where this
-            # dedicated cluster lives. Consumed only by the transient Billing.StgGlobal
-            # bicepparam; promoted into stg.defaults billing.kusto.* at cutover.
+            # Dedicated stg billing Kusto in hcp-stg-global (E8a_v4; E8ads_v5 is not
+            # offered in uksouth). Consumed by the transient Billing.StgGlobal bicepparam.
             billingKustoName: "arohcpHoBo{{ .ctx.environment }}"
             billingKustoSku: "Standard_E8a_v4"
           # E2E

--- a/dev-infrastructure/geography-pipeline.yaml
+++ b/dev-infrastructure/geography-pipeline.yaml
@@ -29,6 +29,7 @@ resourceGroups:
     - stg
     regions:
     - uksouth
+    - westus3
   - clouds:
     - public
     environments:
@@ -67,6 +68,7 @@ resourceGroups:
     - stg
     regions:
     - uksouth
+    - westus3
   - clouds:
     - public
     environments:


### PR DESCRIPTION
[AROSLSRE-1657](https://redhat.atlassian.net/browse/AROSLSRE-1657)

### What

Introduces `westus3` as a second STG region and binds it to the dedicated
`hcp-stg-global` subscription, following the parallel per-region-global model
(Strategy B). uksouth is left completely untouched on the shared `hcp-global`
sub. Two changes:

- `config/config.msft.clouds-overlay.yaml`: a transient `stgGlobalV2` block that
  carries the dedicated `hcp-stg-global` global-stack names (the `...2` ACR / KV /
  geneva / frontdoor / oidc / grafana resources and the dedicated `-stg` DNS parent
  zones), and a `stg.regions.westus3` block that maps
  `global.subscription.key: hcp-stg-global`, its US-geography Kusto cluster
  (`hcp-stg-us-1` in `hcp-kusto-stg-us`), and those `...2` global names.
- `dev-infrastructure/geography-pipeline.yaml`: adds `westus3` to the STG
  `executionConstraints` for the service and kusto-infra rollout blocks so the
  region is actually rolled.

### Why

STG currently runs only in uksouth, which is capacity-constrained. We are moving
STG to westus3. Rather than an in-place, env-wide cutover, we bring westus3 up in
parallel on its own dedicated global subscription and decommission uksouth at the
end. This keeps the live uksouth region and its shared-sub bindings unchanged
throughout the migration, so there is no big-bang risk.

### Testing

- `cd config && make materialize` reports zero drift.
- `make render-service-configuration-examples` renders cleanly, with westus3
  bound to `hcp-stg-global` (Kusto `hcp-stg-us-1`, the `...2` global names, and the
  dedicated `-stg` DNS zones) while uksouth still renders on `hcp-global` and the
  shared zones. No unit/e2e tests apply to a config-only binding change.

### Special notes for your reviewer

This is the ARO-HCP half of a coordinated two-repo change. The matching
sdp-pipelines PR (region operational overrides + geography rollout wiring) depends
on this one and will bump its pinned ARO-HCP revision once this merges. The
`stgGlobalV2` block is transient scaffolding for the migration and is removed once
uksouth is retired.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
