### PR TITLE
chore: update component image digests (excluding clusters-service)

### DIFF
--- a/acm/deploy/helm/multicluster-engine-crds/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine-crds/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.11.4
+appVersion: 2.11.5
 description: A Helm chart for multicluster-engine - CRDs
 keywords:
 - mce
@@ -7,6 +7,6 @@ keywords:
 - multiclusterengine
 name: multicluster-engine-crds
 sources:
-- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:c8b9aa2f3e0d3db6c11974c2ae820dab5cf3c290f7de8b5115e1839e0a8aab1d
+- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:6a742a2bdb7aa8b7bb260dc378671d50522972954c9f2e36960c92602ba442a1
 type: application
-version: 2.11.4
+version: 2.11.5

--- a/acm/deploy/helm/multicluster-engine/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.11.4
+appVersion: 2.11.5
 description: A Helm chart for multicluster-engine
 keywords:
 - mce
@@ -7,6 +7,6 @@ keywords:
 - multiclusterengine
 name: multicluster-engine
 sources:
-- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:c8b9aa2f3e0d3db6c11974c2ae820dab5cf3c290f7de8b5115e1839e0a8aab1d
+- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:6a742a2bdb7aa8b7bb260dc378671d50522972954c9f2e36960c92602ba442a1
 type: application
-version: 2.11.4
+version: 2.11.5

--- a/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-operator.deployment.yaml
+++ b/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-operator.deployment.yaml
@@ -25,15 +25,6 @@ spec:
         ocm-antiaffinity-selector: backplane-operator
     spec:
       affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: aro-hcp.azure.com/role
-                operator: In
-                values:
-                - infra
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
@@ -65,7 +56,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: OPERAND_IMAGE_ADDON_MANAGER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/addon-manager-rhel9@sha256:35ec22ca9f2bccf3a3980da610446f0fe16489d982858bdaa081c43c26166481'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/addon-manager-rhel9@sha256:0828aeffb6d23a85161080b44e39eec7cbc0c8df608168abc51ae5e03708ed5c'
         - name: OPERAND_IMAGE_AZURE_SERVICE_OPERATOR_RHEL9
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/azure-service-operator-rhel9@sha256:b0e5a3d7cab4553bcc116926720d3516d648d98d47225006a6fefdc8bc5d560f'
         - name: OPERAND_IMAGE_BACKPLANE_MUST_GATHER
@@ -73,11 +64,11 @@ spec:
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AGENT
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-agent-rhel9@sha256:1fd717d6983c8f94e8bff258acd5d13df7d6f2ea3ce8a674b9957c587a6597b4'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AWS_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-aws-rhel9@sha256:eb917455c03264da728905fa56848dd7bfa84460908ab12f05a30133c0fa0de2'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-aws-rhel9@sha256:c8c5180c1ecc8e6a6e04d9e5aa47911cb990712c0280b2e75e32ef98300c8e5f'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AZURE_RHEL9
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-azure-rhel9@sha256:bb7c342dbc4c2194be04a46207da8d39d44b1836bb0012c2bac60f478356c9b4'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_KUBEVIRT
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-kubevirt-rhel9@sha256:6d03af92c20ec06b05cb57916675b24b7103a4773769a1210feaa0cce90a7722'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-kubevirt-rhel9@sha256:1139eb9e5a11886599946a6402aa40c0bb30ca08579bcd0a2e94faf2405bf768'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_OPENSHIFT_ASSISTED_BOOTSTRAP
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/capoa-bootstrap-rhel9@sha256:dab3d5a734b64e2c7d9a39392c009fa40f64561a35b32c7861bed05f7abbf2e2'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_OPENSHIFT_ASSISTED_CONTROL_PLANE
@@ -91,25 +82,25 @@ spec:
         - name: OPERAND_IMAGE_CLUSTER_IMAGE_SET_CONTROLLER
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-image-set-controller-rhel9@sha256:d0d110872dd1f20ebb76d355d3d8698e4a207c65081125378e4492988318efb0'
         - name: OPERAND_IMAGE_CLUSTERLIFECYCLE_STATE_METRICS
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/clusterlifecycle-state-metrics-rhel9@sha256:301351e54f42c333b8e0cd9cb24adec404a091cc94622df4c76e3632e8614bd7'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/clusterlifecycle-state-metrics-rhel9@sha256:6e24980ed434cc63fb79f493c42117730cb9ba5a0a144cef9aa68281c9d2ff38'
         - name: OPERAND_IMAGE_CLUSTER_PROXY
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-proxy-rhel9@sha256:2396461e130fabacedf11e9fc8aab00329d19a9b3ca8a60036687272cdffaf72'
         - name: OPERAND_IMAGE_CONSOLE_MCE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/console-mce-rhel9@sha256:857f7f06bf4f3e9f5cbca3a58b280740ed761697ac5b97322d8c6f814746b56c'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/console-mce-rhel9@sha256:d70b374626f9012303a10f42f676a2fb9e3dc9a40a441ae9d0527e222806d087'
         - name: OPERAND_IMAGE_DISCOVERY_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/discovery-rhel9@sha256:3c1d0f728d34f042181a4d319dc38ed1b8407dd3be1bc3fe54b21ca86faa0ecb'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/discovery-rhel9@sha256:71f86829f156c915d0aaeab0c9098c2a8576544b3dfa98b83a019987ff7d6f49'
         - name: OPERAND_IMAGE_OPENSHIFT_HIVE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hive-rhel9@sha256:c9fb0bcfc80fb00208eb69944eac094de063b5e875b311036447419121823430'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hive-rhel9@sha256:382a3fdf358dce7c1b1d672f7b1d21fac2a98a09b5a173ae1184f388ccf2bbdb'
         - name: OPERAND_IMAGE_HYPERSHIFT_ADDON_OPERATOR
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-addon-rhel9-operator@sha256:676f9dde0c30b0e7007d060e341312ab87e1233e50cb01d1cea385e4912d2e59'
         - name: OPERAND_IMAGE_HYPERSHIFT_CLI
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-cli-rhel9@sha256:8d9cf8ce6c42b25dc279bdfb04d10a7b8c192bec30c40bce45a16f7f4d48009f'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-cli-rhel9@sha256:0dd39bbfce3a0bd4cacc2af28e4f5146df3182928a826a4dc68c7d9893b6fc2e'
         - name: OPERAND_IMAGE_HYPERSHIFT_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-rhel9-operator@sha256:e85d83ae338069d3e925ae2baa513ee077363f8180d97c87b171add1e720cc39'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-rhel9-operator@sha256:7b245201e2b583bc1d99c632c8dd844878ea1d6d0fa81a0ecc8d119ae245fe1f'
         - name: OPERAND_IMAGE_IMAGE_BASED_INSTALL_OPERATOR
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/image-based-install-rhel9@sha256:c0a7d4e82216bd1ed630d745e60fea1a6eafdd0b9d9155714f1ced1199ce2bf0'
         - name: OPERAND_IMAGE_KUBE_RBAC_PROXY_MCE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/kube-rbac-proxy-mce-rhel9@sha256:4e5a74a5822aeeb2cd2f21b0140c772f398173b1e39bdf9ee42ffadad672560e'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/kube-rbac-proxy-mce-rhel9@sha256:332c7fe4387ec4bd73b1e041fba3e3c9e176197c273b25826c6a5d1f72c20a36'
         - name: OPERAND_IMAGE_MANAGEDCLUSTER_IMPORT_CONTROLLER
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/managedcluster-import-controller-rhel9@sha256:9715a520636e949ff6ae733ecf2b2b709bb1b8ae72c9022a9cf7c1fcb6bbaa5b'
         - name: OPERAND_IMAGE_MANAGED_SERVICEACCOUNT
@@ -119,13 +110,13 @@ spec:
         - name: OPERAND_IMAGE_PROVIDER_CREDENTIAL_CONTROLLER
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/provider-credential-controller-rhel9@sha256:1b45105a89f728f7cf7ea8e2342e63414d4c7500626576a7217e1daf25433872'
         - name: OPERAND_IMAGE_PLACEMENT
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/placement-rhel9@sha256:f126a6df7d182ca56d2da3a48ee5341ed76900e13ca0f598e003a37753b7d823'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/placement-rhel9@sha256:0cec9928a2a747e0b2340f26c3b9a3306b49ca2a40aa71edb05f24b3e9a019e8'
         - name: OPERAND_IMAGE_REGISTRATION
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-rhel9@sha256:1375e7a35a29ae8a249c78f614d3c660e0cbd40eb56e1a53cc3a8cdb898b758c'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-rhel9@sha256:546d393363b6be7546e47d371957ac5a63a7ef13dfe2ee9210bd012167d4b604'
         - name: OPERAND_IMAGE_REGISTRATION_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-operator-rhel9@sha256:87892d2614200830c7eefc84547ce90d9183535fc3db858c034e6fbfc47cc0f4'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-operator-rhel9@sha256:40d6b0e818d5b26e553c78bcb72cdb238ade7832cd5d4e24c4edc60a034451b8'
         - name: OPERAND_IMAGE_WORK
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/work-rhel9@sha256:497f05b2ef1f30e387c7f93be8ad5251e3a5a76594c1ff4b28a20206e5daa897'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/work-rhel9@sha256:c8e4b323fe77f1625d50e7fddf8cb6a98f4ea81379b117e3ae43f5f28f4fb344'
         - name: OPERAND_IMAGE_ASSISTED_IMAGE_SERVICE
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-image-service-rhel9@sha256:48305470fa7e55e78165734d094022a14ac9d083573974036c1f40021c362ba1'
         - name: OPERAND_IMAGE_ASSISTED_INSTALLER
@@ -143,12 +134,12 @@ spec:
         - name: OPERAND_IMAGE_POSTGRESQL_13
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/postgresql-13@sha256:97b64c18a32944b86fd1a118aa0d1aa04ff1fad8068c3c20f6e94af24712ff36'
         - name: OPERAND_IMAGE_BACKPLANE_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:1eb05b6ebd871d000a34d59bc4f98cdc6254678cc0fd699bfb18ffa755cf4328'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:73ae653945eec4ebb928a753cfbb9f52d5a7488aac6aa1bb542c6ea6de294960'
         - name: OPERATOR_VERSION
-          value: 2.11.4
+          value: 2.11.5
         - name: OPERATOR_PACKAGE
           value: multicluster-engine
-        image: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:1eb05b6ebd871d000a34d59bc4f98cdc6254678cc0fd699bfb18ffa755cf4328'
+        image: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:73ae653945eec4ebb928a753cfbb9f52d5a7488aac6aa1bb542c6ea6de294960'
         livenessProbe:
           httpGet:
             path: /healthz
@@ -180,6 +171,8 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+      nodeSelector:
+        aro-hcp.azure.com/role: infra
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce.yaml
+++ b/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce.yaml
@@ -3461,15 +3461,6 @@ spec:
         ocm-antiaffinity-selector: backplane-operator
     spec:
       affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: aro-hcp.azure.com/role
-                operator: In
-                values:
-                - infra
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - podAffinityTerm:
@@ -3581,7 +3572,7 @@ spec:
         - name: OPERAND_IMAGE_BACKPLANE_OPERATOR
           value: 'arohcpsvcdev.azurecr.io/acm-d-cache/backplane-rhel9-operator@sha256:1234567890'
         - name: OPERATOR_VERSION
-          value: 2.11.4
+          value: 2.11.5
         - name: OPERATOR_PACKAGE
           value: multicluster-engine
         image: 'arohcpsvcdev.azurecr.io/acm-d-cache/backplane-rhel9-operator@sha256:1234567890'
@@ -3616,6 +3607,8 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+      nodeSelector:
+        aro-hcp.azure.com/role: infra
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1036,7 +1036,7 @@ defaults:
     image:
       registry: quay.io
       repository: app-sre/aro-hcp-clusters-service
-      digest: sha256:4394f21f23e397728efe03d6e0680d717ce21a9ed4f7be3ea7b2aa042bd64574 # 2b4f2a905a7641ca9bcc02dd74004c493497b531 (2026-07-31 08:16)
+      digest: sha256:981637a1e08c3a6c86f3631c6642f6f1412c2e89d306590f72958712f7a9211d # 9b8050b0c3afb0a70d866f38cc912680cc745ba9 (2026-07-29 16:14)
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -158,7 +158,7 @@ defaults:
       image:
         registry: mcr.microsoft.com
         repository: oss/v2/fluent/fluent-bit
-        digest: sha256:c81f949228a0d446aea4966d8da39cfcd63f17c69a5eae143ce8264ddddc5777 # v5.0.4 (2026-07-28 19:40)
+        digest: sha256:e8df41b2461b466e5f1d28157f7931f7c68b4b0917258e12de4d7922fd283703 # v5.0.4 (2026-07-31 18:54)
       resources:
         requests:
           cpu: 100m
@@ -174,14 +174,14 @@ defaults:
       image:
         registry: mcr.microsoft.com
         repository: geneva/distroless/mdsd
-        digest: sha256:5c0159feac3312c447b10c840558a5db6591f78c498cf9150e010be9fa860a20 # 1.43.0-20260728-3 (2026-07-28 17:38)
+        digest: sha256:83b9cbd2662c56a6d6858210bfb375e81a5d6bea5462786d5005a473ad2ee657 # 1.43.0-20260730-1 (2026-07-30 17:43)
   # Kube Events
   kubeEvents:
     enabled: true
     image:
       registry: kubernetesshared.azurecr.io
       repository: shared/kube-events
-      digest: sha256:10a020acbc382e490deecdc78ad7945cbd26852f301f7a25f06ac89a3de8d802 # 20260726.1 (2026-07-26 03:24)
+      digest: sha256:dea4ec46b0d97261cedd62ab6235e6aa6002e5aac8fab87b80d41e57f9658f82 # 20260802.1 (2026-08-02 03:25)
     k8s:
       namespace: monitoring
       serviceAccountName: ke-serviceaccount
@@ -367,7 +367,7 @@ defaults:
     image:
       registry: quay.io
       repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
-      digest: sha256:0a0397b7e1fec51b2704e5c9ca131ebc1cb607d1ee9c882fd6205f9b7ca6b724 # 3ce5a9b281bbf76f2b68dc2b850c525b322ab316 (2026-07-29 23:17)
+      digest: sha256:0678815cb79fd6489303c08d74e4403e68e88e05eeec7c665904905f5e2253a5 # 9a71d6a1383fc6f5600210eab996588a8bd5168c (2026-08-01 04:25)
     namespace: hypershift
     additionalInstallArg: '--enable-cpo-overrides'
     # By default we set it to empty as this tag is only required for msft environments. We override
@@ -467,15 +467,15 @@ defaults:
     server:
       registry: registry.stage.redhat.io
       repository: oadp/oadp-velero-rhel9
-      digest: sha256:a48979677ab533f849bf8c15eaab148f74857c8f48da945f52f10f029fdb569c # 1.6.1 (2026-07-27 18:10)
+      digest: sha256:edf402e1bdf5f4446f3316001cd5a323b037a0e9b54e8e2be8c0b768e95d9f74 # 1.6.1 (2026-08-03 05:41)
     azurePlugin:
       registry: registry.stage.redhat.io
       repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
-      digest: sha256:c4c26fca6614917e9b2812415e8f912fc45cfe6ea1755efea443670763898e3d # 1.6.1 (2026-07-27 18:00)
+      digest: sha256:f149e158d5bd4805920121d11656e89c1f43666e9929af4af99e8187e311a431 # 1.6.1 (2026-08-03 05:44)
     hypershiftPlugin:
       registry: registry.stage.redhat.io
       repository: oadp/oadp-hypershift-velero-plugin-rhel9
-      digest: sha256:e072512980311316a92b5cfc9252b7d71fc9e534d8db8a9db2ff1d7004e1524b # 1.6.1 (2026-07-27 18:00)
+      digest: sha256:a3eea2c4ffbda320d9351a2498086f9061965ef1a0f6979bb07ae0ea085a0c16 # 1.6.1 (2026-08-03 05:39)
   # SVC cluster specifics
   svc:
     subscription:
@@ -612,7 +612,7 @@ defaults:
           registry: arohcpsvcdev.azurecr.io
           repository: thanos/thanos
           tag: v0.41.0
-          sha: 6249f7aaadd3695df637fb2eb4cb9a9955611eee691c3970892fe9c0dc3f2db6 # v0.42.2 (2026-07-16 20:22)
+          sha: b567818fe608067eb0f1d7c2c4fe361e7ad83c8a256234c97685f1d0bf670cc8 # v0.42.4 (2026-07-30 13:37)
   # MGMT cluster specifics
   mgmt:
     stamps:
@@ -744,7 +744,7 @@ defaults:
           registry: arohcpsvcdev.azurecr.io
           repository: thanos/thanos
           tag: v0.41.0
-          sha: 6249f7aaadd3695df637fb2eb4cb9a9955611eee691c3970892fe9c0dc3f2db6 # v0.42.2 (2026-07-16 20:22)
+          sha: b567818fe608067eb0f1d7c2c4fe361e7ad83c8a256234c97685f1d0bf670cc8 # v0.42.4 (2026-07-30 13:37)
   # Backend
   backend:
     image:
@@ -992,7 +992,7 @@ defaults:
         image:
           registry: mcr.microsoft.com
           repository: azurelinux/base/nginx
-          digest: sha256:b770cd63558c97c4e19d6f0dbe22b7a636b1eb4d267efe37f1ad44cdaecfddb9 # 1.28.3-8-azl3.0.20260728 (2026-07-29 01:59)
+          digest: sha256:2c0ba08f2ebb48b3938b103cdce87450110a2f8ad76dd6a082d0dcd3e02c289e # 1.28.3-8-azl3.0.20260728 (2026-07-31 23:27)
     eventGrid:
       name: "arohcp-{{ .ctx.environment }}-maestro-{{ .ctx.regionShort }}" # [globally-unique]
       maxClientSessionsPerAuthName: 6
@@ -1025,18 +1025,18 @@ defaults:
       bundle:
         registry: quay.io
         repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
-        digest: sha256:72b7793fba6c2f320616b4c2b8542e6c93fed6793ee51e19e019ba92dd1b2334 # v2.16.3-546 (2026-07-30 05:08)
+        digest: sha256:55e5f7fc053cbd9ccbae7a3c4521a0b2d83586e319d023296d7224d2b226e247 # v2.16.3-548 (2026-08-02 13:33)
     mce:
       bundle:
         registry: quay.io
         repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
-        digest: sha256:c8b9aa2f3e0d3db6c11974c2ae820dab5cf3c290f7de8b5115e1839e0a8aab1d # v2.11.4-591 (2026-07-30 05:03)
+        digest: sha256:6a742a2bdb7aa8b7bb260dc378671d50522972954c9f2e36960c92602ba442a1 # v2.11.5-595 (2026-08-02 13:32)
   # Cluster Service
   clustersService:
     image:
       registry: quay.io
       repository: app-sre/aro-hcp-clusters-service
-      digest: sha256:981637a1e08c3a6c86f3631c6642f6f1412c2e89d306590f72958712f7a9211d # 9b8050b0c3afb0a70d866f38cc912680cc745ba9 (2026-07-29 16:14)
+      digest: sha256:4394f21f23e397728efe03d6e0680d717ce21a9ed4f7be3ea7b2aa042bd64574 # 2b4f2a905a7641ca9bcc02dd74004c493497b531 (2026-07-31 08:16)
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active
@@ -1098,7 +1098,7 @@ defaults:
       image:
         registry: arohcpsvcdev.azurecr.io
         repository: image-sync/oc-mirror
-        digest: sha256:aa1a693a0d0d990392bc851153352a8d9180a1d9b1e501af22a13234af52a7d3 # cd55650 (2026-07-30 05:18)
+        digest: sha256:7e4125022646fcbb01e3c24af7f670ae2ca3b93532b8594c284475daab24c81d # 141a4c5 (2026-08-02 08:17)
       pullSecretName: ocmirror-pull-secret
       operatorVersionsToMirror: "4.18,4.19,4.20,4.21,4.22"
   # Automation Account

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:c8b9aa2f3e0d3db6c11974c2ae820dab5cf3c290f7de8b5115e1839e0a8aab1d
+      digest: sha256:6a742a2bdb7aa8b7bb260dc378671d50522972954c9f2e36960c92602ba442a1
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:72b7793fba6c2f320616b4c2b8542e6c93fed6793ee51e19e019ba92dd1b2334
+      digest: sha256:55e5f7fc053cbd9ccbae7a3c4521a0b2d83586e319d023296d7224d2b226e247
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -72,7 +72,7 @@ armHelperTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 arobit:
   forwarder:
     image:
-      digest: sha256:c81f949228a0d446aea4966d8da39cfcd63f17c69a5eae143ce8264ddddc5777
+      digest: sha256:e8df41b2461b466e5f1d28157f7931f7c68b4b0917258e12de4d7922fd283703
       registry: mcr.microsoft.com
       repository: oss/v2/fluent/fluent-bit
     resources:
@@ -88,7 +88,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:5c0159feac3312c447b10c840558a5db6591f78c498cf9150e010be9fa860a20
+      digest: sha256:83b9cbd2662c56a6d6858210bfb375e81a5d6bea5462786d5005a473ad2ee657
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci00
   image:
-    digest: sha256:981637a1e08c3a6c86f3631c6642f6f1412c2e89d306590f72958712f7a9211d
+    digest: sha256:4394f21f23e397728efe03d6e0680d717ce21a9ed4f7be3ea7b2aa042bd64574
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:
@@ -451,7 +451,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:0a0397b7e1fec51b2704e5c9ca131ebc1cb607d1ee9c882fd6205f9b7ca6b724
+    digest: sha256:0678815cb79fd6489303c08d74e4403e68e88e05eeec7c665904905f5e2253a5
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -471,7 +471,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:aa1a693a0d0d990392bc851153352a8d9180a1d9b1e501af22a13234af52a7d3
+      digest: sha256:7e4125022646fcbb01e3c24af7f670ae2ca3b93532b8594c284475daab24c81d
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""
@@ -503,7 +503,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:10a020acbc382e490deecdc78ad7945cbd26852f301f7a25f06ac89a3de8d802
+    digest: sha256:dea4ec46b0d97261cedd62ab6235e6aa6002e5aac8fab87b80d41e57f9658f82
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -557,7 +557,7 @@ maestro:
     managedIdentityName: maestro-consumer
     sidecar:
       image:
-        digest: sha256:b770cd63558c97c4e19d6f0dbe22b7a636b1eb4d267efe37f1ad44cdaecfddb9
+        digest: sha256:2c0ba08f2ebb48b3938b103cdce87450110a2f8ad76dd6a082d0dcd3e02c289e
         registry: mcr.microsoft.com
         repository: azurelinux/base/nginx
   certIssuer: Self
@@ -709,7 +709,7 @@ mgmt:
       image:
         registry: arohcpsvcdev.azurecr.io
         repository: thanos/thanos
-        sha: 6249f7aaadd3695df637fb2eb4cb9a9955611eee691c3970892fe9c0dc3f2db6
+        sha: b567818fe608067eb0f1d7c2c4fe361e7ad83c8a256234c97685f1d0bf670cc8
         tag: v0.41.0
   rg: hcp-underlay-ci00-j7654321-mgmt-1
   stampIdentifier: "1"
@@ -1070,7 +1070,7 @@ svc:
       image:
         registry: arohcpsvcdev.azurecr.io
         repository: thanos/thanos
-        sha: 6249f7aaadd3695df637fb2eb4cb9a9955611eee691c3970892fe9c0dc3f2db6
+        sha: b567818fe608067eb0f1d7c2c4fe361e7ad83c8a256234c97685f1d0bf670cc8
         tag: v0.41.0
   rg: hcp-underlay-ci00-j7654321-svc
   subscription:
@@ -1110,14 +1110,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:c4c26fca6614917e9b2812415e8f912fc45cfe6ea1755efea443670763898e3d
+    digest: sha256:f149e158d5bd4805920121d11656e89c1f43666e9929af4af99e8187e311a431
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:e072512980311316a92b5cfc9252b7d71fc9e534d8db8a9db2ff1d7004e1524b
+    digest: sha256:a3eea2c4ffbda320d9351a2498086f9061965ef1a0f6979bb07ae0ea085a0c16
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:a48979677ab533f849bf8c15eaab148f74857c8f48da945f52f10f029fdb569c
+    digest: sha256:edf402e1bdf5f4446f3316001cd5a323b037a0e9b54e8e2be8c0b768e95d9f74
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci00
   image:
-    digest: sha256:4394f21f23e397728efe03d6e0680d717ce21a9ed4f7be3ea7b2aa042bd64574
+    digest: sha256:981637a1e08c3a6c86f3631c6642f6f1412c2e89d306590f72958712f7a9211d
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci01
   image:
-    digest: sha256:4394f21f23e397728efe03d6e0680d717ce21a9ed4f7be3ea7b2aa042bd64574
+    digest: sha256:981637a1e08c3a6c86f3631c6642f6f1412c2e89d306590f72958712f7a9211d
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:c8b9aa2f3e0d3db6c11974c2ae820dab5cf3c290f7de8b5115e1839e0a8aab1d
+      digest: sha256:6a742a2bdb7aa8b7bb260dc378671d50522972954c9f2e36960c92602ba442a1
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:72b7793fba6c2f320616b4c2b8542e6c93fed6793ee51e19e019ba92dd1b2334
+      digest: sha256:55e5f7fc053cbd9ccbae7a3c4521a0b2d83586e319d023296d7224d2b226e247
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -72,7 +72,7 @@ armHelperTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 arobit:
   forwarder:
     image:
-      digest: sha256:c81f949228a0d446aea4966d8da39cfcd63f17c69a5eae143ce8264ddddc5777
+      digest: sha256:e8df41b2461b466e5f1d28157f7931f7c68b4b0917258e12de4d7922fd283703
       registry: mcr.microsoft.com
       repository: oss/v2/fluent/fluent-bit
     resources:
