### PR TITLE
admin credential API with transition

### DIFF
--- a/test/util/framework/helpers_v20260901preview.go
+++ b/test/util/framework/helpers_v20260901preview.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
 	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
+	"github.com/Azure/ARO-HCP/internal/utils"
 	hcpsdk20260901preview "github.com/Azure/ARO-HCP/test/sdk/v20260901preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 )
 
@@ -813,6 +814,10 @@ func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster20260901(
 		},
 		nil,
 	)
+	if err != nil {
+		// flat fail during development so we can see if the new path works or fails.
+		return nil, utils.TrackError(err)
+	}
 	if err != nil {
 		// Fall back to the old 0240610 mechanism during the transition period.
 		fallbackFactory, fallbackErr := tc.Get20240610ClientFactory(ctx)


### PR DESCRIPTION
Now ready to review.  It adds a new flow for getting credentials, while keeping the old working for a transition.  We merge this one so that dev PRs exercise the newer path, while int, stg, prod use the old until we can rollout the new API version.