### PR TITLE
feat: add admin API endpoint to set per-nodepool minimum version

### DIFF
--- a/admin/server/go.mod
+++ b/admin/server/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0
+	github.com/blang/semver/v4 v4.0.0
 	github.com/go-logr/logr v1.4.3
 	github.com/microsoft/go-otel-audit v0.2.2
 	github.com/openshift-online/ocm-sdk-go v0.1.499
@@ -31,7 +32,6 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/admin/server/handlers/hcp/minimumnodepoolversion.go
+++ b/admin/server/handlers/hcp/minimumnodepoolversion.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/blang/semver/v4"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// HCPMinimumNodePoolVersionHandler sets ServiceProviderNodePoolSpecVersion
+// MinimumVersion on the per-nodepool ServiceProviderNodePool.
+// It intentionally writes only that one field — every other Spec/Status value
+// is left as-is — so SRE callers can adjust the version of a particular nodepool
+// without touching anything else on the document.
+type HCPMinimumNodePoolVersionHandler struct {
+	resourcesDBClient database.ResourcesDBClient
+}
+
+func NewHCPMinimumNodePoolVersionHandler(resourcesDBClient database.ResourcesDBClient) *HCPMinimumNodePoolVersionHandler {
+	return &HCPMinimumNodePoolVersionHandler{resourcesDBClient: resourcesDBClient}
+}
+
+// minimumNodePoolVersionRequest is the wire shape for the request body. The
+// MinimumVersion field is a pointer-string so callers can distinguish "set to value"
+// (non-nil) from "clear the version" (nil/absent). An explicit empty string is
+// rejected.
+type minimumNodePoolVersionRequest struct {
+	MinimumVersion *string `json:"minimumVersion"`
+}
+
+func (h *HCPMinimumNodePoolVersionHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) error {
+	clusterResourceID, err := utils.ResourceIDFromContext(request.Context())
+	if err != nil {
+		return arm.NewCloudError(http.StatusBadRequest, arm.CloudErrorCodeInvalidRequestContent, "", "invalid resource identifier in request")
+	}
+
+	nodepoolName := request.PathValue("nodepoolName")
+	if nodepoolName == "" {
+		return arm.NewCloudError(http.StatusBadRequest, arm.CloudErrorCodeInvalidRequestContent, "", "nodepoolName parameter is required")
+	}
+
+	resourceID, err := api.ToNodePoolResourceID(clusterResourceID.SubscriptionID, clusterResourceID.ResourceGroupName, clusterResourceID.Name, nodepoolName)
+	if err != nil {
+		return arm.NewCloudError(http.StatusBadRequest, arm.CloudErrorCodeInvalidRequestContent, "", "failed to construct nodepool resource ID: %v", err)
+	}
+
+	var body minimumNodePoolVersionRequest
+	if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+		return arm.NewCloudError(http.StatusBadRequest, arm.CloudErrorCodeInvalidRequestContent, "", "invalid JSON body: %v", err)
+	}
+	// A nil body.MinimumVersion means the caller is clearing the SRE-selected version.
+	// The nodepool upgrade version controller applies the effective version desired
+	// by the customer instead, if that version is a valid one.
+	// An explicit empty string is not a valid tier and is rejected separately from
+	// the omitted case.
+	if body.MinimumVersion != nil && *body.MinimumVersion == "" {
+		return arm.NewCloudError(http.StatusBadRequest, arm.CloudErrorCodeInvalidRequestContent, "", "minimumVersion must not be empty; omit the field to clear")
+	}
+
+	var versionPtr *semver.Version
+	if body.MinimumVersion != nil {
+		version, err := semver.Parse(*body.MinimumVersion)
+		if err != nil {
+			return arm.NewCloudError(http.StatusBadRequest, arm.CloudErrorCodeInvalidRequestContent, "", "invalid semver %q: %v", *body.MinimumVersion, err)
+		}
+		versionPtr = &version
+	}
+
+	existing, err := database.GetOrCreateServiceProviderNodePool(request.Context(), h.resourcesDBClient, resourceID)
+	if err != nil {
+		return fmt.Errorf("failed to get ServiceProviderNodePool: %w", err)
+	}
+
+	replacement := existing.DeepCopy()
+	replacement.Spec.NodePoolVersion.MinimumVersion = versionPtr
+
+	_, err = h.resourcesDBClient.ServiceProviderNodePools(resourceID.SubscriptionID, resourceID.ResourceGroupName, resourceID.Parent.Name, resourceID.Name).Replace(request.Context(), replacement, nil)
+	if err != nil {
+		return fmt.Errorf("failed to replace ServiceProviderNodePool: %w", err)
+	}
+
+	_, err = arm.WriteJSONResponse(writer, http.StatusOK, minimumNodePoolVersionRequest{MinimumVersion: body.MinimumVersion})
+	return utils.TrackError(err)
+}

--- a/admin/server/handlers/hcp/minimumnodepoolversion_test.go
+++ b/admin/server/handlers/hcp/minimumnodepoolversion_test.go
@@ -1,0 +1,239 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/require"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api"
+	"github.com/Azure/ARO-HCP/internal/api/arm"
+	"github.com/Azure/ARO-HCP/internal/database"
+	"github.com/Azure/ARO-HCP/internal/databasetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+var (
+	testClusterResourceID  = api.Must(azcorearm.ParseResourceID(api.TestClusterResourceID))
+	testNodePoolResourceID = api.Must(azcorearm.ParseResourceID(api.TestNodePoolResourceID))
+)
+
+// defaultSetup returns a setup func for the happy path: cluster resource ID in
+// context, nodepoolName path value set, and the given JSON body on the request.
+// For error cases that need to omit one of these, provide a custom setup inline.
+func defaultSetup(body string) func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) (context.Context, *http.Request) {
+	return func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) (context.Context, *http.Request) {
+		t.Helper()
+		ctx = utils.ContextWithResourceID(ctx, testClusterResourceID)
+		req := httptest.NewRequest(http.MethodPost, "/minimumversion", strings.NewReader(body))
+		req.SetPathValue("nodepoolName", api.TestNodePoolName)
+		return ctx, req
+	}
+}
+
+// seedMinVersion pre-populates a ServiceProviderNodePool with the given
+// MinimumVersion so tests can verify overwrite and clear behaviour.
+func seedMinVersion(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient, version string) {
+	t.Helper()
+	existing, err := database.GetOrCreateServiceProviderNodePool(ctx, db, testNodePoolResourceID)
+	require.NoError(t, err)
+	v := semver.MustParse(version)
+	existing.Spec.NodePoolVersion.MinimumVersion = &v
+	_, err = db.ServiceProviderNodePools(testNodePoolResourceID.SubscriptionID, testNodePoolResourceID.ResourceGroupName, testNodePoolResourceID.Parent.Name, testNodePoolResourceID.Name).Replace(ctx, existing, nil)
+	require.NoError(t, err)
+}
+
+// expectCloudError returns a validate func that asserts the handler returned
+// an arm.CloudError with the given status code and error substring.
+func expectCloudError(expectedStatusCode int, expectedError string) func(t *testing.T, err error, recorder *httptest.ResponseRecorder, db *databasetesting.MockResourcesDBClient) {
+	return func(t *testing.T, err error, recorder *httptest.ResponseRecorder, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		require.Error(t, err)
+		var cloudErr *arm.CloudError
+		require.True(t, errors.As(err, &cloudErr), "expected CloudError but got %T: %v", err, err)
+		require.Equal(t, expectedStatusCode, cloudErr.StatusCode)
+		require.Contains(t, err.Error(), expectedError)
+	}
+}
+
+// expectVersion returns a validate func that asserts a successful handler call
+// and checks both the Cosmos document and the HTTP response body match the
+// expected version. Pass nil to assert the version was cleared.
+func expectVersion(wantVersion *semver.Version) func(t *testing.T, err error, recorder *httptest.ResponseRecorder, db *databasetesting.MockResourcesDBClient) {
+	return func(t *testing.T, err error, recorder *httptest.ResponseRecorder, db *databasetesting.MockResourcesDBClient) {
+		t.Helper()
+		require.NoError(t, err)
+
+		spnp, err := db.ServiceProviderNodePools(testNodePoolResourceID.SubscriptionID, testNodePoolResourceID.ResourceGroupName, testNodePoolResourceID.Parent.Name, testNodePoolResourceID.Name).Get(context.Background(), api.ServiceProviderNodePoolResourceName)
+		require.NoError(t, err)
+
+		var respBody minimumNodePoolVersionRequest
+		require.NoError(t, json.NewDecoder(recorder.Body).Decode(&respBody))
+
+		if wantVersion == nil {
+			require.Nil(t, spnp.Spec.NodePoolVersion.MinimumVersion, "expected MinimumVersion cleared")
+			require.Nil(t, respBody.MinimumVersion, "expected response minimumVersion nil")
+		} else {
+			require.NotNil(t, spnp.Spec.NodePoolVersion.MinimumVersion, "expected MinimumVersion to be set")
+			require.True(t, spnp.Spec.NodePoolVersion.MinimumVersion.EQ(*wantVersion), "expected version %s, got %s", wantVersion, spnp.Spec.NodePoolVersion.MinimumVersion)
+			require.NotNil(t, respBody.MinimumVersion, "expected response version set")
+			require.Equal(t, wantVersion.String(), *respBody.MinimumVersion)
+		}
+	}
+}
+
+func TestMinimumNodePoolVersionHandler(t *testing.T) {
+	// Each test case defines two callbacks:
+	//   setup    — configures the context, request, and DB state; use defaultSetup
+	//              for the happy path, or inline a func to omit context/path values.
+	//   validate — asserts the handler result; use expectCloudError for error cases
+	//              or expectVersion for success cases (nil = version cleared).
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) (context.Context, *http.Request)
+		validate func(t *testing.T, err error, recorder *httptest.ResponseRecorder, db *databasetesting.MockResourcesDBClient)
+	}{
+		{
+			name: "missing resource ID",
+			setup: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) (context.Context, *http.Request) {
+				t.Helper()
+				req := httptest.NewRequest(http.MethodPost, "/minimumversion", strings.NewReader(`{"minimumVersion":"4.17.0"}`))
+				req.SetPathValue("nodepoolName", api.TestNodePoolName)
+				return ctx, req
+			},
+			validate: expectCloudError(http.StatusBadRequest, "invalid resource identifier in request"),
+		},
+		{
+			name: "missing nodepoolName path value",
+			setup: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) (context.Context, *http.Request) {
+				t.Helper()
+				ctx = utils.ContextWithResourceID(ctx, testClusterResourceID)
+				req := httptest.NewRequest(http.MethodPost, "/minimumversion", strings.NewReader(`{"minimumVersion":"4.17.0"}`))
+				return ctx, req
+			},
+			validate: expectCloudError(http.StatusBadRequest, "nodepoolName parameter is required"),
+		},
+		{
+			name:     "invalid JSON body",
+			setup:    defaultSetup(`{not json`),
+			validate: expectCloudError(http.StatusBadRequest, "invalid JSON body"),
+		},
+		{
+			name:     "empty string minimumVersion rejected",
+			setup:    defaultSetup(`{"minimumVersion":""}`),
+			validate: expectCloudError(http.StatusBadRequest, "minimumVersion must not be empty"),
+		},
+		{
+			name:     "invalid semver value",
+			setup:    defaultSetup(`{"minimumVersion":"not-semver"}`),
+			validate: expectCloudError(http.StatusBadRequest, "invalid semver"),
+		},
+		{
+			name:     "valid semver sets MinimumVersion",
+			setup:    defaultSetup(`{"minimumVersion":"4.17.0"}`),
+			validate: expectVersion(semverPtr("4.17.0")),
+		},
+		{
+			name: "overwrites existing MinimumVersion",
+			setup: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) (context.Context, *http.Request) {
+				t.Helper()
+				seedMinVersion(t, ctx, db, "4.17.0")
+				return defaultSetup(`{"minimumVersion":"4.18.0"}`)(t, ctx, db)
+			},
+			validate: expectVersion(semverPtr("4.18.0")),
+		},
+		{
+			name: "omitted minimumVersion clears previously-set value",
+			setup: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) (context.Context, *http.Request) {
+				t.Helper()
+				seedMinVersion(t, ctx, db, "4.17.0")
+				return defaultSetup(`{}`)(t, ctx, db)
+			},
+			validate: expectVersion(nil),
+		},
+		{
+			name: "explicit null clears previously-set value",
+			setup: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) (context.Context, *http.Request) {
+				t.Helper()
+				seedMinVersion(t, ctx, db, "4.17.0")
+				return defaultSetup(`{"minimumVersion":null}`)(t, ctx, db)
+			},
+			validate: expectVersion(nil),
+		},
+		{
+			name:     "omitted minimumVersion on fresh SPNP is a no-op success",
+			setup:    defaultSetup(`{}`),
+			validate: expectVersion(nil),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			db := databasetesting.NewMockResourcesDBClient()
+			handler := NewHCPMinimumNodePoolVersionHandler(db)
+
+			ctx, req := tt.setup(t, ctx, db)
+			recorder := httptest.NewRecorder()
+			err := handler.ServeHTTP(recorder, req.WithContext(ctx))
+			tt.validate(t, err, recorder, db)
+		})
+	}
+}
+
+func TestMinimumNodePoolVersionHandler_PreservesOtherFields(t *testing.T) {
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	db := databasetesting.NewMockResourcesDBClient()
+
+	existing, err := database.GetOrCreateServiceProviderNodePool(ctx, db, testNodePoolResourceID)
+	require.NoError(t, err)
+	desiredVersion := semver.MustParse("4.16.0")
+	existing.Spec.NodePoolVersion.DesiredVersion = &desiredVersion
+	_, err = db.ServiceProviderNodePools(testNodePoolResourceID.SubscriptionID, testNodePoolResourceID.ResourceGroupName, testNodePoolResourceID.Parent.Name, testNodePoolResourceID.Name).Replace(ctx, existing, nil)
+	require.NoError(t, err)
+
+	handler := NewHCPMinimumNodePoolVersionHandler(db)
+	ctx = utils.ContextWithResourceID(ctx, testClusterResourceID)
+
+	req := httptest.NewRequest(http.MethodPost, "/minimumversion", strings.NewReader(`{"minimumVersion":"4.17.0"}`))
+	req = req.WithContext(ctx)
+	req.SetPathValue("nodepoolName", api.TestNodePoolName)
+	recorder := httptest.NewRecorder()
+
+	require.NoError(t, handler.ServeHTTP(recorder, req))
+
+	spnp, err := db.ServiceProviderNodePools(testNodePoolResourceID.SubscriptionID, testNodePoolResourceID.ResourceGroupName, testNodePoolResourceID.Parent.Name, testNodePoolResourceID.Name).Get(ctx, api.ServiceProviderNodePoolResourceName)
+	require.NoError(t, err)
+	require.NotNil(t, spnp.Spec.NodePoolVersion.DesiredVersion)
+	require.True(t, spnp.Spec.NodePoolVersion.DesiredVersion.EQ(desiredVersion), "expected DesiredVersion preserved as %s, got %s", desiredVersion, spnp.Spec.NodePoolVersion.DesiredVersion)
+	require.NotNil(t, spnp.Spec.NodePoolVersion.MinimumVersion)
+	require.True(t, spnp.Spec.NodePoolVersion.MinimumVersion.EQ(semver.MustParse("4.17.0")), "expected MinimumVersion 4.17.0, got %v", spnp.Spec.NodePoolVersion.MinimumVersion)
+}
+
+func semverPtr(s string) *semver.Version {
+	v := semver.MustParse(s)
+	return &v
+}

--- a/admin/server/server/admin.go
+++ b/admin/server/server/admin.go
@@ -126,6 +126,10 @@ func NewAdminAPI(
 		middleware.V1HCPResourcePattern("POST", "/desiredcontrolplanesize"),
 		hcpMiddleware.HandlerFunc(errorutils.ReportError(hcp.NewHCPDesiredControlPlaneSizeHandler(resourcesDBClient).ServeHTTP)),
 	)
+	middlewareMux.Handle(
+		middleware.V1HCPResourcePattern("POST", "/nodepools/{nodepoolName}/minimumversion"),
+		hcpMiddleware.HandlerFunc(errorutils.ReportError(hcp.NewHCPMinimumNodePoolVersionHandler(resourcesDBClient).ServeHTTP)),
+	)
 
 	// Non-HCP admin routes
 	middlewareMux.Handle("GET /admin/helloworld", handlers.HelloWorldHandler())

--- a/backend/pkg/controllers/nodepool/version/nodepool_version_controller.go
+++ b/backend/pkg/controllers/nodepool/version/nodepool_version_controller.go
@@ -107,10 +107,13 @@ func NewNodePoolVersionController(
 
 // NeedsWork reports whether this controller has anything to do for the given
 // NodePool. The work this controller does is persist the customer's desired
-// version onto the ServiceProviderNodePool, which is needed when:
+// version or SRE desired version onto the ServiceProviderNodePool, which is
+// needed when:
 //   - the NodePool's customer-visible Properties.Version.ID is set, and
 //   - the ServiceProviderNodePool's Spec.NodePoolVersion.DesiredVersion does
-//     not already equal that value (otherwise nothing would change).
+//     not already equal that value (otherwise nothing would change). Or
+//   - the ServiceProviderNodePool's Spec.NodePoolVersion.MinimumVersion
+//     is set, and it is greater than the Spec.NodePoolVersion.DesiredVersion
 //
 // Both arguments must be non-nil; SyncOnce gates the cache miss before calling
 // NeedsWork.
@@ -135,6 +138,10 @@ func (c *nodePoolVersionSyncer) NeedsWork(nodePool *api.HCPOpenShiftClusterNodeP
 		return true
 	}
 
+	if serviceProviderNodePool.Spec.NodePoolVersion.MinimumVersion != nil && serviceProviderNodePool.Spec.NodePoolVersion.MinimumVersion.GT(*serviceProviderNodePool.Spec.NodePoolVersion.DesiredVersion) {
+		return true
+	}
+
 	return false
 }
 