@@ -88,7 +88,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:5c0159feac3312c447b10c840558a5db6591f78c498cf9150e010be9fa860a20
+      digest: sha256:83b9cbd2662c56a6d6858210bfb375e81a5d6bea5462786d5005a473ad2ee657
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci01
   image:
-    digest: sha256:981637a1e08c3a6c86f3631c6642f6f1412c2e89d306590f72958712f7a9211d
+    digest: sha256:4394f21f23e397728efe03d6e0680d717ce21a9ed4f7be3ea7b2aa042bd64574
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:
@@ -451,7 +451,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:0a0397b7e1fec51b2704e5c9ca131ebc1cb607d1ee9c882fd6205f9b7ca6b724
+    digest: sha256:0678815cb79fd6489303c08d74e4403e68e88e05eeec7c665904905f5e2253a5
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -471,7 +471,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:aa1a693a0d0d990392bc851153352a8d9180a1d9b1e501af22a13234af52a7d3
+      digest: sha256:7e4125022646fcbb01e3c24af7f670ae2ca3b93532b8594c284475daab24c81d
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""
@@ -503,7 +503,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:10a020acbc382e490deecdc78ad7945cbd26852f301f7a25f06ac89a3de8d802
+    digest: sha256:dea4ec46b0d97261cedd62ab6235e6aa6002e5aac8fab87b80d41e57f9658f82
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -557,7 +557,7 @@ maestro:
     managedIdentityName: maestro-consumer
     sidecar:
       image:
-        digest: sha256:b770cd63558c97c4e19d6f0dbe22b7a636b1eb4d267efe37f1ad44cdaecfddb9
+        digest: sha256:2c0ba08f2ebb48b3938b103cdce87450110a2f8ad76dd6a082d0dcd3e02c289e
         registry: mcr.microsoft.com
         repository: azurelinux/base/nginx
   certIssuer: Self
@@ -709,7 +709,7 @@ mgmt:
       image:
         registry: arohcpsvcdev.azurecr.io
         repository: thanos/thanos
-        sha: 6249f7aaadd3695df637fb2eb4cb9a9955611eee691c3970892fe9c0dc3f2db6
+        sha: b567818fe608067eb0f1d7c2c4fe361e7ad83c8a256234c97685f1d0bf670cc8
         tag: v0.41.0
   rg: hcp-underlay-ci01-j7654321-mgmt-1
   stampIdentifier: "1"
@@ -1070,7 +1070,7 @@ svc:
       image:
         registry: arohcpsvcdev.azurecr.io
         repository: thanos/thanos
-        sha: 6249f7aaadd3695df637fb2eb4cb9a9955611eee691c3970892fe9c0dc3f2db6
+        sha: b567818fe608067eb0f1d7c2c4fe361e7ad83c8a256234c97685f1d0bf670cc8
         tag: v0.41.0
   rg: hcp-underlay-ci01-j7654321-svc
   subscription:
@@ -1110,14 +1110,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:c4c26fca6614917e9b2812415e8f912fc45cfe6ea1755efea443670763898e3d
+    digest: sha256:f149e158d5bd4805920121d11656e89c1f43666e9929af4af99e8187e311a431
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:e072512980311316a92b5cfc9252b7d71fc9e534d8db8a9db2ff1d7004e1524b
+    digest: sha256:a3eea2c4ffbda320d9351a2498086f9061965ef1a0f6979bb07ae0ea085a0c16
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:a48979677ab533f849bf8c15eaab148f74857c8f48da945f52f10f029fdb569c
+    digest: sha256:edf402e1bdf5f4446f3316001cd5a323b037a0e9b54e8e2be8c0b768e95d9f74
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:4394f21f23e397728efe03d6e0680d717ce21a9ed4f7be3ea7b2aa042bd64574
+    digest: sha256:981637a1e08c3a6c86f3631c6642f6f1412c2e89d306590f72958712f7a9211d
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:c8b9aa2f3e0d3db6c11974c2ae820dab5cf3c290f7de8b5115e1839e0a8aab1d
+      digest: sha256:6a742a2bdb7aa8b7bb260dc378671d50522972954c9f2e36960c92602ba442a1
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:72b7793fba6c2f320616b4c2b8542e6c93fed6793ee51e19e019ba92dd1b2334
+      digest: sha256:55e5f7fc053cbd9ccbae7a3c4521a0b2d83586e319d023296d7224d2b226e247
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -72,7 +72,7 @@ armHelperTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 arobit:
   forwarder:
     image:
-      digest: sha256:c81f949228a0d446aea4966d8da39cfcd63f17c69a5eae143ce8264ddddc5777
+      digest: sha256:e8df41b2461b466e5f1d28157f7931f7c68b4b0917258e12de4d7922fd283703
       registry: mcr.microsoft.com
       repository: oss/v2/fluent/fluent-bit
     resources:
@@ -88,7 +88,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:5c0159feac3312c447b10c840558a5db6591f78c498cf9150e010be9fa860a20
+      digest: sha256:83b9cbd2662c56a6d6858210bfb375e81a5d6bea5462786d5005a473ad2ee657
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:981637a1e08c3a6c86f3631c6642f6f1412c2e89d306590f72958712f7a9211d
+    digest: sha256:4394f21f23e397728efe03d6e0680d717ce21a9ed4f7be3ea7b2aa042bd64574
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:
@@ -451,7 +451,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:0a0397b7e1fec51b2704e5c9ca131ebc1cb607d1ee9c882fd6205f9b7ca6b724
+    digest: sha256:0678815cb79fd6489303c08d74e4403e68e88e05eeec7c665904905f5e2253a5
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -471,7 +471,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:aa1a693a0d0d990392bc851153352a8d9180a1d9b1e501af22a13234af52a7d3
+      digest: sha256:7e4125022646fcbb01e3c24af7f670ae2ca3b93532b8594c284475daab24c81d
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""
@@ -503,7 +503,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:10a020acbc382e490deecdc78ad7945cbd26852f301f7a25f06ac89a3de8d802
+    digest: sha256:dea4ec46b0d97261cedd62ab6235e6aa6002e5aac8fab87b80d41e57f9658f82
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -557,7 +557,7 @@ maestro:
     managedIdentityName: maestro-consumer
     sidecar:
       image:
-        digest: sha256:b770cd63558c97c4e19d6f0dbe22b7a636b1eb4d267efe37f1ad44cdaecfddb9
+        digest: sha256:2c0ba08f2ebb48b3938b103cdce87450110a2f8ad76dd6a082d0dcd3e02c289e
         registry: mcr.microsoft.com
         repository: azurelinux/base/nginx
   certIssuer: Self
@@ -707,7 +707,7 @@ mgmt:
       image:
         registry: arohcpsvcdev.azurecr.io
         repository: thanos/thanos
