### PR TITLE
feat: route opstool alerts to PagerDuty

### DIFF
--- a/dev-infrastructure/configurations/opstool-alerting.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/opstool-alerting.tmpl.bicepparam
@@ -1,4 +1,4 @@
 using '../templates/opstool-alerting.bicep'
 
-param alertEmail = '{{ .opstool.alerting.email }}'
+param workloadKVName = '{{ .opstool.keyVault.name }}'
 param alertingEnabled = {{ .opstool.alerting.enabled }}

--- a/dev-infrastructure/modules/keyvault/keyvault.bicep
+++ b/dev-infrastructure/modules/keyvault/keyvault.bicep
@@ -10,6 +10,9 @@ param enableSoftDelete bool
 @description('Toggle to make the keyvault private.')
 param private bool
 
+@description('Allow ARM deployments to retrieve secrets from the Key Vault.')
+param enabledForTemplateDeployment bool = false
+
 @description('Tag key for the keyvault.')
 param tagKey string
 
@@ -36,7 +39,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2024-04-01-preview' = {
     enableRbacAuthorization: true
     enabledForDeployment: false
     enabledForDiskEncryption: false
-    enabledForTemplateDeployment: false
+    enabledForTemplateDeployment: enabledForTemplateDeployment
     enableSoftDelete: enableSoftDelete
     publicNetworkAccess: private ? 'Disabled' : 'Enabled'
     sku: {

--- a/dev-infrastructure/modules/metrics/pagerduty-actiongroup.bicep
+++ b/dev-infrastructure/modules/metrics/pagerduty-actiongroup.bicep
@@ -1,0 +1,25 @@
+@description('PagerDuty Microsoft Azure integration URL.')
+@secure()
+param integrationUrl string
+
+@description('Enable or disable alerting.')
+param alertingEnabled bool
+
+resource pagerDutyActionGroup 'Microsoft.Insights/actionGroups@2024-10-01-preview' = {
+  name: 'opstool-pagerduty'
+  location: 'global'
+  properties: {
+    enabled: alertingEnabled
+    groupShortName: 'opstool-pd'
+    webhookReceivers: [
+      {
+        name: 'pagerduty'
+        serviceUri: integrationUrl
+        useCommonAlertSchema: false
+      }
+    ]
+  }
+}
+
+output actionGroupId string = pagerDutyActionGroup.id
+output actionGroupName string = pagerDutyActionGroup.name

--- a/dev-infrastructure/templates/opstool-alerting.bicep
+++ b/dev-infrastructure/templates/opstool-alerting.bicep
@@ -1,28 +1,22 @@
 // Shared alerting infrastructure for the opstool environment
-// This creates a shared email action group that can be used by all apps in the cluster
 
-@description('Email address for alert notifications')
-param alertEmail string
+@description('Name of the opstool workload Key Vault')
+param workloadKVName string
 
 @description('Enable or disable alerting')
 param alertingEnabled bool = true
 
-// Shared Email Action Group for all opstool alerts
-resource emailActionGroup 'Microsoft.Insights/actionGroups@2024-10-01-preview' = {
-  name: 'opstool-email-alerts'
-  location: 'global'
-  properties: {
-    enabled: alertingEnabled
-    groupShortName: 'opstool-ag'
-    emailReceivers: [
-      {
-        name: 'primary-contact'
-        emailAddress: alertEmail
-        useCommonAlertSchema: true
-      }
-    ]
+resource workloadKV 'Microsoft.KeyVault/vaults@2024-04-01-preview' existing = {
+  name: workloadKVName
+}
+
+module pagerDutyActionGroup '../modules/metrics/pagerduty-actiongroup.bicep' = {
+  name: 'opstool-pagerduty-action-group'
+  params: {
+    alertingEnabled: alertingEnabled
+    integrationUrl: workloadKV.getSecret('pagerduty-azure-integration-url')
   }
 }
 
-output actionGroupId string = emailActionGroup.id
-output actionGroupName string = emailActionGroup.name
+output actionGroupId string = pagerDutyActionGroup.outputs.actionGroupId
+output actionGroupName string = pagerDutyActionGroup.outputs.actionGroupName

--- a/dev-infrastructure/templates/opstool-cluster.bicep
+++ b/dev-infrastructure/templates/opstool-cluster.bicep
@@ -341,6 +341,7 @@ module workloadKV '../modules/keyvault/keyvault.bicep' = {
     keyVaultName: workloadKVName
     enableSoftDelete: false
     private: false
+    enabledForTemplateDeployment: true
     tagKey: 'aroHCPPurpose'
     tagValue: 'opstool-workload-secrets'
   }

--- a/dev-infrastructure/templates/output-opstool-cluster.bicep
+++ b/dev-infrastructure/templates/output-opstool-cluster.bicep
@@ -58,12 +58,12 @@ resource azureMonitorWorkspace 'Microsoft.Monitor/accounts@2023-04-03' existing 
   name: azureMonitorWorkspaceName
 }
 
-resource sharedActionGroup 'Microsoft.Insights/actionGroups@2024-10-01-preview' existing = {
-  name: 'opstool-email-alerts'
+resource pagerDutyActionGroup 'Microsoft.Insights/actionGroups@2024-10-01-preview' existing = {
+  name: 'opstool-pagerduty'
 }
 
 output aksClusterName string = aksClusterName
-output sharedActionGroupId string = sharedActionGroup.id
+output sharedActionGroupId string = pagerDutyActionGroup.id
 output azureMonitorWorkspaceId string = azureMonitorWorkspace.id
 output workloadKVName string = workloadKV.name
 output workloadKVUrl string = workloadKV.properties.vaultUri

--- a/docs/ci/quota-monitoring.md
+++ b/docs/ci/quota-monitoring.md
@@ -47,7 +47,7 @@ The quickest way to check current quota usage is the [Azure Quota Dashboard](htt
 
 ## Alerts
 
-Alert rules are defined in `tooling/tenant-quota/alerting.bicep` and deployed into the `opstool` Azure Monitor Workspace. Notifications go through the shared `opstool-email-alerts` Action Group. The primary alert fires when no metrics have been received for an extended period, which typically indicates a collector pod issue or an expired service principal credential.
+Alert rules are defined in `tooling/tenant-quota/alerting.bicep` and deployed into the `opstool` Azure Monitor Workspace. Notifications go through the shared `opstool-pagerduty` Action Group, whose sole receiver is the low-urgency ARO HCP DEV CI PagerDuty service. PagerDuty posts incident updates to the team Slack channel without paging an engineer. The webhook URL is read from the `pagerduty-azure-integration-url` secret in the opstool Key Vault. The primary alert fires when no metrics have been received for an extended period, which typically indicates a collector pod issue or an expired service principal credential.
 
 ## When Quota Is Tight
 

--- a/docs/ops/opstool-cluster-guide.md
+++ b/docs/ops/opstool-cluster-guide.md
@@ -103,7 +103,7 @@ Observability in `opstool` is intentionally simple:
 - In-cluster Prometheus is deployed by the infra pipeline.
 - Prometheus remote writes metrics into the standalone `opstool` Azure Monitor Workspace.
 - Alerting is defined in Azure Monitor Prometheus rule groups, not in-cluster `PrometheusRule` objects.
-- All workloads share the `opstool-email-alerts` Action Group for notifications.
+- The tenant-quota alert deployment uses the shared `opstool-pagerduty` Action Group for low-urgency incident management and Slack notifications.
 
 When adding workload monitoring:
 

--- a/docs/ops/opstool-cluster-guide.md
+++ b/docs/ops/opstool-cluster-guide.md
@@ -67,7 +67,7 @@ The infra template provisions:
 - A workload Key Vault for app secrets.
 - A dedicated Azure Monitor Workspace for the cluster.
 - Data collection resources for Prometheus remote write into Azure Monitor.
-- A shared email Action Group for alert notifications.
+- A shared PagerDuty Action Group for alert notifications.
 - Shared user-assigned managed identities already used by the cluster, such as `opstool`, `prometheus`, and `tenant-quota`.
 
 The output template `dev-infrastructure/templates/output-opstool-cluster.bicep` exposes the shared values that child workload pipelines consume, including:

--- a/tooling/tenant-quota/README.md
+++ b/tooling/tenant-quota/README.md
@@ -86,7 +86,7 @@ In short, a Key Vault secret update can be picked up without restarting the pod,
 
 ## Alerts
 
-Alert rules are defined in `alerting.bicep` and deployed into the `opstool` Azure Monitor Workspace. Notifications use the shared `opstool-email-alerts` Action Group provided by the `DevCI.Unprivileged` rollout.
+Alert rules are defined in `alerting.bicep` and deployed into the `opstool` Azure Monitor Workspace. Notifications use the shared `opstool-pagerduty` Action Group provided by the `DevCI.Unprivileged` rollout.
 
 ## Local Development
 


### PR DESCRIPTION
No tracking issue exists; this is an operational integration requested for the DEV CI alerting setup.

### What

- replace the opstool email action group with `opstool-pagerduty`
- retrieve the PagerDuty Microsoft Azure integration URL securely from the opstool Key Vault
- retain the existing `sharedActionGroupId` output contract used by tenant-quota alerts
- document the PagerDuty and Slack notification path

### Why

DEV CI alerts need incident lifecycle management and 24x7 Slack visibility without paging individual engineers. Keeping the PagerDuty routing key in Key Vault prevents the secret from entering repository configuration or generated deployment artifacts.

### Testing

- `az bicep build --file dev-infrastructure/templates/opstool-alerting.bicep --stdout`
- `az bicep build --file dev-infrastructure/templates/opstool-cluster.bicep --stdout`
- `az bicep build --file dev-infrastructure/templates/output-opstool-cluster.bicep --stdout`
- `make validate-config-pipelines`

No automated test was added because this change configures Azure Monitor and Key Vault resources rather than application behavior. End-to-end verification requires deploying the action group and firing a DEV CI alert.

Reviewer: @raelga

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Absence of a tracking ticket is explained
- [x] Screenshots included or applicability explained
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge
