### PR TITLE
fix: mark KubePodNotReady for clusters-service as known false positive

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
@@ -21,6 +21,11 @@ knownIssues:
   reason: "Newly added stuck-async-operation alerts (https://github.com/Azure/ARO-HCP/pull/5952) surface a pre-existing problem: Azure Monitor Workspace ingestion latency (metrics can take ~10min to ingest) makes async operations look stuck and latches onto E2E runs even when the tests pass. Observed blocking green E2E runs (per https://cihealth.tools.hcpsvc.osadev.cloud/run-log?q=BackendAsync): BackendAsyncOperationClusterDeleteStuck, BackendAsyncOperationExternalAuthDeleteStuck, BackendAsyncOperationClusterCreateStuck, BackendAsyncOperationNodePoolDeleteStuck, BackendAsyncOperationNodePoolCreateStuck, BackendAsyncOperationStuck. Owner @stevekuznetsov; durable fix is the AMW auto-scaler (https://github.com/Azure/ARO-HCP/pull/6036). Marked known so it stops blocking the merge queue until that lands."
 - name: "KubePodNotReady"
   labels:
+    namespace: "clusters-service"
+    pod: "clusters-service-.*"
+  reason: "False positive caused by stale metrics in the remote write pipeline. The pod transitions from Pending to Running in under 2 minutes, but the metric update takes up to 4 minutes to propagate through OSS Prometheus remote write and Azure Monitor ingestion, making the 5-minute for duration insufficient. Upstream kube-prometheus-stack uses for: 15m to absorb this latency. Tracked in https://issues.redhat.com/browse/AROSLSRE-1656."
+- name: "KubePodNotReady"
+  labels:
     namespace: "klusterlet-.*"
   reason: "Klusterlet addon pods take a while to start when clusters are slow to provision, so this is a downstream issue and just noise."
 - name: "KubePodNotReady"


### PR DESCRIPTION
## Summary

- Adds `KubePodNotReady` for `clusters-service` pods to the known issues list so it stops blocking CI

## Why

Investigation ([AROSLSRE-1656](https://redhat.atlassian.net/browse/AROSLSRE-1656)) confirmed these alerts are **false positives caused by stale metrics in the remote write pipeline**:

- Pods transition Pending → Running in under 2 minutes (init container crash-loops on `SecretProviderClass` not yet deployed, then recovers)
- Metric propagation through OSS Prometheus → remote write → Azure Monitor ingestion takes up to 4 minutes
- Combined, this exceeds the 5-minute `for` threshold even though the pod was never actually Pending for 5 minutes
- Upstream kube-prometheus-stack uses `for: 15m` to absorb exactly this kind of pipeline latency; ARO-HCP reduced it to `for: 5m`

Kusto analysis of 229 pods on 2026-07-30 showed zero pods with a Pending upper bound ≥5 minutes, yet 38 pods received false alerts.

Ref: https://issues.redhat.com/browse/AROSLSRE-1656

## Test plan

- [ ] Verify CI runs no longer block on `KubePodNotReady` alerts for `clusters-service` pods
- [ ] Separately track the durable fix (increase `for` duration or fix pipeline latency) in [AROSLSRE-1656](https://redhat.atlassian.net/browse/AROSLSRE-1656)

🤖 Generated with [Claude Code](https://claude.com/claude-code)