-        sha: 6249f7aaadd3695df637fb2eb4cb9a9955611eee691c3970892fe9c0dc3f2db6
+        sha: b567818fe608067eb0f1d7c2c4fe361e7ad83c8a256234c97685f1d0bf670cc8
         tag: v0.41.0
   rg: hcp-underlay-cspr-westus3-mgmt-1
   stampIdentifier: "1"
@@ -1066,7 +1066,7 @@ svc:
       image:
         registry: arohcpsvcdev.azurecr.io
         repository: thanos/thanos
-        sha: 6249f7aaadd3695df637fb2eb4cb9a9955611eee691c3970892fe9c0dc3f2db6
+        sha: b567818fe608067eb0f1d7c2c4fe361e7ad83c8a256234c97685f1d0bf670cc8
         tag: v0.41.0
   rg: hcp-underlay-cspr-westus3-svc
   subscription:
@@ -1106,14 +1106,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:c4c26fca6614917e9b2812415e8f912fc45cfe6ea1755efea443670763898e3d
+    digest: sha256:f149e158d5bd4805920121d11656e89c1f43666e9929af4af99e8187e311a431
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:e072512980311316a92b5cfc9252b7d71fc9e534d8db8a9db2ff1d7004e1524b
+    digest: sha256:a3eea2c4ffbda320d9351a2498086f9061965ef1a0f6979bb07ae0ea085a0c16
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:a48979677ab533f849bf8c15eaab148f74857c8f48da945f52f10f029fdb569c
+    digest: sha256:edf402e1bdf5f4446f3316001cd5a323b037a0e9b54e8e2be8c0b768e95d9f74
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:c8b9aa2f3e0d3db6c11974c2ae820dab5cf3c290f7de8b5115e1839e0a8aab1d
+      digest: sha256:6a742a2bdb7aa8b7bb260dc378671d50522972954c9f2e36960c92602ba442a1
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:72b7793fba6c2f320616b4c2b8542e6c93fed6793ee51e19e019ba92dd1b2334
+      digest: sha256:55e5f7fc053cbd9ccbae7a3c4521a0b2d83586e319d023296d7224d2b226e247
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -72,7 +72,7 @@ armHelperTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 arobit:
   forwarder:
     image:
-      digest: sha256:c81f949228a0d446aea4966d8da39cfcd63f17c69a5eae143ce8264ddddc5777
+      digest: sha256:e8df41b2461b466e5f1d28157f7931f7c68b4b0917258e12de4d7922fd283703
       registry: mcr.microsoft.com
       repository: oss/v2/fluent/fluent-bit
     resources:
@@ -88,7 +88,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:5c0159feac3312c447b10c840558a5db6591f78c498cf9150e010be9fa860a20
+      digest: sha256:83b9cbd2662c56a6d6858210bfb375e81a5d6bea5462786d5005a473ad2ee657
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:981637a1e08c3a6c86f3631c6642f6f1412c2e89d306590f72958712f7a9211d
+    digest: sha256:4394f21f23e397728efe03d6e0680d717ce21a9ed4f7be3ea7b2aa042bd64574
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:
@@ -451,7 +451,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:0a0397b7e1fec51b2704e5c9ca131ebc1cb607d1ee9c882fd6205f9b7ca6b724
+    digest: sha256:0678815cb79fd6489303c08d74e4403e68e88e05eeec7c665904905f5e2253a5
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -471,7 +471,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:aa1a693a0d0d990392bc851153352a8d9180a1d9b1e501af22a13234af52a7d3
+      digest: sha256:7e4125022646fcbb01e3c24af7f670ae2ca3b93532b8594c284475daab24c81d
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""
@@ -503,7 +503,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:10a020acbc382e490deecdc78ad7945cbd26852f301f7a25f06ac89a3de8d802
+    digest: sha256:dea4ec46b0d97261cedd62ab6235e6aa6002e5aac8fab87b80d41e57f9658f82
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -557,7 +557,7 @@ maestro:
     managedIdentityName: maestro-consumer
     sidecar:
       image:
-        digest: sha256:b770cd63558c97c4e19d6f0dbe22b7a636b1eb4d267efe37f1ad44cdaecfddb9
+        digest: sha256:2c0ba08f2ebb48b3938b103cdce87450110a2f8ad76dd6a082d0dcd3e02c289e
         registry: mcr.microsoft.com
         repository: azurelinux/base/nginx
   certIssuer: Self
@@ -707,7 +707,7 @@ mgmt:
       image:
         registry: arohcpsvcdev.azurecr.io
         repository: thanos/thanos
-        sha: 6249f7aaadd3695df637fb2eb4cb9a9955611eee691c3970892fe9c0dc3f2db6
+        sha: b567818fe608067eb0f1d7c2c4fe361e7ad83c8a256234c97685f1d0bf670cc8
         tag: v0.41.0
   rg: hcp-underlay-dev-westus3-mgmt-1
   stampIdentifier: "1"
@@ -1066,7 +1066,7 @@ svc:
       image:
         registry: arohcpsvcdev.azurecr.io
         repository: thanos/thanos
-        sha: 6249f7aaadd3695df637fb2eb4cb9a9955611eee691c3970892fe9c0dc3f2db6
+        sha: b567818fe608067eb0f1d7c2c4fe361e7ad83c8a256234c97685f1d0bf670cc8
         tag: v0.41.0
   rg: hcp-underlay-dev-westus3-svc
   subscription:
@@ -1106,14 +1106,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:c4c26fca6614917e9b2812415e8f912fc45cfe6ea1755efea443670763898e3d
+    digest: sha256:f149e158d5bd4805920121d11656e89c1f43666e9929af4af99e8187e311a431
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:e072512980311316a92b5cfc9252b7d71fc9e534d8db8a9db2ff1d7004e1524b
+    digest: sha256:a3eea2c4ffbda320d9351a2498086f9061965ef1a0f6979bb07ae0ea085a0c16
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:a48979677ab533f849bf8c15eaab148f74857c8f48da945f52f10f029fdb569c
+    digest: sha256:edf402e1bdf5f4446f3316001cd5a323b037a0e9b54e8e2be8c0b768e95d9f74
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:4394f21f23e397728efe03d6e0680d717ce21a9ed4f7be3ea7b2aa042bd64574
+    digest: sha256:981637a1e08c3a6c86f3631c6642f6f1412c2e89d306590f72958712f7a9211d
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:4394f21f23e397728efe03d6e0680d717ce21a9ed4f7be3ea7b2aa042bd64574
+    digest: sha256:981637a1e08c3a6c86f3631c6642f6f1412c2e89d306590f72958712f7a9211d
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:c8b9aa2f3e0d3db6c11974c2ae820dab5cf3c290f7de8b5115e1839e0a8aab1d
+      digest: sha256:6a742a2bdb7aa8b7bb260dc378671d50522972954c9f2e36960c92602ba442a1
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:72b7793fba6c2f320616b4c2b8542e6c93fed6793ee51e19e019ba92dd1b2334
+      digest: sha256:55e5f7fc053cbd9ccbae7a3c4521a0b2d83586e319d023296d7224d2b226e247
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -72,7 +72,7 @@ armHelperTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 arobit:
   forwarder:
     image:
-      digest: sha256:c81f949228a0d446aea4966d8da39cfcd63f17c69a5eae143ce8264ddddc5777
+      digest: sha256:e8df41b2461b466e5f1d28157f7931f7c68b4b0917258e12de4d7922fd283703
       registry: mcr.microsoft.com
       repository: oss/v2/fluent/fluent-bit
     resources:
@@ -88,7 +88,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:5c0159feac3312c447b10c840558a5db6591f78c498cf9150e010be9fa860a20
+      digest: sha256:83b9cbd2662c56a6d6858210bfb375e81a5d6bea5462786d5005a473ad2ee657
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:981637a1e08c3a6c86f3631c6642f6f1412c2e89d306590f72958712f7a9211d
+    digest: sha256:4394f21f23e397728efe03d6e0680d717ce21a9ed4f7be3ea7b2aa042bd64574
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:
@@ -451,7 +451,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:0a0397b7e1fec51b2704e5c9ca131ebc1cb607d1ee9c882fd6205f9b7ca6b724
+    digest: sha256:0678815cb79fd6489303c08d74e4403e68e88e05eeec7c665904905f5e2253a5
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -471,7 +471,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:aa1a693a0d0d990392bc851153352a8d9180a1d9b1e501af22a13234af52a7d3
+      digest: sha256:7e4125022646fcbb01e3c24af7f670ae2ca3b93532b8594c284475daab24c81d
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""
@@ -503,7 +503,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:10a020acbc382e490deecdc78ad7945cbd26852f301f7a25f06ac89a3de8d802
+    digest: sha256:dea4ec46b0d97261cedd62ab6235e6aa6002e5aac8fab87b80d41e57f9658f82
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -557,7 +557,7 @@ maestro:
     managedIdentityName: maestro-consumer
     sidecar:
       image:
-        digest: sha256:b770cd63558c97c4e19d6f0dbe22b7a636b1eb4d267efe37f1ad44cdaecfddb9
+        digest: sha256:2c0ba08f2ebb48b3938b103cdce87450110a2f8ad76dd6a082d0dcd3e02c289e
         registry: mcr.microsoft.com
         repository: azurelinux/base/nginx
   certIssuer: Self
@@ -707,7 +707,7 @@ mgmt:
       image:
         registry: arohcpsvcdev.azurecr.io
         repository: thanos/thanos
-        sha: 6249f7aaadd3695df637fb2eb4cb9a9955611eee691c3970892fe9c0dc3f2db6
+        sha: b567818fe608067eb0f1d7c2c4fe361e7ad83c8a256234c97685f1d0bf670cc8
         tag: v0.41.0
   rg: hcp-underlay-perf-usw3ptest-mgmt-1
   stampIdentifier: "1"
@@ -1066,7 +1066,7 @@ svc:
       image:
         registry: arohcpsvcdev.azurecr.io
         repository: thanos/thanos
-        sha: 6249f7aaadd3695df637fb2eb4cb9a9955611eee691c3970892fe9c0dc3f2db6
+        sha: b567818fe608067eb0f1d7c2c4fe361e7ad83c8a256234c97685f1d0bf670cc8
         tag: v0.41.0
   rg: hcp-underlay-perf-usw3ptest-svc
   subscription:
@@ -1106,14 +1106,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:c4c26fca6614917e9b2812415e8f912fc45cfe6ea1755efea443670763898e3d
+    digest: sha256:f149e158d5bd4805920121d11656e89c1f43666e9929af4af99e8187e311a431
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:e072512980311316a92b5cfc9252b7d71fc9e534d8db8a9db2ff1d7004e1524b
+    digest: sha256:a3eea2c4ffbda320d9351a2498086f9061965ef1a0f6979bb07ae0ea085a0c16
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:a48979677ab533f849bf8c15eaab148f74857c8f48da945f52f10f029fdb569c
+    digest: sha256:edf402e1bdf5f4446f3316001cd5a323b037a0e9b54e8e2be8c0b768e95d9f74
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:4394f21f23e397728efe03d6e0680d717ce21a9ed4f7be3ea7b2aa042bd64574
+    digest: sha256:981637a1e08c3a6c86f3631c6642f6f1412c2e89d306590f72958712f7a9211d
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:c8b9aa2f3e0d3db6c11974c2ae820dab5cf3c290f7de8b5115e1839e0a8aab1d
+      digest: sha256:6a742a2bdb7aa8b7bb260dc378671d50522972954c9f2e36960c92602ba442a1
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:72b7793fba6c2f320616b4c2b8542e6c93fed6793ee51e19e019ba92dd1b2334
+      digest: sha256:55e5f7fc053cbd9ccbae7a3c4521a0b2d83586e319d023296d7224d2b226e247
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -72,7 +72,7 @@ armHelperTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 arobit:
   forwarder:
     image:
-      digest: sha256:c81f949228a0d446aea4966d8da39cfcd63f17c69a5eae143ce8264ddddc5777
+      digest: sha256:e8df41b2461b466e5f1d28157f7931f7c68b4b0917258e12de4d7922fd283703
       registry: mcr.microsoft.com
       repository: oss/v2/fluent/fluent-bit
     resources:
@@ -88,7 +88,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:5c0159feac3312c447b10c840558a5db6591f78c498cf9150e010be9fa860a20
+      digest: sha256:83b9cbd2662c56a6d6858210bfb375e81a5d6bea5462786d5005a473ad2ee657
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -172,7 +172,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:981637a1e08c3a6c86f3631c6642f6f1412c2e89d306590f72958712f7a9211d
+    digest: sha256:4394f21f23e397728efe03d6e0680d717ce21a9ed4f7be3ea7b2aa042bd64574
     registry: quay.io
     repository: app-sre/aro-hcp-clusters-service
   k8s:
@@ -451,7 +451,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides
   image:
