### PR TITLE
fix: scope KubePodNotReady to OSS Prometheus

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyHCPPrometheusAlertingRules.bicep
@@ -68,7 +68,7 @@ resource kubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           summary: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for more than 5 minutes.'
           title: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for more than 5 minutes.'
         }
-        expression: 'sum by (namespace, pod, cluster) (max by (namespace, pod, cluster) (kube_pod_status_phase{job="kube-state-metrics",namespace!~"klusterlet-.*",phase=~"Pending|Unknown|Failed"}) * on (namespace, pod, cluster) group_left (owner_kind) topk by (namespace, pod, cluster) (1, max by (namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"}))) > 0'
+        expression: 'sum by (namespace, pod, cluster) (max by (namespace, pod, cluster) (kube_pod_status_phase{job="kube-state-metrics",namespace!~"klusterlet-.*",phase=~"Pending|Unknown|Failed",prometheus="prometheus/prometheus"}) * on (namespace, pod, cluster) group_left (owner_kind) topk by (namespace, pod, cluster) (1, max by (namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job",prometheus="prometheus/prometheus"}))) > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
@@ -68,7 +68,7 @@ resource svcKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
           summary: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for more than 5 minutes.'
           title: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for more than 5 minutes.'
         }
-        expression: 'sum by (namespace, pod, cluster) (max by (namespace, pod, cluster) (kube_pod_status_phase{job="kube-state-metrics",namespace!~"klusterlet-.*",phase=~"Pending|Unknown|Failed"}) * on (namespace, pod, cluster) group_left (owner_kind) topk by (namespace, pod, cluster) (1, max by (namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"}))) > 0'
+        expression: 'sum by (namespace, pod, cluster) (max by (namespace, pod, cluster) (kube_pod_status_phase{job="kube-state-metrics",namespace!~"klusterlet-.*",phase=~"Pending|Unknown|Failed",prometheus="prometheus/prometheus"}) * on (namespace, pod, cluster) group_left (owner_kind) topk by (namespace, pod, cluster) (1, max by (namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job",prometheus="prometheus/prometheus"}))) > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -68,7 +68,7 @@ resource msftKubernetesApps 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           summary: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for more than 5 minutes.'
           title: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for more than 5 minutes.'
         }
-        expression: 'sum by (namespace, pod, cluster) (max by (namespace, pod, cluster) (kube_pod_status_phase{job="kube-state-metrics",namespace!~"klusterlet-.*",phase=~"Pending|Unknown|Failed"}) * on (namespace, pod, cluster) group_left (owner_kind) topk by (namespace, pod, cluster) (1, max by (namespace, pod, owner_kind, cluster) (kube_pod_owner{namespace=~"billing|credential-refresher",owner_kind!="Job"}))) > 0'
+        expression: 'sum by (namespace, pod, cluster) (max by (namespace, pod, cluster) (kube_pod_status_phase{job="kube-state-metrics",namespace!~"klusterlet-.*",phase=~"Pending|Unknown|Failed",prometheus="prometheus/prometheus"}) * on (namespace, pod, cluster) group_left (owner_kind) topk by (namespace, pod, cluster) (1, max by (namespace, pod, owner_kind, cluster) (kube_pod_owner{namespace=~"billing|credential-refresher",owner_kind!="Job",prometheus="prometheus/prometheus"}))) > 0'
         for: 'PT5M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }

--- a/observability/alerts/kubernetesControlPlane-prometheusRule.yaml
+++ b/observability/alerts/kubernetesControlPlane-prometheusRule.yaml
@@ -32,9 +32,9 @@ spec:
       expr: |
         sum by (namespace, pod, cluster) (
           max by(namespace, pod, cluster) (
-            kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown|Failed", namespace!~"klusterlet-.*"}
+            kube_pod_status_phase{job="kube-state-metrics", prometheus="prometheus/prometheus", phase=~"Pending|Unknown|Failed", namespace!~"klusterlet-.*"}
           ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
-            1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
+            1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{prometheus="prometheus/prometheus", owner_kind!="Job"})
           )
         ) > 0
       for: 5m

--- a/observability/alerts/kubernetesControlPlane-prometheusRule.yaml.diff
+++ b/observability/alerts/kubernetesControlPlane-prometheusRule.yaml.diff
@@ -29,9 +29,10 @@
          sum by (namespace, pod, cluster) (
            max by(namespace, pod, cluster) (
 -            kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
-+            kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown|Failed", namespace!~"klusterlet-.*"}
++            kube_pod_status_phase{job="kube-state-metrics", prometheus="prometheus/prometheus", phase=~"Pending|Unknown|Failed", namespace!~"klusterlet-.*"}
            ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
-             1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
+-            1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
++            1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{prometheus="prometheus/prometheus", owner_kind!="Job"})
            )
          ) > 0
 -      for: 15m

--- a/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
@@ -21,11 +21,6 @@ knownIssues:
   reason: "Newly added stuck-async-operation alerts (https://github.com/Azure/ARO-HCP/pull/5952) surface a pre-existing problem: Azure Monitor Workspace ingestion latency (metrics can take ~10min to ingest) makes async operations look stuck and latches onto E2E runs even when the tests pass. Observed blocking green E2E runs (per https://cihealth.tools.hcpsvc.osadev.cloud/run-log?q=BackendAsync): BackendAsyncOperationClusterDeleteStuck, BackendAsyncOperationExternalAuthDeleteStuck, BackendAsyncOperationClusterCreateStuck, BackendAsyncOperationNodePoolDeleteStuck, BackendAsyncOperationNodePoolCreateStuck, BackendAsyncOperationStuck. Owner @stevekuznetsov; durable fix is the AMW auto-scaler (https://github.com/Azure/ARO-HCP/pull/6036). Marked known so it stops blocking the merge queue until that lands."
 - name: "KubePodNotReady"
   labels:
-    namespace: "clusters-service"
-    pod: "clusters-service-.*"
-  reason: "False positive caused by stale metrics in the remote write pipeline. The pod transitions from Pending to Running in under 2 minutes, but the metric update takes up to 4 minutes to propagate through OSS Prometheus remote write and Azure Monitor ingestion, making the 5-minute for duration insufficient. Upstream kube-prometheus-stack uses for: 15m to absorb this latency. Tracked in https://issues.redhat.com/browse/AROSLSRE-1656."
-- name: "KubePodNotReady"
-  labels:
     namespace: "klusterlet-.*"
   reason: "Klusterlet addon pods take a while to start when clusters are slow to provision, so this is a downstream issue and just noise."
 - name: "KubePodNotReady"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1656

### What

Scope both `KubePodNotReady` input metrics to the authoritative OSS Prometheus producer with `prometheus="prometheus/prometheus"`, regenerate the Azure alert rule outputs, and remove the temporary `clusters-service` known-issue exemption from the e2e observability step.

### Why

AKS-managed `ama-metrics-ksm` can start before our configuration disables its kube-state-metrics target. During that bootstrap window it may publish a Pod as `Pending`, remove the target after applying the configuration, and leave the final `Pending=1` sample available to Prometheus lookback.

The existing `max by(namespace, pod, cluster)` combines that stale AMA series with the two intended OSS Prometheus replicas. It therefore selects `1` even while both authoritative replicas continuously report `0`, causing intermittent false `KubePodNotReady` alerts and failed e2e jobs.

The `job="kube-state-metrics"` label cannot disambiguate these producers because both use it. The `prometheus="prometheus/prometheus"` label explicitly selects the intended producer while preserving HA deduplication across its replicas.

### Before/after

```mermaid
flowchart LR
  subgraph After["After: authoritative producer selected"]
    A2["AMA bootstrap series<br/>excluded"]
    O21["OSS replica 0<br/>Pending = 0"] --> M2["max = 0"]
    O22["OSS replica 1<br/>Pending = 0"] --> M2
    M2 --> C["alert condition clear"]
  end

  subgraph Before["Before: producer sources combined"]
    A1["AMA bootstrap series<br/>Pending = 1 (stale)"] --> M1["max = 1"]
    O11["OSS replica 0<br/>Pending = 0"] --> M1
    O12["OSS replica 1<br/>Pending = 0"] --> M1
    M1 --> F["false alert condition"]
  end
```

Replaying the captured incident timestamp against Azure Managed Prometheus returned all three affected `clusters-service` Pods with the old expression and no Pods with the filtered expression.

### Testing

- `make -C observability verify-rule`
- Prometheus rule generator unit tests
- `go test ./cmd/aro-hcp-tests/gather-observability` from `test/`
- Regenerated Kusto-only HCP, Kusto-only service, and Microsoft Azure alert rule Bicep
- Replayed the old and fixed expressions against the captured live incident

### Special notes for your reviewer

Review requested from observability/infrastructure owners @geoberle and @janboll.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Before/after visualization included (metrics/alerting change)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (not applicable; change is ready for review)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented (not applicable; selector is self-describing)
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge (none open)
