### PR TITLE
test: add E2E coverage for deleting an HCP cluster with missing MIs

### DIFF
--- a/nonlocal-e2e-specs.txt
+++ b/nonlocal-e2e-specs.txt
@@ -10,6 +10,7 @@
   "creates and deletes a GPU nodepool in a single cluster",
   "should allow pods with images from allowed registries and have a valid allowlist",
   "should be able to create an HCP cluster then delete it by deleting the customer resource group",
+  "should be able to delete an HCP cluster whose managed identities were deleted first",
   "should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings",
   "should confirm the HCP cluster is deleted (not found)",
   "should create an HCP cluster and validate TLS certificates",

--- a/test/e2e/cluster_delete_missing_identities.go
+++ b/test/e2e/cluster_delete_missing_identities.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+	"github.com/Azure/ARO-HCP/test/util/verifiers"
+)
+
+var _ = Describe("Customer", func() {
+	It("should be able to delete an HCP cluster whose managed identities were deleted first",
+		labels.RequireNothing,
+		labels.High,
+		labels.Positive,
+		labels.StageAndProdOnly,
+		// This test creates its own dedicated identities (useMsiPool=false) so it can
+		// safely delete them, and never leases from the shared identity container pool.
+		labels.MIContainers(0),
+		func(ctx context.Context) {
+			const customerClusterName = "missing-mi-hcp-cluster"
+			tc := framework.NewTestContext()
+
+			By("creating the customer resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "delete-mi-rg", tc.Location())
+			Expect(err).NotTo(HaveOccurred(), "failed to create customer resource group")
+
+			clusterParams := framework.NewDefaultClusterParams20240610()
+			clusterParams.ClusterName = customerClusterName
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.ManagedResourceGroupName = managedResourceGroupName
+
+			By("deploying customer infrastructure (NSG, VNet, subnet, KeyVault)")
+			customerInfraResult, err := tc.CreateBicepTemplateAndWait(ctx,
+				framework.WithTemplateFromFS(TestArtifactsFS, "test-artifacts/generated-test-artifacts/modules/customer-infra.json"),
+				framework.WithDeploymentName("customer-infra-"+customerClusterName),
+				framework.WithScope(framework.BicepDeploymentScopeResourceGroup),
+				framework.WithClusterResourceGroup(*resourceGroup.Name),
+				framework.WithParameters(map[string]interface{}{
+					"clusterName": customerClusterName,
+				}),
+				framework.WithTimeout(45*time.Minute),
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to deploy customer infrastructure")
+			clusterParams, err = framework.PopulateClusterParamsFromCustomerInfraDeployment20240610(clusterParams, customerInfraResult)
+			Expect(err).NotTo(HaveOccurred(), "failed to populate cluster params from customer infra deployment")
+
+			// This test deletes the cluster's managed identities, so it must own dedicated
+			// identities it can safely delete. Staging and Production CI runs with POOLED_IDENTITIES=true,
+			// where the standard helper would lease managed identities from a shared, reused
+			// pool; deleting those would corrupt the pool for other specs and consume Azure
+			// directory quota. We therefore always create dedicated identities in the customer
+			// resource group (useMsiPool=false), regardless of the pooled-identities setting,
+			// and never lease from the pool.
+			By("deploying dedicated managed identities in the customer resource group")
+			identities := framework.NewDefaultIdentitiesWithSuffix(customerClusterName)
+			managedIdentitiesResult, err := tc.CreateBicepTemplateAndWait(ctx,
+				framework.WithTemplateFromFS(TestArtifactsFS, "test-artifacts/generated-test-artifacts/modules/managed-identities.json"),
+				framework.WithDeploymentName(fmt.Sprintf("mi-%s-%s", customerClusterName, rand.String(6))),
+				framework.WithScope(framework.BicepDeploymentScopeSubscription),
+				framework.WithLocation(tc.Location()),
+				framework.WithParameters(map[string]interface{}{
+					"useMsiPool":               false,
+					"clusterResourceGroupName": *resourceGroup.Name,
+					"msiResourceGroupName":     *resourceGroup.Name,
+					"identities":               identities,
+					"rbacScope":                framework.RBACScopeResourceGroup,
+					"nsgName":                  clusterParams.NsgName,
+					"vnetName":                 clusterParams.VnetName,
+					"subnetName":               clusterParams.SubnetName,
+					"keyVaultName":             clusterParams.KeyVaultName,
+					"clusterName":              customerClusterName,
+				}),
+				framework.WithTimeout(45*time.Minute),
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to deploy dedicated managed identities")
+			clusterParams, err = framework.PopulateClusterParamsFromManagedIdentitiesDeployment20240610(clusterParams, managedIdentitiesResult)
+			Expect(err).NotTo(HaveOccurred(), "failed to populate cluster params from managed identities deployment")
+
+			By("creating the HCP cluster")
+			err = tc.CreateHCPClusterFromParam20240610(
+				ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				framework.ClusterCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q", customerClusterName)
+
+			hcpClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+
+			By("ensuring the cluster is viable before deleting its identities")
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
+				ctx,
+				hcpClient,
+				*resourceGroup.Name,
+				customerClusterName,
+				framework.GetAdminRESTConfigTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for cluster %q", customerClusterName)
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to verify HCP cluster %q is viable", customerClusterName)
+
+			By("deleting all of the cluster's managed identities behind the scenes")
+			err = tc.DeleteUserAssignedIdentities(ctx, *resourceGroup.Name, identities.ToSlice())
+			Expect(err).NotTo(HaveOccurred(), "failed to delete managed identities for cluster %q", customerClusterName)
+
+			By("deleting the HCP cluster")
+			err = framework.DeleteHCPCluster20240610(
+				ctx,
+				hcpClient,
+				*resourceGroup.Name,
+				customerClusterName,
+				framework.HCPClusterDeletionTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to delete HCP cluster %q whose managed identities were deleted", customerClusterName)
+
+			By("verifying the cluster resource is deleted (Not Found)")
+			_, err = hcpClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
+			Expect(err).To(HaveOccurred(), "expected an error when getting deleted cluster %q", customerClusterName)
+			var respErr *azcore.ResponseError
+			Expect(errors.As(err, &respErr)).To(BeTrue(), "expected azcore.ResponseError when getting deleted cluster %q, got %v", customerClusterName, err)
+			Expect(respErr.StatusCode).To(Equal(http.StatusNotFound), "expected HTTP 404 when getting deleted cluster %q", customerClusterName)
+
+			By("verifying the managed resource group is deleted (404)")
+			rgClient := tc.GetARMResourcesClientFactoryOrDie(ctx).NewResourceGroupsClient()
+			// Delta-only logging: Eventually discards intermediate errors, so without this
+			// a long wait produces no output at all. Only log when the observation changes.
+			lastObserved := ""
+			logObservedDelta := func(observed string) {
+				if observed == lastObserved {
+					return
+				}
+				lastObserved = observed
+				GinkgoLogr.Info("waiting for managed resource group deletion",
+					"resourceGroup", managedResourceGroupName, "expected", "HTTP 404", "observed", observed)
+			}
+			Eventually(func() error {
+				_, err := rgClient.Get(ctx, managedResourceGroupName, nil)
+				if err == nil {
+					logObservedDelta("resource group still exists")
+					return fmt.Errorf("managed resource group %q still exists", managedResourceGroupName)
+				}
+				var respErr *azcore.ResponseError
+				if errors.As(err, &respErr) {
+					if respErr.StatusCode == http.StatusNotFound {
+						return nil
+					}
+					logObservedDelta(fmt.Sprintf("HTTP %d (%s)", respErr.StatusCode, respErr.ErrorCode))
+				} else {
+					logObservedDelta(fmt.Sprintf("non-HTTP error: %v", err))
+				}
+				return fmt.Errorf("unexpected error getting managed resource group %q: %w", managedResourceGroupName, err)
+			}, 15*time.Minute, 30*time.Second).Should(Succeed(), "expected managed resource group %q to be deleted", managedResourceGroupName)
+		})
+})

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -75,3 +75,4 @@ Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings
 Customer should not be able to perform various invalid operations on cluster resources
 Customer should be able to list available HCP OpenShift versions and validate response content
+Customer should be able to delete an HCP cluster whose managed identities were deleted first

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -75,3 +75,4 @@ Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings
 Customer should not be able to perform various invalid operations on cluster resources
 Customer should be able to list available HCP OpenShift versions and validate response content
+Customer should be able to delete an HCP cluster whose managed identities were deleted first

--- a/test/util/framework/identities_helper.go
+++ b/test/util/framework/identities_helper.go
@@ -334,6 +334,64 @@ func (tc *perItOrDescribeTestContext) NextLeasedIdentityPool() (LeasedIdentityPo
 	return tc.getLeasedIdentities()
 }
 
+// DeleteUserAssignedIdentities deletes the named user-assigned managed identities from
+// the given resource group. It is used to simulate a customer deleting the managed
+// identities of a running cluster before requesting cluster deletion. Identities that
+// are already gone (HTTP 404) are treated as successfully deleted, so the call is
+// idempotent.
+//
+// Only use it on dedicated identities the test created itself (useMsiPool=false).
+// Deleting identities out of the shared pool would corrupt it for other specs and
+// consume Azure directory quota, so the call is rejected with an error when the given
+// resource group is one of the pool's identity containers.
+func (tc *perItOrDescribeTestContext) DeleteUserAssignedIdentities(ctx context.Context, resourceGroup string, identityNames []string) error {
+	startTime := time.Now()
+	defer func() {
+		tc.RecordTestStep(fmt.Sprintf("Delete %d user-assigned identities in resource group %s", len(identityNames), resourceGroup), startTime, time.Now())
+	}()
+
+	// The env var lists every container in the pool, so this also rejects containers
+	// leased by another spec, which tc.leasedIdentityContainers() would not catch. It is
+	// unset in non-pooled mode, where the loop is a no-op.
+	for _, pooledResourceGroup := range strings.Fields(os.Getenv(LeasedMSIContainersEnvvar)) {
+		if strings.EqualFold(pooledResourceGroup, resourceGroup) {
+			return fmt.Errorf("refusing to delete user-assigned identities in resource group %q: it is a shared identity container listed in %s; this helper may only be used on dedicated identities the test created itself (useMsiPool=false)", resourceGroup, LeasedMSIContainersEnvvar)
+		}
+	}
+
+	creds, err := tc.perBinaryInvocationTestContext.getAzureCredentials()
+	if err != nil {
+		return fmt.Errorf("failed to get Azure credentials: %w", err)
+	}
+	subscriptionID, err := tc.getSubscriptionIDUnlocked(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get subscription ID: %w", err)
+	}
+
+	msiClientFactory, err := armmsi.NewClientFactory(subscriptionID, creds, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create MSI client factory: %w", err)
+	}
+	identitiesClient := msiClientFactory.NewUserAssignedIdentitiesClient()
+
+	var errs []error
+	for _, identityName := range identityNames {
+		if _, err := identitiesClient.Delete(ctx, resourceGroup, identityName, nil); err != nil {
+			var respErr *azcore.ResponseError
+			if errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound {
+				ginkgo.GinkgoLogr.Info("User-assigned identity already deleted",
+					"identity", identityName, "resourceGroup", resourceGroup)
+				continue
+			}
+			errs = append(errs, fmt.Errorf("failed to delete user-assigned identity %q in resource group %q: %w", identityName, resourceGroup, err))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
 // leasedIdentityContainers returns the list of resource groups that are currently leased
 // to the calling test spec.
 func (tc *perItOrDescribeTestContext) leasedIdentityContainers() ([]string, error) {


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-23172

### What

Adds an E2E test that verifies a customer can delete a hosted ARO HCP cluster even when the cluster's managed identities were deleted first.

The test:

1. Creates a customer resource group, customer infrastructure (NSG, VNet, subnet, KeyVault) and **dedicated** managed identities.
2. Creates an HCP cluster and confirms it is viable.
3. Deletes **all** of the cluster's managed identities.
4. Deletes the cluster and asserts that both the cluster resource and its managed resource group are actually gone (HTTP 404).

It also adds a small framework helper, `DeleteUserAssignedIdentities`, because the Azure credentials on the test context are unexported and a spec in `package e2e` cannot construct an `armmsi` client itself.

### Why

Customers can delete the managed identities backing a running HCP cluster.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge