### PR TITLE
feat: generalize kube-applier desire keys for credential request and revocation scopes

### DIFF
--- a/backend/pkg/utils/controllerutils/system_admin_credential_request_watching_controller.go
+++ b/backend/pkg/utils/controllerutils/system_admin_credential_request_watching_controller.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerutils
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
+	"github.com/Azure/ARO-HCP/internal/database/informers/coreinformers"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
+)
+
+// SystemAdminCredentialRequestSyncer is the interface that credential-request-watching
+// controllers must implement. It mirrors ClusterSyncer but is keyed on
+// SystemAdminCredentialRequestKey.
+type SystemAdminCredentialRequestSyncer interface {
+	SyncOnce(ctx context.Context, keyObj SystemAdminCredentialRequestKey) error
+}
+
+type systemAdminCredentialRequestWatchingController struct {
+	name   string
+	syncer SystemAdminCredentialRequestSyncer
+
+	resourcesDBClient corecosmosstorage.ResourcesDBClient
+}
+
+// NewSystemAdminCredentialRequestWatchingController creates a controller that fires on
+// individual SystemAdminCredentialRequest informer events rather than
+// cluster-level events. This ensures controllers react immediately when a
+// credential request is created or updated, instead of relying on periodic
+// cluster resync.
+//
+// kubeApplierInformers is optional: when non-nil, the controller also enqueues
+// on ReadDesire events from the union kube-applier informer surface (the same
+// pattern as ClusterWatchingController, but walking up to the credential
+// request resource type instead of the cluster type).
+func NewSystemAdminCredentialRequestWatchingController(
+	name string,
+	resourcesDBClient corecosmosstorage.ResourcesDBClient,
+	backendInformers coreinformers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
+	resyncDuration time.Duration,
+	syncer SystemAdminCredentialRequestSyncer,
+) Controller {
+
+	systemAdminCredentialRequestSyncer := &systemAdminCredentialRequestWatchingController{
+		name:              name,
+		resourcesDBClient: resourcesDBClient,
+		syncer:            syncer,
+	}
+	controller := newGenericWatchingController(name, api.SystemAdminCredentialRequestResourceType, systemAdminCredentialRequestSyncer)
+
+	// this happens when unit tests don't want triggering. This isn't beautiful, but fails to do nothing which is pretty safe.
+	if backendInformers != nil {
+		credentialRequestInformer, _ := backendInformers.SystemAdminCredentialRequests()
+		err := controller.QueueForInformers(resyncDuration, credentialRequestInformer)
+		if err != nil {
+			panic(err) // coding error
+		}
+	}
+
+	if kubeApplierInformers != nil {
+		// ReadDesires for credential requests sit two levels below the credential
+		// request: .../hcpOpenShiftClusters/<cluster>/systemAdminCredentialRequests/<cred>/readDesires/<name>
+		// maxDepth of 1 means we walk up one parent to the credential request.
+		readDesireInformer, _ := kubeApplierInformers.ReadDesires()
+		if err := controller.QueueForInformersWithMaxDepth(resyncDuration, 1, readDesireInformer); err != nil {
+			panic(err) // coding error
+		}
+	}
+
+	return controller
+}
+
+func (c *systemAdminCredentialRequestWatchingController) SyncOnce(ctx context.Context, key SystemAdminCredentialRequestKey) error {
+	defer utilruntime.HandleCrash(DegradedControllerPanicHandler(
+		ctx,
+		c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).SystemAdminCredentialRequests(key.HCPClusterName).Controllers(key.CredentialName),
+		c.name,
+		key.InitialController))
+
+	syncErr := c.syncer.SyncOnce(ctx, key) // we'll handle this in a moment.
+
+	controllerWriteErr := WriteController(
+		ctx,
+		c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).SystemAdminCredentialRequests(key.HCPClusterName).Controllers(key.CredentialName),
+		c.name,
+		key.InitialController,
+		ReportSyncError(syncErr),
+	)
+
+	return errors.Join(syncErr, controllerWriteErr)
+}
+
+func (c *systemAdminCredentialRequestWatchingController) CooldownChecker() controllerutil.CooldownChecker {
+	return nil
+}
+
+func (c *systemAdminCredentialRequestWatchingController) MakeKey(resourceID *azcorearm.ResourceID) SystemAdminCredentialRequestKey {
+	// resourceID is of type systemAdminCredentialRequests, nested under the cluster:
+	// /subscriptions/<sub>/resourceGroups/<rg>/providers/microsoft.redhatopenshift/hcpopenshiftclusters/<cluster>/systemAdminCredentialRequests/<credName>
+	return SystemAdminCredentialRequestKey{
+		SubscriptionID:    resourceID.SubscriptionID,
+		ResourceGroupName: resourceID.ResourceGroupName,
+		HCPClusterName:    resourceID.Parent.Name,
+		CredentialName:    resourceID.Name,
+	}
+}

--- a/backend/pkg/utils/controllerutils/system_admin_credential_revocation_watching_controller.go
+++ b/backend/pkg/utils/controllerutils/system_admin_credential_revocation_watching_controller.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerutils
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
+	"github.com/Azure/ARO-HCP/internal/database/informers/coreinformers"
+)
+
+// SystemAdminCredentialRevocationSyncer is the interface that revocation-watching controllers must
+// implement. It mirrors ClusterSyncer but is keyed on
+// SystemAdminCredentialRevocationKey.
+type SystemAdminCredentialRevocationSyncer interface {
+	SyncOnce(ctx context.Context, keyObj SystemAdminCredentialRevocationKey) error
+}
+
+type systemAdminCredentialRevocationWatchingController struct {
+	name   string
+	syncer SystemAdminCredentialRevocationSyncer
+
+	resourcesDBClient corecosmosstorage.ResourcesDBClient
+}
+
+// NewSystemAdminCredentialRevocationWatchingController creates a controller that fires on individual
+// SystemAdminCredentialRevocation informer events. Each revocation drives its own
+// lifecycle (marking credential requests for deletion, managing the CRR desires,
+// and final teardown), so keying on the revocation lets a small set of focused
+// controllers react immediately to revocation changes and re-poll on resync.
+func NewSystemAdminCredentialRevocationWatchingController(
+	name string,
+	resourcesDBClient corecosmosstorage.ResourcesDBClient,
+	backendInformers coreinformers.BackendInformers,
+	resyncDuration time.Duration,
+	syncer SystemAdminCredentialRevocationSyncer,
+) Controller {
+
+	systemAdminCredentialRevocationSyncer := &systemAdminCredentialRevocationWatchingController{
+		name:              name,
+		resourcesDBClient: resourcesDBClient,
+		syncer:            syncer,
+	}
+	controller := newGenericWatchingController(name, api.SystemAdminCredentialRevocationResourceType, systemAdminCredentialRevocationSyncer)
+
+	// this happens when unit tests don't want triggering. This isn't beautiful, but fails to do nothing which is pretty safe.
+	if backendInformers != nil {
+		revocationInformer, _ := backendInformers.SystemAdminCredentialRevocations()
+		err := controller.QueueForInformers(resyncDuration, revocationInformer)
+		if err != nil {
+			panic(err) // coding error
+		}
+	}
+
+	return controller
+}
+
+func (c *systemAdminCredentialRevocationWatchingController) SyncOnce(ctx context.Context, key SystemAdminCredentialRevocationKey) error {
+	defer utilruntime.HandleCrash(DegradedControllerPanicHandler(
+		ctx,
+		c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).SystemAdminCredentialRevocations(key.HCPClusterName).Controllers(key.RevocationName),
+		c.name,
+		key.InitialController))
+
+	syncErr := c.syncer.SyncOnce(ctx, key)
+
+	controllerWriteErr := WriteController(
+		ctx,
+		c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).SystemAdminCredentialRevocations(key.HCPClusterName).Controllers(key.RevocationName),
+		c.name,
+		key.InitialController,
+		ReportSyncError(syncErr),
+	)
+
+	return errors.Join(syncErr, controllerWriteErr)
+}
+
+func (c *systemAdminCredentialRevocationWatchingController) CooldownChecker() controllerutil.CooldownChecker {
+	return nil
+}
+
+func (c *systemAdminCredentialRevocationWatchingController) MakeKey(resourceID *azcorearm.ResourceID) SystemAdminCredentialRevocationKey {
+	// resourceID is of type systemAdminCredentialRevocations, nested under the cluster:
+	// /subscriptions/<sub>/resourceGroups/<rg>/providers/microsoft.redhatopenshift/hcpopenshiftclusters/<cluster>/systemAdminCredentialRevocations/<name>
+	return SystemAdminCredentialRevocationKey{
+		SubscriptionID:    resourceID.SubscriptionID,
+		ResourceGroupName: resourceID.ResourceGroupName,
+		HCPClusterName:    resourceID.Parent.Name,
+		RevocationName:    resourceID.Name,
+	}
+}

--- a/backend/pkg/utils/controllerutils/util.go
+++ b/backend/pkg/utils/controllerutils/util.go
@@ -184,6 +184,78 @@ func (k *HCPExternalAuthKey) InitialController(controllerName string) *api.Contr
 	}
 }
 
+// SystemAdminCredentialRequestKey is for driving workqueues keyed for credential requests
+type SystemAdminCredentialRequestKey struct {
+	SubscriptionID    string `json:"subscriptionID"`
+	ResourceGroupName string `json:"resourceGroupName"`
+	HCPClusterName    string `json:"hcpClusterName"`
+	CredentialName    string `json:"credentialName"`
+}
+
+func (k SystemAdminCredentialRequestKey) GetResourceID() *azcorearm.ResourceID {
+	return api.Must(api.ToSystemAdminCredentialRequestResourceID(k.SubscriptionID, k.ResourceGroupName, k.HCPClusterName, k.CredentialName))
+}
+
+func (k SystemAdminCredentialRequestKey) GetClusterResourceID() *azcorearm.ResourceID {
+	return api.Must(api.ToClusterResourceID(k.SubscriptionID, k.ResourceGroupName, k.HCPClusterName))
+}
+
+func (k SystemAdminCredentialRequestKey) AddLoggerValues(logger logr.Logger) logr.Logger {
+	return logger.WithValues(
+		utils.LogValues{}.
+			AddLogValuesForResourceID(k.GetResourceID())...)
+}
+
+func (k SystemAdminCredentialRequestKey) InitialController(controllerName string) *api.Controller {
+	resourceID := api.Must(azcorearm.ParseResourceID(k.GetResourceID().String() + "/" + api.ControllerResourceTypeName + "/" + controllerName))
+	return &api.Controller{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+		},
+		ExternalID: k.GetResourceID(),
+		Status: api.ControllerStatus{
+			Conditions: []metav1.Condition{},
+		},
+	}
+}
+
+// SystemAdminCredentialRevocationKey is for driving workqueues keyed for revocations
+type SystemAdminCredentialRevocationKey struct {
+	SubscriptionID    string `json:"subscriptionID"`
+	ResourceGroupName string `json:"resourceGroupName"`
+	HCPClusterName    string `json:"hcpClusterName"`
+	RevocationName    string `json:"revocationName"`
+}
+
+func (k SystemAdminCredentialRevocationKey) GetResourceID() *azcorearm.ResourceID {
+	return api.Must(api.ToSystemAdminCredentialRevocationResourceID(k.SubscriptionID, k.ResourceGroupName, k.HCPClusterName, k.RevocationName))
+}
+
+func (k SystemAdminCredentialRevocationKey) GetClusterResourceID() *azcorearm.ResourceID {
+	return api.Must(api.ToClusterResourceID(k.SubscriptionID, k.ResourceGroupName, k.HCPClusterName))
+}
+
+func (k SystemAdminCredentialRevocationKey) AddLoggerValues(logger logr.Logger) logr.Logger {
+	return logger.WithValues(
+		utils.LogValues{}.
+			AddLogValuesForResourceID(k.GetResourceID())...)
+}
+
+func (k SystemAdminCredentialRevocationKey) InitialController(controllerName string) *api.Controller {
+	resourceID := api.Must(azcorearm.ParseResourceID(k.GetResourceID().String() + "/" + api.ControllerResourceTypeName + "/" + controllerName))
+	return &api.Controller{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+		},
+		ExternalID: k.GetResourceID(),
+		Status: api.ControllerStatus{
+			Conditions: []metav1.Condition{},
+		},
+	}
+}
+
 // controllerMutationFunc is called when trying to write a controller. It gives a spot for computation of a value.
 // It should only perform short calls, not long lookups.  It must not fail. Think of it as a way to write information
 // that you have already precomputed.

--- a/kube-applier/docs/02-api-types.md
+++ b/kube-applier/docs/02-api-types.md
@@ -126,25 +126,98 @@ Mirror the existing `api.ToClusterResourceIDString` helpers
 (`internal/api/types_cluster.go`). Add:
 
 ```go
-// internal/api/kubeapplier/resource_ids.go
-func ToApplyDesireResourceIDString(sub, rg, cluster, name string) string
-func ToApplyDesireUnderNodePoolResourceIDString(sub, rg, cluster, np, name string) string
-func ToReadDesireResourceIDString(sub, rg, cluster, name string) string
-func ToReadDesireUnderNodePoolResourceIDString(sub, rg, cluster, np, name string) string
-func ParseDesireResourceID(id string) (DesireKey, error)
+// internal/api/kubeapplier/types_cosmosdata.go
+func ToClusterScopedApplyDesireResourceIDString(sub, rg, cluster, name string) string
+func ToNodePoolScopedApplyDesireResourceIDString(sub, rg, cluster, np, name string) string
+// ... and ReadDesire variants
+// (there is no DeleteDesire type; deletion is an ApplyDesire with Spec.Type=Delete)
 ```
 
-These are the canonical way to build the `ApplyDesire` and `ReadDesire`
-resource IDs and to extract index keys (see Doc 04 for `ByCluster` /
-`ByNodePool` indexers).
+These are the canonical way to build the `*Desire` resource IDs and to
+extract index keys (see Doc 04 for `ByCluster` / `ByNodePool` indexers).
+
+### 2.6 Credential-scoped desires (SystemAdminCredentialRequest & SystemAdminCredentialRevocation)
+
+Desire resources can have `SystemAdminCredentialRequest` **and**
+`SystemAdminCredentialRevocation` as parent resources, in addition to clusters
+and node pools. This enables proper nesting so that credential-related desires
+are scoped under the credential request or revocation they belong to, and the
+resource hierarchy matches the resource that owns them.
+
+**Resource types** (in `registry.go`):
+
+```go
+CredentialRequestScopedApplyDesireResourceType = nestedResourceType(ClusterResourceTypeName, SystemAdminCredentialRequestResourceTypeName, ApplyDesireResourceTypeName)
+CredentialRequestScopedReadDesireResourceType  = nestedResourceType(ClusterResourceTypeName, SystemAdminCredentialRequestResourceTypeName, ReadDesireResourceTypeName)
+
+RevocationScopedApplyDesireResourceType = nestedResourceType(ClusterResourceTypeName, SystemAdminCredentialRevocationResourceTypeName, ApplyDesireResourceTypeName)
+RevocationScopedReadDesireResourceType  = nestedResourceType(ClusterResourceTypeName, SystemAdminCredentialRevocationResourceTypeName, ReadDesireResourceTypeName)
+```
+
+> There is no `DeleteDesire` resource type. Deletion is modeled as an
+> `ApplyDesire` whose `Spec.Type` is `Delete` (the `ApplyDesireSpec.Type`
+> discriminated union described under "Current state" above), so
+> credential teardown reuses the ApplyDesire type rather than a
+> distinct DeleteDesire.
+
+**Resource ID builders** (in `types_cosmosdata.go`):
+
+```go
+func ToCredentialRequestScopedApplyDesireResourceIDString(sub, rg, cluster, credReq, name string) string
+func ToCredentialRequestScopedReadDesireResourceIDString(sub, rg, cluster, credReq, name string) string
+
+func ToRevocationScopedApplyDesireResourceIDString(sub, rg, cluster, revocation, name string) string
+func ToRevocationScopedReadDesireResourceIDString(sub, rg, cluster, revocation, name string) string
+```
+
+These produce resource IDs of the form:
+
+```
+/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.RedHatOpenShift/
+  hcpOpenShiftClusters/{cluster}/systemAdminCredentialRequests/{cred}/
+  applyDesires/{name}
+
+/subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.RedHatOpenShift/
+  hcpOpenShiftClusters/{cluster}/systemAdminCredentialRevocations/{revocation}/
+  applyDesires/{name}
+```
+
+**Cosmos CRUD** (in `internal/database/kube_applier_client.go`): the
+`KubeApplierDBClient` interface exposes per-parent CRUD accessors alongside the
+existing cluster/node-pool ones:
+
+```go
+ApplyDesiresForCredentialRequest(sub, rg, cluster, credReq string) (ResourceCRUD[...], error)
+ReadDesiresForCredentialRequest(sub, rg, cluster, credReq string) (ResourceCRUD[...], error)
+ApplyDesiresForRevocation(sub, rg, cluster, revocation string) (ResourceCRUD[...], error)
+ReadDesiresForRevocation(sub, rg, cluster, revocation string) (ResourceCRUD[...], error)
+```
+
+The per-management-cluster listers and change-feed informers list all four
+scopes (cluster, node pool, credential request, revocation) so nested desires
+are indexed and cleanup via `ListForCluster` still finds every desire under a
+cluster regardless of its parent.
+
+**Controllers**: the desires-creator nests a credential's CSR / CSRApproval /
+RBAC / ReadDesire under its `SystemAdminCredentialRequest`, and the
+revocation-desires controller nests the CRR / RBAC / ReadDesire under its
+`SystemAdminCredentialRevocation`. The teardown controllers delete each
+credential's or revocation's desires through the matching scoped CRUD.
+
+**Rationale**: Nesting desires under `SystemAdminCredentialRequest` /
+`SystemAdminCredentialRevocation` makes cleanup automatic when the parent
+document is deleted, removes the need for an `OutstandingDesires` tracking
+field, lets controllers fire when desires change via informer watches, and
+makes it easy to find all desires for a specific credential request or
+revocation.
 
 ## Acceptance for this layer
 
 - `go build ./internal/api/...` passes.
 - Generated deepcopy compiles and is committed.
 - Hand-written unit tests in `internal/api/kubeapplier/*_test.go` cover:
