### PR TITLE
feat: update azcosmos library from v1.5.0-beta.7 to v1.5.0

### DIFF
--- a/admin/server/go.mod
+++ b/admin/server/go.mod
@@ -23,7 +23,7 @@ require (
 require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources/v3 v3.0.1 // indirect

--- a/admin/server/go.sum
+++ b/admin/server/go.sum
@@ -9,8 +9,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpz
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1/go.mod h1:IYus9qsFobWIc2YVwe/WPjcnyCkPKtnHAqUYeebc8z0=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 h1:xFaZZ+IubdftrDHnGGwZ6QvQ3KHTtWl2MCK+GMt2vxs=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0/go.mod h1:mCBhUhlMjLLJKr5aqw2TNS/VqJOie8MzWq3DAMJeKso=
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7 h1:8jCpUsqk6zRiGzPGxWbYoOAYEDWMEJhAzgaBKkpWe30=
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7/go.mod h1:MIyTWizpwnsX4LS9/tW1II9JL+D25Ypzj6URaT9NcgQ=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0 h1:wtCn7MemMD9eo4/NdpJ6S/MFD2BV2CDwoEfvl5th2vM=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0/go.mod h1:MIyTWizpwnsX4LS9/tW1II9JL+D25Ypzj6URaT9NcgQ=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7.0 h1:LkHbJbgF3YyvC53aqYGR+wWQDn2Rdp9AQdGndf9QvY4=

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/ARO-HCP/internal v0.0.0-00010101000000-000000000000
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
-	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7
+	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi v1.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -6,8 +6,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpz
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1/go.mod h1:IYus9qsFobWIc2YVwe/WPjcnyCkPKtnHAqUYeebc8z0=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 h1:xFaZZ+IubdftrDHnGGwZ6QvQ3KHTtWl2MCK+GMt2vxs=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0/go.mod h1:mCBhUhlMjLLJKr5aqw2TNS/VqJOie8MzWq3DAMJeKso=
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7 h1:8jCpUsqk6zRiGzPGxWbYoOAYEDWMEJhAzgaBKkpWe30=
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7/go.mod h1:MIyTWizpwnsX4LS9/tW1II9JL+D25Ypzj6URaT9NcgQ=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0 h1:wtCn7MemMD9eo4/NdpJ6S/MFD2BV2CDwoEfvl5th2vM=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0/go.mod h1:MIyTWizpwnsX4LS9/tW1II9JL+D25Ypzj6URaT9NcgQ=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0 h1:Hp+EScFOu9HeCbeW8WU2yQPJd4gGwhMgKxWe+G6jNzw=

--- a/docs/cosmos-resource-deletion.md
+++ b/docs/cosmos-resource-deletion.md
@@ -73,7 +73,7 @@ and index-friendly. This filter applies to:
 
 ### Change Feed Behavior
 
-The `processDocument` method in `ChangeFeedWatcher` checks `DeletionTimestamp` on every
+The `processItem` method in `ChangeFeedWatcher` checks `DeletionTimestamp` on every
 document surfaced by the change feed:
 
 - **DeletionTimestamp is non-nil AND the resource was previously seen** (in the list snapshot

--- a/fleet/go.mod
+++ b/fleet/go.mod
@@ -26,7 +26,7 @@ require (
 
 require (
 	dario.cat/mergo v1.0.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
 	github.com/Masterminds/semver/v3 v3.5.0 // indirect

--- a/fleet/go.sum
+++ b/fleet/go.sum
@@ -6,8 +6,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpz
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1/go.mod h1:IYus9qsFobWIc2YVwe/WPjcnyCkPKtnHAqUYeebc8z0=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 h1:xFaZZ+IubdftrDHnGGwZ6QvQ3KHTtWl2MCK+GMt2vxs=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0/go.mod h1:mCBhUhlMjLLJKr5aqw2TNS/VqJOie8MzWq3DAMJeKso=
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7 h1:8jCpUsqk6zRiGzPGxWbYoOAYEDWMEJhAzgaBKkpWe30=
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7/go.mod h1:MIyTWizpwnsX4LS9/tW1II9JL+D25Ypzj6URaT9NcgQ=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0 h1:wtCn7MemMD9eo4/NdpJ6S/MFD2BV2CDwoEfvl5th2vM=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0/go.mod h1:MIyTWizpwnsX4LS9/tW1II9JL+D25Ypzj6URaT9NcgQ=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=

--- a/frontend/go.mod
+++ b/frontend/go.mod
@@ -91,7 +91,7 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7
+	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect

--- a/frontend/go.sum
+++ b/frontend/go.sum
@@ -6,8 +6,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpz
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1/go.mod h1:IYus9qsFobWIc2YVwe/WPjcnyCkPKtnHAqUYeebc8z0=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 h1:xFaZZ+IubdftrDHnGGwZ6QvQ3KHTtWl2MCK+GMt2vxs=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0/go.mod h1:mCBhUhlMjLLJKr5aqw2TNS/VqJOie8MzWq3DAMJeKso=
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7 h1:8jCpUsqk6zRiGzPGxWbYoOAYEDWMEJhAzgaBKkpWe30=
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7/go.mod h1:MIyTWizpwnsX4LS9/tW1II9JL+D25Ypzj6URaT9NcgQ=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0 h1:wtCn7MemMD9eo4/NdpJ6S/MFD2BV2CDwoEfvl5th2vM=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0/go.mod h1:MIyTWizpwnsX4LS9/tW1II9JL+D25Ypzj6URaT9NcgQ=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -152,8 +152,8 @@ type ResourcesDBClient interface {
 // Any Cosmos container that exposes its change feed satisfies it — both the
 // shared "Resources" container and per-management-cluster kube-applier containers.
 type ChangeFeedClient interface {
-	GetChangeFeed(ctx context.Context, options *azcosmos.ChangeFeedOptions) (azcosmos.ChangeFeedResponse, error)
-	GetFeedRanges(ctx context.Context) ([]azcosmos.FeedRange, error)
+	ReadChangeFeed(ctx context.Context, options *azcosmos.ChangeFeedOptions) (azcosmos.ChangeFeedResponse, error)
+	ReadFeedRanges(ctx context.Context, options *azcosmos.FeedRangesOptions) ([]azcosmos.FeedRange, error)
 }
 
 var _ ResourcesDBClient = &resourcesCosmosDBClient{}
@@ -237,12 +237,12 @@ func (d *resourcesCosmosDBClient) ResourcesGlobalListers() ResourcesGlobalLister
 	return NewCosmosResourcesGlobalListers(d.resources)
 }
 
-func (d *resourcesCosmosDBClient) GetChangeFeed(ctx context.Context, options *azcosmos.ChangeFeedOptions) (azcosmos.ChangeFeedResponse, error) {
-	return d.resources.GetChangeFeed(ctx, options)
+func (d *resourcesCosmosDBClient) ReadChangeFeed(ctx context.Context, options *azcosmos.ChangeFeedOptions) (azcosmos.ChangeFeedResponse, error) {
+	return d.resources.ReadChangeFeed(ctx, options)
 }
 
-func (d *resourcesCosmosDBClient) GetFeedRanges(ctx context.Context) ([]azcosmos.FeedRange, error) {
-	resourcesFeedRanges, err := d.resources.GetFeedRanges(ctx)
+func (d *resourcesCosmosDBClient) ReadFeedRanges(ctx context.Context, options *azcosmos.FeedRangesOptions) ([]azcosmos.FeedRange, error) {
+	resourcesFeedRanges, err := d.resources.ReadFeedRanges(ctx, options)
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}

--- a/internal/database/fleet_client.go
+++ b/internal/database/fleet_client.go
@@ -79,12 +79,12 @@ func NewFleetDBClientFromContainer(container *azcosmos.ContainerClient) FleetDBC
 	return &cosmosFleetDBClient{container: container}
 }
 
-func (c *cosmosFleetDBClient) GetChangeFeed(ctx context.Context, options *azcosmos.ChangeFeedOptions) (azcosmos.ChangeFeedResponse, error) {
-	return c.container.GetChangeFeed(ctx, options)
+func (c *cosmosFleetDBClient) ReadChangeFeed(ctx context.Context, options *azcosmos.ChangeFeedOptions) (azcosmos.ChangeFeedResponse, error) {
+	return c.container.ReadChangeFeed(ctx, options)
 }
 
-func (c *cosmosFleetDBClient) GetFeedRanges(ctx context.Context) ([]azcosmos.FeedRange, error) {
-	return c.container.GetFeedRanges(ctx)
+func (c *cosmosFleetDBClient) ReadFeedRanges(ctx context.Context, options *azcosmos.FeedRangesOptions) ([]azcosmos.FeedRange, error) {
+	return c.container.ReadFeedRanges(ctx, options)
 }
 
 func (c *cosmosFleetDBClient) Stamps() StampsCRUD {

--- a/internal/database/informers/changefeed_list_watch.go
+++ b/internal/database/informers/changefeed_list_watch.go
@@ -283,7 +283,8 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(fmt.Errorf("finished"))
 
-	feedRanges, err := c.changeFeedClient.GetFeedRanges(ctx)
+	options := &azcosmos.FeedRangesOptions{}
+	feedRanges, err := c.changeFeedClient.ReadFeedRanges(ctx, options)
 	if err != nil {
 		retErr := utils.TrackError(err)
 		utilruntime.HandleError(retErr)
@@ -516,7 +517,7 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 		}
 
 		logger.V(4).Info("reading feed range", "options", options)
-		response, err := c.changeFeedClient.GetChangeFeed(ctx, options)
+		response, err := c.changeFeedClient.ReadChangeFeed(ctx, options)
 		if err != nil {
 			return utils.TrackError(err)
 		}

--- a/internal/database/informers/changefeed_list_watch.go
+++ b/internal/database/informers/changefeed_list_watch.go
@@ -349,7 +349,7 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 	close(c.beginDelivery)
 }
 
-func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPIType]) processDocument(ctx context.Context, document json.RawMessage) error {
+func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPIType]) processItem(ctx context.Context, item []byte) error {
 	logger := utils.LoggerFromContext(ctx)
 	ready := false
 	for !ready {
@@ -366,7 +366,7 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 	}
 
 	objAsTypedDocument := &database.TypedDocument{}
-	if err := json.Unmarshal(document, objAsTypedDocument); err != nil {
+	if err := json.Unmarshal(item, objAsTypedDocument); err != nil {
 		return utils.TrackError(err)
 	}
 	logger = logger.WithValues(utils.LogValues{}.AddLogValuesForResourceID(objAsTypedDocument.ResourceID)...)
@@ -390,7 +390,7 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 	}
 
 	var cosmosObj CosmosAPIType
-	if err := json.Unmarshal(document, &cosmosObj); err != nil {
+	if err := json.Unmarshal(item, &cosmosObj); err != nil {
 		return utils.TrackError(err)
 	}
 	var internalObj InternalAPITypePointer
@@ -525,8 +525,8 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 		changeFeedStatus = response.RawResponse.StatusCode
 
 		if changeFeedStatus == http.StatusOK {
-			for _, doc := range response.Documents {
-				err = c.processDocument(ctx, doc)
+			for _, item := range response.Items {
+				err = c.processItem(ctx, item)
 				if err != nil {
 					return err
 				}

--- a/internal/database/kube_applier_client.go
+++ b/internal/database/kube_applier_client.go
@@ -203,12 +203,12 @@ func (c *kubeApplierCosmosDBClient) UntypedCRUD(parentResourceID azcorearm.Resou
 	return NewUntypedCRUDWithPartitionKey(c.kubeApplier, parentResourceID, KubeApplierPartitionKeyDeriver{ManagementClusterResourceID: c.managementClusterResourceID}), nil
 }
 
-func (c *kubeApplierCosmosDBClient) GetChangeFeed(ctx context.Context, options *azcosmos.ChangeFeedOptions) (azcosmos.ChangeFeedResponse, error) {
-	return c.kubeApplier.GetChangeFeed(ctx, options)
+func (c *kubeApplierCosmosDBClient) ReadChangeFeed(ctx context.Context, options *azcosmos.ChangeFeedOptions) (azcosmos.ChangeFeedResponse, error) {
+	return c.kubeApplier.ReadChangeFeed(ctx, options)
 }
 
-func (c *kubeApplierCosmosDBClient) GetFeedRanges(ctx context.Context) ([]azcosmos.FeedRange, error) {
-	resourcesFeedRanges, err := c.kubeApplier.GetFeedRanges(ctx)
+func (c *kubeApplierCosmosDBClient) ReadFeedRanges(ctx context.Context, options *azcosmos.FeedRangesOptions) ([]azcosmos.FeedRange, error) {
+	resourcesFeedRanges, err := c.kubeApplier.ReadFeedRanges(ctx, options)
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}

--- a/internal/databasetesting/mock_fleet_client.go
+++ b/internal/databasetesting/mock_fleet_client.go
@@ -112,7 +112,7 @@ func (m *MockFleetDBClient) StoreDocument(cosmosID string, data json.RawMessage)
 	m.changeFeed.record(data)
 }
 
-func (m *MockFleetDBClient) GetChangeFeed(ctx context.Context, options *azcosmos.ChangeFeedOptions) (azcosmos.ChangeFeedResponse, error) {
+func (m *MockFleetDBClient) ReadChangeFeed(ctx context.Context, options *azcosmos.ChangeFeedOptions) (azcosmos.ChangeFeedResponse, error) {
 	var continuation string
 	if options != nil && options.Continuation != nil {
 		continuation = *options.Continuation
@@ -121,7 +121,7 @@ func (m *MockFleetDBClient) GetChangeFeed(ctx context.Context, options *azcosmos
 	return buildMockChangeFeedResponse(docs, nextToken, hasNew), nil
 }
 
-func (m *MockFleetDBClient) GetFeedRanges(ctx context.Context) ([]azcosmos.FeedRange, error) {
+func (m *MockFleetDBClient) ReadFeedRanges(ctx context.Context, options *azcosmos.FeedRangesOptions) ([]azcosmos.FeedRange, error) {
 	return []azcosmos.FeedRange{mockChangeFeedFeedRange}, nil
 }
 

--- a/internal/databasetesting/mock_fleet_client.go
+++ b/internal/databasetesting/mock_fleet_client.go
@@ -117,8 +117,8 @@ func (m *MockFleetDBClient) ReadChangeFeed(ctx context.Context, options *azcosmo
 	if options != nil && options.Continuation != nil {
 		continuation = *options.Continuation
 	}
-	docs, nextToken, hasNew := m.changeFeed.read(continuation)
-	return buildMockChangeFeedResponse(docs, nextToken, hasNew), nil
+	items, nextToken, hasNew := m.changeFeed.read(continuation)
+	return buildMockChangeFeedResponse(items, nextToken, hasNew), nil
 }
 
 func (m *MockFleetDBClient) ReadFeedRanges(ctx context.Context, options *azcosmos.FeedRangesOptions) ([]azcosmos.FeedRange, error) {

--- a/internal/databasetesting/mock_kube_applier_client.go
+++ b/internal/databasetesting/mock_kube_applier_client.go
@@ -188,7 +188,7 @@ func (m *MockKubeApplierDBClient) UntypedCRUD(parentResourceID azcorearm.Resourc
 	return &mockKubeApplierUntypedCRUD{store: m, parentResourceID: parentResourceID}, nil
 }
 
-func (m *MockKubeApplierDBClient) GetChangeFeed(ctx context.Context, options *azcosmos.ChangeFeedOptions) (azcosmos.ChangeFeedResponse, error) {
+func (m *MockKubeApplierDBClient) ReadChangeFeed(ctx context.Context, options *azcosmos.ChangeFeedOptions) (azcosmos.ChangeFeedResponse, error) {
 	var continuation string
 	if options != nil && options.Continuation != nil {
 		continuation = *options.Continuation
@@ -197,7 +197,7 @@ func (m *MockKubeApplierDBClient) GetChangeFeed(ctx context.Context, options *az
 	return buildMockChangeFeedResponse(docs, nextToken, hasNew), nil
 }
 
-func (m *MockKubeApplierDBClient) GetFeedRanges(ctx context.Context) ([]azcosmos.FeedRange, error) {
+func (m *MockKubeApplierDBClient) ReadFeedRanges(ctx context.Context, options *azcosmos.FeedRangesOptions) ([]azcosmos.FeedRange, error) {
 	return []azcosmos.FeedRange{mockChangeFeedFeedRange}, nil
 }
 

--- a/internal/databasetesting/mock_kube_applier_client.go
+++ b/internal/databasetesting/mock_kube_applier_client.go
@@ -193,8 +193,8 @@ func (m *MockKubeApplierDBClient) ReadChangeFeed(ctx context.Context, options *a
 	if options != nil && options.Continuation != nil {
 		continuation = *options.Continuation
 	}
-	docs, nextToken, hasNew := m.changeFeed.read(continuation)
-	return buildMockChangeFeedResponse(docs, nextToken, hasNew), nil
+	items, nextToken, hasNew := m.changeFeed.read(continuation)
+	return buildMockChangeFeedResponse(items, nextToken, hasNew), nil
 }
 
 func (m *MockKubeApplierDBClient) ReadFeedRanges(ctx context.Context, options *azcosmos.FeedRangesOptions) ([]azcosmos.FeedRange, error) {

--- a/internal/databasetesting/mock_resources_changefeed.go
+++ b/internal/databasetesting/mock_resources_changefeed.go
@@ -33,16 +33,16 @@ import (
 // as Replace operations) ARE recorded via StoreDocument.
 type mockChangeFeed struct {
 	mu     sync.Mutex
-	events []json.RawMessage
+	events [][]byte
 }
 
 // record appends a copy of data to the log. The copy isolates the
 // feed's history from any caller-side mutation of the underlying
 // byte slice.
-func (m *mockChangeFeed) record(data json.RawMessage) {
+func (m *mockChangeFeed) record(data []byte) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	cp := make(json.RawMessage, len(data))
+	cp := make([]byte, len(data))
 	copy(cp, data)
 	m.events = append(m.events, cp)
 }
@@ -51,7 +51,7 @@ func (m *mockChangeFeed) record(data json.RawMessage) {
 // (0 if blank/unparseable) and the next position token to hand back
 // to the consumer. hasNew tells the caller whether to report 200 OK
 // or 304 Not Modified upstream.
-func (m *mockChangeFeed) read(continuation string) (docs []json.RawMessage, nextToken string, hasNew bool) {
+func (m *mockChangeFeed) read(continuation string) (items [][]byte, nextToken string, hasNew bool) {
 	start := decodeMockChangeFeedPosition(continuation)
 
 	m.mu.Lock()
@@ -61,7 +61,7 @@ func (m *mockChangeFeed) read(continuation string) (docs []json.RawMessage, next
 		return nil, strconv.Itoa(start), false
 	}
 
-	out := make([]json.RawMessage, len(m.events)-start)
+	out := make([][]byte, len(m.events)-start)
 	copy(out, m.events[start:])
 	return out, strconv.Itoa(len(m.events)), true
 }
@@ -111,7 +111,7 @@ func decodeMockChangeFeedPosition(s string) int {
 // call to GetCompositeContinuationToken — by populating ResourceID,
 // FeedRange, and the response ETag (which the SDK threads into the
 // composite token).
-func buildMockChangeFeedResponse(docs []json.RawMessage, nextToken string, hasNew bool) azcosmos.ChangeFeedResponse {
+func buildMockChangeFeedResponse(items [][]byte, nextToken string, hasNew bool) azcosmos.ChangeFeedResponse {
 	status := http.StatusNotModified
 	if hasNew {
 		status = http.StatusOK
@@ -119,7 +119,7 @@ func buildMockChangeFeedResponse(docs []json.RawMessage, nextToken string, hasNe
 	fr := mockChangeFeedFeedRange
 	return azcosmos.ChangeFeedResponse{
 		ResourceID: "mock-resources-container",
-		Documents:  docs,
+		Items:      items,
 		FeedRange:  &fr,
 		Response: azcosmos.Response{
 			RawResponse: &http.Response{StatusCode: status},

--- a/internal/databasetesting/mock_resources_db_client.go
+++ b/internal/databasetesting/mock_resources_db_client.go
@@ -140,13 +140,13 @@ func (m *MockResourcesDBClient) ServiceProviderNodePools(subscriptionID, resourc
 	return newMockServiceProviderNodePoolCRUD(m, nodePoolResourceID)
 }
 
-// GetChangeFeed reads the in-memory change-feed log. Each
+// ReadChangeFeed reads the in-memory change-feed log. Each
 // successful StoreDocument call records a snapshot of the document;
 // reads return everything past the position encoded in
 // options.Continuation. Hard deletes are not recorded, which mirrors
 // "latest version" mode in real Cosmos DB. Soft deletes go through
 // StoreDocument and are therefore recorded.
-func (m *MockResourcesDBClient) GetChangeFeed(ctx context.Context, options *azcosmos.ChangeFeedOptions) (azcosmos.ChangeFeedResponse, error) {
+func (m *MockResourcesDBClient) ReadChangeFeed(ctx context.Context, options *azcosmos.ChangeFeedOptions) (azcosmos.ChangeFeedResponse, error) {
 	var continuation string
 	if options != nil && options.Continuation != nil {
 		continuation = *options.Continuation
@@ -155,11 +155,11 @@ func (m *MockResourcesDBClient) GetChangeFeed(ctx context.Context, options *azco
 	return buildMockChangeFeedResponse(docs, nextToken, hasNew), nil
 }
 
-// GetFeedRanges returns the single feed range the mock
+// ReadFeedRanges returns the single feed range the mock
 // advertises. Real Cosmos may report many ranges; one is enough for
 // the in-memory mock because there is no partition-level parallelism
 // to model.
-func (m *MockResourcesDBClient) GetFeedRanges(ctx context.Context) ([]azcosmos.FeedRange, error) {
+func (m *MockResourcesDBClient) ReadFeedRanges(ctx context.Context, options *azcosmos.FeedRangesOptions) ([]azcosmos.FeedRange, error) {
 	return []azcosmos.FeedRange{mockChangeFeedFeedRange}, nil
 }
 
@@ -243,7 +243,7 @@ func (m *MockResourcesDBClient) ListAllDocuments(ctx context.Context) ([]*databa
 
 // StoreDocument stores a raw JSON document in the mock database and
 // appends it to the in-memory change-feed log so that consumers of
-// GetChangeFeed see the mutation.
+// ReadChangeFeed see the mutation.
 func (m *MockResourcesDBClient) StoreDocument(cosmosID string, data json.RawMessage) {
 	m.mu.Lock()
 	m.documents[strings.ToLower(cosmosID)] = data

--- a/internal/databasetesting/mock_resources_db_client.go
+++ b/internal/databasetesting/mock_resources_db_client.go
@@ -151,8 +151,8 @@ func (m *MockResourcesDBClient) ReadChangeFeed(ctx context.Context, options *azc
 	if options != nil && options.Continuation != nil {
 		continuation = *options.Continuation
 	}
-	docs, nextToken, hasNew := m.changeFeed.read(continuation)
-	return buildMockChangeFeedResponse(docs, nextToken, hasNew), nil
+	items, nextToken, hasNew := m.changeFeed.read(continuation)
+	return buildMockChangeFeedResponse(items, nextToken, hasNew), nil
 }
 
 // ReadFeedRanges returns the single feed range the mock

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -6,7 +6,7 @@ require (
 	dario.cat/mergo v1.0.1
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
-	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7
+	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/evanphx/json-patch v5.9.11+incompatible

--- a/internal/go.sum
+++ b/internal/go.sum
@@ -6,8 +6,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpz
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1/go.mod h1:IYus9qsFobWIc2YVwe/WPjcnyCkPKtnHAqUYeebc8z0=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 h1:xFaZZ+IubdftrDHnGGwZ6QvQ3KHTtWl2MCK+GMt2vxs=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0/go.mod h1:mCBhUhlMjLLJKr5aqw2TNS/VqJOie8MzWq3DAMJeKso=
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7 h1:8jCpUsqk6zRiGzPGxWbYoOAYEDWMEJhAzgaBKkpWe30=
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7/go.mod h1:MIyTWizpwnsX4LS9/tW1II9JL+D25Ypzj6URaT9NcgQ=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0 h1:wtCn7MemMD9eo4/NdpJ6S/MFD2BV2CDwoEfvl5th2vM=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0/go.mod h1:MIyTWizpwnsX4LS9/tW1II9JL+D25Ypzj6URaT9NcgQ=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=

--- a/kube-applier/go.mod
+++ b/kube-applier/go.mod
@@ -22,7 +22,7 @@ require (
 	cel.dev/expr v0.25.1 // indirect
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect

--- a/kube-applier/go.sum
+++ b/kube-applier/go.sum
@@ -8,8 +8,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpz
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1/go.mod h1:IYus9qsFobWIc2YVwe/WPjcnyCkPKtnHAqUYeebc8z0=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 h1:xFaZZ+IubdftrDHnGGwZ6QvQ3KHTtWl2MCK+GMt2vxs=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0/go.mod h1:mCBhUhlMjLLJKr5aqw2TNS/VqJOie8MzWq3DAMJeKso=
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7 h1:8jCpUsqk6zRiGzPGxWbYoOAYEDWMEJhAzgaBKkpWe30=
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7/go.mod h1:MIyTWizpwnsX4LS9/tW1II9JL+D25Ypzj6URaT9NcgQ=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0 h1:wtCn7MemMD9eo4/NdpJ6S/MFD2BV2CDwoEfvl5th2vM=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0/go.mod h1:MIyTWizpwnsX4LS9/tW1II9JL+D25Ypzj6URaT9NcgQ=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=

--- a/test-integration/backend/changefeed/changefeed_test.go
+++ b/test-integration/backend/changefeed/changefeed_test.go
@@ -222,7 +222,7 @@ func TestChangeFeedListWatcher(t *testing.T) {
 				// Now write a bunch of *other* resource types under the
 				// same subscription. None of these should surface on the
 				// cluster watcher, and none should panic the type filter
-				// or the deserialization path inside processDocument.
+				// or the deserialization path inside processItem.
 				nodePoolRID := env.uniqueNodePoolResourceID(clusterRID, "np-a")
 				createdNP := env.createNodePool(t, nodePoolRID)
 				env.replaceNodePool(t, createdNP)

--- a/test-integration/go.mod
+++ b/test-integration/go.mod
@@ -138,7 +138,7 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7
+	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect

--- a/test-integration/go.sum
+++ b/test-integration/go.sum
@@ -11,8 +11,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpz
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1/go.mod h1:IYus9qsFobWIc2YVwe/WPjcnyCkPKtnHAqUYeebc8z0=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 h1:xFaZZ+IubdftrDHnGGwZ6QvQ3KHTtWl2MCK+GMt2vxs=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0/go.mod h1:mCBhUhlMjLLJKr5aqw2TNS/VqJOie8MzWq3DAMJeKso=
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7 h1:8jCpUsqk6zRiGzPGxWbYoOAYEDWMEJhAzgaBKkpWe30=
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7/go.mod h1:MIyTWizpwnsX4LS9/tW1II9JL+D25Ypzj6URaT9NcgQ=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0 h1:wtCn7MemMD9eo4/NdpJ6S/MFD2BV2CDwoEfvl5th2vM=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0/go.mod h1:MIyTWizpwnsX4LS9/tW1II9JL+D25Ypzj6URaT9NcgQ=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0 h1:Hp+EScFOu9HeCbeW8WU2yQPJd4gGwhMgKxWe+G6jNzw=

--- a/test/go.mod
+++ b/test/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/Azure/ARO-Tools/tools/registration v0.0.0-20260729121920-58ceb447fbb3 // indirect
 	github.com/Azure/ARO-Tools/tools/secret-sync v0.0.0-20260729121920-58ceb447fbb3 // indirect
 	github.com/Azure/ARO-Tools/tools/yamlwrap v0.0.0-20260729121920-58ceb447fbb3 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice v1.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dashboard/armdashboard/v2 v2.0.0 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -96,8 +96,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpz
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1/go.mod h1:IYus9qsFobWIc2YVwe/WPjcnyCkPKtnHAqUYeebc8z0=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 h1:xFaZZ+IubdftrDHnGGwZ6QvQ3KHTtWl2MCK+GMt2vxs=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0/go.mod h1:mCBhUhlMjLLJKr5aqw2TNS/VqJOie8MzWq3DAMJeKso=
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7 h1:8jCpUsqk6zRiGzPGxWbYoOAYEDWMEJhAzgaBKkpWe30=
-github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0-beta.7/go.mod h1:MIyTWizpwnsX4LS9/tW1II9JL+D25Ypzj6URaT9NcgQ=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0 h1:wtCn7MemMD9eo4/NdpJ6S/MFD2BV2CDwoEfvl5th2vM=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.5.0/go.mod h1:MIyTWizpwnsX4LS9/tW1II9JL+D25Ypzj6URaT9NcgQ=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2 v2.0.2 h1:EBiOwZYJUMsjLGJ9x0oNY6ADf+5915P/jhhVcn42KXc=


### PR DESCRIPTION
Move from the beta version to the corresponding GA version, which was released on 2026-07-13.

The new version introduced some breaking changes. This PR contains additional commits with the fixes to solve the breaking changes. The fixes this PR makes are:

```
fix: azcosmos breaking changes renames and function parameters

When updating the azure cosmos library from v1.5.0-beta.7 to v1.5.0
the following breaking changes occurred:
- GetFeedRanges has been renamed to ReadFeedRanges
- GetChangeFeed has been renamed to ReadChangeFeed
- The ReadFeedRanges method now has a new *FeedRangesOptions parameter

This commit fixes those breaking changes. Because we have abstractions
on top of those methods we also renamed our interfaces to match the new
names, as well as add *FeedRangesOptions parameter to our interface of
ReadFeedRanges.
```

```
When updating the azure cosmos library from v1.5.0-beta.7 to v1.5.0
the following breaking changes occurred:
- The ChangeFeedResponse.Documents attribute has been renamed
    to ChangeFeedResponse.Items
- The ChangeFeedResponse.Items type has changed from []json.RawMessage
    to [][]byte

This commit fies those breaking changes by renaming the references
as well as changing the places where its type is referenced from
[]json.RawMessage to [][]byte.
```

The changelog of the new version is: https://github.com/Azure/azure-sdk-for-go/releases/tag/sdk%2Fdata%2Fazcosmos%2Fv1.5.0