### PR TITLE
test: reintroduce e2e test for private KAS (api.visibility: Private)

### DIFF
--- a/test-integration/go.mod
+++ b/test-integration/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Azure/ARO-HCP/internal v0.0.0-00010101000000-000000000000
 	github.com/Azure/ARO-HCP/kube-applier v0.0.0-00010101000000-000000000000
 	github.com/Azure/ARO-HCP/sessiongate v0.0.0-00010101000000-000000000000
-	github.com/Azure/ARO-HCP/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp v0.0.0-00010101000000-000000000000
+	github.com/Azure/ARO-HCP/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp v0.0.0-20260802080030-141a4c58b5ae
 	github.com/google/go-cmp v0.7.0
 	github.com/microsoft/go-otel-audit v0.2.2
 	github.com/openshift-online/ocm-api-model/clientapi v0.0.453

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -146,7 +146,7 @@ var _ = Describe("Authorized CIDRs", func() {
 
 				By("testing connectivity from current machine (should be blocked)")
 				// Try to connect from the test runner (which is not in authorized CIDRs)
-				err = framework.TestHTTPSConnectivity(ctx, apiURL+"/healthz", 5*time.Second)
+				err = framework.TestHTTPSConnectivity(ctx, apiURL+"/healthz", 5*time.Second, true)
 				Expect(err).To(HaveOccurred(), "Connection from unauthorized IP should be blocked")
 				GinkgoWriter.Printf("Connection from unauthorized IP address failed as expected on error: %v\n", err)
 

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -15,11 +15,9 @@ package e2e
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -34,7 +32,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 
 	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
@@ -90,46 +87,9 @@ var _ = Describe("Authorized CIDRs", func() {
 				)
 				Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for authorized CIDRs cluster")
 
-				By("generating SSH key pair for VM")
-				sshPublicKey, _, err := framework.GenerateSSHKeyPair()
-				Expect(err).NotTo(HaveOccurred(), "failed to generate SSH key pair for test VM")
-
 				By("deploying test VM")
-				vmName := fmt.Sprintf("%s-test-vm", clusterName)
-				// The test VM is a throwaway kubectl client: it only needs a public IP
-				// (used as the single authorized CIDR) and to make one API call to the
-				// cluster. We use a small general-purpose D-series SKU (resolved
-				// restriction-aware) rather than the burstable B-series, which is the
-				// SKU class most prone to regional SkuNotAvailable capacity
-				// restrictions, which is what flaked this test.
-				vmSize, err := tc.SelectVMSize(ctx, framework.JumpboxVMSizeSelector())
-				Expect(err).NotTo(HaveOccurred(), "failed to resolve a jumpbox VM size; check VM SKU restrictions/quota for the test subscription in %s", tc.Location())
-				var vmDeployment *armresources.DeploymentExtended
-				var deployErr error
-				// Bounded retry to absorb transient ARM errors, but fail fast on
-				// SkuNotAvailable: a regional capacity restriction is not transient, so
-				// re-submitting an identical request only burns the timeout budget.
-				for attempt := 0; attempt < 3; attempt++ {
-					vmDeployment, deployErr = tc.CreateBicepTemplateAndWait(ctx,
-						framework.WithTemplateFromFS(TestArtifactsFS, "test-artifacts/generated-test-artifacts/modules/test-vm.json"),
-						framework.WithDeploymentName("test-vm"),
-						framework.WithScope(framework.BicepDeploymentScopeResourceGroup),
-						framework.WithClusterResourceGroup(*resourceGroup.Name),
-						framework.WithParameters(map[string]any{
-							"vmName":       vmName,
-							"vnetName":     customerVnetName,
-							"subnetName":   customerVnetSubnetName,
-							"sshPublicKey": sshPublicKey,
-							"vmSize":       vmSize,
-						}),
-						framework.WithTimeout(30*time.Minute),
-					)
-					if deployErr == nil || strings.Contains(deployErr.Error(), "SkuNotAvailable") {
-						break
-					}
-					time.Sleep(20 * time.Second)
-				}
-				Expect(deployErr).NotTo(HaveOccurred(), "failed to deploy test VM")
+				vmName, vmDeployment, err := tc.DeployTestVM(ctx, TestArtifactsFS, *resourceGroup.Name, clusterName, customerVnetName, customerVnetSubnetName)
+				Expect(err).NotTo(HaveOccurred(), "failed to deploy test VM")
 
 				By("extracting VM public IP from deployment outputs")
 				vmPublicIP, err := framework.GetOutputValueString(vmDeployment, "publicIP")
@@ -186,7 +146,7 @@ var _ = Describe("Authorized CIDRs", func() {
 
 				By("testing connectivity from current machine (should be blocked)")
 				// Try to connect from the test runner (which is not in authorized CIDRs)
-				err = testAPIConnectivity(apiURL, 5*time.Second)
+				err = framework.TestHTTPSConnectivity(ctx, apiURL+"/healthz", 5*time.Second)
 				Expect(err).To(HaveOccurred(), "Connection from unauthorized IP should be blocked")
 				GinkgoWriter.Printf("Connection from unauthorized IP address failed as expected on error: %v\n", err)
 
@@ -456,33 +416,6 @@ var _ = Describe("Authorized CIDRs", func() {
 		)
 	})
 })
-
-// Helper to test API connectivity with timeout
-func testAPIConnectivity(apiURL string, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	// Simple HTTP GET to test connectivity
-	req, err := http.NewRequestWithContext(ctx, "GET", apiURL+"/healthz", nil)
-	if err != nil {
-		return err
-	}
-
-	client := &http.Client{
-		Timeout: timeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	return nil
-}
 
 func parseUnavailableResources(output string, skip ...string) []string {
 	skipSet := make(map[string]bool)

--- a/test/e2e/cluster_create_feature_aggregation.go
+++ b/test/e2e/cluster_create_feature_aggregation.go
@@ -222,7 +222,7 @@ var _ = Describe("Customer", func() {
 			// from the test runner to the cluster's public API endpoint should be rejected.
 			// Note: VNet-internal traffic (e.g. from the VM) bypasses this restriction, so
 			// the test runner is the only reliable "external" caller we can use here.
-			err = testAPIConnectivity(apiURL, 10*time.Second)
+			err = framework.TestHTTPSConnectivity(ctx, apiURL+"/healthz", 10*time.Second, true)
 			Expect(err).To(HaveOccurred(), "connection from test runner (IP %s, not in authorized CIDRs) should be blocked by cluster %q API server", testRunnerPublicIP, customerClusterName)
 			GinkgoWriter.Printf("Connection from test runner was correctly blocked: %v\n", err)
 

--- a/test/e2e/cluster_create_private_ingress.go
+++ b/test/e2e/cluster_create_private_ingress.go
@@ -172,7 +172,7 @@ var _ = Describe("Customer", func() {
 			}, 10*time.Minute, 15*time.Second).Should(Succeed())
 
 			By("verifying ingress is NOT reachable from outside the VNet")
-			err = framework.TestHTTPSConnectivity(ctx, appURL, 10*time.Second)
+			err = framework.TestHTTPSConnectivity(ctx, appURL, 10*time.Second, true)
 			Expect(err).To(HaveOccurred(),
 				"private ingress should not be reachable from outside the VNet, but connection succeeded")
 			GinkgoLogr.Info("Confirmed ingress is not reachable from outside the VNet")

--- a/test/e2e/cluster_create_private_ingress.go
+++ b/test/e2e/cluster_create_private_ingress.go
@@ -16,9 +16,7 @@ package e2e
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -111,37 +109,8 @@ var _ = Describe("Customer", func() {
 			GinkgoLogr.Info("Cluster created with private ingress", "clusterName", customerClusterName)
 
 			By("deploying test VM in the same VNet for connectivity verification")
-			sshPublicKey, _, err := framework.GenerateSSHKeyPair()
-			Expect(err).NotTo(HaveOccurred(), "failed to generate SSH key pair for test VM")
-
-			vmName := fmt.Sprintf("%s-test-vm", customerClusterName)
-			vmSize, err := tc.SelectVMSize(ctx, framework.JumpboxVMSizeSelector())
-			Expect(err).NotTo(HaveOccurred(), "failed to resolve a jumpbox VM size for private ingress test")
-
-			var deployErr error
-			for attempt := 0; attempt < 3; attempt++ {
-				if attempt > 0 {
-					time.Sleep(20 * time.Second)
-				}
-				_, deployErr = tc.CreateBicepTemplateAndWait(ctx,
-					framework.WithTemplateFromFS(TestArtifactsFS, "test-artifacts/generated-test-artifacts/modules/test-vm.json"),
-					framework.WithDeploymentName("test-vm"),
-					framework.WithScope(framework.BicepDeploymentScopeResourceGroup),
-					framework.WithClusterResourceGroup(*resourceGroup.Name),
-					framework.WithParameters(map[string]any{
-						"vmName":       vmName,
-						"vnetName":     clusterParams.VnetName,
-						"subnetName":   clusterParams.SubnetName,
-						"sshPublicKey": sshPublicKey,
-						"vmSize":       vmSize,
-					}),
-					framework.WithTimeout(30*time.Minute),
-				)
-				if deployErr == nil || strings.Contains(deployErr.Error(), "SkuNotAvailable") {
-					break
-				}
-			}
-			Expect(deployErr).NotTo(HaveOccurred(), "failed to deploy test VM for private ingress verification")
+			vmName, _, err := tc.DeployTestVM(ctx, TestArtifactsFS, *resourceGroup.Name, customerClusterName, clusterParams.VnetName, clusterParams.SubnetName)
+			Expect(err).NotTo(HaveOccurred(), "failed to deploy test VM for private ingress verification")
 
 			By("creating the node pool")
 			nodePoolParams := framework.NewDefaultNodePoolParams20260630()
@@ -203,41 +172,10 @@ var _ = Describe("Customer", func() {
 			}, 10*time.Minute, 15*time.Second).Should(Succeed())
 
 			By("verifying ingress is NOT reachable from outside the VNet")
-			err = testIngressConnectivity(ctx, appURL, 10*time.Second)
+			err = framework.TestHTTPSConnectivity(ctx, appURL, 10*time.Second)
 			Expect(err).To(HaveOccurred(),
 				"private ingress should not be reachable from outside the VNet, but connection succeeded")
 			GinkgoLogr.Info("Confirmed ingress is not reachable from outside the VNet")
 		},
 	)
 })
-
-// testIngressConnectivity attempts an HTTPS connection to the given URL.
-// Returns nil if the connection succeeds, or an error if it fails.
-// Redirects are disabled to avoid false positives from OAuth redirects.
-func testIngressConnectivity(ctx context.Context, url string, timeout time.Duration) error {
-	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(timeoutCtx, "GET", url, nil)
-	if err != nil {
-		return err
-	}
-
-	client := &http.Client{
-		Timeout: timeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	return nil
-}

--- a/test/e2e/cluster_create_private_kas.go
+++ b/test/e2e/cluster_create_private_kas.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hcpsdk20260630preview "github.com/Azure/ARO-HCP/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+)
+
+// This test creates a cluster with private KAS (api.visibility: Private) using
+// the v2026-06-30-preview API and verifies that:
+//   - The Kubernetes API server is only reachable from within the VNet
+//   - The default ingress remains public (independence of KAS and ingress visibility)
+var _ = Describe("Customer", func() {
+	It("should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public",
+		labels.RequireNothing,
+		labels.Critical,
+		labels.Positive,
+		labels.AroRpApiCompatible,
+		labels.CreateCluster,
+		labels.MIContainers(1),
+		func(ctx context.Context) {
+			const (
+				customerClusterName  = "private-kas"
+				customerNodePoolName = "np-1"
+			)
+
+			tc := framework.NewTestContext()
+
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
+			}
+
+			By("creating a resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "private-kas", tc.Location())
+			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for private KAS test")
+
+			By("creating cluster parameters with private API visibility")
+			clusterParams := framework.NewDefaultClusterParams20260630()
+			clusterParams.ClusterName = customerClusterName
+			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.APIVisibility = "Private"
+			// Private KAS requires OCP >= 4.22 (CS validation rejects lower versions)
+			clusterParams.OpenshiftVersionId = "4.22"
+
+			By("creating customer resources (infrastructure and managed identities)")
+			clusterParams, err = tc.CreateClusterCustomerResources20260630(ctx,
+				resourceGroup,
+				clusterParams,
+				map[string]interface{}{},
+				TestArtifactsFS,
+				framework.RBACScopeResourceGroup,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for private KAS cluster")
+
+			By("deploying test VM in customer VNet")
+			vmName, _, err := tc.DeployTestVM(ctx, TestArtifactsFS, *resourceGroup.Name, customerClusterName, clusterParams.VnetName, clusterParams.SubnetName)
+			Expect(err).NotTo(HaveOccurred(), "failed to deploy test VM for private KAS verification")
+
+			By("creating the HCP cluster with private KAS via v20260630preview")
+			err = tc.CreateHCPClusterFromParam20260630(ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				nil,
+				framework.ClusterCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with private KAS", customerClusterName)
+
+			By("verifying cluster API visibility is Private and ingress is Public via ARM GET")
+			clientFactory := tc.Get20260630ClientFactoryOrDie(ctx)
+			cluster, err := clientFactory.NewHcpOpenShiftClustersClient().Get(
+				ctx,
+				*resourceGroup.Name,
+				customerClusterName,
+				nil,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get cluster %q to verify private KAS", customerClusterName)
+			Expect(cluster.Properties).ToNot(BeNil(), "cluster %q Properties was nil", customerClusterName)
+
+			Expect(cluster.Properties.API).ToNot(BeNil(), "cluster %q Properties.API was nil", customerClusterName)
+			Expect(cluster.Properties.API.Visibility).ToNot(BeNil(), "cluster %q Properties.API.Visibility was nil", customerClusterName)
+			Expect(*cluster.Properties.API.Visibility).To(Equal(hcpsdk20260630preview.VisibilityPrivate),
+				"cluster %q API visibility should be Private", customerClusterName)
+			Expect(cluster.Properties.API.URL).ToNot(BeNil(), "cluster %q Properties.API.URL was nil", customerClusterName)
+			apiURL := *cluster.Properties.API.URL
+			GinkgoLogr.Info("Cluster created with private KAS", "clusterName", customerClusterName, "apiURL", apiURL)
+
+			Expect(cluster.Properties.Ingress).ToNot(BeNil(), "cluster %q Properties.Ingress was nil", customerClusterName)
+			Expect(cluster.Properties.Ingress.Type).ToNot(BeNil(), "cluster %q Properties.Ingress.Type was nil", customerClusterName)
+			Expect(*cluster.Properties.Ingress.Type).To(Equal(hcpsdk20260630preview.IngressTypePublic),
+				"cluster %q ingress type should be Public (private KAS must not affect ingress)", customerClusterName)
+
+			By("creating the node pool")
+			nodePoolParams := framework.NewDefaultNodePoolParams20260630()
+			nodePoolParams.ClusterName = customerClusterName
+			nodePoolParams.NodePoolName = customerNodePoolName
+			nodePoolParams.Replicas = int32(1)
+
+			err = tc.CreateNodePoolFromParam20260630(ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams.ManagedResourceGroupName,
+				customerClusterName,
+				nodePoolParams,
+				framework.NodePoolCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create node pool %q for private KAS cluster %q",
+				customerNodePoolName, customerClusterName)
+
+			By("verifying KAS is reachable from VM inside the VNet")
+			// Get admin credentials via ARM and override the server URL with
+			// the internal LB IP so kubectl on the VM connects through the
+			// private KAS endpoint.
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
+				ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				*resourceGroup.Name,
+				customerClusterName,
+				framework.GetAdminRESTConfigTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for private KAS cluster %q", customerClusterName)
+
+			internalIP, err := framework.GetPrivateKASInternalIP(ctx, tc, clusterParams.ManagedResourceGroupName)
+			Expect(err).NotTo(HaveOccurred(), "failed to find private KAS internal LB IP in managed resource group %q", clusterParams.ManagedResourceGroupName)
+			GinkgoLogr.Info("Found private KAS internal LB", "ip", internalIP, "managedRG", clusterParams.ManagedResourceGroupName)
+
+			adminRESTConfig.Host = fmt.Sprintf("https://%s:443", internalIP)
+
+			kubeconfig, err := framework.GenerateKubeconfig(adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to generate kubeconfig from admin REST config")
+			kubeconfigB64 := base64.StdEncoding.EncodeToString([]byte(kubeconfig))
+
+			// kubectl version hits /version (unauthenticated) through the
+			// internal LB. A successful response proves the private KAS
+			// network path (VM → customer subnet → internal LB → Swift →
+			// KAS pods) is functional.
+			versionCmd := fmt.Sprintf(
+				"echo '%s' | base64 -d > /tmp/kubeconfig && "+
+					"kubectl --kubeconfig=/tmp/kubeconfig version 2>/dev/null",
+				kubeconfigB64,
+			)
+			versionOutput, err := framework.RunVMCommand(ctx, tc, *resourceGroup.Name, vmName, versionCmd, 2*time.Minute)
+			Expect(err).NotTo(HaveOccurred(),
+				"kubectl version should succeed from VM via private KAS internal LB (output: %s)", versionOutput)
+			GinkgoLogr.Info("KAS is reachable from VM inside VNet", "output", versionOutput)
+
+			By("verifying KAS is NOT reachable from outside the VNet")
+			err = framework.TestHTTPSConnectivity(ctx, apiURL+"/healthz", 10*time.Second)
+			Expect(err).To(HaveOccurred(),
+				"private KAS should not be reachable from outside the VNet, but connection to %s succeeded", apiURL)
+			GinkgoLogr.Info("Confirmed KAS is not reachable from outside the VNet", "error", err)
+
+			By("verifying public ingress is reachable from outside the VNet")
+			// The OpenShift console is deployed by default on every cluster
+			// and served through the default ingress router. If the console
+			// URL is reachable from outside the VNet, it proves the default
+			// ingress is public — independent of private KAS.
+			hcpClient := clientFactory.NewHcpOpenShiftClustersClient()
+			var consoleURL string
+			Eventually(func(g Gomega) {
+				resp, err := hcpClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
+				g.Expect(err).NotTo(HaveOccurred(), "failed to get cluster %q for console URL", customerClusterName)
+				g.Expect(resp.Properties).ToNot(BeNil(), "cluster %q Properties was nil", customerClusterName)
+				g.Expect(resp.Properties.Console).ToNot(BeNil(), "cluster %q Properties.Console was nil", customerClusterName)
+				g.Expect(resp.Properties.Console.URL).ToNot(BeNil(), "cluster %q Properties.Console.URL was nil", customerClusterName)
+				consoleURL = *resp.Properties.Console.URL
+			}, 15*time.Minute, 30*time.Second).Should(Succeed(), "console URL should become available for cluster %q", customerClusterName)
+			GinkgoLogr.Info("Console URL available", "url", consoleURL)
+
+			Eventually(func(g Gomega) {
+				err := framework.TestHTTPSConnectivity(ctx, consoleURL, 10*time.Second)
+				g.Expect(err).NotTo(HaveOccurred(),
+					"public ingress (console) should be reachable from outside the VNet for private KAS cluster, but got error: %v", err)
+			}, 10*time.Minute, 15*time.Second).Should(Succeed(),
+				"public ingress should be reachable from outside the VNet despite private KAS")
+			GinkgoLogr.Info("Confirmed public ingress is reachable from outside the VNet despite private KAS")
+		},
+	)
+})

--- a/test/e2e/cluster_create_private_kas.go
+++ b/test/e2e/cluster_create_private_kas.go
@@ -23,13 +23,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	hcpsdk20260630preview "github.com/Azure/ARO-HCP/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	hcpsdk20251223preview "github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 )
 
-// This test creates a cluster with private KAS (api.visibility: Private) using
-// the v2026-06-30-preview API and verifies that:
+// This test creates a cluster with private KAS (api.visibility: Private) and
+// verifies that:
 //   - The Kubernetes API server is only reachable from within the VNet
 //   - The default ingress remains public (independence of KAS and ingress visibility)
 var _ = Describe("Customer", func() {
@@ -58,7 +58,7 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for private KAS test")
 
 			By("creating cluster parameters with private API visibility")
-			clusterParams := framework.NewDefaultClusterParams20260630()
+			clusterParams := framework.NewDefaultClusterParams20251223()
 			clusterParams.ClusterName = customerClusterName
 			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.APIVisibility = "Private"
@@ -66,7 +66,7 @@ var _ = Describe("Customer", func() {
 			clusterParams.OpenshiftVersionId = "4.22"
 
 			By("creating customer resources (infrastructure and managed identities)")
-			clusterParams, err = tc.CreateClusterCustomerResources20260630(ctx,
+			clusterParams, err = tc.CreateClusterCustomerResources20251223(ctx,
 				resourceGroup,
 				clusterParams,
 				map[string]interface{}{},
@@ -79,8 +79,8 @@ var _ = Describe("Customer", func() {
 			vmName, _, err := tc.DeployTestVM(ctx, TestArtifactsFS, *resourceGroup.Name, customerClusterName, clusterParams.VnetName, clusterParams.SubnetName)
 			Expect(err).NotTo(HaveOccurred(), "failed to deploy test VM for private KAS verification")
 
-			By("creating the HCP cluster with private KAS via v20260630preview")
-			err = tc.CreateHCPClusterFromParam20260630(ctx,
+			By("creating the HCP cluster with private KAS")
+			err = tc.CreateHCPClusterFromParam20251223(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams,
@@ -89,9 +89,9 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with private KAS", customerClusterName)
 
-			By("verifying cluster API visibility is Private and ingress is Public via ARM GET")
-			clientFactory := tc.Get20260630ClientFactoryOrDie(ctx)
-			cluster, err := clientFactory.NewHcpOpenShiftClustersClient().Get(
+			By("verifying cluster API visibility is Private via ARM GET")
+			hcpClient := tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+			cluster, err := hcpClient.Get(
 				ctx,
 				*resourceGroup.Name,
 				customerClusterName,
@@ -99,27 +99,21 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to get cluster %q to verify private KAS", customerClusterName)
 			Expect(cluster.Properties).ToNot(BeNil(), "cluster %q Properties was nil", customerClusterName)
-
 			Expect(cluster.Properties.API).ToNot(BeNil(), "cluster %q Properties.API was nil", customerClusterName)
 			Expect(cluster.Properties.API.Visibility).ToNot(BeNil(), "cluster %q Properties.API.Visibility was nil", customerClusterName)
-			Expect(*cluster.Properties.API.Visibility).To(Equal(hcpsdk20260630preview.VisibilityPrivate),
+			Expect(*cluster.Properties.API.Visibility).To(Equal(hcpsdk20251223preview.VisibilityPrivate),
 				"cluster %q API visibility should be Private", customerClusterName)
 			Expect(cluster.Properties.API.URL).ToNot(BeNil(), "cluster %q Properties.API.URL was nil", customerClusterName)
 			apiURL := *cluster.Properties.API.URL
 			GinkgoLogr.Info("Cluster created with private KAS", "clusterName", customerClusterName, "apiURL", apiURL)
 
-			Expect(cluster.Properties.Ingress).ToNot(BeNil(), "cluster %q Properties.Ingress was nil", customerClusterName)
-			Expect(cluster.Properties.Ingress.Type).ToNot(BeNil(), "cluster %q Properties.Ingress.Type was nil", customerClusterName)
-			Expect(*cluster.Properties.Ingress.Type).To(Equal(hcpsdk20260630preview.IngressTypePublic),
-				"cluster %q ingress type should be Public (private KAS must not affect ingress)", customerClusterName)
-
 			By("creating the node pool")
-			nodePoolParams := framework.NewDefaultNodePoolParams20260630()
+			nodePoolParams := framework.NewDefaultNodePoolParams20251223()
 			nodePoolParams.ClusterName = customerClusterName
 			nodePoolParams.NodePoolName = customerNodePoolName
 			nodePoolParams.Replicas = int32(1)
 
-			err = tc.CreateNodePoolFromParam20260630(ctx,
+			err = tc.CreateNodePoolFromParam20251223(ctx,
 				GinkgoLogr,
 				*resourceGroup.Name,
 				clusterParams.ManagedResourceGroupName,
@@ -168,7 +162,7 @@ var _ = Describe("Customer", func() {
 			GinkgoLogr.Info("KAS is reachable from VM inside VNet", "output", versionOutput)
 
 			By("verifying KAS is NOT reachable from outside the VNet")
-			err = framework.TestHTTPSConnectivity(ctx, apiURL+"/healthz", 10*time.Second)
+			err = framework.TestHTTPSConnectivity(ctx, apiURL+"/healthz", 10*time.Second, true)
 			Expect(err).To(HaveOccurred(),
 				"private KAS should not be reachable from outside the VNet, but connection to %s succeeded", apiURL)
 			GinkgoLogr.Info("Confirmed KAS is not reachable from outside the VNet", "error", err)
@@ -178,7 +172,6 @@ var _ = Describe("Customer", func() {
 			// and served through the default ingress router. If the console
 			// URL is reachable from outside the VNet, it proves the default
 			// ingress is public — independent of private KAS.
-			hcpClient := clientFactory.NewHcpOpenShiftClustersClient()
 			var consoleURL string
 			Eventually(func(g Gomega) {
 				resp, err := hcpClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
@@ -191,7 +184,7 @@ var _ = Describe("Customer", func() {
 			GinkgoLogr.Info("Console URL available", "url", consoleURL)
 
 			Eventually(func(g Gomega) {
-				err := framework.TestHTTPSConnectivity(ctx, consoleURL, 10*time.Second)
+				err := framework.TestHTTPSConnectivity(ctx, consoleURL, 10*time.Second, true)
 				g.Expect(err).NotTo(HaveOccurred(),
 					"public ingress (console) should be reachable from outside the VNet for private KAS cluster, but got error: %v", err)
 			}, 10*time.Minute, 15*time.Second).Should(Succeed(),

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -10,6 +10,7 @@ Customer should be able to create a no-CNI private cluster with a private key va
 Customer should be able to create a cluster and node pools with aggregated advanced features
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
+Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -9,6 +9,7 @@ Customer should be able to create a no-CNI private cluster with a private key va
 Customer should be able to create a cluster and node pools with aggregated advanced features
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
+Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -9,6 +9,7 @@ Customer should be able to create a no-CNI private cluster with a private key va
 Customer should be able to create a cluster and node pools with aggregated advanced features
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
+Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -12,6 +12,7 @@ Customer should be able to create a no-CNI private cluster with a private key va
 Customer should be able to create a cluster and node pools with aggregated advanced features
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
+Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -9,6 +9,7 @@ Customer should be able to create a no-CNI private cluster with a private key va
 Customer should be able to create a cluster and node pools with aggregated advanced features
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
+Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -9,6 +9,7 @@ Customer should be able to create a no-CNI private cluster with a private key va
 Customer should be able to create a cluster and node pools with aggregated advanced features
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
+Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public
 Create HCPOpenShiftCluster with Private KeyVault should create a cluster with private keyvault using v20251223preview API
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation

--- a/test/util/framework/connectivity_helper.go
+++ b/test/util/framework/connectivity_helper.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"time"
+)
+
+// TestHTTPSConnectivity attempts an HTTPS connection to the given URL.
+// Returns nil if the connection succeeds, or an error if it fails (DNS, timeout,
+// connection refused, etc.). TLS validation is skipped — this tests network
+// reachability, not certificate validity. Redirects are not followed.
+func TestHTTPSConnectivity(ctx context.Context, url string, timeout time.Duration) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(timeoutCtx, "GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}

--- a/test/util/framework/connectivity_helper.go
+++ b/test/util/framework/connectivity_helper.go
@@ -23,9 +23,10 @@ import (
 
 // TestHTTPSConnectivity attempts an HTTPS connection to the given URL.
 // Returns nil if the connection succeeds, or an error if it fails (DNS, timeout,
-// connection refused, etc.). TLS validation is skipped — this tests network
-// reachability, not certificate validity. Redirects are not followed.
-func TestHTTPSConnectivity(ctx context.Context, url string, timeout time.Duration) error {
+// connection refused, etc.). When insecureSkipVerify is true, TLS certificate
+// validation is skipped — useful for testing network reachability without
+// requiring valid certificates. Redirects are not followed.
+func TestHTTPSConnectivity(ctx context.Context, url string, timeout time.Duration, insecureSkipVerify bool) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
@@ -34,11 +35,14 @@ func TestHTTPSConnectivity(ctx context.Context, url string, timeout time.Duratio
 		return err
 	}
 
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if insecureSkipVerify {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // caller explicitly opted in
+	}
+
 	client := &http.Client{
-		Timeout: timeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
+		Timeout:   timeout,
+		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},

--- a/test/util/framework/resource_group_helper.go
+++ b/test/util/framework/resource_group_helper.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
+)
+
+// GetPrivateKASInternalIP finds the private IP address of the internal load
+// balancer created by HyperShift for a private KAS cluster. The internal LB
+// is in the cluster's managed resource group and has a frontend IP on the
+// customer's subnet. Returns the IP address or an error if not found.
+func GetPrivateKASInternalIP(ctx context.Context, tc interface {
+	SubscriptionID(ctx context.Context) (string, error)
+	AzureCredential() (azcore.TokenCredential, error)
+}, managedResourceGroup string) (string, error) {
+	subscriptionID, err := tc.SubscriptionID(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get subscription ID: %w", err)
+	}
+
+	azCreds, err := tc.AzureCredential()
+	if err != nil {
+		return "", fmt.Errorf("failed to get Azure credentials: %w", err)
+	}
+
+	lbClient, err := armnetwork.NewLoadBalancersClient(subscriptionID, azCreds, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create load balancers client: %w", err)
+	}
+
+	pager := lbClient.NewListPager(managedResourceGroup, nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to list load balancers in %q: %w", managedResourceGroup, err)
+		}
+		for _, lb := range page.Value {
+			if lb.Properties == nil || lb.Properties.FrontendIPConfigurations == nil {
+				continue
+			}
+			for _, fip := range lb.Properties.FrontendIPConfigurations {
+				if fip.Properties == nil {
+					continue
+				}
+				// Internal LBs have a private IP and no public IP
+				if fip.Properties.PrivateIPAddress != nil && fip.Properties.PublicIPAddress == nil {
+					return *fip.Properties.PrivateIPAddress, nil
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no internal load balancer found in managed resource group %q", managedResourceGroup)
+}

--- a/test/util/framework/sample_app.go
+++ b/test/util/framework/sample_app.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"embed"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.yaml.in/yaml/v2"
@@ -153,6 +154,44 @@ func DeploySampleApp(ctx context.Context, adminRESTConfig *rest.Config, nodeSele
 		Namespace: nsName,
 		RouteHost: host,
 	}, nil
+}
+
+// SampleAppManifests returns the serving app's Deployment, Service, and Route
+// as a multi-document YAML string with each resource's namespace set to the
+// given value. This is the same set of resources created by DeploySampleApp,
+// but in a form suitable for `kubectl apply -f -` (e.g. from a VM when KAS
+// is not directly reachable from the test runner).
+func SampleAppManifests(namespace string) (string, error) {
+	deploymentYAML, err := servingAppFiles.ReadFile("artifacts/serving_app/deployment.yaml")
+	if err != nil {
+		return "", fmt.Errorf("failed to read deployment.yaml: %w", err)
+	}
+	serviceYAML, err := servingAppFiles.ReadFile("artifacts/serving_app/service.yaml")
+	if err != nil {
+		return "", fmt.Errorf("failed to read service.yaml: %w", err)
+	}
+	routeYAML, err := servingAppFiles.ReadFile("artifacts/serving_app/route.yaml")
+	if err != nil {
+		return "", fmt.Errorf("failed to read route.yaml: %w", err)
+	}
+
+	// Inject namespace into each document by unmarshalling, setting namespace,
+	// and remarshalling.
+	var docs []string
+	for _, raw := range [][]byte{deploymentYAML, serviceYAML, routeYAML} {
+		obj := &unstructured.Unstructured{}
+		if err := sigyaml.Unmarshal(raw, obj); err != nil {
+			return "", fmt.Errorf("failed to unmarshal manifest: %w", err)
+		}
+		obj.SetNamespace(namespace)
+		patched, err := sigyaml.Marshal(obj.Object)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal manifest: %w", err)
+		}
+		docs = append(docs, string(patched))
+	}
+
+	return strings.Join(docs, "---\n"), nil
 }
 
 // createResource unmarshals YAML into an unstructured object and creates it

--- a/test/util/framework/vm_helper.go
+++ b/test/util/framework/vm_helper.go
@@ -16,6 +16,7 @@ package framework
 
 import (
 	"context"
+	"embed"
 	"errors"
 	"fmt"
 	"io"
@@ -32,7 +33,79 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 )
+
+// DeployTestVM deploys a test VM in the given VNet/subnet with a retry loop
+// that absorbs transient ARM errors but fails fast on SkuNotAvailable.
+// Returns the VM name and the deployment (which can be used to extract outputs
+// like the public IP via GetOutputValueString).
+func (tc *perItOrDescribeTestContext) DeployTestVM(
+	ctx context.Context,
+	testArtifactsFS embed.FS,
+	resourceGroupName string,
+	clusterName string,
+	vnetName string,
+	subnetName string,
+) (string, *armresources.DeploymentExtended, error) {
+	sshPublicKey, _, err := GenerateSSHKeyPair()
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to generate SSH key pair: %w", err)
+	}
+
+	vmName := fmt.Sprintf("%s-test-vm", clusterName)
+	vmSize, err := tc.SelectVMSize(ctx, JumpboxVMSizeSelector())
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to resolve jumpbox VM size: %w", err)
+	}
+
+	var deployment *armresources.DeploymentExtended
+	var deployErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			time.Sleep(20 * time.Second)
+		}
+		deployment, deployErr = tc.CreateBicepTemplateAndWait(ctx,
+			WithTemplateFromFS(testArtifactsFS, "test-artifacts/generated-test-artifacts/modules/test-vm.json"),
+			WithDeploymentName("test-vm"),
+			WithScope(BicepDeploymentScopeResourceGroup),
+			WithClusterResourceGroup(resourceGroupName),
+			WithParameters(map[string]any{
+				"vmName":       vmName,
+				"vnetName":     vnetName,
+				"subnetName":   subnetName,
+				"sshPublicKey": sshPublicKey,
+				"vmSize":       vmSize,
+			}),
+			WithTimeout(30*time.Minute),
+		)
+		if deployErr == nil || strings.Contains(deployErr.Error(), "SkuNotAvailable") {
+			break
+		}
+	}
+	if deployErr != nil {
+		return "", nil, fmt.Errorf("failed to deploy test VM: %w", deployErr)
+	}
+
+	return vmName, deployment, nil
+}
+
+// RunKubectlOnVM writes the given base64-encoded kubeconfig to the VM and runs
+// a kubectl command. This is the standard pattern for interacting with a cluster
+// whose KAS is only reachable from within the VNet.
+func RunKubectlOnVM(ctx context.Context, tc interface {
+	SubscriptionID(ctx context.Context) (string, error)
+	AzureCredential() (azcore.TokenCredential, error)
+}, resourceGroup, vmName, kubeconfigB64, kubectlArgs string, pollTimeout time.Duration) (string, error) {
+	// Redirect stderr to /dev/null because RunVMCommand treats any stderr
+	// content as an error, and kubectl writes warnings (e.g. TLS, API
+	// discovery) to stderr even on success.
+	cmd := fmt.Sprintf(
+		"echo '%s' | base64 -d > /tmp/kubeconfig && kubectl --kubeconfig=/tmp/kubeconfig %s 2>/dev/null",
+		kubeconfigB64, kubectlArgs,
+	)
+	return RunVMCommand(ctx, tc, resourceGroup, vmName, cmd, pollTimeout)
+}
 
 // Helper to run command on VM
 func RunVMCommand(ctx context.Context, tc interface {


### PR DESCRIPTION
## Summary

Reintroduces the private KAS e2e test (originally #6217, reverted in #6349) with fixes:

- **Switched to v20251223preview API** — `api.visibility` exists in all API versions, so no timebomb skip is needed. This was the root cause of the revert (v20260630preview was not registered in higher environments).
- **Explicit TLS skip** — `TestHTTPSConnectivity` now takes an `insecureSkipVerify` parameter so callers explicitly opt in, addressing the CodeQL finding.
- **Dropped `ingress.type` ARM assertion** — only available in v20260630preview. Public ingress is verified functionally via console URL reachability instead.

### What the test verifies

Creates a cluster with `api.visibility: Private` and checks:
1. ARM GET returns `api.visibility=Private`
2. KAS is reachable from a VM inside the VNet (`kubectl version` via internal LB)
3. KAS is NOT reachable from outside the VNet
4. Public ingress works (console URL reachable from outside — proves KAS/ingress independence)

### Shared helper refactoring (from original PR)

- `framework.DeployTestVM()` — extracted from private KAS, private ingress, and authorized CIDRs tests
- `framework.RunKubectlOnVM()` — kubeconfig write + kubectl execution on VM
- `framework.TestHTTPSConnectivity()` — in `connectivity_helper.go` with explicit TLS parameter
- `framework.GetPrivateKASInternalIP()` — in `resource_group_helper.go` (Azure RG query)
- `framework.SampleAppManifests()` — returns sample app YAML for `kubectl apply -f -`

## Test plan

- [x] `go build -tags E2Etests ./test/e2e/` compiles
- [x] `golangci-lint` passes (0 issues)
- [x] Suite fixtures updated
- [x] Test passed locally against pers env (all verifications succeed)
- [ ] CI e2e pass

Ref: [ARO-23333](https://redhat.atlassian.net/browse/ARO-23333)
Ref: [AROSLSRE-1674](https://redhat.atlassian.net/browse/AROSLSRE-1674)

🤖 Generated with [Claude Code](https://claude.com/claude-code)