### PR TITLE
feat: gate kube-applier startup probe on CosmosDB reachability

### DIFF
--- a/kube-applier/deploy/templates/deployment.yaml
+++ b/kube-applier/deploy/templates/deployment.yaml
@@ -58,6 +58,19 @@ spec:
         - name: metrics
           containerPort: 8081
           protocol: TCP
+        startupProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 30
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          periodSeconds: 20
+          failureThreshold: 3
         readinessProbe:
           httpGet:
             path: /healthz

--- a/kube-applier/pkg/app/kube_applier.go
+++ b/kube-applier/pkg/app/kube_applier.go
@@ -24,6 +24,7 @@ import (
 
 	_ "k8s.io/component-base/metrics/prometheus/clientgo"
 
+	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -33,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/component-base/metrics/legacyregistry"
 
+	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/database/informers"
 	sharedleaderelection "github.com/Azure/ARO-HCP/internal/leaderelection"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -40,6 +42,10 @@ import (
 	"github.com/Azure/ARO-HCP/kube-applier/pkg/controllers/apply_desire"
 	"github.com/Azure/ARO-HCP/kube-applier/pkg/controllers/read_desire_manager"
 )
+
+// cosmosProbeTimeout bounds the Cosmos query behind /readyz so a hung query
+// cannot hold the handler open after the kubelet has given up on the probe.
+const cosmosProbeTimeout = 5 * time.Second
 
 // Run is the binary's main loop. It serves /healthz and /metrics, then runs
 // the controllers under a leader-election lease. Run returns when ctx is
@@ -63,21 +69,7 @@ func (o *Options) Run(ctx context.Context) error {
 	)
 
 	if o.HealthzServerListenAddress != "" {
-		healthGauge := promauto.With(o.metricsRegisterer()).NewGauge(prometheus.GaugeOpts{
-			Name: "kube_applier_health", Help: "kube_applier_health is 1 when healthy",
-		})
-		mux := http.NewServeMux()
-		mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-			if err := electionChecker.Check(r); err != nil {
-				logger.Error(err, "readiness probe failed")
-				http.Error(w, "lease not renewed", http.StatusServiceUnavailable)
-				healthGauge.Set(0)
-				return
-			}
-			w.WriteHeader(http.StatusOK)
-			healthGauge.Set(1)
-		})
-		server := &http.Server{Addr: o.HealthzServerListenAddress, Handler: mux}
+		server := &http.Server{Addr: o.HealthzServerListenAddress, Handler: o.newHealthzMux(logger, electionChecker)}
 		wg.Add(1)
 		go func() {
 			defer cancel(fmt.Errorf("healthz server exited"))
@@ -126,6 +118,56 @@ func (o *Options) Run(ctx context.Context) error {
 	wg.Wait()
 	logger.Info(fmt.Sprintf("%s (%s) stopped", AppShortDescriptionName, version.CommitSHA))
 	return errors.Join(errs...)
+}
+
+func (o *Options) newHealthzMux(logger logr.Logger, electionChecker *leaderelection.HealthzAdaptor) *http.ServeMux {
+	healthGauge := promauto.With(o.metricsRegisterer()).NewGauge(prometheus.GaugeOpts{
+		Name: "kube_applier_health", Help: "kube_applier_health is 1 when healthy",
+	})
+	cosmosGauge := promauto.With(o.metricsRegisterer()).NewGauge(prometheus.GaugeOpts{
+		Name: "kube_applier_cosmos_health", Help: "kube_applier_cosmos_health is 1 when the Cosmos container answers a query",
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		if err := electionChecker.Check(r); err != nil {
+			logger.Error(err, "readiness probe failed")
+			http.Error(w, "lease not renewed", http.StatusServiceUnavailable)
+			healthGauge.Set(0)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		healthGauge.Set(1)
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), cosmosProbeTimeout)
+		defer cancel()
+		if err := o.checkCosmos(ctx); err != nil {
+			logger.Error(err, "cosmos startup probe failed")
+			http.Error(w, "cosmos container not queryable", http.StatusServiceUnavailable)
+			cosmosGauge.Set(0)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		cosmosGauge.Set(1)
+	})
+	return mux
+}
+
+// checkCosmos issues one real data-plane query against cosmos.
+func (o *Options) checkCosmos(ctx context.Context) error {
+	pageSizeHint := int32(1)
+	iter, err := o.KubeApplierDBClient.Listers().ApplyDesires().List(ctx,
+		&database.DBClientListResourceDocsOptions{PageSizeHint: &pageSizeHint})
+	if err != nil {
+		return err
+	}
+	// The query is only issued once the iterator is pulled. An empty container
+	// yields no items and no error, which is a healthy result.
+	for range iter.Items(ctx) {
+		break
+	}
+	return iter.GetError()
 }
 
 // runControllersUnderLeaderElection wires the two controllers and runs them

--- a/kube-applier/pkg/app/kube_applier_test.go
+++ b/kube-applier/pkg/app/kube_applier_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"k8s.io/client-go/tools/leaderelection"
+
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+)
+
+func TestHealthzMuxProbes(t *testing.T) {
+	// A Cosmos 403 surfaces when the query pager is pulled, not when the lister
+	// is constructed, so the stub reports it through GetError().
+	cosmosDown := errors.New("403 Forbidden: request blocked by auth")
+
+	for _, tc := range []struct {
+		name         string
+		dbClient     database.KubeApplierDBClient
+		wantHealthz  int
+		wantReadyz   int
+		wantGaugeSet float64
+	}{
+		{
+			name:         "cosmos reachable",
+			dbClient:     databasetesting.NewMockKubeApplierDBClient(),
+			wantHealthz:  http.StatusOK,
+			wantReadyz:   http.StatusOK,
+			wantGaugeSet: 1,
+		},
+		{
+			name:         "cosmos unreachable",
+			dbClient:     failingDBClient{err: cosmosDown},
+			wantHealthz:  http.StatusOK, // process health must not follow Cosmos
+			wantReadyz:   http.StatusServiceUnavailable,
+			wantGaugeSet: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			registry := prometheus.NewRegistry()
+			o := &Options{
+				KubeApplierDBClient: tc.dbClient,
+				MetricsRegisterer:   registry,
+				MetricsGatherer:     registry,
+			}
+			mux := o.newHealthzMux(testr.New(t), leaderelection.NewLeaderHealthzAdaptor(20*time.Second))
+
+			for path, want := range map[string]int{"/healthz": tc.wantHealthz, "/readyz": tc.wantReadyz} {
+				recorder := httptest.NewRecorder()
+				mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, path, nil))
+				if recorder.Code != want {
+					t.Errorf("GET %s: got status %d, want %d (body %q)", path, recorder.Code, want, recorder.Body.String())
+				}
+			}
+
+			if got := gaugeValue(t, registry, "kube_applier_cosmos_health"); got != tc.wantGaugeSet {
+				t.Errorf("kube_applier_cosmos_health: got %v, want %v", got, tc.wantGaugeSet)
+			}
+		})
+	}
+}
+
+func gaugeValue(t *testing.T, gatherer prometheus.Gatherer, name string) float64 {
+	t.Helper()
+	families, err := gatherer.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+	for _, family := range families {
+		if family.GetName() == name {
+			return family.GetMetric()[0].GetGauge().GetValue()
+		}
+	}
+	t.Fatalf("metric %q was not registered", name)
+	return 0
+}
+
+// failingDBClient is a KubeApplierDBClient whose ApplyDesires query fails the
+// way a Cosmos data-plane 403 does: the lister is built fine, the error comes
+// out of the iterator. Only Listers() is exercised; the embedded nil interface
+// panics loudly if anything else is called.
+type failingDBClient struct {
+	database.KubeApplierDBClient
+	err error
+}
+
+func (c failingDBClient) Listers() database.KubeApplierListers {
+	return failingListers{err: c.err}
+}
+
+type failingListers struct {
+	database.KubeApplierListers
+	err error
+}
+
+func (l failingListers) ApplyDesires() database.GlobalLister[kubeapplier.ApplyDesire] {
+	return failingLister{err: l.err}
+}
+
+type failingLister struct {
+	err error
+}
+
+func (l failingLister) List(context.Context, *database.DBClientListResourceDocsOptions) (database.DBClientIterator[kubeapplier.ApplyDesire], error) {
+	return failingIterator(l), nil
+}
+
+type failingIterator struct {
+	err error
+}
+
+func (i failingIterator) Items(context.Context) database.DBClientIteratorItem[kubeapplier.ApplyDesire] {
+	return func(yield func(string, *kubeapplier.ApplyDesire) bool) {}
+}
+
+func (i failingIterator) GetContinuationToken() string { return "" }
+
+func (i failingIterator) GetError() error { return i.err }

--- a/kube-applier/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_kube_applier.yaml
+++ b/kube-applier/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_kube_applier.yaml
@@ -242,6 +242,24 @@ spec:
         - name: metrics
           containerPort: 8081
           protocol: TCP
+        # /readyz queries the Cosmos container; the pod stays not-Ready until
+        # that query succeeds, so a broken Cosmos connection stalls the rollout
+        # instead of going live (ITN-2026-00171). Liveness and readiness stay on
+        # /healthz (leader-election watchdog only) so a Cosmos outage cannot
+        # restart-loop every replica or drop them from the metrics endpoints.
+        startupProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 30
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          periodSeconds: 20
+          failureThreshold: 3
         readinessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
kube-applier had only a readiness probe, and it checked the leader-election lease — nothing checked Cosmos. During ITN-2026-00171 every Cosmos query returned 403 while the pods stayed Ready, so the broken version rolled out and stage E2E cluster creation timed out.

Add /readyz, which runs one real data-plane query (single ApplyDesire page) against this pod's container, and wire it to a new startupProbe so a pod never goes Ready while Cosmos is unreachable. Add a livenessProbe on /healthz. Liveness and readiness deliberately stay off Cosmos: a Cosmos blip must not restart-loop every replica or drop the pods out of the metrics endpoints mid-incident.

Jira: [ARO-27566](https://redhat.atlassian.net/browse/ARO-27566)

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
