### PR TITLE
fix: deduplicate UJNodePoolStuckOperation alert across metric replicas

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -526,7 +526,7 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
           summary: '{{ $labels.cluster }}: Node Pool operation for {{ $labels.resource_id }} stuck in {{ $labels.phase }} for over 2 hours'
           title: '{{ $labels.cluster }}: Node Pool operation for {{ $labels.resource_id }} stuck in {{ $labels.phase }} for over 2 hours'
         }
-        expression: 'max_over_time((((time() - backend_resource_operation_start_time_seconds{resource_type=~".*nodepools",subscription_id!~"974ebd46-8ad3-41e3-afef-7ef25fd5c371|e8c5a115-842d-4d7e-98ad-cfb2c50b209e|e627aa70-36a3-40b0-8e68-975269e39d7b|6ed122d1-7e03-4a01-baae-9020abf350d4|64f0619f-ebc2-4156-9d91-c4c781de7e54|dee2f1be-a999-4e19-b027-221e7adaf7d3|8d696692-794f-4cdb-ba25-9250c9e9ec4c|ec435068-e722-475f-8504-c91b72a5dc51|403d9de9-132b-4974-94a5-5b78bdfa191e"}) and backend_resource_operation_phase_info{phase=~"updating|deleting",resource_type=~".*nodepools"} == 1) > 7200)[6h:5m])'
+        expression: 'max by (cluster, environment, region, subscription_id, resource_id, resource_type, operation_type, phase) (max_over_time((((time() - backend_resource_operation_start_time_seconds{resource_type=~".*nodepools",subscription_id!~"974ebd46-8ad3-41e3-afef-7ef25fd5c371|e8c5a115-842d-4d7e-98ad-cfb2c50b209e|e627aa70-36a3-40b0-8e68-975269e39d7b|6ed122d1-7e03-4a01-baae-9020abf350d4|64f0619f-ebc2-4156-9d91-c4c781de7e54|dee2f1be-a999-4e19-b027-221e7adaf7d3|8d696692-794f-4cdb-ba25-9250c9e9ec4c|ec435068-e722-475f-8504-c91b72a5dc51|403d9de9-132b-4974-94a5-5b78bdfa191e"}) and backend_resource_operation_phase_info{phase=~"updating|deleting",resource_type=~".*nodepools"} == 1) > 7200)[6h:5m]))'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }

--- a/observability/alerts/nodepool-slo-prometheusRule.yaml
+++ b/observability/alerts/nodepool-slo-prometheusRule.yaml
@@ -192,7 +192,7 @@ spec:
           max_over_time(
             (
               (
-                (time() - backend_resource_operation_start_time_seconds{resource_type=~".*nodepools", subscription_id!~"974ebd46-8ad3-41e3-afef-7ef25fd5c371|e8c5a115-842d-4d7e-98ad-cfb2c50b209e|e627aa70-36a3-40b0-8e68-975269e39d7b|6ed122d1-7e03-4a01-baae-9020abf350d4|64f0619f-ebc2-4156-9d91-c4c781de7e54|dee2f1be-a999-4e19-b027-221e7adaf7d3|8d696692-794f-4cdb-ba25-9250c9e9ec4c|ec435068-e722-475f-8504-c91b72a5dc51|  403d9de9-132b-4974-94a5-5b78bdfa191e"})
+                (time() - backend_resource_operation_start_time_seconds{resource_type=~".*nodepools", subscription_id!~"974ebd46-8ad3-41e3-afef-7ef25fd5c371|e8c5a115-842d-4d7e-98ad-cfb2c50b209e|e627aa70-36a3-40b0-8e68-975269e39d7b|6ed122d1-7e03-4a01-baae-9020abf350d4|64f0619f-ebc2-4156-9d91-c4c781de7e54|dee2f1be-a999-4e19-b027-221e7adaf7d3|8d696692-794f-4cdb-ba25-9250c9e9ec4c|ec435068-e722-475f-8504-c91b72a5dc51|403d9de9-132b-4974-94a5-5b78bdfa191e"})
                 and
                 backend_resource_operation_phase_info{resource_type=~".*nodepools", phase=~"updating|deleting"} == 1
               ) > 7200

--- a/observability/alerts/nodepool-slo-prometheusRule.yaml
+++ b/observability/alerts/nodepool-slo-prometheusRule.yaml
@@ -179,14 +179,25 @@ spec:
     # distinct stuck episodes more than 6h apart still get their own incident.
     - alert: UJNodePoolStuckOperation
       expr: |
-        max_over_time(
-          (
+        max by (
+          cluster,
+          environment,
+          region,
+          subscription_id,
+          resource_id,
+          resource_type,
+          operation_type,
+          phase
+        ) (
+          max_over_time(
             (
-              (time() - backend_resource_operation_start_time_seconds{resource_type=~".*nodepools", subscription_id!~"974ebd46-8ad3-41e3-afef-7ef25fd5c371|e8c5a115-842d-4d7e-98ad-cfb2c50b209e|e627aa70-36a3-40b0-8e68-975269e39d7b|6ed122d1-7e03-4a01-baae-9020abf350d4|64f0619f-ebc2-4156-9d91-c4c781de7e54|dee2f1be-a999-4e19-b027-221e7adaf7d3|8d696692-794f-4cdb-ba25-9250c9e9ec4c|ec435068-e722-475f-8504-c91b72a5dc51|403d9de9-132b-4974-94a5-5b78bdfa191e"})
-              and
-              backend_resource_operation_phase_info{resource_type=~".*nodepools", phase=~"updating|deleting"} == 1
-            ) > 7200
-          )[6h:5m]
+              (
+                (time() - backend_resource_operation_start_time_seconds{resource_type=~".*nodepools", subscription_id!~"974ebd46-8ad3-41e3-afef-7ef25fd5c371|e8c5a115-842d-4d7e-98ad-cfb2c50b209e|e627aa70-36a3-40b0-8e68-975269e39d7b|6ed122d1-7e03-4a01-baae-9020abf350d4|64f0619f-ebc2-4156-9d91-c4c781de7e54|dee2f1be-a999-4e19-b027-221e7adaf7d3|8d696692-794f-4cdb-ba25-9250c9e9ec4c|ec435068-e722-475f-8504-c91b72a5dc51|  403d9de9-132b-4974-94a5-5b78bdfa191e"})
+                and
+                backend_resource_operation_phase_info{resource_type=~".*nodepools", phase=~"updating|deleting"} == 1
+              ) > 7200
+            )[6h:5m]
+          )
         )
       for: 15m
       labels:

--- a/observability/alerts/nodepool-slo-prometheusRule_test.yaml
+++ b/observability/alerts/nodepool-slo-prometheusRule_test.yaml
@@ -483,3 +483,40 @@ tests:
   - eval_time: 150m
     alertname: UJNodePoolStuckOperation
     exp_alerts: []
+# ========================================
+# Test 16: Duplicate stuck series across a volatile label collapse into one alert
+# ========================================
+# The same wedged node pool is scraped as two series that differ only by a volatile
+# label (here `instance`, but the same applies to pod/prometheus_replica). Without
+# the `max by (...)` aggregation this would fan out into two identical IcM incidents
+# for a single stuck resource. The aggregation drops the volatile label, so both
+# series collapse into a single output series and exactly one alert fires (with no
+# `instance` label carried through).
+- interval: 1m
+  input_series:
+  - series: 'backend_resource_operation_start_time_seconds{resource_id="/sub/10/np/dup", subscription_id="sub-10", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="update", phase="updating", cluster="mgmt-1", instance="prom-a"}'
+    values: "0+0x155"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/10/np/dup", subscription_id="sub-10", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="update", phase="updating", cluster="mgmt-1", instance="prom-a"}'
+    values: "1+0x155"
+  - series: 'backend_resource_operation_start_time_seconds{resource_id="/sub/10/np/dup", subscription_id="sub-10", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="update", phase="updating", cluster="mgmt-1", instance="prom-b"}'
+    values: "0+0x155"
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/10/np/dup", subscription_id="sub-10", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="update", phase="updating", cluster="mgmt-1", instance="prom-b"}'
+    values: "1+0x155"
+  alert_rule_test:
+  # Two duplicate series in → exactly one alert out (instance label dropped).
+  - eval_time: 150m
+    alertname: UJNodePoolStuckOperation
+    exp_alerts:
+    - exp_labels:
+        cluster: "mgmt-1"
+        component: slo
+        operation_type: "update"
+        phase: "updating"
+        resource_id: "/sub/10/np/dup"
+        resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
+        severity: info
+        subscription_id: "sub-10"
+      exp_annotations:
+        summary: "mgmt-1: Node Pool operation for /sub/10/np/dup stuck in updating for over 2 hours"
+        description: "Node pool operation for /sub/10/np/dup has been in updating phase for over 2 hours. Stuck operations are invisible to success/failure SLIs and require investigation."
+        runbook_url: "https://aka.ms/arohcp-runbook-nodepool"

--- a/observability/alerts/nodepool-slo-prometheusRule_test.yaml
+++ b/observability/alerts/nodepool-slo-prometheusRule_test.yaml
@@ -491,27 +491,31 @@ tests:
 # the `max by (...)` aggregation this would fan out into two identical IcM incidents
 # for a single stuck resource. The aggregation drops the volatile label, so both
 # series collapse into a single output series and exactly one alert fires (with no
-# `instance` label carried through).
+# `instance` label carried through). The routing labels in the `max by (...)`
+# allowlist (`environment`, `region`) are identical across the duplicates and must
+# survive the aggregation, so they are carried through to the single output alert.
 - interval: 1m
   input_series:
-  - series: 'backend_resource_operation_start_time_seconds{resource_id="/sub/10/np/dup", subscription_id="sub-10", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="update", phase="updating", cluster="mgmt-1", instance="prom-a"}'
+  - series: 'backend_resource_operation_start_time_seconds{resource_id="/sub/10/np/dup", subscription_id="sub-10", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="update", phase="updating", cluster="mgmt-1", environment="int", region="uksouth", instance="prom-a"}'
     values: "0+0x155"
-  - series: 'backend_resource_operation_phase_info{resource_id="/sub/10/np/dup", subscription_id="sub-10", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="update", phase="updating", cluster="mgmt-1", instance="prom-a"}'
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/10/np/dup", subscription_id="sub-10", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="update", phase="updating", cluster="mgmt-1", environment="int", region="uksouth", instance="prom-a"}'
     values: "1+0x155"
-  - series: 'backend_resource_operation_start_time_seconds{resource_id="/sub/10/np/dup", subscription_id="sub-10", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="update", phase="updating", cluster="mgmt-1", instance="prom-b"}'
+  - series: 'backend_resource_operation_start_time_seconds{resource_id="/sub/10/np/dup", subscription_id="sub-10", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="update", phase="updating", cluster="mgmt-1", environment="int", region="uksouth", instance="prom-b"}'
     values: "0+0x155"
-  - series: 'backend_resource_operation_phase_info{resource_id="/sub/10/np/dup", subscription_id="sub-10", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="update", phase="updating", cluster="mgmt-1", instance="prom-b"}'
+  - series: 'backend_resource_operation_phase_info{resource_id="/sub/10/np/dup", subscription_id="sub-10", resource_type="microsoft.redhatopenshift/hcpopenshiftclusters/nodepools", operation_type="update", phase="updating", cluster="mgmt-1", environment="int", region="uksouth", instance="prom-b"}'
     values: "1+0x155"
   alert_rule_test:
-  # Two duplicate series in → exactly one alert out (instance label dropped).
+  # Two duplicate series in → exactly one alert out (instance dropped; environment/region preserved).
   - eval_time: 150m
     alertname: UJNodePoolStuckOperation
     exp_alerts:
     - exp_labels:
         cluster: "mgmt-1"
         component: slo
+        environment: "int"
         operation_type: "update"
         phase: "updating"
+        region: "uksouth"
         resource_id: "/sub/10/np/dup"
         resource_type: "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools"
         severity: info


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-28778

### What

Deduplicates the `UJNodePoolStuckOperation` node-pool SLO alert so a single wedged node pool produces exactly one alert/incident regardless of how many Prometheus replicas scrape the metric. Specifically:

- Wraps the stuck-operation expression in  `max by (cluster, environment, region, subscription_id, resource_id,
  resource_type, operation_type, phase) (...)`, dropping volatile scrape/replica labels (`pod` / `instance` / `prometheus_replica`) from the alert identity
- Adds a promtool unit test (Test 16) that feeds two identical stuck-operation series differing only by a volatile `instance` label and asserts a single alert fires.

### Why

The `max by (...)` aggregation in the `UJNodePoolStuckOperation` rule was introduced specifically to deduplicate alerts across volatile scrape/replica labels (`pod` / `instance` / `prometheus_replica`), so a single wedged node pool does not
fan out into multiple identical IcM incidents. The existing promtool tests only used single-series inputs and never exercised the multi-replica duplication case, leaving this behavior uncovered — a silent regression here would page on-call with duplicate incidents. This test locks in the dedup guarantee.

### Testing

- **Unit tests**: Added `Test 16` in `nodepool-slo-prometheusRule_test.yaml`. Verified it passes via the rule generator, which runs `promtool test rules` on the extracted rules:
  ```sh
  make -C tooling/prometheus-rules run-rp-services