### PR TITLE
feat: export Prow CI job metrics

### DIFF
--- a/config/config-dev-ci.schema.json
+++ b/config/config-dev-ci.schema.json
@@ -268,6 +268,7 @@
               "description": "Tenant quota collector configuration",
               "properties": {
                 "image": { "$ref": "#/$defs/Image" },
+                "prow": { "$ref": "#/$defs/ProwMetricsConfig" },
                 "tenants": {
                   "type": "array",
                   "description": "List of Azure AD tenants to monitor for directory and subscription quota",
@@ -534,6 +535,30 @@
         }
       },
       "required": ["tenantId", "tenantName", "servicePrincipalClientId", "keyVaultSecretName"]
+    },
+    "ProwMetricsConfig": {
+      "type": "object",
+      "description": "Configuration for collecting ARO-HCP Prow job metrics",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "baseURL": { "type": "string", "format": "uri" },
+        "interval": { "type": "string", "description": "Prow polling interval as a Go duration" },
+        "retention": { "type": "string", "description": "How long completed runs remain exposed as active metrics" },
+        "repository": {
+          "type": "object",
+          "properties": {
+            "org": { "type": "string" },
+            "name": { "type": "string" }
+          },
+          "required": ["org", "name"]
+        },
+        "excludeJobs": {
+          "type": "array",
+          "description": "Exact Prow job names to exclude",
+          "items": { "type": "string" }
+        }
+      },
+      "required": ["enabled", "baseURL", "interval", "retention", "repository", "excludeJobs"]
     },
     "SubscriptionQuotaConfig": {
       "type": "object",

--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -162,6 +162,15 @@ clouds:
             registry: "arohcpsvcdev.azurecr.io"
             repository: "tenant-quota-collector"
             digest: sha256:36f2251c61812dded8489affdc5b16f010705da6001bbfa90e10e318922e5a4d # dd702fa31e866201f704288af2b1e5a2d87d8848 (2026-08-04 19:49)
+          prow:
+            enabled: true
+            baseURL: "https://prow.ci.openshift.org"
+            interval: "5m"
+            retention: "24h"
+            repository:
+              org: "Azure"
+              name: "ARO-HCP"
+            excludeJobs: []
           tenants:
           - tenantId: "64dc69e4-d083-49fc-9569-ebece1dd1408"
             tenantName: "RedHat0"

--- a/tooling/tenant-quota/README.md
+++ b/tooling/tenant-quota/README.md
@@ -2,7 +2,7 @@
 
 `tenant-quota` is the historical name of the extensible DEV CI telemetry exporter running on the standalone `opstool` AKS cluster. It began by collecting tenant and subscription quota data, but its scope is growing beyond quota-only telemetry.
 
-Current examples include tenant capacity, subscription quota, and E2E resource-group expiry. The design also supports future Prow and other CI telemetry sources without turning this README into a fixed collector or metric inventory.
+Current examples include tenant capacity, subscription quota, E2E resource-group expiry, and Prow job outcomes and durations. The design supports additional CI telemetry sources without turning this README into a fixed collector or metric inventory.
 
 For alert response, routing, and monitoring maintenance, use the canonical [DEV CI Monitoring and Alert Response](../../docs/ci/dev-ci-monitoring.md) runbook.
 

--- a/tooling/tenant-quota/deploy/Chart.yaml
+++ b/tooling/tenant-quota/deploy/Chart.yaml
@@ -3,4 +3,4 @@ name: tenant-quota-collector
 version: 0.1.0
 appVersion: 0.1.0
 kubeVersion: ">=1.27.0"
-description: Tenant Quota Collector - collects Azure AD tenant quota metrics from Microsoft Graph API.
+description: Collects Azure quota and ARO HCP Prow CI metrics.

--- a/tooling/tenant-quota/deploy/config.yaml.tmpl
+++ b/tooling/tenant-quota/deploy/config.yaml.tmpl
@@ -15,6 +15,22 @@
 interval: "5m"
 timeout: "30s"
 cacheTTL: "24h"
+prow:
+  enabled: {{ .opstool.tenantQuota.prow.enabled }}
+  baseURL: "{{ .opstool.tenantQuota.prow.baseURL }}"
+  interval: "{{ .opstool.tenantQuota.prow.interval }}"
+  retention: "{{ .opstool.tenantQuota.prow.retention }}"
+  repository:
+    org: "{{ .opstool.tenantQuota.prow.repository.org }}"
+    name: "{{ .opstool.tenantQuota.prow.repository.name }}"
+{{- if .opstool.tenantQuota.prow.excludeJobs }}
+  excludeJobs:
+{{- range .opstool.tenantQuota.prow.excludeJobs }}
+  - "{{ . }}"
+{{- end }}
+{{- else }}
+  excludeJobs: []
+{{- end }}
 tenants:
 {{- range .opstool.tenantQuota.tenants }}
 - tenantId: "{{ .tenantId }}"

--- a/tooling/tenant-quota/deploy/templates/configmap.yaml
+++ b/tooling/tenant-quota/deploy/templates/configmap.yaml
@@ -9,6 +9,15 @@ data:
     interval: "5m"
     timeout: "30s"
     cacheTTL: "24h"
+    prow:
+      enabled: {{ .Values.prow.enabled }}
+      baseURL: "{{ .Values.prow.baseURL }}"
+      interval: "{{ .Values.prow.interval }}"
+      retention: "{{ .Values.prow.retention }}"
+      repository:
+        org: "{{ .Values.prow.repository.org }}"
+        name: "{{ .Values.prow.repository.name }}"
+      excludeJobs: {{ .Values.prow.excludeJobs | toJson }}
     tenants:
       {{- range .Values.tenants }}
       - tenantId: "{{ .tenantId }}"

--- a/tooling/tenant-quota/deploy/values.yaml
+++ b/tooling/tenant-quota/deploy/values.yaml
@@ -10,4 +10,13 @@ secretProvider:
   keyVault: ""
   msiClientId: ""
   tenantId: ""
+prow:
+  enabled: false
+  baseURL: ""
+  interval: "5m"
+  retention: "24h"
+  repository:
+    org: ""
+    name: ""
+  excludeJobs: []
 tenants: []

--- a/tooling/tenant-quota/deploy/values.yaml.tmpl
+++ b/tooling/tenant-quota/deploy/values.yaml.tmpl
@@ -6,6 +6,22 @@ secretProvider:
   keyVault: "__keyVaultName__"
   msiClientId: "__tenantQuotaUAMIClientId__"
   tenantId: "64dc69e4-d083-49fc-9569-ebece1dd1408"
+prow:
+  enabled: {{ .opstool.tenantQuota.prow.enabled }}
+  baseURL: "{{ .opstool.tenantQuota.prow.baseURL }}"
+  interval: "{{ .opstool.tenantQuota.prow.interval }}"
+  retention: "{{ .opstool.tenantQuota.prow.retention }}"
+  repository:
+    org: "{{ .opstool.tenantQuota.prow.repository.org }}"
+    name: "{{ .opstool.tenantQuota.prow.repository.name }}"
+{{- if .opstool.tenantQuota.prow.excludeJobs }}
+  excludeJobs:
+{{- range .opstool.tenantQuota.prow.excludeJobs }}
+  - "{{ . }}"
+{{- end }}
+{{- else }}
+  excludeJobs: []
+{{- end }}
 tenants:
 {{- range .opstool.tenantQuota.tenants }}
 - tenantId: "{{ .tenantId }}"

--- a/tooling/tenant-quota/main.go
+++ b/tooling/tenant-quota/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/Azure/ARO-HCP/tooling/azutils/subscriptions"
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/config"
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/credentials"
+	prowmetrics "github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/prow"
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/resourcegroups"
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/subscriptionquota"
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/tenantquota"
@@ -95,6 +96,12 @@ func run(logger *slog.Logger) error {
 		e2eRGCollector := resourcegroups.NewCollector(resourcegroups.E2ECollectorConfig, cfg, logger, credProvider)
 		registry.MustRegister(e2eRGCollector)
 		go e2eRGCollector.Start(ctx)
+	}
+
+	if cfg.Prow.Enabled {
+		prowCollector := prowmetrics.NewCollector(cfg, logger)
+		registry.MustRegister(prowCollector)
+		go prowCollector.Start(ctx)
 	}
 
 	mux := http.NewServeMux()

--- a/tooling/tenant-quota/pkg/config/config.go
+++ b/tooling/tenant-quota/pkg/config/config.go
@@ -16,7 +16,9 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -28,6 +30,8 @@ const (
 	DefaultCacheTTL            = 24 * time.Hour
 	DefaultRoleAssignmentLimit = 4000
 	DefaultScope               = "https://graph.microsoft.com/.default"
+	DefaultProwInterval        = 5 * time.Minute
+	DefaultProwRetention       = 24 * time.Hour
 )
 
 type Config struct {
@@ -35,10 +39,28 @@ type Config struct {
 	Timeout  string         `yaml:"timeout"`
 	CacheTTL string         `yaml:"cacheTTL,omitempty"`
 	Tenants  []TenantConfig `yaml:"tenants"`
+	Prow     ProwConfig     `yaml:"prow,omitempty"`
 
 	intervalDuration time.Duration
 	timeoutDuration  time.Duration
 	cacheTTLDuration time.Duration
+}
+
+type ProwConfig struct {
+	Enabled     bool                 `yaml:"enabled"`
+	BaseURL     string               `yaml:"baseURL"`
+	Interval    string               `yaml:"interval,omitempty"`
+	Retention   string               `yaml:"retention,omitempty"`
+	Repository  ProwRepositoryConfig `yaml:"repository"`
+	ExcludeJobs []string             `yaml:"excludeJobs,omitempty"`
+
+	intervalDuration  time.Duration
+	retentionDuration time.Duration
+}
+
+type ProwRepositoryConfig struct {
+	Org  string `yaml:"org"`
+	Name string `yaml:"name"`
 }
 
 type TenantConfig struct {
@@ -89,6 +111,9 @@ func (c *Config) Validate() error {
 	if err := parseDuration(c.CacheTTL, DefaultCacheTTL, &c.cacheTTLDuration, "cacheTTL"); err != nil {
 		return err
 	}
+	if err := c.Prow.validate(); err != nil {
+		return err
+	}
 
 	if len(c.Tenants) == 0 {
 		return fmt.Errorf("at least one tenant must be configured")
@@ -123,6 +148,43 @@ func (c *Config) Validate() error {
 	return nil
 }
 
+func (c *ProwConfig) validate() error {
+	if err := parseDuration(c.Interval, DefaultProwInterval, &c.intervalDuration, "prow.interval"); err != nil {
+		return err
+	}
+	if err := parseDuration(c.Retention, DefaultProwRetention, &c.retentionDuration, "prow.retention"); err != nil {
+		return err
+	}
+	if !c.Enabled {
+		return nil
+	}
+
+	parsedURL, err := url.Parse(strings.TrimSpace(c.BaseURL))
+	if err != nil || parsedURL.Host == "" || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
+		return fmt.Errorf("prow.baseURL must be a valid HTTP or HTTPS URL")
+	}
+	if strings.TrimSpace(c.Repository.Org) == "" {
+		return fmt.Errorf("prow.repository.org is required")
+	}
+	if strings.TrimSpace(c.Repository.Name) == "" {
+		return fmt.Errorf("prow.repository.name is required")
+	}
+
+	seen := make(map[string]struct{}, len(c.ExcludeJobs))
+	for i, jobName := range c.ExcludeJobs {
+		normalized := strings.TrimSpace(jobName)
+		if normalized == "" {
+			return fmt.Errorf("prow.excludeJobs[%d] must not be empty", i)
+		}
+		if _, found := seen[normalized]; found {
+			return fmt.Errorf("prow.excludeJobs[%d] duplicates %q", i, normalized)
+		}
+		seen[normalized] = struct{}{}
+		c.ExcludeJobs[i] = normalized
+	}
+	return nil
+}
+
 func parseDuration(raw string, defaultVal time.Duration, dst *time.Duration, name string) error {
 	if raw == "" {
 		*dst = defaultVal
@@ -149,6 +211,14 @@ func (c *Config) GetTimeout() time.Duration {
 
 func (c *Config) GetCacheTTL() time.Duration {
 	return c.cacheTTLDuration
+}
+
+func (c *ProwConfig) GetInterval() time.Duration {
+	return c.intervalDuration
+}
+
+func (c *ProwConfig) GetRetention() time.Duration {
+	return c.retentionDuration
 }
 
 // HasSubscriptions returns true if any tenant has subscription quota monitoring configured.

--- a/tooling/tenant-quota/pkg/config/config.go
+++ b/tooling/tenant-quota/pkg/config/config.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -170,18 +172,15 @@ func (c *ProwConfig) validate() error {
 		return fmt.Errorf("prow.repository.name is required")
 	}
 
-	seen := make(map[string]struct{}, len(c.ExcludeJobs))
+	excludedJobs := sets.New[string]()
 	for i, jobName := range c.ExcludeJobs {
 		normalized := strings.TrimSpace(jobName)
 		if normalized == "" {
 			return fmt.Errorf("prow.excludeJobs[%d] must not be empty", i)
 		}
-		if _, found := seen[normalized]; found {
-			return fmt.Errorf("prow.excludeJobs[%d] duplicates %q", i, normalized)
-		}
-		seen[normalized] = struct{}{}
-		c.ExcludeJobs[i] = normalized
+		excludedJobs.Insert(normalized)
 	}
+	c.ExcludeJobs = sets.List(excludedJobs)
 	return nil
 }
 

--- a/tooling/tenant-quota/pkg/config/config_test.go
+++ b/tooling/tenant-quota/pkg/config/config_test.go
@@ -81,6 +81,12 @@ func TestConfigValidate(t *testing.T) {
 				if cfg.GetCacheTTL() != DefaultCacheTTL {
 					t.Fatalf("cacheTTL: got %v, want %v", cfg.GetCacheTTL(), DefaultCacheTTL)
 				}
+				if cfg.Prow.GetInterval() != DefaultProwInterval {
+					t.Fatalf("prow interval: got %v, want %v", cfg.Prow.GetInterval(), DefaultProwInterval)
+				}
+				if cfg.Prow.GetRetention() != DefaultProwRetention {
+					t.Fatalf("prow retention: got %v, want %v", cfg.Prow.GetRetention(), DefaultProwRetention)
+				}
 			},
 		},
 		{
@@ -133,6 +139,80 @@ func TestConfigValidate(t *testing.T) {
 			cfg:        minimalValidConfig(),
 			mutate:     func(cfg *Config) { cfg.CacheTTL = "bad" },
 			wantErrSub: "invalid cacheTTL",
+		},
+		{
+			name: "valid prow config",
+			cfg:  minimalValidConfig(),
+			mutate: func(cfg *Config) {
+				cfg.Prow = validProwConfig()
+				cfg.Prow.Interval = "10m"
+				cfg.Prow.Retention = "48h"
+				cfg.Prow.ExcludeJobs = []string{" excluded-job "}
+			},
+			assertions: func(t *testing.T, cfg Config) {
+				t.Helper()
+				if cfg.Prow.GetInterval() != 10*time.Minute {
+					t.Fatalf("prow interval: got %v, want 10m", cfg.Prow.GetInterval())
+				}
+				if cfg.Prow.GetRetention() != 48*time.Hour {
+					t.Fatalf("prow retention: got %v, want 48h", cfg.Prow.GetRetention())
+				}
+				if len(cfg.Prow.ExcludeJobs) != 1 || cfg.Prow.ExcludeJobs[0] != "excluded-job" {
+					t.Fatalf("prow excludeJobs: got %v", cfg.Prow.ExcludeJobs)
+				}
+			},
+		},
+		{
+			name: "prow disabled allows empty connection settings",
+			cfg:  minimalValidConfig(),
+			mutate: func(cfg *Config) {
+				cfg.Prow = ProwConfig{Enabled: false}
+			},
+		},
+		{
+			name: "prow invalid base URL",
+			cfg:  minimalValidConfig(),
+			mutate: func(cfg *Config) {
+				cfg.Prow = validProwConfig()
+				cfg.Prow.BaseURL = "not-a-url"
+			},
+			wantErrSub: "prow.baseURL",
+		},
+		{
+			name: "prow missing repository org",
+			cfg:  minimalValidConfig(),
+			mutate: func(cfg *Config) {
+				cfg.Prow = validProwConfig()
+				cfg.Prow.Repository.Org = ""
+			},
+			wantErrSub: "prow.repository.org is required",
+		},
+		{
+			name: "prow missing repository name",
+			cfg:  minimalValidConfig(),
+			mutate: func(cfg *Config) {
+				cfg.Prow = validProwConfig()
+				cfg.Prow.Repository.Name = ""
+			},
+			wantErrSub: "prow.repository.name is required",
+		},
+		{
+			name: "prow empty exclusion",
+			cfg:  minimalValidConfig(),
+			mutate: func(cfg *Config) {
+				cfg.Prow = validProwConfig()
+				cfg.Prow.ExcludeJobs = []string{""}
+			},
+			wantErrSub: "prow.excludeJobs[0] must not be empty",
+		},
+		{
+			name: "prow duplicate exclusion",
+			cfg:  minimalValidConfig(),
+			mutate: func(cfg *Config) {
+				cfg.Prow = validProwConfig()
+				cfg.Prow.ExcludeJobs = []string{"job", "job"}
+			},
+			wantErrSub: `prow.excludeJobs[1] duplicates "job"`,
 		},
 		{
 			name:       "no tenants",
@@ -246,6 +326,17 @@ func TestConfigValidate(t *testing.T) {
 	}
 }
 
+func validProwConfig() ProwConfig {
+	return ProwConfig{
+		Enabled: true,
+		BaseURL: "https://prow.ci.openshift.org",
+		Repository: ProwRepositoryConfig{
+			Org:  "Azure",
+			Name: "ARO-HCP",
+		},
+	}
+}
+
 func TestLoadFromFile(t *testing.T) {
 	type testCase struct {
 		name       string
@@ -259,6 +350,14 @@ func TestLoadFromFile(t *testing.T) {
 			setup: func(t *testing.T) string {
 				t.Helper()
 				return writeYAML(t, `
+prow:
+  enabled: true
+  baseURL: "https://prow.ci.openshift.org"
+  repository:
+    org: "Azure"
+    name: "ARO-HCP"
+  excludeJobs:
+    - "excluded-job"
 tenants:
   - tenantId: "tid-1"
     servicePrincipalClientId: "sp-id"
@@ -292,6 +391,9 @@ tenants:
 				}
 				if cfg.Tenants[0].Subscriptions[0].SubscriptionID != "" {
 					t.Fatalf("subscriptionId: got %q, want empty runtime-resolved value", cfg.Tenants[0].Subscriptions[0].SubscriptionID)
+				}
+				if !cfg.Prow.Enabled || cfg.Prow.Repository.Name != "ARO-HCP" {
+					t.Fatalf("prow config: got %#v", cfg.Prow)
 				}
 			},
 		},

--- a/tooling/tenant-quota/pkg/config/config_test.go
+++ b/tooling/tenant-quota/pkg/config/config_test.go
@@ -17,6 +17,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -206,13 +207,18 @@ func TestConfigValidate(t *testing.T) {
 			wantErrSub: "prow.excludeJobs[0] must not be empty",
 		},
 		{
-			name: "prow duplicate exclusion",
+			name: "prow duplicate exclusions are deduplicated",
 			cfg:  minimalValidConfig(),
 			mutate: func(cfg *Config) {
 				cfg.Prow = validProwConfig()
-				cfg.Prow.ExcludeJobs = []string{"job", "job"}
+				cfg.Prow.ExcludeJobs = []string{" job-b ", "job-a", "job-b"}
 			},
-			wantErrSub: `prow.excludeJobs[1] duplicates "job"`,
+			assertions: func(t *testing.T, cfg Config) {
+				t.Helper()
+				if !slices.Equal(cfg.Prow.ExcludeJobs, []string{"job-a", "job-b"}) {
+					t.Fatalf("prow excludeJobs: got %v, want [job-a job-b]", cfg.Prow.ExcludeJobs)
+				}
+			},
 		},
 		{
 			name:       "no tenants",

--- a/tooling/tenant-quota/pkg/prow/collector.go
+++ b/tooling/tenant-quota/pkg/prow/collector.go
@@ -16,6 +16,7 @@ package prow
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -32,10 +33,25 @@ import (
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/prowjobs"
 )
 
+const (
+	invalidReasonMissingJobName        = "missing_job_name"
+	invalidReasonMissingBuildID        = "missing_build_id"
+	invalidReasonMissingStartTime      = "missing_start_time"
+	invalidReasonMissingCompletionTime = "missing_completion_time"
+	invalidReasonInvalidTimeRange      = "invalid_time_range"
+)
+
 var (
 	infoMetricLabels           = []string{"job_name", "job_type", "build_id", "result"}
 	durationBucketMetricLabels = []string{"job_name", "job_type", "result", "le"}
-	durationBuckets            = []float64{
+	invalidJobReasons          = []string{
+		invalidReasonMissingJobName,
+		invalidReasonMissingBuildID,
+		invalidReasonMissingStartTime,
+		invalidReasonMissingCompletionTime,
+		invalidReasonInvalidTimeRange,
+	}
+	durationBuckets = []float64{
 		60,
 		300,
 		600,
@@ -84,11 +100,14 @@ type Collector struct {
 	collectionSuccessDesc *prometheus.Desc
 	lastSuccessDesc       *prometheus.Desc
 	cachedRunsDesc        *prometheus.Desc
+	invalidJobsDesc       *prometheus.Desc
 
 	mu                   sync.RWMutex
 	runs                 map[string]runMetrics
 	collectionSuccess    float64
 	lastSuccessTimestamp float64
+	seenInvalidJobs      sets.Set[string]
+	invalidJobCounts     map[string]float64
 }
 
 func NewCollector(cfg *config.Config, logger *slog.Logger, clients ...prowjobs.Client) *Collector {
@@ -134,7 +153,15 @@ func NewCollector(cfg *config.Config, logger *slog.Logger, clients ...prowjobs.C
 			nil,
 			nil,
 		),
-		runs: make(map[string]runMetrics),
+		invalidJobsDesc: prometheus.NewDesc(
+			"prow_ci_invalid_jobs_total",
+			"Total number of unique malformed completed Prow CI jobs observed since exporter start",
+			[]string{"reason"},
+			nil,
+		),
+		runs:             make(map[string]runMetrics),
+		seenInvalidJobs:  sets.New[string](),
+		invalidJobCounts: make(map[string]float64, len(invalidJobReasons)),
 	}
 }
 
@@ -144,6 +171,7 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.collectionSuccessDesc
 	ch <- c.lastSuccessDesc
 	ch <- c.cachedRunsDesc
+	ch <- c.invalidJobsDesc
 }
 
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
@@ -155,6 +183,10 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	collectionSuccess := c.collectionSuccess
 	lastSuccessTimestamp := c.lastSuccessTimestamp
 	cachedRuns := len(c.runs)
+	invalidJobCounts := make(map[string]float64, len(invalidJobReasons))
+	for _, reason := range invalidJobReasons {
+		invalidJobCounts[reason] = c.invalidJobCounts[reason]
+	}
 	c.mu.RUnlock()
 
 	durations := make(map[durationMetricKey]*durationMetrics)
@@ -200,6 +232,14 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(c.collectionSuccessDesc, prometheus.GaugeValue, collectionSuccess)
 	ch <- prometheus.MustNewConstMetric(c.lastSuccessDesc, prometheus.GaugeValue, lastSuccessTimestamp)
 	ch <- prometheus.MustNewConstMetric(c.cachedRunsDesc, prometheus.GaugeValue, float64(cachedRuns))
+	for _, reason := range invalidJobReasons {
+		ch <- prometheus.MustNewConstMetric(
+			c.invalidJobsDesc,
+			prometheus.CounterValue,
+			invalidJobCounts[reason],
+			reason,
+		)
+	}
 }
 
 func (c *Collector) Start(ctx context.Context) {
@@ -265,7 +305,23 @@ func (c *Collector) collectOnce(ctx context.Context) error {
 		if excluded.Has(jobName) {
 			continue
 		}
-		if !validCompletedJob(job) {
+		if !prowjobs.IsTerminalState(job.Status.State) {
+			continue
+		}
+		if reason := invalidCompletedJobReason(job); reason != "" {
+			jobID := invalidJobID(job)
+			if !c.seenInvalidJobs.Has(jobID) {
+				c.seenInvalidJobs.Insert(jobID)
+				c.invalidJobCounts[reason]++
+				c.logger.Warn(
+					"Skipping malformed completed Prow CI job",
+					"reason", reason,
+					"prowJob", strings.TrimSpace(job.Metadata.Name),
+					"jobName", jobName,
+					"buildID", strings.TrimSpace(job.Status.BuildID),
+					"state", prowjobs.NormalizeState(job.Status.State),
+				)
+			}
 			continue
 		}
 
@@ -328,11 +384,36 @@ func refsMatch(refs prowjobs.Refs, repository config.ProwRepositoryConfig) bool 
 		strings.EqualFold(strings.TrimSpace(refs.Repo), strings.TrimSpace(repository.Name))
 }
 
-func validCompletedJob(job prowjobs.Job) bool {
-	return strings.TrimSpace(job.Spec.Job) != "" &&
-		strings.TrimSpace(job.Status.BuildID) != "" &&
-		prowjobs.IsTerminalState(job.Status.State) &&
-		!job.Status.StartTime.IsZero() &&
-		!job.Status.CompletionTime.IsZero() &&
-		!job.Status.CompletionTime.Before(job.Status.StartTime)
+func invalidCompletedJobReason(job prowjobs.Job) string {
+	switch {
+	case strings.TrimSpace(job.Spec.Job) == "":
+		return invalidReasonMissingJobName
+	case strings.TrimSpace(job.Status.BuildID) == "":
+		return invalidReasonMissingBuildID
+	case job.Status.StartTime.IsZero():
+		return invalidReasonMissingStartTime
+	case job.Status.CompletionTime.IsZero():
+		return invalidReasonMissingCompletionTime
+	case job.Status.CompletionTime.Before(job.Status.StartTime):
+		return invalidReasonInvalidTimeRange
+	default:
+		return ""
+	}
+}
+
+func invalidJobID(job prowjobs.Job) string {
+	if name := strings.TrimSpace(job.Metadata.Name); name != "" {
+		return name
+	}
+
+	identity := fmt.Sprintf(
+		"%s\x00%s\x00%s\x00%s\x00%s\x00%s",
+		job.Spec.Job,
+		job.Status.BuildID,
+		job.Status.State,
+		job.Status.StartTime.UTC().Format(time.RFC3339Nano),
+		job.Status.CompletionTime.UTC().Format(time.RFC3339Nano),
+		job.Status.URL,
+	)
+	return fmt.Sprintf("fallback:%x", sha256.Sum256([]byte(identity)))
 }

--- a/tooling/tenant-quota/pkg/prow/collector.go
+++ b/tooling/tenant-quota/pkg/prow/collector.go
@@ -147,10 +147,17 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	c.mu.RLock()
-	defer c.mu.RUnlock()
+	runs := make([]runMetrics, 0, len(c.runs))
+	for _, run := range c.runs {
+		runs = append(runs, run)
+	}
+	collectionSuccess := c.collectionSuccess
+	lastSuccessTimestamp := c.lastSuccessTimestamp
+	cachedRuns := len(c.runs)
+	c.mu.RUnlock()
 
 	durations := make(map[durationMetricKey]*durationMetrics)
-	for _, run := range c.runs {
+	for _, run := range runs {
 		labels := []string{run.jobName, run.jobType, run.buildID, run.result}
 		ch <- prometheus.MustNewConstMetric(c.infoDesc, prometheus.GaugeValue, 1, labels...)
 
@@ -189,9 +196,9 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			append(labels, "+Inf")...,
 		)
 	}
-	ch <- prometheus.MustNewConstMetric(c.collectionSuccessDesc, prometheus.GaugeValue, c.collectionSuccess)
-	ch <- prometheus.MustNewConstMetric(c.lastSuccessDesc, prometheus.GaugeValue, c.lastSuccessTimestamp)
-	ch <- prometheus.MustNewConstMetric(c.cachedRunsDesc, prometheus.GaugeValue, float64(len(c.runs)))
+	ch <- prometheus.MustNewConstMetric(c.collectionSuccessDesc, prometheus.GaugeValue, collectionSuccess)
+	ch <- prometheus.MustNewConstMetric(c.lastSuccessDesc, prometheus.GaugeValue, lastSuccessTimestamp)
+	ch <- prometheus.MustNewConstMetric(c.cachedRunsDesc, prometheus.GaugeValue, float64(cachedRuns))
 }
 
 func (c *Collector) Start(ctx context.Context) {

--- a/tooling/tenant-quota/pkg/prow/collector.go
+++ b/tooling/tenant-quota/pkg/prow/collector.go
@@ -110,8 +110,8 @@ func NewCollector(cfg *config.Config, logger *slog.Logger, clients ...prowjobs.C
 			nil,
 		),
 		durationBucketDesc: prometheus.NewDesc(
-			"prow_ci_job_duration_seconds_bucket",
-			"Number of completed Prow CI jobs in the retention window with duration at or below the bucket boundary",
+			"prow_ci_job_duration_window_runs",
+			"Number of completed Prow CI jobs in the retention window with duration at or below the le boundary; use histogram_quantile() directly without rate() or increase()",
 			durationBucketMetricLabels,
 			nil,
 		),

--- a/tooling/tenant-quota/pkg/prow/collector.go
+++ b/tooling/tenant-quota/pkg/prow/collector.go
@@ -1,0 +1,333 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prow
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/config"
+	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/prowjobs"
+)
+
+var (
+	infoMetricLabels           = []string{"job_name", "job_type", "build_id", "result"}
+	durationBucketMetricLabels = []string{"job_name", "job_type", "result", "le"}
+	durationBuckets            = []float64{
+		60,
+		300,
+		600,
+		900,
+		1200,
+		1500,
+		1800,
+		2700,
+		3600,
+		5400,
+		7200,
+		7800,
+		8400,
+		9000,
+		10800,
+	}
+)
+
+type runMetrics struct {
+	jobName      string
+	jobType      string
+	buildID      string
+	result       string
+	duration     float64
+	completionAt time.Time
+}
+
+type durationMetricKey struct {
+	jobName string
+	jobType string
+	result  string
+}
+
+type durationMetrics struct {
+	buckets []float64
+}
+
+type Collector struct {
+	config *config.Config
+	logger *slog.Logger
+	client prowjobs.Client
+	now    func() time.Time
+
+	infoDesc              *prometheus.Desc
+	durationBucketDesc    *prometheus.Desc
+	collectionSuccessDesc *prometheus.Desc
+	lastSuccessDesc       *prometheus.Desc
+	cachedRunsDesc        *prometheus.Desc
+
+	mu                   sync.RWMutex
+	runs                 map[string]runMetrics
+	collectionSuccess    float64
+	lastSuccessTimestamp float64
+}
+
+func NewCollector(cfg *config.Config, logger *slog.Logger, clients ...prowjobs.Client) *Collector {
+	var client prowjobs.Client
+	if len(clients) > 0 {
+		client = clients[0]
+	} else {
+		client = prowjobs.NewHTTPClient(cfg.Prow.BaseURL, cfg.GetTimeout())
+	}
+
+	return &Collector{
+		config: cfg,
+		logger: logger,
+		client: client,
+		now:    time.Now,
+		infoDesc: prometheus.NewDesc(
+			"prow_ci_job_info",
+			"Information about a completed Prow CI job",
+			infoMetricLabels,
+			nil,
+		),
+		durationBucketDesc: prometheus.NewDesc(
+			"prow_ci_job_duration_seconds_bucket",
+			"Number of completed Prow CI jobs in the retention window with duration at or below the bucket boundary",
+			durationBucketMetricLabels,
+			nil,
+		),
+		collectionSuccessDesc: prometheus.NewDesc(
+			"prow_ci_collection_success",
+			"Whether the most recent Prow CI collection succeeded",
+			nil,
+			nil,
+		),
+		lastSuccessDesc: prometheus.NewDesc(
+			"prow_ci_collection_last_success_timestamp_seconds",
+			"Unix timestamp of the most recent successful Prow CI collection",
+			nil,
+			nil,
+		),
+		cachedRunsDesc: prometheus.NewDesc(
+			"prow_ci_cached_runs",
+			"Number of completed Prow CI runs currently exposed",
+			nil,
+			nil,
+		),
+		runs: make(map[string]runMetrics),
+	}
+}
+
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.infoDesc
+	ch <- c.durationBucketDesc
+	ch <- c.collectionSuccessDesc
+	ch <- c.lastSuccessDesc
+	ch <- c.cachedRunsDesc
+}
+
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	durations := make(map[durationMetricKey]*durationMetrics)
+	for _, run := range c.runs {
+		labels := []string{run.jobName, run.jobType, run.buildID, run.result}
+		ch <- prometheus.MustNewConstMetric(c.infoDesc, prometheus.GaugeValue, 1, labels...)
+
+		key := durationMetricKey{
+			jobName: run.jobName,
+			jobType: run.jobType,
+			result:  run.result,
+		}
+		metrics, found := durations[key]
+		if !found {
+			metrics = &durationMetrics{buckets: make([]float64, len(durationBuckets)+1)}
+			durations[key] = metrics
+		}
+		for i, upperBound := range durationBuckets {
+			if run.duration <= upperBound {
+				metrics.buckets[i]++
+			}
+		}
+		metrics.buckets[len(durationBuckets)]++
+	}
+	for key, metrics := range durations {
+		labels := []string{key.jobName, key.jobType, key.result}
+		for i, upperBound := range durationBuckets {
+			bucketLabels := append(labels, strconv.FormatFloat(upperBound, 'g', -1, 64))
+			ch <- prometheus.MustNewConstMetric(
+				c.durationBucketDesc,
+				prometheus.GaugeValue,
+				metrics.buckets[i],
+				bucketLabels...,
+			)
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.durationBucketDesc,
+			prometheus.GaugeValue,
+			metrics.buckets[len(durationBuckets)],
+			append(labels, "+Inf")...,
+		)
+	}
+	ch <- prometheus.MustNewConstMetric(c.collectionSuccessDesc, prometheus.GaugeValue, c.collectionSuccess)
+	ch <- prometheus.MustNewConstMetric(c.lastSuccessDesc, prometheus.GaugeValue, c.lastSuccessTimestamp)
+	ch <- prometheus.MustNewConstMetric(c.cachedRunsDesc, prometheus.GaugeValue, float64(len(c.runs)))
+}
+
+func (c *Collector) Start(ctx context.Context) {
+	defer utilruntime.HandleCrash()
+
+	interval := c.config.Prow.GetInterval()
+	c.logger.Info(
+		"Starting Prow CI collection",
+		"interval", interval,
+		"retention", c.config.Prow.GetRetention(),
+		"repository", c.config.Prow.Repository.Org+"/"+c.config.Prow.Repository.Name,
+		"excludedJobs", len(c.config.Prow.ExcludeJobs),
+	)
+
+	c.collect(ctx)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			c.logger.Info("Stopping Prow CI collection")
+			return
+		case <-ticker.C:
+			c.collect(ctx)
+		}
+	}
+}
+
+func (c *Collector) collect(parentCtx context.Context) {
+	ctx, cancel := context.WithTimeout(parentCtx, c.config.GetTimeout())
+	defer cancel()
+
+	if err := c.collectOnce(ctx); err != nil {
+		c.mu.Lock()
+		c.collectionSuccess = 0
+		c.pruneLocked(c.now().UTC())
+		c.mu.Unlock()
+		c.logger.Error("Failed to collect Prow CI jobs", "error", err)
+	}
+}
+
+func (c *Collector) collectOnce(ctx context.Context) error {
+	jobs, err := c.client.ListJobs(ctx)
+	if err != nil {
+		return fmt.Errorf("list Prow jobs: %w", err)
+	}
+
+	now := c.now().UTC()
+	excluded := make(map[string]struct{}, len(c.config.Prow.ExcludeJobs))
+	for _, jobName := range c.config.Prow.ExcludeJobs {
+		excluded[strings.TrimSpace(jobName)] = struct{}{}
+	}
+
+	matched := 0
+	completed := 0
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, job := range jobs {
+		if !matchesRepository(job, c.config.Prow.Repository) {
+			continue
+		}
+		matched++
+
+		jobName := strings.TrimSpace(job.Spec.Job)
+		if _, found := excluded[jobName]; found {
+			continue
+		}
+		if !validCompletedJob(job) {
+			continue
+		}
+
+		result := prowjobs.NormalizeState(job.Status.State)
+		jobType := strings.TrimSpace(job.Spec.Type)
+		if jobType == "" {
+			jobType = "unknown"
+		}
+		buildID := strings.TrimSpace(job.Status.BuildID)
+		completion := job.Status.CompletionTime.UTC()
+		c.runs[jobName+"/"+buildID] = runMetrics{
+			jobName:      jobName,
+			jobType:      jobType,
+			buildID:      buildID,
+			result:       result,
+			duration:     completion.Sub(job.Status.StartTime.UTC()).Seconds(),
+			completionAt: completion,
+		}
+		completed++
+	}
+
+	c.pruneLocked(now)
+	c.collectionSuccess = 1
+	c.lastSuccessTimestamp = float64(now.Unix())
+	c.logger.Info(
+		"Collected Prow CI jobs",
+		"fetched", len(jobs),
+		"repositoryMatches", matched,
+		"completedRuns", completed,
+		"cachedRuns", len(c.runs),
+	)
+	return nil
+}
+
+func (c *Collector) pruneLocked(now time.Time) {
+	retention := c.config.Prow.GetRetention()
+	for key, run := range c.runs {
+		if now.Sub(run.completionAt) >= retention {
+			delete(c.runs, key)
+		}
+	}
+}
+
+func matchesRepository(job prowjobs.Job, repository config.ProwRepositoryConfig) bool {
+	if job.Spec.Refs != nil {
+		if refsMatch(*job.Spec.Refs, repository) {
+			return true
+		}
+	}
+	for _, refs := range job.Spec.ExtraRefs {
+		if refsMatch(refs, repository) {
+			return true
+		}
+	}
+	return false
+}
+
+func refsMatch(refs prowjobs.Refs, repository config.ProwRepositoryConfig) bool {
+	return strings.EqualFold(strings.TrimSpace(refs.Org), strings.TrimSpace(repository.Org)) &&
+		strings.EqualFold(strings.TrimSpace(refs.Repo), strings.TrimSpace(repository.Name))
+}
+
+func validCompletedJob(job prowjobs.Job) bool {
+	return strings.TrimSpace(job.Spec.Job) != "" &&
+		strings.TrimSpace(job.Status.BuildID) != "" &&
+		prowjobs.IsTerminalState(job.Status.State) &&
+		!job.Status.StartTime.IsZero() &&
+		!job.Status.CompletionTime.IsZero() &&
+		!job.Status.CompletionTime.Before(job.Status.StartTime)
+}

--- a/tooling/tenant-quota/pkg/prow/collector.go
+++ b/tooling/tenant-quota/pkg/prow/collector.go
@@ -26,6 +26,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/config"
 	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/prowjobs"
@@ -248,10 +249,7 @@ func (c *Collector) collectOnce(ctx context.Context) error {
 	}
 
 	now := c.now().UTC()
-	excluded := make(map[string]struct{}, len(c.config.Prow.ExcludeJobs))
-	for _, jobName := range c.config.Prow.ExcludeJobs {
-		excluded[strings.TrimSpace(jobName)] = struct{}{}
-	}
+	excluded := sets.New(c.config.Prow.ExcludeJobs...)
 
 	matched := 0
 	completed := 0
@@ -264,7 +262,7 @@ func (c *Collector) collectOnce(ctx context.Context) error {
 		matched++
 
 		jobName := strings.TrimSpace(job.Spec.Job)
-		if _, found := excluded[jobName]; found {
+		if excluded.Has(jobName) {
 			continue
 		}
 		if !validCompletedJob(job) {

--- a/tooling/tenant-quota/pkg/prow/collector_test.go
+++ b/tooling/tenant-quota/pkg/prow/collector_test.go
@@ -15,10 +15,12 @@
 package prow
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -67,6 +69,7 @@ func testConfig(t *testing.T) *config.Config {
 
 func completedJob(name, buildID, state string, completed time.Time) prowjobs.Job {
 	return prowjobs.Job{
+		Metadata: prowjobs.Metadata{Name: name + "-" + buildID},
 		Spec: prowjobs.Spec{
 			Type: "presubmit",
 			Job:  name,
@@ -143,6 +146,57 @@ func TestCollectOnceFiltersAndExportsCompletedJobs(t *testing.T) {
 	assertMetricAbsent(t, metrics, "prow_ci_job_duration_seconds_count")
 	assertMetricAbsent(t, metrics, "prow_ci_job_duration_seconds_sum")
 	assertMetricAbsent(t, metrics, "prow_ci_job_duration_seconds_bucket")
+}
+
+func TestMalformedCompletedJobsAreCountedOnce(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	missingJobName := completedJob("job", "1", "success", now)
+	missingJobName.Metadata.Name = ""
+	missingJobName.Spec.Job = ""
+	missingBuildID := completedJob("job", "2", "failure", now)
+	missingBuildID.Metadata.Name = "missing-build-id"
+	missingBuildID.Status.BuildID = ""
+	missingStartTime := completedJob("job", "3", "error", now)
+	missingStartTime.Metadata.Name = "missing-start-time"
+	missingStartTime.Status.StartTime = time.Time{}
+	missingCompletionTime := completedJob("job", "4", "success", now)
+	missingCompletionTime.Metadata.Name = "missing-completion-time"
+	missingCompletionTime.Status.CompletionTime = time.Time{}
+	invalidTimeRange := completedJob("job", "5", "failure", now)
+	invalidTimeRange.Metadata.Name = "invalid-time-range"
+	invalidTimeRange.Status.StartTime = now.Add(time.Minute)
+	pending := completedJob("job", "", "pending", now)
+	pending.Metadata.Name = "pending"
+	aborted := completedJob("job", "", "aborted", now)
+	aborted.Metadata.Name = "aborted"
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	collector := NewCollector(testConfig(t), logger, &fakeClient{
+		jobs: []prowjobs.Job{
+			missingJobName,
+			missingBuildID,
+			missingStartTime,
+			missingCompletionTime,
+			invalidTimeRange,
+			pending,
+			aborted,
+		},
+	})
+	collector.now = func() time.Time { return now }
+	for range 2 {
+		if err := collector.collectOnce(context.Background()); err != nil {
+			t.Fatalf("collectOnce() error = %v", err)
+		}
+	}
+
+	metrics := gatherMetrics(t, collector)
+	for _, reason := range invalidJobReasons {
+		assertCounter(t, metrics, "prow_ci_invalid_jobs_total", map[string]string{"reason": reason}, 1)
+	}
+	if got := strings.Count(logs.String(), "Skipping malformed completed Prow CI job"); got != len(invalidJobReasons) {
+		t.Fatalf("malformed job warnings = %d, want %d", got, len(invalidJobReasons))
+	}
 }
 
 func TestDurationMetricsAggregateRuns(t *testing.T) {
@@ -260,6 +314,19 @@ func assertGauge(t *testing.T, metrics map[string][]*dto.Metric, name string, la
 	for _, metric := range metrics[name] {
 		if hasLabels(metric, labels) {
 			if got := metric.GetGauge().GetValue(); got != want {
+				t.Fatalf("%s value = %v, want %v", name, got, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("metric %s with labels %v not found", name, labels)
+}
+
+func assertCounter(t *testing.T, metrics map[string][]*dto.Metric, name string, labels map[string]string, want float64) {
+	t.Helper()
+	for _, metric := range metrics[name] {
+		if hasLabels(metric, labels) {
+			if got := metric.GetCounter().GetValue(); got != want {
 				t.Fatalf("%s value = %v, want %v", name, got, want)
 			}
 			return

--- a/tooling/tenant-quota/pkg/prow/collector_test.go
+++ b/tooling/tenant-quota/pkg/prow/collector_test.go
@@ -132,7 +132,7 @@ func TestCollectOnceFiltersAndExportsCompletedJobs(t *testing.T) {
 		"build_id": "1",
 		"result":   "success",
 	}, 1)
-	assertGauge(t, metrics, "prow_ci_job_duration_seconds_bucket", map[string]string{
+	assertGauge(t, metrics, "prow_ci_job_duration_window_runs", map[string]string{
 		"job_name": "periodic-ci-Azure-ARO-HCP-main-health",
 		"job_type": "periodic",
 		"result":   "failure",
@@ -142,6 +142,7 @@ func TestCollectOnceFiltersAndExportsCompletedJobs(t *testing.T) {
 	assertMetricAbsent(t, metrics, "prow_ci_job_completed_timestamp_seconds")
 	assertMetricAbsent(t, metrics, "prow_ci_job_duration_seconds_count")
 	assertMetricAbsent(t, metrics, "prow_ci_job_duration_seconds_sum")
+	assertMetricAbsent(t, metrics, "prow_ci_job_duration_seconds_bucket")
 }
 
 func TestDurationMetricsAggregateRuns(t *testing.T) {
@@ -165,9 +166,9 @@ func TestDurationMetricsAggregateRuns(t *testing.T) {
 		"job_type": "presubmit",
 		"result":   "success",
 	}
-	assertGauge(t, metrics, "prow_ci_job_duration_seconds_bucket", withLabel(labels, "le", "900"), 1)
-	assertGauge(t, metrics, "prow_ci_job_duration_seconds_bucket", withLabel(labels, "le", "1500"), 2)
-	assertGauge(t, metrics, "prow_ci_job_duration_seconds_bucket", withLabel(labels, "le", "+Inf"), 2)
+	assertGauge(t, metrics, "prow_ci_job_duration_window_runs", withLabel(labels, "le", "900"), 1)
+	assertGauge(t, metrics, "prow_ci_job_duration_window_runs", withLabel(labels, "le", "1500"), 2)
+	assertGauge(t, metrics, "prow_ci_job_duration_window_runs", withLabel(labels, "le", "+Inf"), 2)
 }
 
 func TestDurationBuckets(t *testing.T) {

--- a/tooling/tenant-quota/pkg/prow/collector_test.go
+++ b/tooling/tenant-quota/pkg/prow/collector_test.go
@@ -1,0 +1,300 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prow
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/config"
+	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/prowjobs"
+)
+
+type fakeClient struct {
+	jobs []prowjobs.Job
+	err  error
+}
+
+func (f *fakeClient) ListJobs(context.Context) ([]prowjobs.Job, error) {
+	return f.jobs, f.err
+}
+
+func testConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cfg := &config.Config{
+		Timeout: "5s",
+		Tenants: []config.TenantConfig{{
+			TenantID:                 "tenant",
+			ServicePrincipalClientId: "client",
+			KeyVaultSecretName:       "secret",
+		}},
+		Prow: config.ProwConfig{
+			Enabled:   true,
+			BaseURL:   "https://prow.example.com",
+			Interval:  "5m",
+			Retention: "24h",
+			Repository: config.ProwRepositoryConfig{
+				Org:  "Azure",
+				Name: "ARO-HCP",
+			},
+			ExcludeJobs: []string{"pull-ci-Azure-ARO-HCP-main-excluded"},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	return cfg
+}
+
+func completedJob(name, buildID, state string, completed time.Time) prowjobs.Job {
+	return prowjobs.Job{
+		Spec: prowjobs.Spec{
+			Type: "presubmit",
+			Job:  name,
+			Refs: &prowjobs.Refs{Org: "Azure", Repo: "ARO-HCP"},
+		},
+		Status: prowjobs.Status{
+			State:          state,
+			StartTime:      completed.Add(-30 * time.Minute),
+			CompletionTime: completed,
+			URL:            "gs://test-platform-results/pr-logs/pull/Azure_ARO-HCP/123/" + name + "/" + buildID,
+			BuildID:        buildID,
+		},
+	}
+}
+
+func TestCollectOnceFiltersAndExportsCompletedJobs(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	jobs := []prowjobs.Job{
+		completedJob("pull-ci-Azure-ARO-HCP-main-e2e-parallel", "1", "success", now.Add(-time.Hour)),
+		completedJob("pull-ci-Azure-ARO-HCP-main-excluded", "2", "failure", now.Add(-time.Hour)),
+		{
+			Spec: prowjobs.Spec{
+				Type:      "periodic",
+				Job:       "periodic-ci-Azure-ARO-HCP-main-health",
+				ExtraRefs: []prowjobs.Refs{{Org: "Azure", Repo: "ARO-HCP"}},
+			},
+			Status: prowjobs.Status{
+				State:          "failure",
+				StartTime:      now.Add(-2 * time.Hour),
+				CompletionTime: now.Add(-90 * time.Minute),
+				BuildID:        "3",
+			},
+		},
+		{
+			Spec: prowjobs.Spec{
+				Type: "periodic",
+				Job:  "periodic-ci-Azure-ARO-HCP-main-missing-refs",
+			},
+			Status: prowjobs.Status{
+				State:          "success",
+				StartTime:      now.Add(-2 * time.Hour),
+				CompletionTime: now.Add(-90 * time.Minute),
+				BuildID:        "missing-refs",
+			},
+		},
+		completedJob("pull-ci-other-repo", "4", "success", now.Add(-time.Hour)),
+	}
+	jobs[0].Spec.Type = "batch"
+	jobs[4].Spec.Refs = &prowjobs.Refs{Org: "other", Repo: "repo"}
+
+	collector := NewCollector(testConfig(t), testLogger(), &fakeClient{jobs: jobs})
+	collector.now = func() time.Time { return now }
+	if err := collector.collectOnce(context.Background()); err != nil {
+		t.Fatalf("collectOnce() error = %v", err)
+	}
+
+	metrics := gatherMetrics(t, collector)
+	assertGauge(t, metrics, "prow_ci_cached_runs", nil, 2)
+	assertGauge(t, metrics, "prow_ci_collection_success", nil, 1)
+	assertGauge(t, metrics, "prow_ci_job_info", map[string]string{
+		"job_name": "pull-ci-Azure-ARO-HCP-main-e2e-parallel",
+		"job_type": "batch",
+		"build_id": "1",
+		"result":   "success",
+	}, 1)
+	assertGauge(t, metrics, "prow_ci_job_duration_seconds_bucket", map[string]string{
+		"job_name": "periodic-ci-Azure-ARO-HCP-main-health",
+		"job_type": "periodic",
+		"result":   "failure",
+		"le":       "1800",
+	}, 1)
+	assertMetricAbsent(t, metrics, "prow_ci_job_success")
+	assertMetricAbsent(t, metrics, "prow_ci_job_completed_timestamp_seconds")
+	assertMetricAbsent(t, metrics, "prow_ci_job_duration_seconds_count")
+	assertMetricAbsent(t, metrics, "prow_ci_job_duration_seconds_sum")
+}
+
+func TestDurationMetricsAggregateRuns(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	first := completedJob("pull-ci-Azure-ARO-HCP-main-lint", "1", "success", now.Add(-time.Hour))
+	first.Status.StartTime = first.Status.CompletionTime.Add(-10 * time.Minute)
+	second := completedJob("pull-ci-Azure-ARO-HCP-main-lint", "2", "success", now.Add(-30*time.Minute))
+	second.Status.StartTime = second.Status.CompletionTime.Add(-25 * time.Minute)
+
+	collector := NewCollector(testConfig(t), testLogger(), &fakeClient{
+		jobs: []prowjobs.Job{first, second},
+	})
+	collector.now = func() time.Time { return now }
+	if err := collector.collectOnce(context.Background()); err != nil {
+		t.Fatalf("collectOnce() error = %v", err)
+	}
+
+	metrics := gatherMetrics(t, collector)
+	labels := map[string]string{
+		"job_name": "pull-ci-Azure-ARO-HCP-main-lint",
+		"job_type": "presubmit",
+		"result":   "success",
+	}
+	assertGauge(t, metrics, "prow_ci_job_duration_seconds_bucket", withLabel(labels, "le", "900"), 1)
+	assertGauge(t, metrics, "prow_ci_job_duration_seconds_bucket", withLabel(labels, "le", "1500"), 2)
+	assertGauge(t, metrics, "prow_ci_job_duration_seconds_bucket", withLabel(labels, "le", "+Inf"), 2)
+}
+
+func TestDurationBuckets(t *testing.T) {
+	want := []float64{
+		60,
+		300,
+		600,
+		900,
+		1200,
+		1500,
+		1800,
+		2700,
+		3600,
+		5400,
+		7200,
+		7800,
+		8400,
+		9000,
+		10800,
+	}
+	if len(durationBuckets) != len(want) {
+		t.Fatalf("durationBuckets length = %d, want %d", len(durationBuckets), len(want))
+	}
+	for i := range want {
+		if durationBuckets[i] != want[i] {
+			t.Fatalf("durationBuckets[%d] = %v, want %v", i, durationBuckets[i], want[i])
+		}
+	}
+}
+
+func TestCollectErrorPreservesRunsAndReportsFailure(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	client := &fakeClient{
+		jobs: []prowjobs.Job{
+			completedJob("pull-ci-Azure-ARO-HCP-main-e2e-parallel", "1", "success", now.Add(-time.Hour)),
+		},
+	}
+	collector := NewCollector(testConfig(t), testLogger(), client)
+	collector.now = func() time.Time { return now }
+	collector.collect(context.Background())
+
+	client.err = fmt.Errorf("Prow unavailable")
+	collector.collect(context.Background())
+
+	metrics := gatherMetrics(t, collector)
+	assertGauge(t, metrics, "prow_ci_cached_runs", nil, 1)
+	assertGauge(t, metrics, "prow_ci_collection_success", nil, 0)
+}
+
+func TestCollectPrunesRunsByCompletionTime(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	client := &fakeClient{
+		jobs: []prowjobs.Job{
+			completedJob("pull-ci-Azure-ARO-HCP-main-old", "1", "success", now.Add(-25*time.Hour)),
+			completedJob("pull-ci-Azure-ARO-HCP-main-recent", "2", "success", now.Add(-23*time.Hour)),
+		},
+	}
+	collector := NewCollector(testConfig(t), testLogger(), client)
+	collector.now = func() time.Time { return now }
+	if err := collector.collectOnce(context.Background()); err != nil {
+		t.Fatalf("collectOnce() error = %v", err)
+	}
+
+	metrics := gatherMetrics(t, collector)
+	assertGauge(t, metrics, "prow_ci_cached_runs", nil, 1)
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func gatherMetrics(t *testing.T, collector prometheus.Collector) map[string][]*dto.Metric {
+	t.Helper()
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather() error = %v", err)
+	}
+	result := make(map[string][]*dto.Metric, len(families))
+	for _, family := range families {
+		result[family.GetName()] = family.Metric
+	}
+	return result
+}
+
+func assertGauge(t *testing.T, metrics map[string][]*dto.Metric, name string, labels map[string]string, want float64) {
+	t.Helper()
+	for _, metric := range metrics[name] {
+		if hasLabels(metric, labels) {
+			if got := metric.GetGauge().GetValue(); got != want {
+				t.Fatalf("%s value = %v, want %v", name, got, want)
+			}
+			return
+		}
+	}
+	t.Fatalf("metric %s with labels %v not found", name, labels)
+}
+
+func assertMetricAbsent(t *testing.T, metrics map[string][]*dto.Metric, name string) {
+	t.Helper()
+	if _, found := metrics[name]; found {
+		t.Fatalf("metric %s unexpectedly found", name)
+	}
+}
+
+func withLabel(labels map[string]string, name, value string) map[string]string {
+	result := make(map[string]string, len(labels)+1)
+	for labelName, labelValue := range labels {
+		result[labelName] = labelValue
+	}
+	result[name] = value
+	return result
+}
+
+func hasLabels(metric *dto.Metric, want map[string]string) bool {
+	for name, value := range want {
+		found := false
+		for _, label := range metric.Label {
+			if label.GetName() == name && label.GetValue() == value {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/tooling/tenant-quota/pkg/prowjobs/client.go
+++ b/tooling/tenant-quota/pkg/prowjobs/client.go
@@ -1,0 +1,249 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prowjobs
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const maxResponseErrorBytes = 2048
+
+type Metadata struct {
+	Name string `json:"name,omitempty"`
+}
+
+type Refs struct {
+	Org  string `json:"org,omitempty"`
+	Repo string `json:"repo,omitempty"`
+}
+
+type Spec struct {
+	Type      string `json:"type,omitempty"`
+	Job       string `json:"job,omitempty"`
+	Refs      *Refs  `json:"refs,omitempty"`
+	ExtraRefs []Refs `json:"extra_refs,omitempty"`
+}
+
+type Status struct {
+	State          string    `json:"state,omitempty"`
+	StartTime      time.Time `json:"startTime,omitempty"`
+	CompletionTime time.Time `json:"completionTime,omitempty"`
+	URL            string    `json:"url,omitempty"`
+	BuildID        string    `json:"build_id,omitempty"`
+}
+
+type Job struct {
+	Metadata Metadata `json:"metadata,omitempty"`
+	Spec     Spec     `json:"spec,omitempty"`
+	Status   Status   `json:"status,omitempty"`
+}
+
+type Client interface {
+	ListJobs(ctx context.Context) ([]Job, error)
+}
+
+type HTTPClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+func NewHTTPClient(baseURL string, timeout time.Duration) *HTTPClient {
+	return &HTTPClient{
+		baseURL: strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+	}
+}
+
+func (c *HTTPClient) ListJobs(ctx context.Context) ([]Job, error) {
+	endpoint, err := c.endpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	const maxAttempts = 3
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build Prow jobs request: %w", err)
+		}
+		req.Header.Set("Accept", "application/json, application/javascript, text/javascript")
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("prow jobs request failed: %w", err)
+		} else {
+			if resp.StatusCode == http.StatusOK {
+				jobs, err := decodeJobList(resp.Body)
+				resp.Body.Close()
+				if err != nil {
+					return nil, fmt.Errorf("decode Prow jobs response: %w", err)
+				}
+				return jobs, nil
+			}
+			body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxResponseErrorBytes))
+			resp.Body.Close()
+			if readErr != nil {
+				return nil, fmt.Errorf("read Prow jobs error response: %w", readErr)
+			}
+			lastErr = fmt.Errorf(
+				"prow jobs request returned status %d: %s",
+				resp.StatusCode,
+				strings.TrimSpace(string(body)),
+			)
+			if !isRetryableStatus(resp.StatusCode) {
+				return nil, lastErr
+			}
+		}
+
+		if attempt < maxAttempts {
+			timer := time.NewTimer(time.Duration(attempt) * time.Second)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+			}
+		}
+	}
+
+	return nil, lastErr
+}
+
+func (c *HTTPClient) endpoint() (string, error) {
+	if c.baseURL == "" {
+		return "", fmt.Errorf("prow base URL is required")
+	}
+	parsed, err := url.Parse(c.baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse Prow base URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("prow base URL must use http or https")
+	}
+	if strings.HasSuffix(strings.ToLower(parsed.Path), ".js") {
+		return parsed.String(), nil
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/") + "/prowjobs.js"
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+func decodeJobList(reader io.Reader) ([]Job, error) {
+	jsonReader, err := readerFromJSONObject(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	decoder := json.NewDecoder(jsonReader)
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	if delimiter, ok := token.(json.Delim); !ok || delimiter != '{' {
+		return nil, fmt.Errorf("response root is not a JSON object")
+	}
+
+	jobs := make([]Job, 0, 2048)
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return nil, fmt.Errorf("response object key is not a string")
+		}
+		if key != "items" {
+			var ignored json.RawMessage
+			if err := decoder.Decode(&ignored); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		token, err := decoder.Token()
+		if err != nil {
+			return nil, err
+		}
+		if delimiter, ok := token.(json.Delim); !ok || delimiter != '[' {
+			return nil, fmt.Errorf("items is not a JSON array")
+		}
+		for decoder.More() {
+			var job Job
+			if err := decoder.Decode(&job); err != nil {
+				return nil, err
+			}
+			jobs = append(jobs, job)
+		}
+		if _, err := decoder.Token(); err != nil {
+			return nil, err
+		}
+	}
+
+	if _, err := decoder.Token(); err != nil {
+		return nil, err
+	}
+	return jobs, nil
+}
+
+func readerFromJSONObject(reader io.Reader) (io.Reader, error) {
+	buffered := bufio.NewReader(reader)
+	const maxPrefixBytes = 1024 * 1024
+	for i := 0; i < maxPrefixBytes; i++ {
+		value, err := buffered.ReadByte()
+		if err != nil {
+			if err == io.EOF {
+				return nil, fmt.Errorf("response body does not contain a JSON object")
+			}
+			return nil, err
+		}
+		if value == '{' {
+			return io.MultiReader(bytes.NewReader([]byte{'{'}), buffered), nil
+		}
+	}
+	return nil, fmt.Errorf("response JSON object starts after the %d byte prefix limit", maxPrefixBytes)
+}
+
+func IsTerminalState(state string) bool {
+	switch NormalizeState(state) {
+	case "success", "failure", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func NormalizeState(state string) string {
+	return strings.ToLower(strings.TrimSpace(state))
+}
+
+func isRetryableStatus(statusCode int) bool {
+	return statusCode == http.StatusRequestTimeout ||
+		statusCode == http.StatusTooManyRequests ||
+		statusCode >= http.StatusInternalServerError
+}

--- a/tooling/tenant-quota/pkg/prowjobs/client_test.go
+++ b/tooling/tenant-quota/pkg/prowjobs/client_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prowjobs
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHTTPClientListJobs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/prowjobs.js" {
+			t.Fatalf("path = %q, want /prowjobs.js", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/javascript")
+		_, _ = w.Write([]byte(`var allBuilds = {
+  "items": [{
+    "metadata": {"name": "prowjob-id"},
+    "spec": {
+      "type": "presubmit",
+      "job": "pull-ci-Azure-ARO-HCP-main-e2e-parallel",
+      "refs": {"org": "Azure", "repo": "ARO-HCP"}
+    },
+    "status": {
+      "state": "success",
+      "startTime": "2026-08-03T10:00:00Z",
+      "completionTime": "2026-08-03T11:00:00Z",
+      "url": "gs://test-platform-results/example",
+      "build_id": "123"
+    }
+  }]
+};`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewHTTPClient(server.URL, time.Second)
+	jobs, err := client.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs() error = %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+
+	job := jobs[0]
+	if job.Spec.Job != "pull-ci-Azure-ARO-HCP-main-e2e-parallel" {
+		t.Fatalf("job name = %q", job.Spec.Job)
+	}
+	if job.Spec.Refs == nil || job.Spec.Refs.Org != "Azure" || job.Spec.Refs.Repo != "ARO-HCP" {
+		t.Fatalf("refs = %#v", job.Spec.Refs)
+	}
+	if job.Status.BuildID != "123" || job.Status.State != "success" {
+		t.Fatalf("status = %#v", job.Status)
+	}
+}
+
+func TestHTTPClientListJobsRejectsNonSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewHTTPClient(server.URL, 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	if _, err := client.ListJobs(ctx); err == nil {
+		t.Fatal("ListJobs() error = nil, want error")
+	}
+}
+
+func TestIsTerminalState(t *testing.T) {
+	for _, state := range []string{"success", "failure", "error"} {
+		if !IsTerminalState(state) {
+			t.Errorf("IsTerminalState(%q) = false", state)
+		}
+	}
+
+	for _, state := range []string{"", "pending", "triggered", "aborted"} {
+		if IsTerminalState(state) {
+			t.Errorf("IsTerminalState(%q) = true", state)
+		}
+	}
+}


### PR DESCRIPTION
Minimal implementation for https://redhat.atlassian.net/browse/ARO-27249

### What

- ingest successful, failed, and errored `Azure/ARO-HCP` jobs while excluding aborted runs from the public Prow `prowjobs.js` endpoint
- expose per-build job information, rolling job-duration distributions, malformed-job counters, and collector health metrics
- select all repository jobs by default with optional exact-name exclusions
- stream the large Prow response and retain completed runs for 24 hours
- wire the collector into dev-ci configuration, Helm deployment, schema, and documentation

### Why

ARO HCP currently lacks Prometheus metrics that answer basic CI health questions such as job success rate and duration trends. Adding these metrics to the existing opstool exporter makes CI behavior queryable alongside the Azure capacity signals that affect CI.

### Testing

- Unit tests: `cd tooling/tenant-quota && go test ./...`
- Race tests: `go test -race ./pkg/prowjobs ./pkg/prow`
- Lint: targeted `golangci-lint` run for `tooling/tenant-quota/...`
- Build: `cd tooling/tenant-quota && go build ./...`
- Configuration: dev-ci JSON schema validation, local config rendering, Helm rendering, and `make -C config materialize`

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) — pending deployment
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide) — checks rerunning after review fixes
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier), demonstrate that the test is able to detect a defect/error and fail with proper error message and logs which communicates nature of the problem.