-    digest: sha256:0a0397b7e1fec51b2704e5c9ca131ebc1cb607d1ee9c882fd6205f9b7ca6b724
+    digest: sha256:0678815cb79fd6489303c08d74e4403e68e88e05eeec7c665904905f5e2253a5
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -471,7 +471,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:aa1a693a0d0d990392bc851153352a8d9180a1d9b1e501af22a13234af52a7d3
+      digest: sha256:7e4125022646fcbb01e3c24af7f670ae2ca3b93532b8594c284475daab24c81d
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""
@@ -503,7 +503,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:10a020acbc382e490deecdc78ad7945cbd26852f301f7a25f06ac89a3de8d802
+    digest: sha256:dea4ec46b0d97261cedd62ab6235e6aa6002e5aac8fab87b80d41e57f9658f82
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -557,7 +557,7 @@ maestro:
     managedIdentityName: maestro-consumer
     sidecar:
       image:
-        digest: sha256:b770cd63558c97c4e19d6f0dbe22b7a636b1eb4d267efe37f1ad44cdaecfddb9
+        digest: sha256:2c0ba08f2ebb48b3938b103cdce87450110a2f8ad76dd6a082d0dcd3e02c289e
         registry: mcr.microsoft.com
         repository: azurelinux/base/nginx
   certIssuer: Self
@@ -709,7 +709,7 @@ mgmt:
       image:
         registry: arohcpsvcdev.azurecr.io
         repository: thanos/thanos
-        sha: 6249f7aaadd3695df637fb2eb4cb9a9955611eee691c3970892fe9c0dc3f2db6
+        sha: b567818fe608067eb0f1d7c2c4fe361e7ad83c8a256234c97685f1d0bf670cc8
         tag: v0.41.0
   rg: hcp-underlay-pers-usw3test-mgmt-1
   stampIdentifier: "1"
@@ -1070,7 +1070,7 @@ svc:
       image:
         registry: arohcpsvcdev.azurecr.io
         repository: thanos/thanos
-        sha: 6249f7aaadd3695df637fb2eb4cb9a9955611eee691c3970892fe9c0dc3f2db6
+        sha: b567818fe608067eb0f1d7c2c4fe361e7ad83c8a256234c97685f1d0bf670cc8
         tag: v0.41.0
   rg: hcp-underlay-pers-usw3test-svc
   subscription:
@@ -1110,14 +1110,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:c4c26fca6614917e9b2812415e8f912fc45cfe6ea1755efea443670763898e3d
+    digest: sha256:f149e158d5bd4805920121d11656e89c1f43666e9929af4af99e8187e311a431
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:e072512980311316a92b5cfc9252b7d71fc9e534d8db8a9db2ff1d7004e1524b
+    digest: sha256:a3eea2c4ffbda320d9351a2498086f9061965ef1a0f6979bb07ae0ea085a0c16
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:a48979677ab533f849bf8c15eaab148f74857c8f48da945f52f10f029fdb569c
+    digest: sha256:edf402e1bdf5f4446f3316001cd5a323b037a0e9b54e8e2be8c0b768e95d9f74
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -42,20 +42,20 @@ images:
     targets:
     - jsonPath: defaults.hypershift.sharedIngressImage.digest
       filePath: ../../config/config.yaml
-  # Clusters Service image
-  clusters-service:
-    group: cs
-    source:
-      image: quay.io/app-sre/aro-hcp-clusters-service
-      tag: "latest"
-      versionLabel: "vcs-ref"
-      useAuth: true
-      keyVault:
-        url: "https://arohcpdev-global.vault.azure.net/"
-        secretName: "component-sync-pull-secret"
-    targets:
-    - jsonPath: defaults.clustersService.image.digest
-      filePath: ../../config/config.yaml
+  # Clusters Service image - commented out per AROSLSRE-1685: pinned to sha256:981637a1e08c in config.yaml
+  # clusters-service:
+  #   group: cs
+  #   source:
+  #     image: quay.io/app-sre/aro-hcp-clusters-service
+  #     tag: "latest"
+  #     versionLabel: "vcs-ref"
+  #     useAuth: true
+  #     keyVault:
+  #       url: "https://arohcpdev-global.vault.azure.net/"
+  #       secretName: "component-sync-pull-secret"
+  #   targets:
+  #   - jsonPath: defaults.clustersService.image.digest
+  #     filePath: ../../config/config.yaml
   # Kube Events image
   kubeEvents:
     group: obs-agents


### PR DESCRIPTION
[AROSLSRE-1685](https://redhat.atlassian.net/browse/AROSLSRE-1685)

Update images except cluster service

| Name | Old Digest | New Digest | Tag | Date | Status |
| --- | --- | --- | --- | --- | --- |
| arobit-forwarder | c81f949228a0… | e8df41b2461b… | v5.0.4 | 2026-07-31 18:54 | updated |
| arobit-mdsd | 5c0159feac33… | 83b9cbd2662c… | 1.43.0-20260730-1 | 2026-07-30 17:43 | updated |
| kubeEvents | 10a020acbc38… | dea4ec46b0d9… | 20260802.1 | 2026-08-02 03:25 | updated |
| hypershift | 0a0397b7e1fe… | 0678815cb79f… | latest | 2026-08-01 04:25 | updated |
| velero-server | a48979677ab5… | edf402e1bdf5… | 1.6.1 | 2026-08-03 05:41 | updated |
| velero-azure-plugin | c4c26fca6614… | f149e158d5bd… | 1.6.1 | 2026-08-03 05:44 | updated |
| velero-hypershift-plugin | e07251298031… | a3eea2c4ffbd… | 1.6.1 | 2026-08-03 05:39 | updated |
| thanos | 6249f7aaadd3… | b567818fe608… | v0.42.4 | 2026-07-30 13:37 | updated |
| maestro-agent-sidecar | b770cd63558c… | 2c0ba08f2ebb… | 1.28.3-8-azl3.0.20260728 | 2026-07-31 23:27 | updated |
| acm-operator | 72b7793fba6c… | 55e5f7fc053c… | v2.16.3-548 | 2026-08-02 13:33 | updated |
| acm-mce | c8b9aa2f3e0d… | 6a742a2bdb7a… | v2.11.5-595 | 2026-08-02 13:32 | updated |
| clusters-service | 981637a1e08c… | — | — | — | **pinned** |
| imageSync | aa1a693a0d0d… | 7e4125022646… | 141a4c5 | 2026-08-02 08:17 | updated |

**Note:** clusters-service is pinned to `sha256:981637a1e08c` (commit `9b8050b0c3af`, 2026-07-29) and commented out in the image-updater config. The new clusters-service image (commit [2b4f2a905a76](https://github.com/openshift-online/aro-hcp-clusters-service/commit/2b4f2a905a7641ca9bcc02dd74004c493497b531)) removed an API URL gate in the manifestwork controller that was masking a timing gap, causing E2E APIService readiness failures on OCP 4.19 clusters.

Supersedes [#6337](https://github.com/Azure/ARO-HCP/pull/6337)