-  - Round-trip JSON for each of `ApplyDesire` and `ReadDesire` (mirror
-    existing tests on `HCPOpenShiftCluster`).
-  - Resource-ID parse/format symmetry.
+  - Round-trip JSON for each `*Desire` (mirror existing tests on
+    `HCPOpenShiftCluster`).
+  - Resource-ID parse/format symmetry (including credential-request-scoped variants).
 - No code outside `internal/api/kubeapplier` and `internal/api` itself depends
   on this package yet (so this layer can ship in its own PR).

--- a/kube-applier/go.mod
+++ b/kube-applier/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/openshift/library-go v0.0.0-20260504190829-2dd4388d7b89
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.11.1
 	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.3
 	k8s.io/component-base v0.35.3
@@ -92,7 +93,6 @@ require (
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.etcd.io/etcd/api/v3 v3.6.11 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.6.11 // indirect

--- a/kube-applier/pkg/controllers/keys/keys.go
+++ b/kube-applier/pkg/controllers/keys/keys.go
@@ -20,6 +20,7 @@ package keys
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -34,37 +35,24 @@ import (
 )
 
 // ApplyDesireKey identifies a single ApplyDesire by the parts of its resource ID
-// that map to the lister's GetForCluster / GetForNodePool helpers.
+// that map to the lister's CRUD helpers.
 type ApplyDesireKey struct {
 	SubscriptionID    string
 	ResourceGroupName string
 	ClusterName       string
-	NodePoolName      string // empty for cluster-scoped
+	SubResourceType   string // lowercased leaf type name of the intermediate parent (empty for cluster-scoped)
+	SubResourceName   string // name of the intermediate parent (empty for cluster-scoped)
 	Name              string
 }
 
-// IsNodePoolScoped reports whether this key targets a node-pool-scoped desire.
-func (k ApplyDesireKey) IsNodePoolScoped() bool { return len(k.NodePoolName) > 0 }
-
 // CRUD returns the right per-scope CRUD for this key's parent.
 func (k ApplyDesireKey) CRUD(client kubeappliercosmosstorage.KubeApplierApplyDesireCRUD) (cosmosstorageutils.ResourceCRUD[kubeapplier.ApplyDesire, *kubeapplier.ApplyDesire], error) {
-	if k.IsNodePoolScoped() {
-		return client.ApplyDesiresForNodePool(k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.NodePoolName)
-	}
-	return client.ApplyDesiresForCluster(k.SubscriptionID, k.ResourceGroupName, k.ClusterName)
+	return applyDesireCRUD(k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.SubResourceType, k.SubResourceName, client)
 }
 
-// GetResourceID returns the desire's full resource ID. It uses the
-// cluster-scoped or node-pool-scoped builder depending on the key's shape.
+// GetResourceID returns the desire's full resource ID.
 func (k ApplyDesireKey) GetResourceID() *azcorearm.ResourceID {
-	var s string
-	if k.IsNodePoolScoped() {
-		s = kubeapplier.ToNodePoolScopedApplyDesireResourceIDString(
-			k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.NodePoolName, k.Name)
-	} else {
-		s = kubeapplier.ToClusterScopedApplyDesireResourceIDString(
-			k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.Name)
-	}
+	s := desireResourceIDString(k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.SubResourceType, k.SubResourceName, kubeapplier.ApplyDesireResourceTypeName, k.Name)
 	return api.Must(azcorearm.ParseResourceID(s))
 }
 
@@ -81,32 +69,19 @@ type ReadDesireKey struct {
 	SubscriptionID    string
 	ResourceGroupName string
 	ClusterName       string
-	NodePoolName      string
+	SubResourceType   string
+	SubResourceName   string
 	Name              string
 }
 
-// IsNodePoolScoped reports whether this key targets a node-pool-scoped desire.
-func (k ReadDesireKey) IsNodePoolScoped() bool { return len(k.NodePoolName) > 0 }
-
 // CRUD returns the right per-scope CRUD for this key's parent.
 func (k ReadDesireKey) CRUD(client kubeappliercosmosstorage.KubeApplierReadDesireCRUD) (cosmosstorageutils.ResourceCRUD[kubeapplier.ReadDesire, *kubeapplier.ReadDesire], error) {
-	if k.IsNodePoolScoped() {
-		return client.ReadDesiresForNodePool(k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.NodePoolName)
-	}
-	return client.ReadDesiresForCluster(k.SubscriptionID, k.ResourceGroupName, k.ClusterName)
+	return readDesireCRUD(k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.SubResourceType, k.SubResourceName, client)
 }
 
-// GetResourceID returns the desire's full resource ID. It uses the
-// cluster-scoped or node-pool-scoped builder depending on the key's shape.
+// GetResourceID returns the desire's full resource ID.
 func (k ReadDesireKey) GetResourceID() *azcorearm.ResourceID {
-	var s string
-	if k.IsNodePoolScoped() {
-		s = kubeapplier.ToNodePoolScopedReadDesireResourceIDString(
-			k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.NodePoolName, k.Name)
-	} else {
-		s = kubeapplier.ToClusterScopedReadDesireResourceIDString(
-			k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.Name)
-	}
+	s := desireResourceIDString(k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.SubResourceType, k.SubResourceName, kubeapplier.ReadDesireResourceTypeName, k.Name)
 	return api.Must(azcorearm.ParseResourceID(s))
 }
 
@@ -117,13 +92,13 @@ func (k ReadDesireKey) AddLoggerValues(logger logr.Logger) logr.Logger {
 }
 
 // FromResourceID parses an ApplyDesireKey out of a *Desire's resource ID. The
-// caller is expected to have a desire whose resource ID is one of:
+// caller is expected to have a desire whose resource ID follows one of these
+// patterns (or analogous patterns for other cluster sub-resource types):
 //
 //	.../hcpOpenShiftClusters/<c>/applyDesires/<n>
 //	.../hcpOpenShiftClusters/<c>/nodePools/<np>/applyDesires/<n>
-//
-// It is the same parser for all three desire kinds; we just expose typed
-// constructors per kind so callers don't accidentally cross-wire keys.
+//	.../hcpOpenShiftClusters/<c>/systemAdminCredentialRequests/<cr>/applyDesires/<n>
+//	.../hcpOpenShiftClusters/<c>/systemAdminCredentialRevocations/<rev>/applyDesires/<n>
 func ApplyDesireKeyFromResourceID(id *azcorearm.ResourceID) (ApplyDesireKey, error) {
 	parts, err := parseDesireParts(id)
 	if err != nil {
@@ -148,7 +123,8 @@ type desireParts struct {
 	SubscriptionID    string
 	ResourceGroupName string
 	ClusterName       string
-	NodePoolName      string
+	SubResourceType   string
+	SubResourceName   string
 	Name              string
 }
 
@@ -161,33 +137,85 @@ func parseDesireParts(id *azcorearm.ResourceID) (desireParts, error) {
 		ResourceGroupName: id.ResourceGroupName,
 		Name:              id.Name,
 	}
-	// Walk the parent chain to find the containing cluster (and optionally the
-	// containing nodepool). The desire itself is the leaf; its parent is either
-	// the cluster (cluster-scoped) or the nodepool (nodepool-scoped).
+	// Walk the parent chain to find the containing cluster. The desire itself
+	// is the leaf; its parent is either the cluster (cluster-scoped) or an
+	// intermediate sub-resource type (e.g. nodePool, credentialRequest).
 	parent := id.Parent
 	if parent == nil {
 		return desireParts{}, fmt.Errorf("desire %q has no parent in its resource ID", id.String())
 	}
-	if matchesType(parent.ResourceType, api.NodePoolResourceType) {
-		out.NodePoolName = parent.Name
-		if parent.Parent == nil {
-			return desireParts{}, fmt.Errorf(
-				"nodepool-scoped desire %q has no grandparent cluster", id.String(),
-			)
-		}
-		out.ClusterName = parent.Parent.Name
-		return out, nil
-	}
+
 	if matchesType(parent.ResourceType, api.ClusterResourceType) {
 		out.ClusterName = parent.Name
 		return out, nil
 	}
-	return desireParts{}, fmt.Errorf(
-		"desire %q has unsupported parent resource type %s", id.String(), parent.ResourceType,
-	)
+
+	// The immediate parent is an intermediate sub-resource. Record it and
+	// look one more level up for the cluster.
+	out.SubResourceType = strings.ToLower(leafTypeName(parent.ResourceType))
+	out.SubResourceName = parent.Name
+
+	grandparent := parent.Parent
+	if grandparent == nil {
+		return desireParts{}, fmt.Errorf(
+			"desire %q has intermediate parent %s but no grandparent cluster", id.String(), parent.ResourceType,
+		)
+	}
+	if !matchesType(grandparent.ResourceType, api.ClusterResourceType) {
+		return desireParts{}, fmt.Errorf(
+			"desire %q grandparent is %s, not a cluster", id.String(), grandparent.ResourceType,
+		)
+	}
+	out.ClusterName = grandparent.Name
+	return out, nil
 }
 
 func matchesType(got, want azcorearm.ResourceType) bool {
 	return strings.EqualFold(got.Namespace, want.Namespace) &&
 		strings.EqualFold(got.Type, want.Type)
+}
+
+// leafTypeName returns the trailing segment of an ARM ResourceType.
+func leafTypeName(rt azcorearm.ResourceType) string {
+	return rt.Types[len(rt.Types)-1]
+}
+
+// desireResourceIDString builds the lowercased resource ID string for a desire
+// from its decomposed parts.
+func desireResourceIDString(subscriptionID, resourceGroupName, clusterName, subResourceType, subResourceName, desireTypeName, desireName string) string {
+	clusterPath := api.ToClusterResourceIDString(subscriptionID, resourceGroupName, clusterName)
+	if len(subResourceType) == 0 {
+		return strings.ToLower(path.Join(clusterPath, desireTypeName, desireName))
+	}
+	return strings.ToLower(path.Join(clusterPath, subResourceType, subResourceName, desireTypeName, desireName))
+}
+
+func applyDesireCRUD(subscriptionID, resourceGroupName, clusterName, subResourceType, subResourceName string, client kubeappliercosmosstorage.KubeApplierApplyDesireCRUD) (cosmosstorageutils.ResourceCRUD[kubeapplier.ApplyDesire, *kubeapplier.ApplyDesire], error) {
+	switch strings.ToLower(subResourceType) {
+	case "":
+		return client.ApplyDesiresForCluster(subscriptionID, resourceGroupName, clusterName)
+	case strings.ToLower(api.NodePoolResourceTypeName):
+		return client.ApplyDesiresForNodePool(subscriptionID, resourceGroupName, clusterName, subResourceName)
+	case strings.ToLower(api.SystemAdminCredentialRequestResourceTypeName):
+		return client.ApplyDesiresForSystemAdminCredentialRequest(subscriptionID, resourceGroupName, clusterName, subResourceName)
+	case strings.ToLower(api.SystemAdminCredentialRevocationResourceTypeName):
+		return client.ApplyDesiresForSystemAdminCredentialRevocation(subscriptionID, resourceGroupName, clusterName, subResourceName)
+	default:
+		return nil, fmt.Errorf("unsupported sub-resource type %q for apply desire CRUD dispatch", subResourceType)
+	}
+}
+
+func readDesireCRUD(subscriptionID, resourceGroupName, clusterName, subResourceType, subResourceName string, client kubeappliercosmosstorage.KubeApplierReadDesireCRUD) (cosmosstorageutils.ResourceCRUD[kubeapplier.ReadDesire, *kubeapplier.ReadDesire], error) {
+	switch strings.ToLower(subResourceType) {
+	case "":
+		return client.ReadDesiresForCluster(subscriptionID, resourceGroupName, clusterName)
+	case strings.ToLower(api.NodePoolResourceTypeName):
+		return client.ReadDesiresForNodePool(subscriptionID, resourceGroupName, clusterName, subResourceName)
+	case strings.ToLower(api.SystemAdminCredentialRequestResourceTypeName):
+		return client.ReadDesiresForSystemAdminCredentialRequest(subscriptionID, resourceGroupName, clusterName, subResourceName)
+	case strings.ToLower(api.SystemAdminCredentialRevocationResourceTypeName):
+		return client.ReadDesiresForSystemAdminCredentialRevocation(subscriptionID, resourceGroupName, clusterName, subResourceName)
+	default:
+		return nil, fmt.Errorf("unsupported sub-resource type %q for read desire CRUD dispatch", subResourceType)
+	}
 }

--- a/kube-applier/pkg/controllers/keys/keys_test.go
+++ b/kube-applier/pkg/controllers/keys/keys_test.go
@@ -1,0 +1,278 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keys
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/kubeappliercosmosstoragetesting"
+)
+
+const (
+	testSubscription = "00000000-0000-0000-0000-000000000001"
+	testRG           = "test-rg"
+	testCluster      = "test-cluster"
+	testNodePool     = "test-np"
+	testCredReq      = "test-cred-req"
+	testRevocation   = "test-revocation"
+	testDesireName   = "my-desire"
+)
+
+func TestParseDesireParts_ClusterScoped(t *testing.T) {
+	idStr := kubeapplier.ToClusterScopedApplyDesireResourceIDString(testSubscription, testRG, testCluster, testDesireName)
+	id := api.Must(azcorearm.ParseResourceID(idStr))
+
+	key, err := ApplyDesireKeyFromResourceID(id)
+	require.NoError(t, err)
+	require.Equal(t, testSubscription, key.SubscriptionID)
+	require.Equal(t, testRG, key.ResourceGroupName)
+	require.Equal(t, testCluster, key.ClusterName)
+	require.Empty(t, key.SubResourceType)
+	require.Empty(t, key.SubResourceName)
+	require.Equal(t, testDesireName, key.Name)
+}
+
+func TestParseDesireParts_NodePoolScoped(t *testing.T) {
+	idStr := kubeapplier.ToNodePoolScopedApplyDesireResourceIDString(testSubscription, testRG, testCluster, testNodePool, testDesireName)
+	id := api.Must(azcorearm.ParseResourceID(idStr))
+
+	key, err := ApplyDesireKeyFromResourceID(id)
+	require.NoError(t, err)
+	require.Equal(t, testCluster, key.ClusterName)
+	require.Equal(t, "nodepools", key.SubResourceType)
+	require.Equal(t, testNodePool, key.SubResourceName)
+	require.Equal(t, testDesireName, key.Name)
+}
+
+func TestParseDesireParts_SystemAdminCredentialRequestScoped(t *testing.T) {
+	idStr := kubeapplier.ToSystemAdminCredentialRequestScopedApplyDesireResourceIDString(testSubscription, testRG, testCluster, testCredReq, testDesireName)
+	id := api.Must(azcorearm.ParseResourceID(idStr))
+
+	key, err := ApplyDesireKeyFromResourceID(id)
+	require.NoError(t, err)
+	require.Equal(t, testCluster, key.ClusterName)
+	require.Equal(t, "systemadmincredentialrequests", key.SubResourceType)
+	require.Equal(t, testCredReq, key.SubResourceName)
+	require.Equal(t, testDesireName, key.Name)
+}
+
+func TestParseDesireParts_SystemAdminCredentialRevocationScoped(t *testing.T) {
+	idStr := kubeapplier.ToSystemAdminCredentialRevocationScopedApplyDesireResourceIDString(testSubscription, testRG, testCluster, testRevocation, testDesireName)
+	id := api.Must(azcorearm.ParseResourceID(idStr))
+
+	key, err := ApplyDesireKeyFromResourceID(id)
+	require.NoError(t, err)
+	require.Equal(t, testCluster, key.ClusterName)
+	require.Equal(t, "systemadmincredentialrevocations", key.SubResourceType)
+	require.Equal(t, testRevocation, key.SubResourceName)
+	require.Equal(t, testDesireName, key.Name)
+}
+
+func TestParseDesireParts_ReadDesire(t *testing.T) {
+	idStr := kubeapplier.ToSystemAdminCredentialRequestScopedReadDesireResourceIDString(testSubscription, testRG, testCluster, testCredReq, testDesireName)
+	id := api.Must(azcorearm.ParseResourceID(idStr))
+
+	key, err := ReadDesireKeyFromResourceID(id)
+	require.NoError(t, err)
+	require.Equal(t, testCluster, key.ClusterName)
+	require.Equal(t, "systemadmincredentialrequests", key.SubResourceType)
+	require.Equal(t, testCredReq, key.SubResourceName)
+	require.Equal(t, testDesireName, key.Name)
+}
+
+func TestParseDesireParts_ErrorCases(t *testing.T) {
+	t.Run("nil resource ID", func(t *testing.T) {
+		_, err := ApplyDesireKeyFromResourceID(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("no parent", func(t *testing.T) {
+		id := api.Must(azcorearm.ParseResourceID("/subscriptions/" + testSubscription))
+		_, err := ApplyDesireKeyFromResourceID(id)
+		require.Error(t, err)
+	})
+}
+
+func TestGetResourceID_RoundTrips(t *testing.T) {
+	tests := []struct {
+		name  string
+		idStr string
+	}{
+		{
+			name:  "cluster-scoped apply desire",
+			idStr: kubeapplier.ToClusterScopedApplyDesireResourceIDString(testSubscription, testRG, testCluster, testDesireName),
+		},
+		{
+			name:  "nodepool-scoped apply desire",
+			idStr: kubeapplier.ToNodePoolScopedApplyDesireResourceIDString(testSubscription, testRG, testCluster, testNodePool, testDesireName),
+		},
+		{
+			name:  "credential-request-scoped apply desire",
+			idStr: kubeapplier.ToSystemAdminCredentialRequestScopedApplyDesireResourceIDString(testSubscription, testRG, testCluster, testCredReq, testDesireName),
+		},
+		{
+			name:  "revocation-scoped apply desire",
+			idStr: kubeapplier.ToSystemAdminCredentialRevocationScopedApplyDesireResourceIDString(testSubscription, testRG, testCluster, testRevocation, testDesireName),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := api.Must(azcorearm.ParseResourceID(tt.idStr))
+			key, err := ApplyDesireKeyFromResourceID(id)
+			require.NoError(t, err)
+
+			roundTripped := key.GetResourceID()
+			require.Equal(t, strings.ToLower(tt.idStr), strings.ToLower(roundTripped.String()), "GetResourceID should round-trip to the original ID string")
+		})
+	}
+}
+
+func TestGetResourceID_ReadDesireRoundTrips(t *testing.T) {
+	tests := []struct {
+		name  string
+		idStr string
+	}{
+		{
+			name:  "cluster-scoped read desire",
+			idStr: kubeapplier.ToClusterScopedReadDesireResourceIDString(testSubscription, testRG, testCluster, testDesireName),
+		},
+		{
+			name:  "nodepool-scoped read desire",
+			idStr: kubeapplier.ToNodePoolScopedReadDesireResourceIDString(testSubscription, testRG, testCluster, testNodePool, testDesireName),
+		},
+		{
+			name:  "credential-request-scoped read desire",
+			idStr: kubeapplier.ToSystemAdminCredentialRequestScopedReadDesireResourceIDString(testSubscription, testRG, testCluster, testCredReq, testDesireName),
+		},
+		{
+			name:  "revocation-scoped read desire",
+			idStr: kubeapplier.ToSystemAdminCredentialRevocationScopedReadDesireResourceIDString(testSubscription, testRG, testCluster, testRevocation, testDesireName),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := api.Must(azcorearm.ParseResourceID(tt.idStr))
+			key, err := ReadDesireKeyFromResourceID(id)
+			require.NoError(t, err)
+
+			roundTripped := key.GetResourceID()
+			require.Equal(t, strings.ToLower(tt.idStr), strings.ToLower(roundTripped.String()), "GetResourceID should round-trip to the original ID string")
+		})
+	}
+}
+
+func TestApplyDesireKey_CRUD_DispatchesCorrectly(t *testing.T) {
+	ctx := context.Background()
+	mockDB := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClient()
+
+	tests := []struct {
+		name  string
+		idStr string
+	}{
+		{
+			name:  "cluster-scoped",
+			idStr: kubeapplier.ToClusterScopedApplyDesireResourceIDString(testSubscription, testRG, testCluster, testDesireName),
+		},
+		{
+			name:  "nodepool-scoped",
+			idStr: kubeapplier.ToNodePoolScopedApplyDesireResourceIDString(testSubscription, testRG, testCluster, testNodePool, testDesireName),
+		},
+		{
+			name:  "credential-request-scoped",
+			idStr: kubeapplier.ToSystemAdminCredentialRequestScopedApplyDesireResourceIDString(testSubscription, testRG, testCluster, testCredReq, testDesireName),
+		},
+		{
+			name:  "revocation-scoped",
+			idStr: kubeapplier.ToSystemAdminCredentialRevocationScopedApplyDesireResourceIDString(testSubscription, testRG, testCluster, testRevocation, testDesireName),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := api.Must(azcorearm.ParseResourceID(tt.idStr))
+			key, err := ApplyDesireKeyFromResourceID(id)
+			require.NoError(t, err)
+
+			crud, err := key.CRUD(mockDB)
+			require.NoError(t, err, "CRUD dispatch should succeed")
+			require.NotNil(t, crud, "CRUD should return a non-nil value")
+
+			desire := &kubeapplier.ApplyDesire{}
+			desire.ResourceID = id
+			desire.PartitionKey = testSubscription
+
+			created, err := crud.Create(ctx, desire, nil)
+			require.NoError(t, err, "should be able to create via the returned CRUD")
+			require.NotNil(t, created)
+		})
+	}
+}
+
+func TestReadDesireKey_CRUD_DispatchesCorrectly(t *testing.T) {
+	ctx := context.Background()
+	mockDB := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClient()
+
+	tests := []struct {
+		name  string
+		idStr string
+	}{
+		{
+			name:  "cluster-scoped",
+			idStr: kubeapplier.ToClusterScopedReadDesireResourceIDString(testSubscription, testRG, testCluster, testDesireName),
+		},
+		{
+			name:  "nodepool-scoped",
+			idStr: kubeapplier.ToNodePoolScopedReadDesireResourceIDString(testSubscription, testRG, testCluster, testNodePool, testDesireName),
+		},
+		{
+			name:  "credential-request-scoped",
+			idStr: kubeapplier.ToSystemAdminCredentialRequestScopedReadDesireResourceIDString(testSubscription, testRG, testCluster, testCredReq, testDesireName),
+		},
+		{
+			name:  "revocation-scoped",
+			idStr: kubeapplier.ToSystemAdminCredentialRevocationScopedReadDesireResourceIDString(testSubscription, testRG, testCluster, testRevocation, testDesireName),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := api.Must(azcorearm.ParseResourceID(tt.idStr))
+			key, err := ReadDesireKeyFromResourceID(id)
+			require.NoError(t, err)
+
+			crud, err := key.CRUD(mockDB)
+			require.NoError(t, err, "CRUD dispatch should succeed")
+			require.NotNil(t, crud, "CRUD should return a non-nil value")
+
+			desire := &kubeapplier.ReadDesire{}
+			desire.ResourceID = id
+			desire.PartitionKey = testSubscription
+
+			created, err := crud.Create(ctx, desire, nil)
+			require.NoError(t, err, "should be able to create via the returned CRUD")
+			require.NotNil(t, created)
+		})
+	}
+}

--- a/kube-applier/pkg/controllers/read_desire_kubernetes/controller.go
+++ b/kube-applier/pkg/controllers/read_desire_kubernetes/controller.go
@@ -124,7 +124,7 @@ func NewReadDesireKubernetesController(
 			workqueue.TypedRateLimitingQueueConfig[keys.ReadDesireKey]{
 				// Underscores rather than slashes: this name surfaces as a
 				// Prometheus label and slashes complicate downstream tooling.
-				Name: fmt.Sprintf("%s_%s_%s_%s", ReadDesireKubernetesControllerName, key.ClusterName, key.NodePoolName, key.Name),
+				Name: fmt.Sprintf("%s_%s_%s_%s_%s", ReadDesireKubernetesControllerName, key.ClusterName, key.SubResourceType, key.SubResourceName, key.Name),
 			},
 		),
 		writer: desirestatuswriter.New[kubeapplier.ReadDesire, keys.ReadDesireKey, *kubeapplier.ReadDesire](


### PR DESCRIPTION
    Extend the kube-applier key parsing to handle resource IDs scoped
    under systemAdminCredentialRequests and systemAdminCredentialRevocations,
    in addition to the existing cluster and nodepool scopes. Add tests
    and update documentation.
    
