### PR TITLE
[WIP]:Add Istio ASM revision suggestion to image-updater

### DIFF
--- a/tooling/image-updater/README.md
+++ b/tooling/image-updater/README.md
@@ -601,18 +601,69 @@ Use `-v=2` for debugging auth issues, tag filtering, or network failures.
 
 ### Source Fields
 
+Every image needs exactly one primary source: either a container `image` reference (default), or a version-only source that returns a plain version string. See [Version-Only Sources](#version-only-sources) for the escape hatches (`pinnedMeshRevision`, `maxMeshRevision`).
+
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
-| `image` | string | Yes | - | Full image reference (registry/repository) |
-| `tag` | string | No | - | Exact tag (mutually exclusive with `tagPattern`) |
-| `tagPattern` | string | No | - | Regex pattern (mutually exclusive with `tag`) |
-| `versionLabel` | string | No | `org.opencontainers.image.revision` (with `tag`), empty (with `tagPattern`) | Container label to extract for version info |
-| `architecture` | string | No | `amd64` | Target architecture (mutually exclusive with `multiArch`) |
-| `multiArch` | bool | No | `false` | Fetch multi-arch manifest list (mutually exclusive with `architecture`) |
-| `useAuth` | bool | No | `false` | Require authentication (needed for private registries) |
-| `keyVault.url` | string | No | - | Azure Key Vault URL |
-| `keyVault.secretName` | string | No | - | Pull secret name in Key Vault |
-| `repoVersionUpgrade.repoPrefix` | string | No | - | Repo name prefix before version suffix; enables `--repositories` mode for this component |
+| `image` | string | Conditional | - | Full image reference (registry/repository). Required unless a version-only source is set. |
+| `githubLatestRelease` | string | Conditional | - | `owner/repo`; fetch the latest published release tag from GitHub (e.g. `istio/istio`). Version-only source. |
+| `azureAKSMeshRevisions.locations` | list | Conditional | - | ARM locations to query; the highest ASM revision available in **all** of them wins. Version-only source. |
+| `azureAKSMeshRevisions.subscription` | string | No | `$AZURE_SUBSCRIPTION_ID` | Azure subscription for the ARM read. Any subscription with `Microsoft.ContainerService` read works — the API is subscription-scoped but returns product-wide data. |
+| `pinnedMeshRevision` | string | No | - | Only with `azureAKSMeshRevisions`: hard override, write this exact revision and skip the upstream check. Mutually exclusive with `maxMeshRevision`. |
+| `maxMeshRevision` | string | No | - | Only with `azureAKSMeshRevisions`: ceiling; ignore any revision above this. Mutually exclusive with `pinnedMeshRevision`. |
+| `tag` | string | No | - | Exact tag (mutually exclusive with `tagPattern`). Registry sources only. |
+| `tagPattern` | string | No | - | Regex pattern (mutually exclusive with `tag`). Registry sources only. |
+| `versionLabel` | string | No | `org.opencontainers.image.revision` (with `tag`), empty (with `tagPattern`) | Container label to extract for version info. Registry sources only. |
+| `architecture` | string | No | `amd64` | Target architecture (mutually exclusive with `multiArch`). Registry sources only. |
+| `multiArch` | bool | No | `false` | Fetch multi-arch manifest list (mutually exclusive with `architecture`). Registry sources only. |
+| `useAuth` | bool | No | `false` | Require authentication (needed for private registries). Registry sources only. |
+| `keyVault.url` | string | No | - | Azure Key Vault URL. Registry sources only. |
+| `keyVault.secretName` | string | No | - | Pull secret name in Key Vault. Registry sources only. |
+| `repoVersionUpgrade.repoPrefix` | string | No | - | Repo name prefix before version suffix; enables `--repositories` mode for this component. Registry sources only. |
+
+### Version-Only Sources
+
+Some upstream artifacts are published as plain version strings, not container images — for example a GitHub release tag (`istioctl`) or an AKS Istio add-on revision (`asm-1-29`). For these, set a version-only source instead of `image`; the tool writes the version string directly to the target `jsonPath` and skips registry, digest, and architecture logic entirely.
+
+Two version-only sources are supported today:
+
+- **`githubLatestRelease: <owner/repo>`** — used for istioctl (`istio/istio`). Returns the latest published release tag.
+- **`azureAKSMeshRevisions`** — used for the ASM (Azure Service Mesh) revision that AKS installs by default via its `MeshRevisionProfiles` ARM API (the same data as `az aks mesh get-revisions --location <loc>`). Per location the tool derives the AKS-default revision — the highest catalogue entry whose `Upgrades` list is non-empty, i.e. the newest revision that is **not** the bleeding edge. It then intersects the per-location defaults; a bump only happens once every configured region agrees. Any location that fails to respond aborts the whole run — a transient outage must never look like "a new revision is safe to roll".
+
+> **Scope.** image-updater only edits the checked-out `config/config.yaml` and opens a PR. It never contacts int / stage / prod clusters and holds no runtime credentials for them. The ARM read is a public product-catalogue query against any subscription; the resulting revision only reaches an environment once the PR merges and EV2 rolls it out on its normal cadence.
+
+> **Why not the bleeding-edge?** ARM's profile lists every supported revision but does not flag which one AKS installs by default. Filtering to "has upgrades available" is a deterministic proxy: it matches what a fresh cluster actually gets, and it lags newest by ~1 revision, which is exactly the soak-time buffer you'd otherwise reach for with `maxMeshRevision`.
+
+Authentication reuses the same `DefaultAzureCredential` machinery as the ACR sources (`AZURE_TOKEN_CREDENTIALS`, workload identity, or `az login`). No per-cluster access is needed; the profile API is subscription-scoped and returns product-wide data.
+
+#### ASM Revision Escape Hatches
+
+The `azureAKSMeshRevisions` source supports two operator overrides for cases where the natural "pick the highest common revision" behaviour is not what you want. Both are validated against `asm-<major>-<minor>` at config-load time, so a typo can't silently disable the tool.
+
+| Field | Effect | Use Case |
+|-------|--------|----------|
+| `pinnedMeshRevision: asm-1-28` | Skips the upstream check entirely and writes the pinned value. | Roll back to a known-good revision; temporarily disable the automation while investigating an incident. |
+| `maxMeshRevision: asm-1-29` | Fetches upstream and intersects, then discards any revision above the cap. Highest remaining wins. | Hold a bump while you validate a new revision in staging, without rewriting the config each time a newer revision appears. |
+
+`pinnedMeshRevision` and `maxMeshRevision` are mutually exclusive. Neither is meaningful without `azureAKSMeshRevisions`, and setting them elsewhere is a validation error.
+
+Example — cap ASM to 1.29 across four regions until we're ready to move on:
+
+```yaml
+istio-asm-revision:
+  group: istio
+  source:
+    azureAKSMeshRevisions:
+      locations:
+      - uksouth
+      - westus3
+      - eastus2
+      - australiaeast
+    maxMeshRevision: "asm-1-29"
+  targets:
+  - jsonPath: defaults.svc.istio.versions
+    filePath: ../../config/config.yaml
+```
 
 ### Target Fields
 

--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -273,3 +273,34 @@ images:
     targets:
     - jsonPath: defaults.svc.istio.istioctlVersion
       filePath: ../../config/config.yaml
+  # AKS Istio add-on revision. Queries the AKS mesh revision profiles API in
+  # every listed location, derives each region's install-time default (the
+  # highest revision whose Upgrades list is non-empty), and only advances
+  # when every region agrees.
+  #
+  # Locations mirror the actual HCP deployment footprint pulled from
+  # sdp-pipelines/hcp/rendered/public: INT/STG deploy to uksouth only, PROD
+  # deploys to nine regions. Keep this list in sync when the deployment
+  # topology changes so the rollout target never runs ahead of what a slower
+  # region supports. See README for pinnedMeshRevision / maxMeshRevision
+  # escape hatches. Subscription falls back to $AZURE_SUBSCRIPTION_ID.
+  # TODO: drop the targetVersion target once ARO-HCP PR #6236 merges.
+  istio-asm-revision:
+    group: istio
+    source:
+      azureAKSMeshRevisions:
+        locations:
+        - uksouth          # INT, STG, PROD
+        - australiaeast    # PROD
+        - brazilsouth      # PROD
+        - canadacentral    # PROD
+        - centralindia     # PROD
+        - eastus2          # PROD
+        - eastus2euap      # PROD (canary/EUAP)
+        - switzerlandnorth # PROD
+        - westeurope       # PROD
+    targets:
+    - jsonPath: defaults.svc.istio.versions
+      filePath: ../../config/config.yaml
+    - jsonPath: defaults.svc.istio.targetVersion
+      filePath: ../../config/config.yaml

--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -273,17 +273,12 @@ images:
     targets:
     - jsonPath: defaults.svc.istio.istioctlVersion
       filePath: ../../config/config.yaml
-  # AKS Istio add-on revision. Queries the AKS mesh revision profiles API in
-  # every listed location, derives each region's install-time default (the
-  # highest revision whose Upgrades list is non-empty), and only advances
-  # when every region agrees.
+  # Queries AKS mesh revision profiles across all listed locations and
+  # writes the highest default revision common to every region.
   #
-  # Locations mirror the actual HCP deployment footprint pulled from
-  # sdp-pipelines/hcp/rendered/public: INT/STG deploy to uksouth only, PROD
-  # deploys to nine regions. Keep this list in sync when the deployment
-  # topology changes so the rollout target never runs ahead of what a slower
-  # region supports. See README for pinnedMeshRevision / maxMeshRevision
-  # escape hatches. Subscription falls back to $AZURE_SUBSCRIPTION_ID.
+  # Locations should match the HCP deployment footprint. Keep this list
+  # in sync when the topology changes so no region falls behind.
+  # See README for pinnedMeshRevision / maxMeshRevision escape hatches.
   # TODO: drop the targetVersion target once ARO-HCP PR #6236 merges.
   istio-asm-revision:
     group: istio

--- a/tooling/image-updater/go.mod
+++ b/tooling/image-updater/go.mod
@@ -5,6 +5,7 @@ go 1.25.7
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/dusted-go/logging v1.3.0

--- a/tooling/image-updater/go.mod
+++ b/tooling/image-updater/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/dusted-go/logging v1.3.0
@@ -15,6 +16,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.6.7
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/mod v0.36.0
+	golang.org/x/sync v0.22.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.35.3
 	sigs.k8s.io/yaml v1.6.0
@@ -49,7 +51,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	gotest.tools/v3 v3.5.2 // indirect

--- a/tooling/image-updater/go.sum
+++ b/tooling/image-updater/go.sum
@@ -12,10 +12,14 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontai
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v5 v5.0.0/go.mod h1:HcZY0PHPo/7d75p99lB6lK0qYOP4vLRJUBpiehYXtLQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0 h1:xkWEcbsnJWid3rOf/S/LOHy1I55JA+4kw/f8Tnm+Onc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0/go.mod h1:OWKfCmX4X3Vp2w7GSx1LZn8566tOHJBA6K0IAUVNYx0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0 h1:2qsIIvxVT+uE6yrNldntJKlLRgxGbZ85kgtz5SNBhMw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0/go.mod h1:AW8VEadnhw9xox+VaVd9sP7NjzOAnaZBLRH6Tq3cJ38=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0 h1:wxQx2Bt4xzPIKvW59WQf1tJNx/ZZKPfN+EhPX3Z6CYY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0/go.mod h1:TpiwjwnW/khS0LKs4vW5UmmT9OWcxaveS8U7+tlknzo=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0 h1:/g8S6wk65vfC6m3FIxJ+i5QDyN9JWwXI8Hb0Img10hU=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0/go.mod h1:gpl+q95AzZlKVI3xSoseF9QPrypk0hQqBiJYeB/cR/I=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfgcSyHZXJI8J0IWE5MsCGlb2xp9fJiXyxWgmOFg4=

--- a/tooling/image-updater/go.sum
+++ b/tooling/image-updater/go.sum
@@ -8,6 +8,14 @@ github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3 h1:l
 github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3/go.mod h1:MAm7bk0oDLmD8yIkvfbxPW04fxzphPyL+7GzwHxOp6Y=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v5 v5.0.0 h1:5n7dPVqsWfVKw+ZiEKSd3Kzu7gwBkbEBkeXb8rgaE9Q=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v5 v5.0.0/go.mod h1:HcZY0PHPo/7d75p99lB6lK0qYOP4vLRJUBpiehYXtLQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0 h1:xkWEcbsnJWid3rOf/S/LOHy1I55JA+4kw/f8Tnm+Onc=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0/go.mod h1:OWKfCmX4X3Vp2w7GSx1LZn8566tOHJBA6K0IAUVNYx0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0 h1:2qsIIvxVT+uE6yrNldntJKlLRgxGbZ85kgtz5SNBhMw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0/go.mod h1:AW8VEadnhw9xox+VaVd9sP7NjzOAnaZBLRH6Tq3cJ38=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0 h1:/g8S6wk65vfC6m3FIxJ+i5QDyN9JWwXI8Hb0Img10hU=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0/go.mod h1:gpl+q95AzZlKVI3xSoseF9QPrypk0hQqBiJYeB/cR/I=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfgcSyHZXJI8J0IWE5MsCGlb2xp9fJiXyxWgmOFg4=

--- a/tooling/image-updater/internal/clients/aks.go
+++ b/tooling/image-updater/internal/clients/aks.go
@@ -122,6 +122,11 @@ func ResolveSubscription(ctx context.Context) (string, error) {
 // the full catalogue and the subset with a non-empty Upgrades list. Extracted
 // for unit testing without an ARM mock.
 //
+// ARM does not expose an explicit "default" flag on mesh revisions. AKS
+// currently treats the highest revision whose Upgrades list is non-empty as the
+// default installed on new clusters. This heuristic is based on observed ARM
+// responses and should be revisited if the API changes.
+//
 // Rule: pick the highest revision that still has upgrades available. Fall back
 // to the highest revision overall when only the bleeding-edge is listed
 // (single-revision catalogue during a fresh mesh rollout).

--- a/tooling/image-updater/internal/clients/aks.go
+++ b/tooling/image-updater/internal/clients/aks.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clients
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
+
+	"github.com/Azure/ARO-HCP/tooling/image-updater/internal/upgrade"
+)
+
+// ListAKSMeshRevisions returns the AKS-default ASM revision for the given
+// location as a single-element slice. Overridable in tests. Called once per
+// configured location by the updater; the updater intersects results across
+// locations so the tool only advances when every region agrees on the default.
+//
+// ARM's MeshRevisionProfiles API does not surface a `default` flag, so we
+// derive it: the default is the highest revision whose `Upgrades` list is
+// non-empty (i.e. the newest revision that is not the bleeding-edge). This
+// matches what AKS actually installs on a fresh cluster.
+var ListAKSMeshRevisions func(ctx context.Context, subscriptionID, location string) ([]string, error) = defaultListAKSMeshRevisions
+
+func defaultListAKSMeshRevisions(ctx context.Context, subscriptionID, location string) ([]string, error) {
+	if subscriptionID == "" {
+		return nil, fmt.Errorf("aks mesh revisions: subscription ID is required")
+	}
+	if location == "" {
+		return nil, fmt.Errorf("aks mesh revisions: location is required")
+	}
+
+	cred, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{RequireAzureTokenCredentials: true})
+	if err != nil {
+		return nil, fmt.Errorf("aks mesh revisions: create azure credential: %w", err)
+	}
+
+	client, err := armcontainerservice.NewManagedClustersClient(subscriptionID, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("aks mesh revisions: create managed clusters client: %w", err)
+	}
+
+	var upgradable []string
+	var all []string
+	pager := client.NewListMeshRevisionProfilesPager(location, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("aks mesh revisions: list profiles in %s: %w", location, err)
+		}
+		for _, profile := range page.Value {
+			if profile == nil || profile.Properties == nil {
+				continue
+			}
+			for _, rev := range profile.Properties.MeshRevisions {
+				if rev == nil || rev.Revision == nil || *rev.Revision == "" {
+					continue
+				}
+				all = append(all, *rev.Revision)
+				if len(rev.Upgrades) > 0 {
+					upgradable = append(upgradable, *rev.Revision)
+				}
+			}
+		}
+	}
+
+	defaultRev, err := pickDefaultMeshRevision(all, upgradable, location)
+	if err != nil {
+		return nil, err
+	}
+	return []string{defaultRev}, nil
+}
+
+// pickDefaultMeshRevision returns the AKS-default revision for a location given
+// the full catalogue and the subset with a non-empty Upgrades list. Extracted
+// for unit testing without an ARM mock.
+//
+// Rule: pick the highest revision that still has upgrades available. Fall back
+// to the highest revision overall when only the bleeding-edge is listed
+// (single-revision catalogue during a fresh mesh rollout).
+func pickDefaultMeshRevision(all, upgradable []string, location string) (string, error) {
+	if len(all) == 0 {
+		return "", fmt.Errorf("aks mesh revisions: no revisions returned for location %s", location)
+	}
+	pick := upgradable
+	if len(pick) == 0 {
+		pick = all
+	}
+	highest, err := upgrade.HighestAsmRevision(pick)
+	if err != nil {
+		return "", fmt.Errorf("aks mesh revisions: pick default in %s: %w", location, err)
+	}
+	return highest, nil
+}

