### PR TITLE
chore(owners): add SRE approvers for RP rules

### DIFF
--- a/admin/alerts/OWNERS
+++ b/admin/alerts/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - sre-approvers

--- a/backend/alerts/OWNERS
+++ b/backend/alerts/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - sre-approvers

--- a/cluster-service/alerts/OWNERS
+++ b/cluster-service/alerts/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - sre-approvers

--- a/dev-infrastructure/modules/metrics/OWNERS
+++ b/dev-infrastructure/modules/metrics/OWNERS
@@ -1,0 +1,4 @@
+filters:
+  '^(rp-rules|rp-hcp-rules)\.bicep$':
+    approvers:
+      - sre-approvers

--- a/dev-infrastructure/modules/metrics/rules/OWNERS
+++ b/dev-infrastructure/modules/metrics/rules/OWNERS
@@ -1,0 +1,4 @@
+filters:
+  '^(generatedRPPrometheusAlertingRules|generatedRPHCPPrometheusAlertingRules|generatedHCPRecordingRules|generatedRecordingRules)\.bicep$':
+    approvers:
+      - sre-approvers

--- a/docs/alerts/OWNERS
+++ b/docs/alerts/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - sre-approvers

--- a/fleet/alerts/OWNERS
+++ b/fleet/alerts/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - sre-approvers

--- a/frontend/alerts/OWNERS
+++ b/frontend/alerts/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - sre-approvers

--- a/kube-applier/alerts/OWNERS
+++ b/kube-applier/alerts/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - sre-approvers

--- a/maestro/alerts/OWNERS
+++ b/maestro/alerts/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - sre-approvers

--- a/observability/alerts/OWNERS
+++ b/observability/alerts/OWNERS
@@ -1,0 +1,2 @@
+approvers:
+  - sre-approvers


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1641

## Summary
- grants `sre-approvers` access to selected generated RP alerting and recording-rule Bicep outputs, plus RP metrics templates
- adds scoped `OWNERS` files for alert definitions in the selected service, documentation, and observability directories
- keeps SRE ownership limited to alert-related files rather than broad service or infrastructure directories
- **does not** grant access to other teams' alerts bicep files, meaning it's impossible for SRE to approve changes to alerts they don't own
