### PR TITLE
Add sre-approvers alias for observability OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -17,3 +17,10 @@ aliases:
   - sclarkso 
   - venkateshsredhat 
   - weherdh
+  sre-approvers:
+  - SudoBrendan
+  - ehvs
+  - hawkowl
+  - swiencki
+  - tsatam
+  - tuxerrante

--- a/observability/OWNERS
+++ b/observability/OWNERS
@@ -3,9 +3,4 @@ approvers:
 - geoberle
 - raelga
 - service-lifecycle-approvers
-- swiencki
-- tuxerrante
-- tsatam
-- hawkowl
-- SudoBrendan
-- ehvs
+- sre-approvers


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1641

## Summary
- Adds a new `sre-approvers` alias in `OWNERS_ALIASES` with the SRE team members added in #5957: SudoBrendan, ehvs, hawkowl, swiencki, tsatam, tuxerrante
- Replaces the individual user list in `observability/OWNERS` with the `sre-approvers` alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)