@@ -142,6 +149,8 @@ func (c *nodePoolVersionSyncer) NeedsWork(nodePool *api.HCPOpenShiftClusterNodeP
 // the ServiceProviderNodePool in Cosmos DB.
 //
 //   - Reads the customer's desired version from HCPNodePool.Properties.Version.ID.
+//   - Reads the SRE's desired version from ServiceProviderNodePool.Spec.NodePoolVersion.MinimumVersion.
+//   - Selects whether to use customer or SRE version
 //   - Validates it against version change constraints (see validateDesiredNodePoolVersion):
 //   - Exists as a known version in Cincinnati.
 //   - Upgrade: at most +2 minor versions from current, and cannot exceed lowest control plane version.
@@ -196,6 +205,14 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 		return utils.TrackError(err)
 	}
 
+	targetVersion := customerDesiredVersion
+
+	sreDesiredVersion := cachedServiceProviderNodePool.Spec.NodePoolVersion.MinimumVersion
+
+	if sreDesiredVersion != nil && sreDesiredVersion.GT(customerDesiredVersion) {
+		targetVersion = *sreDesiredVersion
+	}
+
 	subscription, err := c.subscriptionLister.Get(ctx, key.SubscriptionID)
 	if database.IsNotFoundError(err) {
 		return nil
@@ -219,7 +236,7 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 	}
 
 	// Validate the customer's desired version before setting it
-	err = c.validateDesiredNodePoolVersion(ctx, &customerDesiredVersion, cachedServiceProviderNodePool, cachedServiceProviderCluster, cachedNodePool.Properties.Version.ChannelGroup, clusterUUID,
+	err = c.validateDesiredNodePoolVersion(ctx, &targetVersion, cachedServiceProviderNodePool, cachedServiceProviderCluster, cachedNodePool.Properties.Version.ChannelGroup, clusterUUID,
 		op.HasOption(api.FeatureExperimentalReleaseFeatures))
 	if err != nil {
 		// Persist IntentFailed on the controller document for Cincinnati VersionNotFound or any non-Cincinnati resolution error.
@@ -248,7 +265,7 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 
 	// Update the serviceProviderNodePool DesiredVersion
 	replacement := cachedServiceProviderNodePool.DeepCopy()
-	replacement.Spec.NodePoolVersion.DesiredVersion = &customerDesiredVersion
+	replacement.Spec.NodePoolVersion.DesiredVersion = &targetVersion
 	_, err = c.resourcesDBClient.ServiceProviderNodePools(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName).Replace(ctx, replacement, nil)
 	if database.IsPreconditionFailedError(err) {
 		// the cache will update eventually since we're out of date and we'll enter this controller again. No need to fail.
@@ -257,7 +274,7 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to replace ServiceProviderNodePool: %w", err))
 	}
-	logger.Info("Updated ServiceProviderNodePool with new desired version", "desiredVersion", customerDesiredVersion.String())
+	logger.Info("Updated ServiceProviderNodePool with new desired version", "desiredVersion", targetVersion.String())
 
 	// Clear IntentFailed condition on successful validation
 	controllerCRUD := c.resourcesDBClient.HCPClusters(key.SubscriptionID, key.ResourceGroupName).
@@ -293,7 +310,7 @@ func (c *nodePoolVersionSyncer) SyncOnce(ctx context.Context, key controllerutil
 func (c *nodePoolVersionSyncer) validateDesiredNodePoolVersion(ctx context.Context, desiredVersion *semver.Version, spNodePool *api.ServiceProviderNodePool, spCluster *api.ServiceProviderCluster,
 	channelGroup string, clusterUUID uuid.UUID, allowExperimentalReleaseFeatures bool) error {
 	if desiredVersion == nil {
-		return fmt.Errorf("customerDesiredVersion is nil, cannot evaluate upgrade")
+		return fmt.Errorf("desiredVersion is nil, cannot evaluate upgrade")
 	}
 
 	logger := utils.LoggerFromContext(ctx)

--- a/backend/pkg/controllers/nodepool/version/nodepool_version_controller_test.go
+++ b/backend/pkg/controllers/nodepool/version/nodepool_version_controller_test.go
@@ -334,6 +334,7 @@ func TestNodePoolVersionSyncer_SyncOnce_IntentFailed(t *testing.T) {
 		customerVersion     string
 		nodePoolVersion     string
 		controlPlaneVersion string
+		minimumVersion      string // SRE-set minimum; empty = none
 		setupCincinnati     func(*cincinnati.MockClient)
 		wantSyncErr         bool
 		wantErrContains     string
@@ -462,6 +463,50 @@ func TestNodePoolVersionSyncer_SyncOnce_IntentFailed(t *testing.T) {
 				})
 			},
 		},
+		{
+			name:                "SRE MinimumVersion overrides lower customer version",
+			customerVersion:     "4.19.10",
+			nodePoolVersion:     "4.19.7",
+			controlPlaneVersion: "4.20.0",
+			minimumVersion:      "4.19.15",
+			setupCincinnati: func(mc *cincinnati.MockClient) {
+				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.15")).Return(
+					configv1.Release{Version: "4.19.15"},
+					[]configv1.Release{},
+					nil,
+					nil,
+				).Times(1)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				verifyDesiredVersion(t, ctx, db, ptr.To(semver.MustParse("4.19.15")))
+				verifyIntentFailed(t, ctx, db, &metav1.Condition{
+					Status: metav1.ConditionFalse,
+					Reason: api.ControllerConditionReasonAsExpected,
+				})
+			},
+		},
+		{
+			name:                "customer version wins when higher than SRE MinimumVersion",
+			customerVersion:     "4.19.20",
+			nodePoolVersion:     "4.19.7",
+			controlPlaneVersion: "4.20.0",
+			minimumVersion:      "4.19.15",
+			setupCincinnati: func(mc *cincinnati.MockClient) {
+				mc.EXPECT().GetUpdates(gomock.Any(), stableURI, "multi", "multi", "stable-4.19", semver.MustParse("4.19.20")).Return(
+					configv1.Release{Version: "4.19.20"},
+					[]configv1.Release{},
+					nil,
+					nil,
+				).Times(1)
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *databasetesting.MockResourcesDBClient) {
+				verifyDesiredVersion(t, ctx, db, ptr.To(semver.MustParse("4.19.20")))
+				verifyIntentFailed(t, ctx, db, &metav1.Condition{
+					Status: metav1.ConditionFalse,
+					Reason: api.ControllerConditionReasonAsExpected,
+				})
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -473,7 +518,7 @@ func TestNodePoolVersionSyncer_SyncOnce_IntentFailed(t *testing.T) {
 			mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
 
 			createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, tt.customerVersion)
-			createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, tt.nodePoolVersion)
+			createServiceProviderNodePoolWithVersionAndMinimum(t, ctx, mockResourcesDBClient, tt.nodePoolVersion, tt.minimumVersion)
 			createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, tt.controlPlaneVersion)
 
 			mockCincinnati := cincinnati.NewMockClient(ctrl)
@@ -557,6 +602,28 @@ func TestNodePoolVersionSyncer_NeedsWork(t *testing.T) {
 	})
 	t.Run("unparseable customer version conservatively needs work", func(t *testing.T) {
 		assert.True(t, syncer.NeedsWork(npWith("not-a-semver"), spnpWithDesired("4.19.15"), spc))
+	})
+
+	spnpWithDesiredAndMinimum := func(desiredVersion, minimumVersion string) *api.ServiceProviderNodePool {
+		spnp := spnpWithDesired(desiredVersion)
+		if minimumVersion != "" {
+			v := semver.MustParse(minimumVersion)
+			spnp.Spec.NodePoolVersion.MinimumVersion = &v
+		}
+		return spnp
+	}
+
+	t.Run("MinimumVersion nil does not trigger work", func(t *testing.T) {
+		assert.False(t, syncer.NeedsWork(npWith("4.19.15"), spnpWithDesiredAndMinimum("4.19.15", ""), spc))
+	})
+	t.Run("MinimumVersion greater than DesiredVersion needs work", func(t *testing.T) {
+		assert.True(t, syncer.NeedsWork(npWith("4.19.15"), spnpWithDesiredAndMinimum("4.19.15", "4.20.8"), spc))
+	})
+	t.Run("MinimumVersion equal to DesiredVersion skips", func(t *testing.T) {
+		assert.False(t, syncer.NeedsWork(npWith("4.19.15"), spnpWithDesiredAndMinimum("4.19.15", "4.19.15"), spc))
+	})
+	t.Run("MinimumVersion less than DesiredVersion skips", func(t *testing.T) {
+		assert.False(t, syncer.NeedsWork(npWith("4.19.15"), spnpWithDesiredAndMinimum("4.19.15", "4.19.10"), spc))
 	})
 }
 
@@ -970,352 +1037,6 @@ func TestNodePoolVersionSyncer_ValidateDesiredNodePoolVersion(t *testing.T) {
 	}
 }
 
