### PR TITLE
fix: relax ACM/MCE infra node scheduling to soft preference

### DIFF
--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/grc/templates/grc-policy-addon-controller.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/grc/templates/grc-policy-addon-controller.yaml
@@ -37,6 +37,10 @@ spec:
                 - ppc64le
                 - s390x
                 - arm64
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
               - key: aro-hcp.azure.com/role
                 operator: In
                 values:

--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/grc/templates/grc-policy-propagator.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/grc/templates/grc-policy-propagator.yaml
@@ -40,6 +40,10 @@ spec:
                 - ppc64le
                 - s390x
                 - arm64
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
               - key: aro-hcp.azure.com/role
                 operator: In
                 values:

--- a/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-operator.deployment.yaml
+++ b/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-operator.deployment.yaml
@@ -25,6 +25,15 @@ spec:
         ocm-antiaffinity-selector: backplane-operator
     spec:
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: aro-hcp.azure.com/role
+                operator: In
+                values:
+                - infra
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
@@ -171,8 +180,6 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
-      nodeSelector:
-        aro-hcp.azure.com/role: infra
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce.yaml
+++ b/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce.yaml
@@ -3461,6 +3461,15 @@ spec:
         ocm-antiaffinity-selector: backplane-operator
     spec:
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: aro-hcp.azure.com/role
+                operator: In
+                values:
+                - infra
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
@@ -3607,8 +3616,6 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
-      nodeSelector:
-        aro-hcp.azure.com/role: infra
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_config.yaml
+++ b/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_config.yaml
@@ -2022,6 +2022,10 @@ spec:
                 - ppc64le
                 - s390x
                 - arm64
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
               - key: aro-hcp.azure.com/role
                 operator: In
                 values:
@@ -2146,6 +2150,10 @@ spec:
                 - ppc64le
                 - s390x
                 - arm64
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
               - key: aro-hcp.azure.com/role
                 operator: In
                 values:


### PR DESCRIPTION
## Why

[AROSLSRE-1428](https://redhat.atlassian.net/browse/AROSLSRE-1428)

When infra nodes are at capacity, ACM/MCE operator and policy controller pods get stuck in Pending because they have hard `nodeSelector` / `requiredDuringScheduling` constraints pinning them to infra nodes. These are critical management-plane controllers — if they can't schedule, cluster lifecycle operations stall.

## What

Relax the infra node scheduling constraint from a hard requirement to a soft preference (`preferredDuringSchedulingIgnoredDuringExecution`, weight 100) for the three deployments we directly control:

- **grc-policy-addon-controller** — `aro-hcp.azure.com/role: infra` moved from `requiredDuringScheduling` to `preferredDuringScheduling` (note: the diff looks like a 4-line addition, but it is actually a structural move — the role expression is re-parented from the required block to the preferred block)
- **grc-policy-propagator** — same change
- **multicluster-engine-operator** — `nodeSelector` replaced with `preferredDuringScheduling` nodeAffinity

Tolerations are unchanged — pods can still schedule on tainted infra nodes.

### Intentionally unchanged

The `MultiClusterEngine` CR, `AddOnDeploymentConfig`, `KlusterletConfig`, and `cluster-lifecycle` values still carry hard `nodeSelector: aro-hcp.azure.com/role: infra`. This is intentional: the `MultiClusterEngine` CRD only supports `spec.nodeSelector` (a simple label map) and `spec.tolerations` — it has no `spec.affinity` field, so there is no way to express a soft preference through it. The same applies to the other CRD-managed resources.

This means under temporary infra node capacity pressure, the three operators will schedule elsewhere while their managed agents/addons remain on infra nodes. If infra nodes are completely absent, only the operators run — their managed workloads will stay Pending until infra capacity returns.

## Test plan

- [x] Helm fixture tests pass (`make -C config materialize`)
- [ ] Verify in dev environment that pods prefer infra nodes under normal conditions
- [ ] Verify pods schedule on worker nodes when infra nodes are at capacity


🤖 Generated with [Claude Code](https://claude.com/claude-code)