### PR TITLE
fix(config): distinguish stg subscription display names from prod

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -74,6 +74,19 @@ clouds:
               # the uksouth hcp-stg-uk-* cluster.
               kustoName: "hcp-{{ .ctx.environment }}-us-1"
         defaults:
+          # Carry the environment in the subscription display names for stage, so the
+          # stg subscriptions are distinguishable from the identically-named prod ones.
+          # The base config.yaml default omits the environment (that stays as prod);
+          # this only overrides stage, matching the global sub which already includes it.
+          svc:
+            subscription:
+              displayName: "Azure Red Hat OpenShift HCP - {{ .ctx.environment }} - {{ .ev2.regionFriendlyName }} - SVC"
+          mgmt:
+            subscription:
+              displayName: "Azure Red Hat OpenShift HCP - {{ .ctx.environment }} - {{ .ev2.regionFriendlyName }} - MGMT - {{ .ctx.stamp }}"
+          serviceKeyVault:
+            subscription:
+              displayName: "Azure Red Hat OpenShift HCP - {{ .ctx.environment }} - {{ .ev2.regionFriendlyName }} - SVC"
           # This must be defined here, so our ci jobs can know this
           kusto:
             kustoName: "hcp-stg-uk-2"

--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -76,7 +76,7 @@ clouds:
         defaults:
           # Carry the environment in the subscription display names for stage, so the
           # stg subscriptions are distinguishable from the identically-named prod ones.
-          # The base config.yaml default omits the environment (that stays as prod);
+          # The base config.yaml default omits the environment, so prod is unchanged;
           # this only overrides stage, matching the global sub which already includes it.
           svc:
             subscription:


### PR DESCRIPTION
## Why

Bringing up the new STG region (westus3) surfaced that the stage subscription display names render identically to prod. For example both stage and prod produce `Azure Red Hat OpenShift HCP - West US 3 - MGMT - 1` and `... - West US 3 - SVC`, with nothing to tell the environments apart in the Azure portal / subscription lists. The global subscription already carries the environment (`... - stg - Global`), the SVC, MGMT and serviceKeyVault subscriptions did not.

## What

Add stage-only overrides in `config.msft.clouds-overlay.yaml` that prepend the environment to the SVC, MGMT and serviceKeyVault subscription display names:

- `Azure Red Hat OpenShift HCP - stg - West US 3 - SVC`
- `Azure Red Hat OpenShift HCP - stg - West US 3 - MGMT - 1`

The base `config/config.yaml` default is left unchanged, so prod keeps its current names. This only touches the stage environment and applies to every stage region (uksouth and westus3), matching the pattern the global subscription already uses.

Verified with `templatize configuration render` for stg and prod (westus3 and uksouth): stg names now include `stg`, prod names are unchanged. No rendered files change in this repo since only the `dev` cloud is materialized here; the public rendered configs are produced in sdp-pipelines from this overlay.

Jira: https://redhat.atlassian.net/browse/AROSLSRE-1657