-func TestNodePoolVersionSyncer_SyncOnce_DesiredExceedsControlPlaneFails(t *testing.T) {
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockClientCache := cincinnati.NewMockClientCache(ctrl)
-	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(cincinnati.NewMockClient(ctrl)).AnyTimes()
-
-	// Create node pool with desired version 4.19.15 (exceeds control plane 4.19.10)
-	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
-
-	// Create ServiceProviderCluster with control plane at 4.19.10 (lower than desired)
-	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.19.10")
-
-	// Create ServiceProviderNodePool with active version 4.19.5 (so desired is not already active)
-	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.5")
-
-	syncer := &nodePoolVersionSyncer{
-		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
-		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
-		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
-		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
-		readDesireLister:              newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:             mockResourcesDBClient,
-		cincinnatiClientCache:         mockClientCache,
-	}
-
-	testKey := controllerutils.HCPNodePoolKey{
-		SubscriptionID:    testSubscriptionID,
-		ResourceGroupName: testResourceGroupName,
-		HCPClusterName:    testClusterName,
-		HCPNodePoolName:   testNodePoolName,
-	}
-
-	ctx = utils.ContextWithLogger(ctx, logr.Discard())
-	err := syncer.SyncOnce(ctx, testKey)
-
-	// Validation failure persists IntentFailed and SyncOnce returns nil.
-	require.NoError(t, err)
-	spnp, err := mockResourcesDBClient.ServiceProviderNodePools(
-		testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
-	).Get(ctx, api.ServiceProviderNodePoolResourceName)
-	require.NoError(t, err)
-	assert.Nil(t, spnp.Spec.NodePoolVersion.DesiredVersion, "desired version must not be persisted when validation fails")
-}
-
-func TestNodePoolVersionSyncer_SyncOnce_SucceedsWithoutCincinnatiEdge(t *testing.T) {
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCincinnati := cincinnati.NewMockClient(ctrl)
-
-	// Create node pool with desired version 4.19.10
-	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.10")
-
-	// Create ServiceProviderCluster with control plane at 4.20.0 (allows the desired version)
-	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
-
-	// Create ServiceProviderNodePool with active version 4.19.7
-	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.7")
-
-	mockCincinnati.EXPECT().
-		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.10"))).
-		Return(
-			configv1.Release{Version: "4.19.10"},
-			[]configv1.Release{},
-			nil,
-			nil,
-		).
-		Times(1)
-
-	mockClientCache := cincinnati.NewMockClientCache(ctrl)
-	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
-
-	syncer := &nodePoolVersionSyncer{
-		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
-		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
-		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
-		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
-		readDesireLister:              newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:             mockResourcesDBClient,
-		cincinnatiClientCache:         mockClientCache,
-	}
-
-	testKey := controllerutils.HCPNodePoolKey{
-		SubscriptionID:    testSubscriptionID,
-		ResourceGroupName: testResourceGroupName,
-		HCPClusterName:    testClusterName,
-		HCPNodePoolName:   testNodePoolName,
-	}
-
-	ctx = utils.ContextWithLogger(ctx, logr.Discard())
-	err := syncer.SyncOnce(ctx, testKey)
-
-	require.NoError(t, err)
-
-	// Verify the ServiceProviderNodePool DesiredVersion was updated
-	spnp, err := mockResourcesDBClient.ServiceProviderNodePools(
-		testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
-	).Get(ctx, api.ServiceProviderNodePoolResourceName)
-	require.NoError(t, err)
-	require.NotNil(t, spnp.Spec.NodePoolVersion.DesiredVersion)
-	expectedDesiredVersion := semver.MustParse("4.19.10")
-	require.True(t, expectedDesiredVersion.EQ(*spnp.Spec.NodePoolVersion.DesiredVersion))
-}
-
-func TestNodePoolVersionSyncer_SyncOnce_VersionNotInCincinnatiFails(t *testing.T) {
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCincinnati := cincinnati.NewMockClient(ctrl)
-
-	// Create node pool with desired version 4.19.99 (does not exist in Cincinnati)
-	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.99")
-
-	// Create ServiceProviderCluster with control plane at 4.20.0
-	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
-
-	// Create ServiceProviderNodePool with active version 4.19.7
-	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.7")
-
-	mockCincinnati.EXPECT().
-		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.99"))).
-		Return(
-			configv1.Release{},
-			nil,
-			nil,
-			&cvocincinnati.Error{Reason: "VersionNotFound", Message: "version 4.19.99 not found"},
-		).
-		Times(1)
-
-	mockClientCache := cincinnati.NewMockClientCache(ctrl)
-	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
-
-	syncer := &nodePoolVersionSyncer{
-		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
-		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
-		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
-		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
-		readDesireLister:              newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:             mockResourcesDBClient,
-		cincinnatiClientCache:         mockClientCache,
-	}
-
-	testKey := controllerutils.HCPNodePoolKey{
-		SubscriptionID:    testSubscriptionID,
-		ResourceGroupName: testResourceGroupName,
-		HCPClusterName:    testClusterName,
-		HCPNodePoolName:   testNodePoolName,
-	}
-
-	ctx = utils.ContextWithLogger(ctx, logr.Discard())
-	err := syncer.SyncOnce(ctx, testKey)
-
-	// Cincinnati VersionNotFound persists IntentFailed; SyncOnce returns nil.
-	require.NoError(t, err)
-	spnp, err := mockResourcesDBClient.ServiceProviderNodePools(
-		testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
-	).Get(ctx, api.ServiceProviderNodePoolResourceName)
-	require.NoError(t, err)
-	assert.Nil(t, spnp.Spec.NodePoolVersion.DesiredVersion, "desired version must not be persisted when validation fails")
-}
-
-func TestNodePoolVersionSyncer_SyncOnce_DowngradeVersionNotInCincinnatiFails(t *testing.T) {
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCincinnati := cincinnati.NewMockClient(ctrl)
-
-	// Create node pool with desired version 4.19.99 (does not exist in Cincinnati)
-	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.99")
-
-	// Create ServiceProviderCluster with control plane at 4.20.0
-	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
-
-	// Create ServiceProviderNodePool with active version 4.19.7
-	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.7")
-
-	mockCincinnati.EXPECT().
-		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.99"))).
-		Return(
-			configv1.Release{},
-			nil,
-			nil,
-			&cvocincinnati.Error{Reason: "VersionNotFound", Message: "version 4.19.99 not found"},
-		).
-		Times(1)
-
-	mockClientCache := cincinnati.NewMockClientCache(ctrl)
-	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
-
-	syncer := &nodePoolVersionSyncer{
-		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
-		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
-		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
-		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
-		readDesireLister:              newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:             mockResourcesDBClient,
-		cincinnatiClientCache:         mockClientCache,
-	}
-
-	testKey := controllerutils.HCPNodePoolKey{
-		SubscriptionID:    testSubscriptionID,
-		ResourceGroupName: testResourceGroupName,
-		HCPClusterName:    testClusterName,
-		HCPNodePoolName:   testNodePoolName,
-	}
-
-	ctx = utils.ContextWithLogger(ctx, logr.Discard())
-	err := syncer.SyncOnce(ctx, testKey)
-
-	// Cincinnati VersionNotFound persists IntentFailed; SyncOnce returns nil.
-	require.NoError(t, err)
-	spnp, err := mockResourcesDBClient.ServiceProviderNodePools(
-		testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
-	).Get(ctx, api.ServiceProviderNodePoolResourceName)
-	require.NoError(t, err)
-	assert.Nil(t, spnp.Spec.NodePoolVersion.DesiredVersion, "desired version must not be persisted when validation fails")
-}
-
-func TestNodePoolVersionSyncer_SyncOnce_DowngradeWithinSkewSucceeds(t *testing.T) {
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCincinnati := cincinnati.NewMockClient(ctrl)
-
-	// Create node pool with desired version 4.19.5 (z-stream downgrade from 4.19.10)
-	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.5")
-
-	// Create ServiceProviderCluster with control plane at 4.20.0
-	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
-
-	// SPNP must exist in cache for SyncOnce to proceed.
-	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.10")
-
-	mockCincinnati.EXPECT().
-		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(semver.MustParse("4.19.5"))).
-		Return(
-			configv1.Release{Version: "4.19.5"},
-			[]configv1.Release{},
-			nil,
-			nil,
-		).
-		Times(1)
-
-	mockClientCache := cincinnati.NewMockClientCache(ctrl)
-	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
-
-	syncer := &nodePoolVersionSyncer{
-		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
-		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
-		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
-		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
-		readDesireLister:              newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:             mockResourcesDBClient,
-		cincinnatiClientCache:         mockClientCache,
-	}
-
-	testKey := controllerutils.HCPNodePoolKey{
-		SubscriptionID:    testSubscriptionID,
-		ResourceGroupName: testResourceGroupName,
-		HCPClusterName:    testClusterName,
-		HCPNodePoolName:   testNodePoolName,
-	}
-
-	ctx = utils.ContextWithLogger(ctx, logr.Discard())
-	err := syncer.SyncOnce(ctx, testKey)
-
-	require.NoError(t, err)
-
-	// Verify the ServiceProviderNodePool DesiredVersion was updated to the downgrade target
-	spnp, err := mockResourcesDBClient.ServiceProviderNodePools(
-		testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
-	).Get(ctx, api.ServiceProviderNodePoolResourceName)
-	require.NoError(t, err)
-	require.NotNil(t, spnp.Spec.NodePoolVersion.DesiredVersion)
-	expectedDesiredVersion := semver.MustParse("4.19.5")
-	require.True(t, expectedDesiredVersion.EQ(*spnp.Spec.NodePoolVersion.DesiredVersion))
-}
-
-func TestNodePoolVersionSyncer_SyncOnce_ValidUpgradeSucceeds(t *testing.T) {
-	ctx := context.Background()
-	ctrl := gomock.NewController(t)
-
-	mockResourcesDBClient := databasetesting.NewMockResourcesDBClient()
-	mockCincinnati := cincinnati.NewMockClient(ctrl)
-
-	// Create node pool with desired version 4.19.15 (valid upgrade from 4.19.10)
-	createTestNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.15")
-
-	// Create ServiceProviderCluster with control plane at 4.20.0
-	createServiceProviderClusterWithVersion(t, ctx, mockResourcesDBClient, "4.20.0")
-
-	// SPNP must exist in cache for SyncOnce to proceed.
-	createServiceProviderNodePoolWithVersion(t, ctx, mockResourcesDBClient, "4.19.10")
-
-	mockCincinnati.EXPECT().
-		GetUpdates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(
-			configv1.Release{Version: "4.19.15"},
-			[]configv1.Release{},
-			nil,
-			nil,
-		).
-		Times(1)
-
-	mockClientCache := cincinnati.NewMockClientCache(ctrl)
-	mockClientCache.EXPECT().GetOrCreateClient(gomock.Any()).Return(mockCincinnati).AnyTimes()
-
-	syncer := &nodePoolVersionSyncer{
-		nodePoolLister:                &listertesting.DBNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
-		serviceProviderNodePoolLister: &listertesting.DBServiceProviderNodePoolLister{ResourcesDBClient: mockResourcesDBClient},
-		serviceProviderClusterLister:  &listertesting.DBServiceProviderClusterLister{ResourcesDBClient: mockResourcesDBClient},
-		subscriptionLister:            &listertesting.DBSubscriptionLister{ResourcesDBClient: mockResourcesDBClient},
-		readDesireLister:              newValidHostedClusterReadDesireLister(t),
-		resourcesDBClient:             mockResourcesDBClient,
-		cincinnatiClientCache:         mockClientCache,
-	}
-
-	testKey := controllerutils.HCPNodePoolKey{
-		SubscriptionID:    testSubscriptionID,
-		ResourceGroupName: testResourceGroupName,
-		HCPClusterName:    testClusterName,
-		HCPNodePoolName:   testNodePoolName,
-	}
-
-	ctx = utils.ContextWithLogger(ctx, logr.Discard())
-	err := syncer.SyncOnce(ctx, testKey)
-	require.NoError(t, err)
-
-	// Verify the ServiceProviderNodePool was updated correctly
-	spnp, err := mockResourcesDBClient.ServiceProviderNodePools(
-		testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName,
-	).Get(ctx, api.ServiceProviderNodePoolResourceName)
-	require.NoError(t, err)
-
-	// Verify DesiredVersion was persisted
-	require.NotNil(t, spnp.Spec.NodePoolVersion.DesiredVersion)
-	expectedDesiredVersion := semver.MustParse("4.19.15")
-	require.True(t, expectedDesiredVersion.EQ(*spnp.Spec.NodePoolVersion.DesiredVersion))
-}
-
 func TestNodePoolVersionSyncer_SyncOnce_DesiredVersionUnchangedOnFailure_ChangedOnSuccess(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
@@ -1540,6 +1261,37 @@ func createServiceProviderNodePoolWithVersion(t *testing.T, ctx context.Context,
 				},
 			},
 		},