--- a/tooling/image-updater/internal/clients/aks.go
+++ b/tooling/image-updater/internal/clients/aks.go
@@ -20,9 +20,14 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 
 	"github.com/Azure/ARO-HCP/tooling/image-updater/internal/upgrade"
 )
+
+func newAzureCredential() (*azidentity.DefaultAzureCredential, error) {
+	return azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{RequireAzureTokenCredentials: true})
+}
 
 // ListAKSMeshRevisions returns the AKS-default ASM revision for the given
 // location as a single-element slice. Overridable in tests. Called once per
@@ -43,11 +48,13 @@ func defaultListAKSMeshRevisions(ctx context.Context, subscriptionID, location s
 		return nil, fmt.Errorf("aks mesh revisions: location is required")
 	}
 
-	cred, err := azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{RequireAzureTokenCredentials: true})
+	cred, err := newAzureCredential()
 	if err != nil {
 		return nil, fmt.Errorf("aks mesh revisions: create azure credential: %w", err)
 	}
 
+	// ARM requires a subscription in the URL even though the mesh revision
+	// data is product-wide and identical across all subscriptions.
 	client, err := armcontainerservice.NewManagedClustersClient(subscriptionID, cred, nil)
 	if err != nil {
 		return nil, fmt.Errorf("aks mesh revisions: create managed clusters client: %w", err)
@@ -82,6 +89,33 @@ func defaultListAKSMeshRevisions(ctx context.Context, subscriptionID, location s
 		return nil, err
 	}
 	return []string{defaultRev}, nil
+}
+
+// ResolveSubscription returns the first enabled subscription visible to the
+// current Azure credentials. This avoids requiring a hardcoded subscription
+// ID when the mesh revision profiles API data is product-wide anyway.
+func ResolveSubscription(ctx context.Context) (string, error) {
+	cred, err := newAzureCredential()
+	if err != nil {
+		return "", fmt.Errorf("resolve subscription: create credential: %w", err)
+	}
+	client, err := armsubscriptions.NewClient(cred, nil)
+	if err != nil {
+		return "", fmt.Errorf("resolve subscription: create client: %w", err)
+	}
+	pager := client.NewListPager(nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return "", fmt.Errorf("resolve subscription: list: %w", err)
+		}
+		for _, sub := range page.Value {
+			if sub != nil && sub.State != nil && *sub.State == armsubscriptions.SubscriptionStateEnabled && sub.SubscriptionID != nil {
+				return *sub.SubscriptionID, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("resolve subscription: no enabled subscriptions found for the current credentials")
 }
 
 // pickDefaultMeshRevision returns the AKS-default revision for a location given

--- a/tooling/image-updater/internal/clients/aks_test.go
+++ b/tooling/image-updater/internal/clients/aks_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clients
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPickDefaultMeshRevision(t *testing.T) {
+	tests := []struct {
+		name       string
+		all        []string
+		upgradable []string
+		want       string
+		wantErrIn  string
+	}{
+		{
+			name:       "steady_state_picks_highest_with_upgrades",
+			all:        []string{"asm-1-28", "asm-1-29", "asm-1-30"},
+			upgradable: []string{"asm-1-28", "asm-1-29"},
+			want:       "asm-1-29",
+		},
+		{
+			name:       "after_promotion_default_moves_forward",
+			all:        []string{"asm-1-29", "asm-1-30", "asm-1-31"},
+			upgradable: []string{"asm-1-29", "asm-1-30"},
+			want:       "asm-1-30",
+		},
+		{
+			name:       "single_revision_catalogue_falls_back_to_only_option",
+			all:        []string{"asm-1-30"},
+			upgradable: nil,
+			want:       "asm-1-30",
+		},
+		{
+			name:       "two_revision_catalogue_picks_the_upgradable_one",
+			all:        []string{"asm-1-29", "asm-1-30"},
+			upgradable: []string{"asm-1-29"},
+			want:       "asm-1-29",
+		},
+		{
+			name:       "ignores_lower_bleeding_edge_when_higher_has_upgrades",
+			all:        []string{"asm-1-9", "asm-1-10"},
+			upgradable: []string{"asm-1-9"},
+			want:       "asm-1-9",
+		},
+		{
+			name:      "empty_input_returns_error",
+			all:       nil,
+			wantErrIn: "no revisions returned",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := pickDefaultMeshRevision(tc.all, tc.upgradable, "westus3")
+			if tc.wantErrIn != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrIn) {
+					t.Fatalf("expected error containing %q, got %v", tc.wantErrIn, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPickDefaultMeshRevision_UsesNumericOrdering(t *testing.T) {
+	// Regression guard: lexical sort would rank "asm-1-9" > "asm-1-10".
+	got, err := pickDefaultMeshRevision(
+		[]string{"asm-1-9", "asm-1-10", "asm-1-11"},
+		[]string{"asm-1-9", "asm-1-10"},
+		"eastus2",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "asm-1-10" {
+		t.Fatalf("got %q, want asm-1-10 (numeric, not lexical)", got)
+	}
+}
+
+func TestPickDefaultMeshRevision_ErrorIncludesLocation(t *testing.T) {
+	_, err := pickDefaultMeshRevision(nil, nil, "australiaeast")
+	if err == nil || !strings.Contains(err.Error(), "australiaeast") {
+		t.Fatalf("expected error to mention location, got %v", err)
+	}
+}

--- a/tooling/image-updater/internal/config/config.go
+++ b/tooling/image-updater/internal/config/config.go
@@ -45,17 +45,32 @@ type ImageConfig struct {
 
 // Source defines where to fetch the latest image digest (or version string) from
 type Source struct {
-	Image               string              `yaml:"image"`
-	GitHubLatestRelease string              `yaml:"githubLatestRelease,omitempty"` // If set, fetch latest release tag from GitHub (e.g. "istio/istio"); used for version-only targets, ignores Image for fetch
-	Tag                 string              `yaml:"tag,omitempty"`                 // Exact tag to use (mutually exclusive with TagPattern)
-	TagPattern          string              `yaml:"tagPattern,omitempty"`          // Regex pattern to filter tags (mutually exclusive with Tag)
-	VersionLabel        string              `yaml:"versionLabel,omitempty"`        // Container label to fetch for human-friendly version (defaults to "org.opencontainers.image.revision" when tag is used, empty when tagPattern is used)
-	Architecture        string              `yaml:"architecture,omitempty"`        // Specific architecture to use (e.g., "amd64", "arm64"). Mutually exclusive with MultiArch.
-	MultiArch           bool                `yaml:"multiArch,omitempty"`           // If true, fetch the multi-arch manifest list digest instead of a specific architecture
-	UseAuth             *bool               `yaml:"useAuth,omitempty"`             // true = use auth, nil/false = anonymous (default)
-	KeyVault            *KeyVaultConfig     `yaml:"keyVault,omitempty"`            // Optional: Azure Key Vault config for fetching pull secrets
-	RepoVersionUpgrade  *RepoVersionUpgrade `yaml:"repoVersionUpgrade,omitempty"`  // Optional: enables repository version upgrade checks for this component
+	Image                 string                       `yaml:"image"`
+	GitHubLatestRelease   string                       `yaml:"githubLatestRelease,omitempty"`   // If set, fetch latest release tag from GitHub (e.g. "istio/istio"); used for version-only targets, ignores Image for fetch
+	AzureAKSMeshRevisions *AzureAKSMeshRevisionsSource `yaml:"azureAKSMeshRevisions,omitempty"` // If set, query AKS mesh revision profiles across the listed locations and intersect; used for version-only targets
+	PinnedMeshRevision    string                       `yaml:"pinnedMeshRevision,omitempty"`    // With azureAKSMeshRevisions: hard override, write this exact value and skip the upstream check. Mutually exclusive with maxMeshRevision.
+	MaxMeshRevision       string                       `yaml:"maxMeshRevision,omitempty"`       // With azureAKSMeshRevisions: cap; ignore any revision above this. Mutually exclusive with pinnedMeshRevision.
+	Tag                   string                       `yaml:"tag,omitempty"`                   // Exact tag to use (mutually exclusive with TagPattern)
+	TagPattern            string                       `yaml:"tagPattern,omitempty"`            // Regex pattern to filter tags (mutually exclusive with Tag)
+	VersionLabel          string                       `yaml:"versionLabel,omitempty"`          // Container label to fetch for human-friendly version (defaults to "org.opencontainers.image.revision" when tag is used, empty when tagPattern is used)
+	Architecture          string                       `yaml:"architecture,omitempty"`          // Specific architecture to use (e.g., "amd64", "arm64"). Mutually exclusive with MultiArch.
+	MultiArch             bool                         `yaml:"multiArch,omitempty"`             // If true, fetch the multi-arch manifest list digest instead of a specific architecture
+	UseAuth               *bool                        `yaml:"useAuth,omitempty"`               // true = use auth, nil/false = anonymous (default)
+	KeyVault              *KeyVaultConfig              `yaml:"keyVault,omitempty"`              // Optional: Azure Key Vault config for fetching pull secrets
+	RepoVersionUpgrade    *RepoVersionUpgrade          `yaml:"repoVersionUpgrade,omitempty"`    // Optional: enables repository version upgrade checks for this component
 }
+
+// AzureAKSMeshRevisionsSource configures the AKS mesh revision profiles source.
+// The updater queries every location and picks the highest revision available
+// in all of them, so a rollout target is never above what any region supports.
+type AzureAKSMeshRevisionsSource struct {
+	Locations    []string `yaml:"locations"`              // ARM locations to intersect (e.g. [uksouth, westus3, eastus2]). Order does not matter.
+	Subscription string   `yaml:"subscription,omitempty"` // Optional; falls back to $AZURE_SUBSCRIPTION_ID.
+}
+
+// asmRevisionFormat matches asm-<major>-<minor>; enforced on
+// PinnedMeshRevision and MaxMeshRevision so typos surface at load time.
+var asmRevisionFormat = regexp.MustCompile(`^asm-\d+-\d+$`)
 
 // RepoVersionUpgrade configures repository version upgrade detection for a component.
 // When set, the update --repositories mode will check Quay for next-version repos.
@@ -75,32 +90,92 @@ type Target struct {
 	FilePath string `yaml:"filePath"`
 }
 
-// Validate checks if the Source configuration is valid
-func (s *Source) Validate() error {
-	if s.GitHubLatestRelease != "" {
-		// GitHub latest release: require "owner/repo" format with non-empty parts
-		parts := strings.SplitN(s.GitHubLatestRelease, "/", 2)
-		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-			return fmt.Errorf("githubLatestRelease must be in format owner/repo (e.g. istio/istio)")
-		}
-		// Registry-specific fields are not allowed with githubLatestRelease
-		if s.Image != "" {
-			return fmt.Errorf("image must not be set when githubLatestRelease is used")
-		}
-		if s.Tag != "" || s.TagPattern != "" {
-			return fmt.Errorf("tag/tagPattern must not be set when githubLatestRelease is used")
-		}
-		if s.Architecture != "" || s.MultiArch {
-			return fmt.Errorf("architecture/multiArch must not be set when githubLatestRelease is used")
-		}
-		if s.UseAuth != nil || s.KeyVault != nil || s.VersionLabel != "" {
-			return fmt.Errorf("useAuth/keyVault/versionLabel must not be set when githubLatestRelease is used")
-		}
-		return nil
-	}
+// ProducesVersionString reports whether this source yields a plain version
+// string rather than a container digest. Add or remove version-only sources
+// here; call sites branch on this predicate.
+func (s *Source) ProducesVersionString() bool {
+	return s.GitHubLatestRelease != "" || s.AzureAKSMeshRevisions != nil
+}
 
+// VersionOnlySourceNames returns the yaml field names of version-only sources
+// for use in error messages. Keep in sync with ProducesVersionString.
+func VersionOnlySourceNames() []string {
+	return []string{"githubLatestRelease", "azureAKSMeshRevisions"}
+}
+
+// disallowRegistryFields errors if any registry-oriented field is populated.
+func (s *Source) disallowRegistryFields(sourceKind string) error {
+	switch {
+	case s.Image != "":
+		return fmt.Errorf("image must not be set when %s is used", sourceKind)
+	case s.Tag != "" || s.TagPattern != "":
+		return fmt.Errorf("tag/tagPattern must not be set when %s is used", sourceKind)
+	case s.Architecture != "" || s.MultiArch:
+		return fmt.Errorf("architecture/multiArch must not be set when %s is used", sourceKind)
+	case s.UseAuth != nil || s.KeyVault != nil || s.VersionLabel != "":
+		return fmt.Errorf("useAuth/keyVault/versionLabel must not be set when %s is used", sourceKind)
+	}
+	return nil
+}
+
+// Validate dispatches per source type; shape mirrors updater.fetchLatestValue.
+func (s *Source) Validate() error {
+	if s.AzureAKSMeshRevisions == nil && (s.PinnedMeshRevision != "" || s.MaxMeshRevision != "") {
+		return fmt.Errorf("pinnedMeshRevision/maxMeshRevision only apply when azureAKSMeshRevisions is set")
+	}
+	switch {
+	case s.AzureAKSMeshRevisions != nil:
+		return s.validateAzureAKSMeshRevisions()
+	case s.GitHubLatestRelease != "":
+		return s.validateGitHubLatestRelease()
+	default:
+		return s.validateRegistrySource()
+	}
+}
+
+func (s *Source) validateAzureAKSMeshRevisions() error {
+	if s.GitHubLatestRelease != "" {
+		return fmt.Errorf("githubLatestRelease and azureAKSMeshRevisions are mutually exclusive")
+	}
+	if len(s.AzureAKSMeshRevisions.Locations) == 0 {
+		return fmt.Errorf("azureAKSMeshRevisions.locations must list at least one Azure location")
+	}
+	seen := make(map[string]struct{}, len(s.AzureAKSMeshRevisions.Locations))
+	for _, loc := range s.AzureAKSMeshRevisions.Locations {
+		if loc == "" {
+			return fmt.Errorf("azureAKSMeshRevisions.locations must not contain empty strings")
+		}
+		if _, dup := seen[loc]; dup {
+			return fmt.Errorf("azureAKSMeshRevisions.locations contains duplicate entry %q", loc)
+		}
+		seen[loc] = struct{}{}
+	}
+	if err := s.disallowRegistryFields("azureAKSMeshRevisions"); err != nil {
+		return err
+	}
+	if s.PinnedMeshRevision != "" && s.MaxMeshRevision != "" {
+		return fmt.Errorf("pinnedMeshRevision and maxMeshRevision are mutually exclusive")
+	}
+	if s.PinnedMeshRevision != "" && !asmRevisionFormat.MatchString(s.PinnedMeshRevision) {
+		return fmt.Errorf("pinnedMeshRevision %q must match asm-<major>-<minor> (e.g. asm-1-28)", s.PinnedMeshRevision)
+	}
+	if s.MaxMeshRevision != "" && !asmRevisionFormat.MatchString(s.MaxMeshRevision) {
+		return fmt.Errorf("maxMeshRevision %q must match asm-<major>-<minor> (e.g. asm-1-29)", s.MaxMeshRevision)
+	}
+	return nil
+}
+
+func (s *Source) validateGitHubLatestRelease() error {
+	parts := strings.SplitN(s.GitHubLatestRelease, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return fmt.Errorf("githubLatestRelease must be in format owner/repo (e.g. istio/istio)")
+	}
+	return s.disallowRegistryFields("githubLatestRelease")
+}
+
+func (s *Source) validateRegistrySource() error {
 	if s.Image == "" {
-		return fmt.Errorf("image is required when githubLatestRelease is not set")
+		return fmt.Errorf("image is required when no version-only source (%s) is set", strings.Join(VersionOnlySourceNames(), ", "))
 	}
 	if s.Tag != "" && s.TagPattern != "" {
 		return fmt.Errorf("tag and tagPattern are mutually exclusive, only one can be specified")
@@ -138,9 +213,12 @@ func (s *Source) GetEffectiveVersionLabel() string {
 	return ""
 }
 
-// SourceDescription returns a short, opaque description of the source for logging (image ref or GitHub repo).
+// SourceDescription returns a short label for logs.
 func (s *Source) SourceDescription() string {
-	if s.GitHubLatestRelease != "" {
+	switch {
+	case s.AzureAKSMeshRevisions != nil:
+		return "aks mesh revision profiles (" + strings.Join(s.AzureAKSMeshRevisions.Locations, ",") + ")"
+	case s.GitHubLatestRelease != "":
 		return "github.com/" + s.GitHubLatestRelease
 	}
 	return s.Image
@@ -199,10 +277,10 @@ func Load(configPath string) (*Config, error) {
 		if err := imageConfig.Source.Validate(); err != nil {
 			return nil, fmt.Errorf("invalid configuration for image %q: %w", name, err)
 		}
-		if imageConfig.Source.GitHubLatestRelease != "" {
+		if imageConfig.Source.ProducesVersionString() {
 			for _, target := range imageConfig.Targets {
 				if strings.HasSuffix(target.JsonPath, ".digest") || strings.HasSuffix(target.JsonPath, ".sha") {
-					return nil, fmt.Errorf("image %q: githubLatestRelease targets must not use .digest or .sha paths (got %q)", name, target.JsonPath)
+					return nil, fmt.Errorf("image %q: version-only sources (githubLatestRelease/azureAKSMeshRevisions) must not use .digest or .sha paths (got %q)", name, target.JsonPath)
 				}
 			}
 		}

--- a/tooling/image-updater/internal/config/config_test.go
+++ b/tooling/image-updater/internal/config/config_test.go
@@ -1101,6 +1101,152 @@ func TestSource_Validate(t *testing.T) {
 			wantErr:    true,
 			wantErrMsg: "useAuth/keyVault/versionLabel must not be set",
 		},
+		{
+			name: "valid: azureAKSMeshRevisions minimal",
+			source: Source{
+				AzureAKSMeshRevisions: &AzureAKSMeshRevisionsSource{
+					Locations: []string{"westus3"},
+				},
+			},
+		},
+		{
+			name: "valid: azureAKSMeshRevisions multiple locations",
+			source: Source{
+				AzureAKSMeshRevisions: &AzureAKSMeshRevisionsSource{
+					Locations: []string{"uksouth", "westus3", "eastus2"},
+				},
+			},
+		},
+		{
+			name: "valid: azureAKSMeshRevisions with maxMeshRevision",
+			source: Source{
+				AzureAKSMeshRevisions: &AzureAKSMeshRevisionsSource{
+					Locations: []string{"westus3"},
+				},
+				MaxMeshRevision: "asm-1-29",
+			},
+		},
+		{
+			name: "valid: azureAKSMeshRevisions with pinnedMeshRevision",
+			source: Source{
+				AzureAKSMeshRevisions: &AzureAKSMeshRevisionsSource{
+					Locations: []string{"westus3"},
+				},
+				PinnedMeshRevision: "asm-1-28",
+			},
+		},
+		{
+			name: "valid: azureAKSMeshRevisions with explicit subscription",
+			source: Source{
+				AzureAKSMeshRevisions: &AzureAKSMeshRevisionsSource{
+					Locations:    []string{"westus3"},
+					Subscription: "00000000-0000-0000-0000-000000000000",
+				},
+			},
+		},
+		{
+			name: "invalid: azureAKSMeshRevisions empty locations",
+			source: Source{
+				AzureAKSMeshRevisions: &AzureAKSMeshRevisionsSource{
+					Locations: nil,
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "azureAKSMeshRevisions.locations must list at least one Azure location",
+		},
+		{
+			name: "invalid: azureAKSMeshRevisions blank location entry",
+			source: Source{
+				AzureAKSMeshRevisions: &AzureAKSMeshRevisionsSource{
+					Locations: []string{"westus3", ""},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "azureAKSMeshRevisions.locations must not contain empty strings",
+		},
+		{
+			name: "invalid: azureAKSMeshRevisions duplicate locations",
+			source: Source{
+				AzureAKSMeshRevisions: &AzureAKSMeshRevisionsSource{
+					Locations: []string{"westus3", "westus3"},
+				},
+			},
+			wantErr:    true,
+			wantErrMsg: "azureAKSMeshRevisions.locations contains duplicate entry \"westus3\"",
+		},
+		{
+			name: "invalid: azureAKSMeshRevisions with githubLatestRelease",
+			source: Source{
+				AzureAKSMeshRevisions: &AzureAKSMeshRevisionsSource{
+					Locations: []string{"westus3"},
+				},
+				GitHubLatestRelease: "istio/istio",
+			},
+			wantErr:    true,
+			wantErrMsg: "githubLatestRelease and azureAKSMeshRevisions are mutually exclusive",
+		},
+		{
+			name: "invalid: azureAKSMeshRevisions with image",
+			source: Source{
+				AzureAKSMeshRevisions: &AzureAKSMeshRevisionsSource{
+					Locations: []string{"westus3"},
+				},
+				Image: "quay.io/foo/bar",
+			},
+			wantErr:    true,
+			wantErrMsg: "image must not be set when azureAKSMeshRevisions is used",
+		},
+		{
+			name: "invalid: pinnedMeshRevision and maxMeshRevision both set",
+			source: Source{
+				AzureAKSMeshRevisions: &AzureAKSMeshRevisionsSource{
+					Locations: []string{"westus3"},
+				},
+				PinnedMeshRevision: "asm-1-28",
+				MaxMeshRevision:    "asm-1-29",
+			},
+			wantErr:    true,
+			wantErrMsg: "pinnedMeshRevision and maxMeshRevision are mutually exclusive",
+		},
+		{
+			name: "invalid: pinnedMeshRevision malformed",
+			source: Source{
+				AzureAKSMeshRevisions: &AzureAKSMeshRevisionsSource{
+					Locations: []string{"westus3"},
+				},
+				PinnedMeshRevision: "1.28",
+			},
+			wantErr:    true,
+			wantErrMsg: "pinnedMeshRevision \"1.28\" must match asm-<major>-<minor>",
+		},
+		{
+			name: "invalid: pinnedMeshRevision without azureAKSMeshRevisions",
+			source: Source{
+				Image:              "quay.io/foo/bar",
+				Tag:                "v1",
+				PinnedMeshRevision: "asm-1-28",
+			},
+			wantErr:    true,
+			wantErrMsg: "pinnedMeshRevision/maxMeshRevision only apply when azureAKSMeshRevisions is set",
+		},
+		{
+			name: "invalid: pinnedMeshRevision with githubLatestRelease (regression guard)",
+			source: Source{
+				GitHubLatestRelease: "istio/istio",
+				PinnedMeshRevision:  "asm-1-28",
+			},
+			wantErr:    true,
+			wantErrMsg: "pinnedMeshRevision/maxMeshRevision only apply when azureAKSMeshRevisions is set",
+		},
+		{
+			name: "invalid: maxMeshRevision with githubLatestRelease (regression guard)",
+			source: Source{
+				GitHubLatestRelease: "istio/istio",
+				MaxMeshRevision:     "asm-1-29",
+			},
+			wantErr:    true,
+			wantErrMsg: "pinnedMeshRevision/maxMeshRevision only apply when azureAKSMeshRevisions is set",
+		},
 	}
 
 	for _, tt := range tests {

--- a/tooling/image-updater/internal/options/options.go
+++ b/tooling/image-updater/internal/options/options.go
@@ -203,7 +203,7 @@ func (v *ValidatedUpdateOptions) Complete(ctx context.Context) (*updater.Updater
 	// Key format: "registry:useAuth" (e.g., "quay.io:true", "quay.io:false")
 	registryClients := make(map[string]clients.RegistryClient)
 	for _, imageConfig := range v.Config.Images {
-		if imageConfig.Source.GitHubLatestRelease != "" {
+		if imageConfig.Source.ProducesVersionString() {
 			continue
 		}
 		registry, _, err := imageConfig.Source.ParseImageReference()
@@ -252,8 +252,8 @@ func validateConfig(cfg *config.Config) error {
 	}
 
 	for name, img := range cfg.Images {
-		if img.Source.Image == "" && img.Source.GitHubLatestRelease == "" {
-			return fmt.Errorf("image %s: source image or githubLatestRelease is required", name)
+		if !img.Source.ProducesVersionString() && img.Source.Image == "" {
+			return fmt.Errorf("image %s: source image or one of [%s] is required", name, strings.Join(config.VersionOnlySourceNames(), ", "))
 		}
 
 		if len(img.Targets) == 0 {

--- a/tooling/image-updater/internal/options/options_test.go
+++ b/tooling/image-updater/internal/options/options_test.go
@@ -265,7 +265,7 @@ func TestValidateConfig(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			wantErrMsg: "source image or githubLatestRelease is required",
+			wantErrMsg: "source image or one of [githubLatestRelease, azureAKSMeshRevisions] is required",
 		},
 		{
 			name: "no targets configured",

--- a/tooling/image-updater/internal/updater/updater.go
+++ b/tooling/image-updater/internal/updater/updater.go
@@ -25,12 +25,18 @@ import (
 	"github.com/Azure/ARO-HCP/tooling/image-updater/internal/clients"
 	"github.com/Azure/ARO-HCP/tooling/image-updater/internal/config"
 	"github.com/Azure/ARO-HCP/tooling/image-updater/internal/output"
+	"github.com/Azure/ARO-HCP/tooling/image-updater/internal/upgrade"
 	"github.com/Azure/ARO-HCP/tooling/image-updater/internal/yaml"
 )
 
 const (
 	DefaultArchitecture = "amd64"
 )
+
+// meshRevisionsLister returns the ASM revisions available for a subscription in
+// a single location. Injected on the Updater so orchestration is testable
+// without hitting ARM. Defaults to clients.ListAKSMeshRevisions.
+type meshRevisionsLister func(ctx context.Context, subscriptionID, location string) ([]string, error)
 
 // Updater contains all pre-created resources needed for execution
 type Updater struct {
@@ -42,19 +48,23 @@ type Updater struct {
 	Updates         map[string][]yaml.Update
 	OutputFile      string
 	OutputFormat    string
+	// ListMeshRevisions is called once per configured location; results are
+	// intersected before applying max/pin. Overridable in tests.
+	ListMeshRevisions meshRevisionsLister
 }
 
 // New creates a new Updater with all necessary resources pre-initialized
 func New(cfg *config.Config, dryRun bool, forceUpdate bool, registryClients map[string]clients.RegistryClient, yamlEditors map[string]yaml.EditorInterface, outputFile, outputFormat string) *Updater {
 	return &Updater{
-		Config:          cfg,
-		DryRun:          dryRun,
-		ForceUpdate:     forceUpdate,
-		RegistryClients: registryClients,
-		YAMLEditors:     yamlEditors,
-		Updates:         make(map[string][]yaml.Update),
-		OutputFile:      outputFile,
-		OutputFormat:    outputFormat,
+		Config:            cfg,
+		DryRun:            dryRun,
+		ForceUpdate:       forceUpdate,
+		RegistryClients:   registryClients,
+		YAMLEditors:       yamlEditors,
+		Updates:           make(map[string][]yaml.Update),
+		OutputFile:        outputFile,
+		OutputFormat:      outputFormat,
+		ListMeshRevisions: clients.ListAKSMeshRevisions,
 	}
 }
 
@@ -149,29 +159,106 @@ func (u *Updater) outputResults(ctx context.Context) error {
 	return nil
 }
 
-// fetchLatestValue retrieves the latest value from the source (registry digest or tag/version, or GitHub latest release).
+// fetchLatestValue dispatches to a per-source-type fetcher.
+//
+// To remove a version-only source: delete its case here, delete the matching
+// fetch<Source> method, drop the field from config.Source, and remove the
+// term from Source.ProducesVersionString().
 func (u *Updater) fetchLatestValue(ctx context.Context, source config.Source) (*clients.Tag, error) {
 	logger, err := logr.FromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("logger not found in context: %w", err)
 	}
 
-	if source.GitHubLatestRelease != "" {
-		logger.V(2).Info("fetching latest release from GitHub", "repo", source.GitHubLatestRelease)
-		release, err := clients.GetLatestRelease(ctx, source.GitHubLatestRelease)
-		if err != nil {
-			return nil, fmt.Errorf("github latest release %s: %w", source.GitHubLatestRelease, err)
-		}
-		return &clients.Tag{Name: release.Version, Version: release.Version, LastModified: release.PublishedAt}, nil
+	switch {
+	case source.AzureAKSMeshRevisions != nil:
+		return u.fetchAzureAKSMeshRevisions(ctx, logger, source)
+	case source.GitHubLatestRelease != "":
+		return u.fetchGitHubLatestRelease(ctx, logger, source)
 	}
 
-	// Registry path: parse image reference and use existing client
+	return u.fetchRegistryTag(ctx, source)
+}
+
+// fetchAzureAKSMeshRevisions queries every configured location, intersects the
+// available ASM revisions, applies the max cap, and returns the highest. Any
+// per-location error fails the whole call so a transient outage cannot look
+// like "a new revision is safe to roll".
+func (u *Updater) fetchAzureAKSMeshRevisions(ctx context.Context, logger logr.Logger, source config.Source) (*clients.Tag, error) {
+	if source.PinnedMeshRevision != "" {
+		logger.V(2).Info("mesh revision hard-pinned; skipping upstream check", "pinned", source.PinnedMeshRevision)
+		return &clients.Tag{Name: source.PinnedMeshRevision, Version: source.PinnedMeshRevision}, nil
+	}
+
+	subscription := source.AzureAKSMeshRevisions.Subscription
+	if subscription == "" {
+		subscription = os.Getenv("AZURE_SUBSCRIPTION_ID")
+	}
+	if subscription == "" {
+		return nil, fmt.Errorf("azure aks mesh revisions: subscription not set (config field or AZURE_SUBSCRIPTION_ID)")
+	}
+
+	locations := source.AzureAKSMeshRevisions.Locations
+	perLocation := make([][]string, 0, len(locations))
+	for _, loc := range locations {
+		logger.V(2).Info("fetching aks mesh revisions", "location", loc)
+		revs, err := u.ListMeshRevisions(ctx, subscription, loc)
+		if err != nil {
+			return nil, fmt.Errorf("azure aks mesh revisions: %w", err)
+		}
+		logger.V(2).Info("aks returned revisions", "location", loc, "count", len(revs))
+		perLocation = append(perLocation, revs)
+	}
+
+	revisions := upgrade.IntersectAsmRevisions(perLocation...)
+	if len(revisions) == 0 {
+		return nil, fmt.Errorf("azure aks mesh revisions: no revision is available in every location %v", locations)
+	}
+	logger.V(2).Info("intersection across locations", "revisions", revisions)
+
+	if source.MaxMeshRevision != "" {
+		filtered := revisions[:0]
+		for _, r := range revisions {
+			if upgrade.CompareAsmRevisions(r, source.MaxMeshRevision) <= 0 {
+				filtered = append(filtered, r)
+			}
+		}
+		if len(filtered) == 0 {
+			return nil, fmt.Errorf("azure aks mesh revisions: all revisions available across %v are above maxMeshRevision=%s", locations, source.MaxMeshRevision)
+		}
+		logger.V(2).Info("applied maxMeshRevision cap", "cap", source.MaxMeshRevision, "keptCount", len(filtered), "droppedCount", len(revisions)-len(filtered))
+		revisions = filtered
+	}
+
+	highest, err := upgrade.HighestAsmRevision(revisions)
+	if err != nil {
+		return nil, fmt.Errorf("azure aks mesh revisions: %w", err)
+	}
+	return &clients.Tag{Name: highest, Version: highest}, nil
+}
+
+// fetchGitHubLatestRelease resolves the latest published GitHub release tag.
+func (u *Updater) fetchGitHubLatestRelease(ctx context.Context, logger logr.Logger, source config.Source) (*clients.Tag, error) {
+	logger.V(2).Info("fetching latest release from GitHub", "repo", source.GitHubLatestRelease)
+	release, err := clients.GetLatestRelease(ctx, source.GitHubLatestRelease)
+	if err != nil {
+		return nil, fmt.Errorf("github latest release %s: %w", source.GitHubLatestRelease, err)
+	}
+	return &clients.Tag{Name: release.Version, Version: release.Version, LastModified: release.PublishedAt}, nil
+}
+
+// fetchRegistryTag resolves the latest tag/digest from a container registry.
+func (u *Updater) fetchRegistryTag(ctx context.Context, source config.Source) (*clients.Tag, error) {
+	logger, err := logr.FromContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("logger not found in context: %w", err)
+	}
+
 	registry, repository, err := source.ParseImageReference()
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse registry from image reference: %w", err)
 	}
 
-	// Determine useAuth for this specific image - default to false if not specified
 	useAuth := false
 	if source.UseAuth != nil {
 		useAuth = *source.UseAuth
@@ -225,9 +312,9 @@ func (u *Updater) ProcessImageUpdates(ctx context.Context, name string, tag *cli
 	logger.V(2).Info("Current digest", "name", name, "currentDigest", currentDigest)
 
 	var newDigest string
-	if source.GitHubLatestRelease != "" {
+	if source.ProducesVersionString() {
 		if strings.HasSuffix(target.JsonPath, ".digest") || strings.HasSuffix(target.JsonPath, ".sha") {
-			return fmt.Errorf("githubLatestRelease targets must not use .digest or .sha paths (got %q)", target.JsonPath)
+			return fmt.Errorf("version-only sources (githubLatestRelease/azureAKSMeshRevisions) must not use .digest or .sha paths (got %q)", target.JsonPath)
 		}
 		newDigest = tag.Version
 		if newDigest == "" {

--- a/tooling/image-updater/internal/updater/updater.go
+++ b/tooling/image-updater/internal/updater/updater.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/Azure/ARO-HCP/tooling/image-updater/internal/clients"
 	"github.com/Azure/ARO-HCP/tooling/image-updater/internal/config"
@@ -187,7 +189,7 @@ func (u *Updater) fetchLatestValue(ctx context.Context, source config.Source) (*
 func (u *Updater) fetchAzureAKSMeshRevisions(ctx context.Context, logger logr.Logger, source config.Source) (*clients.Tag, error) {
 	if source.PinnedMeshRevision != "" {
 		logger.V(2).Info("mesh revision hard-pinned; skipping upstream check", "pinned", source.PinnedMeshRevision)
-		return &clients.Tag{Name: source.PinnedMeshRevision, Version: source.PinnedMeshRevision}, nil
+		return &clients.Tag{Name: source.PinnedMeshRevision, Version: source.PinnedMeshRevision, LastModified: time.Now()}, nil
 	}
 
 	subscription := source.AzureAKSMeshRevisions.Subscription
@@ -195,19 +197,32 @@ func (u *Updater) fetchAzureAKSMeshRevisions(ctx context.Context, logger logr.Lo
 		subscription = os.Getenv("AZURE_SUBSCRIPTION_ID")
 	}
 	if subscription == "" {
-		return nil, fmt.Errorf("azure aks mesh revisions: subscription not set (config field or AZURE_SUBSCRIPTION_ID)")
-	}
-
-	locations := source.AzureAKSMeshRevisions.Locations
-	perLocation := make([][]string, 0, len(locations))
-	for _, loc := range locations {
-		logger.V(2).Info("fetching aks mesh revisions", "location", loc)
-		revs, err := u.ListMeshRevisions(ctx, subscription, loc)
+		logger.V(2).Info("no subscription configured; resolving from Azure credentials")
+		resolved, err := clients.ResolveSubscription(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("azure aks mesh revisions: %w", err)
 		}
-		logger.V(2).Info("aks returned revisions", "location", loc, "count", len(revs))
-		perLocation = append(perLocation, revs)
+		logger.V(2).Info("resolved subscription from credentials", "subscription", resolved)
+		subscription = resolved
+	}
+
+	locations := source.AzureAKSMeshRevisions.Locations
+	perLocation := make([][]string, len(locations))
+	g, gCtx := errgroup.WithContext(ctx)
+	for i, loc := range locations {
+		logger.V(2).Info("fetching aks mesh revisions", "location", loc)
+		g.Go(func() error {
+			revs, err := u.ListMeshRevisions(gCtx, subscription, loc)
+			if err != nil {
+				return fmt.Errorf("azure aks mesh revisions: %w", err)
+			}
+			logger.V(2).Info("aks returned revisions", "location", loc, "count", len(revs))
+			perLocation[i] = revs
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
 
 	revisions := upgrade.IntersectAsmRevisions(perLocation...)
@@ -234,7 +249,7 @@ func (u *Updater) fetchAzureAKSMeshRevisions(ctx context.Context, logger logr.Lo
 	if err != nil {
 		return nil, fmt.Errorf("azure aks mesh revisions: %w", err)
 	}
-	return &clients.Tag{Name: highest, Version: highest}, nil
+	return &clients.Tag{Name: highest, Version: highest, LastModified: time.Now()}, nil
 }
 
 // fetchGitHubLatestRelease resolves the latest published GitHub release tag.

--- a/tooling/image-updater/internal/updater/updater_test.go
+++ b/tooling/image-updater/internal/updater/updater_test.go
@@ -815,3 +815,209 @@ config:
 		}
 	})
 }
+
+// stubMeshLister lets tests drive fetchAzureAKSMeshRevisions without ARM.
+type stubMeshLister struct {
+	byLocation map[string][]string
+	err        error
+	calls      []string
+}
+
+func (s *stubMeshLister) list(_ context.Context, _ string, location string) ([]string, error) {
+	s.calls = append(s.calls, location)
+	if s.err != nil {
+		return nil, s.err
+	}
+	revs, ok := s.byLocation[location]
+	if !ok {
+		return nil, fmt.Errorf("stub: no data for location %q", location)
+	}
+	return revs, nil
+}
+
+func newMeshUpdater(t *testing.T, cfg *config.Config, lister *stubMeshLister) *Updater {
+	t.Helper()
+	u := New(cfg, false, false, nil, nil, "", "table")
+	u.ListMeshRevisions = lister.list
+	return u
+}
+
+func TestUpdater_FetchAzureAKSMeshRevisions_IntersectAndHighest(t *testing.T) {
+	t.Setenv("AZURE_SUBSCRIPTION_ID", "00000000-0000-0000-0000-000000000000")
+
+	source := config.Source{
+		AzureAKSMeshRevisions: &config.AzureAKSMeshRevisionsSource{
+			Locations: []string{"uksouth", "westus3", "eastus2"},
+		},
+	}
+	lister := &stubMeshLister{byLocation: map[string][]string{
+		"uksouth": {"asm-1-28", "asm-1-29", "asm-1-30"},
+		"westus3": {"asm-1-28", "asm-1-29"}, // no 1-30 yet
+		"eastus2": {"asm-1-28", "asm-1-29", "asm-1-30"},
+	}}
+	u := newMeshUpdater(t, &config.Config{}, lister)
+	ctx := logr.NewContext(context.Background(), testLogger())
+
+	tag, err := u.fetchAzureAKSMeshRevisions(ctx, testLogger(), source)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag.Name != "asm-1-29" {
+		t.Errorf("got %q, want asm-1-29 (highest common across all locations)", tag.Name)
+	}
+	if len(lister.calls) != 3 {
+		t.Errorf("expected 3 location calls, got %d (%v)", len(lister.calls), lister.calls)
+	}
+}
+
+func TestUpdater_FetchAzureAKSMeshRevisions_PinBypassesFetch(t *testing.T) {
+	// Pin must short-circuit before touching ARM even if env is unset.
+	source := config.Source{
+		AzureAKSMeshRevisions: &config.AzureAKSMeshRevisionsSource{
+			Locations: []string{"uksouth"},
+		},
+		PinnedMeshRevision: "asm-1-28",
+	}
+	lister := &stubMeshLister{err: fmt.Errorf("should not be called")}
+	u := newMeshUpdater(t, &config.Config{}, lister)
+	ctx := logr.NewContext(context.Background(), testLogger())
+
+	tag, err := u.fetchAzureAKSMeshRevisions(ctx, testLogger(), source)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag.Name != "asm-1-28" {
+		t.Errorf("got %q, want asm-1-28", tag.Name)
+	}
+	if len(lister.calls) != 0 {
+		t.Errorf("expected 0 ARM calls under pin, got %d", len(lister.calls))
+	}
+}
+
+func TestUpdater_FetchAzureAKSMeshRevisions_MaxCap(t *testing.T) {
+	t.Setenv("AZURE_SUBSCRIPTION_ID", "00000000-0000-0000-0000-000000000000")
+	source := config.Source{
+		AzureAKSMeshRevisions: &config.AzureAKSMeshRevisionsSource{
+			Locations: []string{"uksouth"},
+		},
+		MaxMeshRevision: "asm-1-29",
+	}
+	lister := &stubMeshLister{byLocation: map[string][]string{
+		"uksouth": {"asm-1-28", "asm-1-29", "asm-1-30"},
+	}}
+	u := newMeshUpdater(t, &config.Config{}, lister)
+	ctx := logr.NewContext(context.Background(), testLogger())
+
+	tag, err := u.fetchAzureAKSMeshRevisions(ctx, testLogger(), source)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag.Name != "asm-1-29" {
+		t.Errorf("got %q, want asm-1-29 (cap applied)", tag.Name)
+	}
+}
+
+func TestUpdater_FetchAzureAKSMeshRevisions_MissingSubscription(t *testing.T) {
+	t.Setenv("AZURE_SUBSCRIPTION_ID", "")
+	source := config.Source{
+		AzureAKSMeshRevisions: &config.AzureAKSMeshRevisionsSource{
+			Locations: []string{"uksouth"},
+		},
+	}
+	lister := &stubMeshLister{err: fmt.Errorf("should not be called")}
+	u := newMeshUpdater(t, &config.Config{}, lister)
+	ctx := logr.NewContext(context.Background(), testLogger())
+
+	_, err := u.fetchAzureAKSMeshRevisions(ctx, testLogger(), source)
+	if err == nil || !strings.Contains(err.Error(), "subscription not set") {
+		t.Errorf("expected 'subscription not set' error, got %v", err)
+	}
+}
+
+func TestUpdater_FetchAzureAKSMeshRevisions_LocationErrorFailsFast(t *testing.T) {
+	t.Setenv("AZURE_SUBSCRIPTION_ID", "00000000-0000-0000-0000-000000000000")
+	source := config.Source{
+		AzureAKSMeshRevisions: &config.AzureAKSMeshRevisionsSource{
+			Locations: []string{"uksouth", "westus3"},
+		},
+	}
+	lister := &stubMeshLister{err: fmt.Errorf("transient outage")}
+	u := newMeshUpdater(t, &config.Config{}, lister)
+	ctx := logr.NewContext(context.Background(), testLogger())
+
+	_, err := u.fetchAzureAKSMeshRevisions(ctx, testLogger(), source)
+	if err == nil || !strings.Contains(err.Error(), "transient outage") {
+		t.Errorf("expected transient outage error, got %v", err)
+	}
+}
+
+func TestUpdater_FetchAzureAKSMeshRevisions_EmptyIntersection(t *testing.T) {
+	t.Setenv("AZURE_SUBSCRIPTION_ID", "00000000-0000-0000-0000-000000000000")
+	source := config.Source{
+		AzureAKSMeshRevisions: &config.AzureAKSMeshRevisionsSource{
+			Locations: []string{"uksouth", "westus3"},
+		},
+	}
+	lister := &stubMeshLister{byLocation: map[string][]string{
+		"uksouth": {"asm-1-30"},
+		"westus3": {"asm-1-28"},
+	}}
+	u := newMeshUpdater(t, &config.Config{}, lister)
+	ctx := logr.NewContext(context.Background(), testLogger())
+
+	_, err := u.fetchAzureAKSMeshRevisions(ctx, testLogger(), source)
+	if err == nil || !strings.Contains(err.Error(), "no revision is available in every location") {
+		t.Errorf("expected empty-intersection error, got %v", err)
+	}
+}
+
+// Mirrors the new default-tracking semantics: each region reports a single
+// "default" revision, and the tool only advances when every region agrees.
+// This is the "wait for the rollout to finish" behaviour we rely on.
+func TestUpdater_FetchAzureAKSMeshRevisions_DefaultTracking_MidRolloutHolds(t *testing.T) {
+	t.Setenv("AZURE_SUBSCRIPTION_ID", "00000000-0000-0000-0000-000000000000")
+	source := config.Source{
+		AzureAKSMeshRevisions: &config.AzureAKSMeshRevisionsSource{
+			Locations: []string{"uksouth", "westus3", "eastus2", "australiaeast"},
+		},
+	}
+	lister := &stubMeshLister{byLocation: map[string][]string{
+		"uksouth":       {"asm-1-30"}, // promoted ahead
+		"westus3":       {"asm-1-29"},
+		"eastus2":       {"asm-1-29"},
+		"australiaeast": {"asm-1-29"},
+	}}
+	u := newMeshUpdater(t, &config.Config{}, lister)
+	ctx := logr.NewContext(context.Background(), testLogger())
+
+	_, err := u.fetchAzureAKSMeshRevisions(ctx, testLogger(), source)
+	if err == nil || !strings.Contains(err.Error(), "no revision is available in every location") {
+		t.Errorf("expected empty-intersection error while promotion is mid-flight, got %v", err)
+	}
+}
+
+// Steady state: every region reports the same default → tool advances.
+func TestUpdater_FetchAzureAKSMeshRevisions_DefaultTracking_SteadyState(t *testing.T) {
+	t.Setenv("AZURE_SUBSCRIPTION_ID", "00000000-0000-0000-0000-000000000000")
+	source := config.Source{
+		AzureAKSMeshRevisions: &config.AzureAKSMeshRevisionsSource{
+			Locations: []string{"uksouth", "westus3", "eastus2", "australiaeast"},
+		},
+	}
+	lister := &stubMeshLister{byLocation: map[string][]string{
+		"uksouth":       {"asm-1-29"},
+		"westus3":       {"asm-1-29"},
+		"eastus2":       {"asm-1-29"},
+		"australiaeast": {"asm-1-29"},
+	}}
+	u := newMeshUpdater(t, &config.Config{}, lister)
+	ctx := logr.NewContext(context.Background(), testLogger())
+
+	got, err := u.fetchAzureAKSMeshRevisions(ctx, testLogger(), source)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "asm-1-29" {
+		t.Errorf("got %q, want asm-1-29", got.Name)
+	}
+}

--- a/tooling/image-updater/internal/updater/updater_test.go
+++ b/tooling/image-updater/internal/updater/updater_test.go
@@ -929,8 +929,8 @@ func TestUpdater_FetchAzureAKSMeshRevisions_MissingSubscription(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), testLogger())
 
 	_, err := u.fetchAzureAKSMeshRevisions(ctx, testLogger(), source)
-	if err == nil || !strings.Contains(err.Error(), "subscription not set") {
-		t.Errorf("expected 'subscription not set' error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "resolve subscription") {
+		t.Errorf("expected 'resolve subscription' error, got %v", err)
 	}
 }
 

--- a/tooling/image-updater/internal/upgrade/asm.go
+++ b/tooling/image-updater/internal/upgrade/asm.go
@@ -34,11 +34,11 @@ func ParseAsmRevision(rev string) (major, minor int, err error) {
 	}
 	major, err = strconv.Atoi(parts[0])
 	if err != nil {
-		return 0, 0, fmt.Errorf("asm revision %q: bad major: %w", rev, err)
+		return 0, 0, fmt.Errorf("asm revision %q: invalid major version: %w", rev, err)
 	}
 	minor, err = strconv.Atoi(parts[1])
 	if err != nil {
-		return 0, 0, fmt.Errorf("asm revision %q: bad minor: %w", rev, err)
+		return 0, 0, fmt.Errorf("asm revision %q: invalid minor version: %w", rev, err)
 	}
 	return major, minor, nil
 }

--- a/tooling/image-updater/internal/upgrade/asm.go
+++ b/tooling/image-updater/internal/upgrade/asm.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// ParseAsmRevision splits "asm-<major>-<minor>" into its numeric parts, so
+// asm-1-9 compares older than asm-1-10 rather than sorting lexicographically.
+func ParseAsmRevision(rev string) (major, minor int, err error) {
+	const prefix = "asm-"
+	if !strings.HasPrefix(rev, prefix) {
+		return 0, 0, fmt.Errorf("asm revision %q missing %q prefix", rev, prefix)
+	}
+	parts := strings.SplitN(strings.TrimPrefix(rev, prefix), "-", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("asm revision %q does not match asm-<major>-<minor>", rev)
+	}
+	major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("asm revision %q: bad major: %w", rev, err)
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("asm revision %q: bad minor: %w", rev, err)
+	}
+	return major, minor, nil
+}
+
+// CompareAsmRevisions follows the cmp.Ordered contract for use with
+// slices.SortFunc. Unparseable revisions sort before valid ones so garbage
+// cannot win as the max in HighestAsmRevision.
+func CompareAsmRevisions(a, b string) int {
+	aM, am, aErr := ParseAsmRevision(a)
+	bM, bm, bErr := ParseAsmRevision(b)
+	switch {
+	case aErr != nil && bErr != nil:
+		return strings.Compare(a, b)
+	case aErr != nil:
+		return -1
+	case bErr != nil:
+		return +1
+	case aM != bM:
+		if aM < bM {
+			return -1
+		}
+		return +1
+	case am != bm:
+		if am < bm {
+			return -1
+		}
+		return +1
+	default:
+		return 0
+	}
+}
+
+// HighestAsmRevision returns the maximum revision, or an error if empty.
+func HighestAsmRevision(revisions []string) (string, error) {
+	if len(revisions) == 0 {
+		return "", fmt.Errorf("no asm revisions to pick from")
+	}
+	sorted := slices.Clone(revisions)
+	slices.SortFunc(sorted, CompareAsmRevisions)
+	return sorted[len(sorted)-1], nil
+}
+
+// IntersectAsmRevisions returns revisions present in every input set. Order
+// follows the first set. An empty result means no revision is available
+// everywhere; callers should treat that as an error.
+func IntersectAsmRevisions(sets ...[]string) []string {
+	if len(sets) == 0 {
+		return nil
+	}
+	counts := make(map[string]int, len(sets[0]))
+	for _, r := range sets[0] {
+		counts[r] = 1
+	}
+	for _, s := range sets[1:] {
+		seen := make(map[string]struct{}, len(s))
+		for _, r := range s {
+			if _, dup := seen[r]; dup {
+				continue
+			}
+			seen[r] = struct{}{}
+			if _, ok := counts[r]; ok {
+				counts[r]++
+			}
+		}
+	}
+	var out []string
+	seen := make(map[string]struct{}, len(sets[0]))
+	for _, r := range sets[0] {
+		if _, dup := seen[r]; dup {
+			continue
+		}
+		seen[r] = struct{}{}
+		if counts[r] == len(sets) {
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/tooling/image-updater/internal/upgrade/asm_test.go
+++ b/tooling/image-updater/internal/upgrade/asm_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upgrade
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestParseAsmRevision(t *testing.T) {
+	cases := map[string]struct {
+		wantMajor, wantMinor int
+		wantErr              bool
+	}{
+		"asm-1-28":  {1, 28, false},
+		"asm-1-9":   {1, 9, false},
+		"asm-1-100": {1, 100, false},
+		"asm-2-0":   {2, 0, false},
+		"asm-1":     {0, 0, true},
+		"1-28":      {0, 0, true},
+		"asm-a-b":   {0, 0, true},
+		"":          {0, 0, true},
+	}
+	for in, want := range cases {
+		gotMajor, gotMinor, err := ParseAsmRevision(in)
+		if want.wantErr {
+			if err == nil {
+				t.Errorf("ParseAsmRevision(%q) = (%d,%d,nil), want error", in, gotMajor, gotMinor)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseAsmRevision(%q) error: %v", in, err)
+			continue
+		}
+		if gotMajor != want.wantMajor || gotMinor != want.wantMinor {
+			t.Errorf("ParseAsmRevision(%q) = (%d,%d), want (%d,%d)", in, gotMajor, gotMinor, want.wantMajor, want.wantMinor)
+		}
+	}
+}
+
+func TestCompareAsmRevisions_NumericMinor(t *testing.T) {
+	// asm-1-9 must compare < asm-1-10 (numeric, not lexicographic).
+	if got := CompareAsmRevisions("asm-1-9", "asm-1-10"); got >= 0 {
+		t.Errorf("asm-1-9 vs asm-1-10 = %d, want < 0", got)
+	}
+	if got := CompareAsmRevisions("asm-1-10", "asm-1-9"); got <= 0 {
+		t.Errorf("asm-1-10 vs asm-1-9 = %d, want > 0", got)
+	}
+	if got := CompareAsmRevisions("asm-1-28", "asm-1-28"); got != 0 {
+		t.Errorf("equal revisions returned %d, want 0", got)
+	}
+}
+
+func TestCompareAsmRevisions_MajorWins(t *testing.T) {
+	if got := CompareAsmRevisions("asm-1-999", "asm-2-0"); got >= 0 {
+		t.Errorf("asm-1-999 vs asm-2-0 = %d, want < 0", got)
+	}
+}
+
+func TestCompareAsmRevisions_SortFuncOrder(t *testing.T) {
+	got := []string{"asm-1-29", "asm-1-9", "asm-1-30", "asm-1-26"}
+	slices.SortFunc(got, CompareAsmRevisions)
+	want := []string{"asm-1-9", "asm-1-26", "asm-1-29", "asm-1-30"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("sorted[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestHighestAsmRevision(t *testing.T) {
+	got, err := HighestAsmRevision([]string{"asm-1-26", "asm-1-30", "asm-1-9"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "asm-1-30" {
+		t.Errorf("HighestAsmRevision = %q, want asm-1-30", got)
+	}
+	if _, err := HighestAsmRevision(nil); err == nil {
+		t.Errorf("expected error on empty slice")
+	}
+}
+
+func TestHighestAsmRevision_UnparseableSortsFirst(t *testing.T) {
+	// A garbage entry must not pretend to be the maximum.
+	got, err := HighestAsmRevision([]string{"asm-1-28", "banana", "asm-1-29"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "asm-1-29" {
+		t.Errorf("HighestAsmRevision returned %q, want asm-1-29 (garbage must not win)", got)
+	}
+}
+
+func TestIntersectAsmRevisions(t *testing.T) {
+	cases := []struct {
+		name string
+		in   [][]string
+		want []string
+	}{
+		{
+			name: "no sets",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "single set is returned deduped in first-set order",
+			in:   [][]string{{"asm-1-28", "asm-1-29", "asm-1-28"}},
+			want: []string{"asm-1-28", "asm-1-29"},
+		},
+		{
+			name: "common across all",
+			in: [][]string{
+				{"asm-1-28", "asm-1-29", "asm-1-30"},
+				{"asm-1-29", "asm-1-30"},
+				{"asm-1-30", "asm-1-29"},
+			},
+			want: []string{"asm-1-29", "asm-1-30"},
+		},
+		{
+			name: "no overlap yields empty",
+			in: [][]string{
+				{"asm-1-28"},
+				{"asm-1-29"},
+			},
+			want: nil,
+		},
+		{
+			name: "duplicates within one region do not inflate count",
+			in: [][]string{
+				{"asm-1-29", "asm-1-29"},
+				{"asm-1-28"},
+			},
+			want: nil,
+		},
+		{
+			name: "order follows first set",
+			in: [][]string{
+				{"asm-1-30", "asm-1-28", "asm-1-29"},
+				{"asm-1-28", "asm-1-29", "asm-1-30"},
+			},
+			want: []string{"asm-1-30", "asm-1-28", "asm-1-29"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IntersectAsmRevisions(tc.in...)
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("IntersectAsmRevisions(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What

Adds a new `azureAKSMeshRevisions` source type to the image-updater that queries AKS mesh revision profiles across multiple Azure regions, intersects the results, and writes the highest common default revision to `config/config.yaml`.

### Why

The Istio ASM revision deployed to service clusters needs to track what AKS actually supports. Today this is updated manually. This change automates the process so the image-updater CI job can suggest version bumps alongside container image updates, reducing toil and the risk of falling behind on mesh revisions.  It does not choose the latest revision, it defaults to the AKS-default revision set by Microsoft, which is the most widely tested and frequently patched version.  This also leaves room to upgrade again if the default proves buggy. It is better to upgrade conservatively than to use the latest, as there is no rollback to an older revision once a canary upgrade completes.

### Testing

  - Unit tests for ASM revision parsing, numeric comparison, intersection, and highest-revision selection (`upgrade asm_test.go`)
  - Unit tests for the `pickDefaultMeshRevision` heuristic and input validation (`clients/aks_test.go`)
  - Unit tests for the full fetch pipeline including parallel location queries, pinned/max overrides, empty intersection, and subscription fallback
  (`updater/updater_test.go`)
  - Unit tests for config validation of the new source type and its mutual exclusions (`config/config_test.go`)
  - Ran locally against live AKS ARM API across 9 regions
  
### Special notes for your reviewer

  - The `azureAKSMeshRevisions` source is version-only (like `githubLatestRelease`) — it writes a version string, not a container digest.
  - Subscription ID is resolved automatically from Azure credentials if not configured, so no hardcoded subscription is needed in CI.
  - `pinnedMeshRevision` and `maxMeshRevision` are escape hatches for operators to override the suggested version.
  - This depends on the `defaults.svc.istio.versions` and `defaults.svc.istio.targetVersion` config paths added in PR #6236.
  
### PR Checklist

  - [X] PR is scoped to a single task (no mixed concerns)
  - [X] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
  - [X] Summary explains the "Why" behind the change
  - [ ] Linked to relevant ticket/issue
  - [ ] Screenshots included (if graph/UI/metrics changes)
  - [X] Self-reviewed the diff
  - [ ] CI/CD checks are passing (ignore Tide)
  - [X] Draft PR used for WIP (if applicable)
  - [X] Commit history is clean (rebased/squashed)
  - [X] Tricky code blocks are commented
  - [ ] Specific reviewers tagged
  - [ ] All comment threads resolved before merge