### PR TITLE
fix(mgmt-agent): increase kube-state-metrics memory limit (AROSLSRE-1680)

### DIFF
--- a/mgmt-agent/pkg/controller/ksmhcp/resources.go
+++ b/mgmt-agent/pkg/controller/ksmhcp/resources.go
@@ -122,10 +122,10 @@ func buildDeployment(namespace, ksmImage, kubeconfigSecretName, kubeconfigKey st
 						WithResources(coreac.ResourceRequirements().
 							WithRequests(corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("10m"),
-								corev1.ResourceMemory: resource.MustParse("32Mi"),
+								corev1.ResourceMemory: resource.MustParse("64Mi"),
 							}).
 							WithLimits(corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("64Mi"),
+								corev1.ResourceMemory: resource.MustParse("128Mi"),
 							})).
 						WithVolumeMounts(
 							coreac.VolumeMount().

--- a/mgmt-agent/pkg/controller/ksmhcp/testdata/zz_fixture_TestBuildDeployment.yaml
+++ b/mgmt-agent/pkg/controller/ksmhcp/testdata/zz_fixture_TestBuildDeployment.yaml
@@ -51,10 +51,10 @@ spec:
           timeoutSeconds: 5
         resources:
           limits:
-            memory: 64Mi
+            memory: 128Mi
           requests:
             cpu: 10m
-            memory: 32Mi
+            memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
<!-- Link to Jira issue -->
[AROSLSRE-1680](https://redhat.atlassian.net/browse/AROSLSRE-1680)

### What

Increase the kube-state-metrics HCP memory request from 32Mi to 64Mi and the limit from 64Mi to 128Mi.

### Why

The Canada Central investigation found repeated `OOMKilled` exits with code 137. The node and the kubelet-parameter DaemonSet were healthy, so the 64Mi container limit was the actionable issue. The full JIT audit log is attached to [AROSLSRE-1680](https://redhat.atlassian.net/browse/AROSLSRE-1680).

### Testing

- Unit tests: `cd mgmt-agent && go test ./pkg/controller/ksmhcp`
- Integration tests: Not run, this changes controller resource sizing only.
- E2E tests: Not run, this changes controller resource sizing only.

### Special notes for your reviewer

Before evidence, from `prod-canadacentral-mgmt-1` on 2026-07-31:

```text
NAMESPACE                     NAME                                      READY  STATUS             RESTARTS
ocm-arohcpprod-...-arohcp4    kube-state-metrics-hcp-7956654957-sgjtm   0/1    CrashLoopBackOff   777
ocm-arohcpprod-...-e1j0m8...  kube-state-metrics-hcp-7956654957-nqcjq   0/1    CrashLoopBackOff   777

Last State:  Terminated
  Reason:    OOMKilled
  Exit Code: 137
Limits:
  memory: 64Mi
```

The kernel logged 3001 OOMKilling events for `kube-state-metr` over 2d18h on that node, while the node itself stayed `Ready` with no memory pressure (11.7 GiB used of 256 GiB). So this is a container cgroup limit, not node exhaustion. The pod starts, syncs with the HCP kube-apiserver, binds both ports and is then killed within a second, so it never fits in 64Mi.

There is no "after" graph yet since the new sizing only takes effect once mgmt-agent rolls out. I'll track restart counts and OOMKills after rollout and raise the limit to 256Mi if it is still not enough. Full JIT audit log is attached to [AROSLSRE-1680](https://redhat.atlassian.net/browse/AROSLSRE-1680).

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