+	}
+	_, err := mockResourcesDBClient.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).Create(ctx, spNodePool, nil)
+	require.NoError(t, err)
+}
+
+func createServiceProviderNodePoolWithVersionAndMinimum(t *testing.T, ctx context.Context, mockResourcesDBClient *databasetesting.MockResourcesDBClient, activeVersion, minimumVersion string) {
+	t.Helper()
+
+	nodePoolResourceID := "/subscriptions/" + testSubscriptionID +
+		"/resourceGroups/" + testResourceGroupName +
+		"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+		"/nodePools/" + testNodePoolName
+	spNodePoolResourceID := nodePoolResourceID + "/" + api.ServiceProviderNodePoolResourceTypeName + "/" + api.ServiceProviderNodePoolResourceName
+
+	version := semver.MustParse(activeVersion)
+	spNodePool := &api.ServiceProviderNodePool{
+		CosmosMetadata: api.CosmosMetadata{
+			ResourceID:   api.Must(azcorearm.ParseResourceID(spNodePoolResourceID)),
+			PartitionKey: strings.ToLower(testSubscriptionID),
+		},
+		Status: api.ServiceProviderNodePoolStatus{
+			NodePoolVersion: api.ServiceProviderNodePoolStatusVersion{
+				ActiveVersions: []api.HCPNodePoolActiveVersion{
+					{Version: &version},
+				},
+			},
+		},
+	}
+	if minimumVersion != "" {
+		minVer := semver.MustParse(minimumVersion)
+		spNodePool.Spec.NodePoolVersion.MinimumVersion = &minVer
 	}
 	_, err := mockResourcesDBClient.ServiceProviderNodePools(testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName).Create(ctx, spNodePool, nil)
 	require.NoError(t, err)

--- a/internal/api/types_serviceprovider_nodepool.go
+++ b/internal/api/types_serviceprovider_nodepool.go
@@ -58,6 +58,12 @@ type ServiceProviderNodePoolSpec struct {
 type ServiceProviderNodePoolSpecVersion struct {
 	// DesiredVersion is the full version the controller wants to upgrade to (format: x.y.z)
 	DesiredVersion *semver.Version `json:"desiredVersion,omitempty"`
+
+	// MinimumVersion is the SRE-selected full version minimum limit for a nodepool.
+	// Stored as a pointer so unset is distinguishable from any explicit choice;
+	// nil means no SRE override has been requested. Valid value is in semver format.
+	// Written by: Admin POST MinimumNodePoolVersion
+	MinimumVersion *semver.Version `json:"minimumVersion,omitempty"`
 }
 
 // ServiceProviderNodePoolStatus contains the observed state of the node pool.

--- a/internal/api/zz_generated.deepcopy.go
+++ b/internal/api/zz_generated.deepcopy.go
@@ -1872,6 +1872,11 @@ func (in *ServiceProviderNodePoolSpecVersion) DeepCopyInto(out *ServiceProviderN
 		*out = new(v4.Version)
 		**out = **in
 	}
+	if in.MinimumVersion != nil {
+		in, out := &in.MinimumVersion, &out.MinimumVersion
+		*out = new(v4.Version)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION


### What

- Add `MinimumVersion` field to `ServiceProviderNodePoolSpecVersion` — an SRE-controlled semver floor per node pool, nil when unset
- New admin API endpoint `POST .../nodepools/{nodepoolName}/minimumversion` to set or clear the minimum version
- Update `nodePoolVersionSyncer` to select `max(customerDesiredVersion, sreMinimumVersion)` as the target version before validation
- Handler tests use callback-based table pattern (`setup`/`validate`); controller tests consolidate SRE minimum version cases into the existing `_IntentFailed` table

### Why

SRE needs to enforce a version floor on individual node pools, ensuring they don't remain on versions below a required threshold. When set, the minimum version overrides the customer's desired version if it is higher; when cleared, the customer's version is used as before.

### Testing

- Unit tests for the admin handler (callback-based table-driven, covering validation errors, set, overwrite, and clear)
- Controller tests extended with SRE minimum version cases in the `_IntentFailed` table test

### Special notes for your reviewer

**Why is this WIP?**
Once we add the SRE selection of a minimumVersion, there will be nodepool updated. This nodepool will be represented in the RP/CosmosDB with a different version that they really have. We need to agree on a correct solution to reflect this reality.

**Usage example:**

Set a minimum version:
```bash
curl -X POST \
  "https://<admin-api>/admin/v1/hcp/subscriptions/<subscription-id>/resourcegroups/<resource-group>/providers/microsoft.redhatopenshift/hcpopenshiftclusters/<cluster-name>/nodepools/<nodepool-name>/minimumversion" \
  -H "Content-Type: application/json" \
  -H "X-Ms-Client-Principal-Name: user@example.com" \
  -d '{"minimumVersion": "4.21.0"}'
```

Response:
```json
{"minimumVersion": "4.21.0"}
```
### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

