### PR TITLE
refactor(mgmt-agent): derive node-health success from the pod LIST (AROSLSRE-1588)

### DIFF
--- a/mgmt-agent/pkg/controller/nodehealth/controller.go
+++ b/mgmt-agent/pkg/controller/nodehealth/controller.go
@@ -161,11 +161,11 @@ func (c *Controller) OnConfigMap(cm *corev1.ConfigMap, key string) {
 	klog.InfoS("node-health config reloaded", "configmap", cm.Name, "enabled", cfg.Enabled)
 	wasEnabled := c.config.Load().Enabled
 	c.SetConfig(cfg)
-	// A disabled->enabled transition needs no warm-up: detection reads both its
-	// failure and its success signal out of the informer caches, so the first
+	// A disabled->enabled transition needs no handling here: detection reads both
+	// its failure and its success signal out of the informer caches, so the first
 	// reconcile after the flip sees the same evidence a controller that had been
 	// enabled all along would.
-	//
+
 	// A hot enabled->disabled flip stops all reconciles, so the gauge would
 	// otherwise freeze at its last value. Zero it immediately so a disabled
 	// controller reads zero wedged nodes rather than a stale count.

--- a/mgmt-agent/pkg/controller/nodehealth/controller.go
+++ b/mgmt-agent/pkg/controller/nodehealth/controller.go
@@ -17,7 +17,6 @@ package nodehealth
 import (
 	"context"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -63,22 +62,6 @@ type Controller struct {
 	eventIndexer cache.Indexer
 	hasSynced    []cache.InformerSynced
 
-	// obsMu guards observedSince and successAt, which are read by the workers and
-	// written by the pod handlers and the config-informer thread (on a
-	// disabled->enabled transition).
-	obsMu sync.Mutex
-	// observedSince is the clock time the controller began observing: cache sync
-	// on start, or a disabled->enabled transition. Detection treats the success
-	// signal as indeterminate until a full window has elapsed since then, so a
-	// cold view after a restart or a hot enable is never misread as no-success.
-	observedSince time.Time
-	// successAt records, per node name, the most recent time the controller saw a
-	// non-host-network PodReadyToStartContainers=True transition. It is advanced
-	// from pod add/update/delete so a success survives its short-lived pod being
-	// deleted, and is pruned by window when read. It is cleared whenever
-	// observation (re)starts.
-	successAt map[string]time.Time
-
 	labeler *labeler
 	clock   func() time.Time
 
@@ -121,9 +104,8 @@ func NewController(
 			podInformer.Informer().HasSynced,
 			eventInformer.Informer().HasSynced,
 		},
-		labeler:   newLabeler(kubeClientset, recorder, clock),
-		clock:     clock,
-		successAt: make(map[string]time.Time),
+		labeler: newLabeler(kubeClientset, recorder, clock),
+		clock:   clock,
 		workqueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: ControllerName},
@@ -138,9 +120,9 @@ func NewController(
 		return nil, fmt.Errorf("failed to add node event handler: %w", err)
 	}
 	if _, err := podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.recordPodSuccess(obj); c.enqueuePodObject(obj) },
-		UpdateFunc: func(_, newObj interface{}) { c.recordPodSuccess(newObj); c.enqueuePodObject(newObj) },
-		DeleteFunc: func(obj interface{}) { c.recordPodSuccess(obj); c.enqueuePodObject(obj) },
+		AddFunc:    func(obj interface{}) { c.enqueuePodObject(obj) },
+		UpdateFunc: func(_, newObj interface{}) { c.enqueuePodObject(newObj) },
+		DeleteFunc: func(obj interface{}) { c.enqueuePodObject(obj) },
 	}); err != nil {
 		return nil, fmt.Errorf("failed to add pod event handler: %w", err)
 	}
@@ -179,13 +161,11 @@ func (c *Controller) OnConfigMap(cm *corev1.ConfigMap, key string) {
 	klog.InfoS("node-health config reloaded", "configmap", cm.Name, "enabled", cfg.Enabled)
 	wasEnabled := c.config.Load().Enabled
 	c.SetConfig(cfg)
-	// A disabled->enabled transition restarts observation: the success map is
-	// discarded and the observedSince warm-up begins now, so the success signal
-	// is treated as indeterminate until a full window has been watched under the
-	// enabled controller.
-	if cfg.Enabled && !wasEnabled {
-		c.beginObserving(c.clock())
-	}
+	// A disabled->enabled transition needs no warm-up: detection reads both its
+	// failure and its success signal out of the informer caches, so the first
+	// reconcile after the flip sees the same evidence a controller that had been
+	// enabled all along would.
+	//
 	// A hot enabled->disabled flip stops all reconciles, so the gauge would
 	// otherwise freeze at its last value. Zero it immediately so a disabled
 	// controller reads zero wedged nodes rather than a stale count.
@@ -242,66 +222,6 @@ func (c *Controller) enqueueEventObject(obj interface{}) {
 	}
 }
 
-// beginObserving (re)starts the observation warm-up: it stamps observedSince to
-// now and clears any recorded success history so a fresh full window must be
-// watched before the success signal is trusted. Called after cache sync in Run
-// and on a disabled->enabled transition.
-func (c *Controller) beginObserving(now time.Time) {
-	c.obsMu.Lock()
-	defer c.obsMu.Unlock()
-	c.observedSince = now
-	c.successAt = make(map[string]time.Time)
-}
-
-// recordPodSuccess advances the per-node success timestamp when a pod shows a
-// fresh sandbox (non-host-network PodReadyToStartContainers=True). It is called
-// from the pod add/update/delete handlers, so a success is captured from the
-// pod's last-seen state even as the short-lived pod is being deleted. A disabled
-// controller records nothing: beginObserving discards the map on startup and on
-// every disabled->enabled transition, so anything recorded while off could never
-// be read, and keeping it would grow the map for every node name ever seen.
-func (c *Controller) recordPodSuccess(obj interface{}) {
-	if !c.config.Load().Enabled {
-		return
-	}
-	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-		obj = tombstone.Obj
-	}
-	pod, ok := obj.(*corev1.Pod)
-	if !ok || pod.Spec.NodeName == "" {
-		return
-	}
-	at, ok := detectors.SuccessAt(pod)
-	if !ok {
-		return
-	}
-	c.obsMu.Lock()
-	defer c.obsMu.Unlock()
-	if prev, exists := c.successAt[pod.Spec.NodeName]; !exists || at.After(prev) {
-		c.successAt[pod.Spec.NodeName] = at
-	}
-}
-
-// observation returns the node's warm-up start and its most recent recorded
-// success, pruning any success older than the widest detector window so the map
-// does not grow without bound.
-func (c *Controller) observation(node string) (observedSince, lastSuccessAt time.Time) {
-	c.obsMu.Lock()
-	defer c.obsMu.Unlock()
-	observedSince = c.observedSince
-	at, ok := c.successAt[node]
-	if !ok {
-		return observedSince, time.Time{}
-	}
-	// Measured in absolute terms so a future-dated timestamp (kubelet clock skew)
-	// is pruned rather than retained forever by a negative age.
-	if c.clock().Sub(at).Abs() >= detectors.MaxWindow() {
-		delete(c.successAt, node)
-		return observedSince, time.Time{}
-	}
-	return observedSince, at
-}
-
 // Run starts the controller workers and blocks until the context is cancelled.
 func (c *Controller) Run(ctx context.Context, workers int) error {
 	defer utilruntime.HandleCrash()
@@ -314,11 +234,10 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 	if ok := cache.WaitForCacheSync(ctx.Done(), c.hasSynced...); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
-	// Record when the controller begins observing. Until a full detector window
-	// has elapsed past this point, detection treats the success signal as
-	// indeterminate so a cold view is never misread as no-success. This also
-	// clears any success history carried across the cache resync.
-	c.beginObserving(c.clock())
+	// No warm-up follows the sync. Detection reads every signal it uses, failures
+	// and successes alike, out of the synced caches, so once the LIST has landed
+	// the controller knows everything a long-running one would and can decide
+	// immediately.
 
 	logger.Info("Starting workers", "count", workers)
 	for i := 0; i < workers; i++ {
@@ -461,8 +380,7 @@ func (c *Controller) syncHandler(ctx context.Context, name string) error {
 		return err
 	}
 
-	observedSince, lastSuccessAt := c.observation(name)
-	decision, snap := detectors.Decide(node, events, pods, c.clock(), observedSince, lastSuccessAt)
+	decision, snap := detectors.Decide(node, events, pods, c.clock())
 	switch decision {
 	case detectors.DecisionWedged:
 		changed, err := c.labeler.label(ctx, node, snap.DetectorName, snap)

--- a/mgmt-agent/pkg/controller/nodehealth/controller_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/controller_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/component-base/metrics/legacyregistry"
 
@@ -145,13 +144,18 @@ func isWedged(t *testing.T, client *fake.Clientset, name string) bool {
 	return getNode(t, client, name).Labels[labelKey] == labelValue
 }
 
-// warmObserved is far enough in the past that a full detector window has elapsed.
-var warmObserved = testNow.Add(-30 * time.Minute)
+// seedSuccess puts a pod that got a sandbox into the pod cache, which is the
+// only place the success signal is read from.
+func seedSuccess(t *testing.T, c *Controller, host, name string, ts time.Time) {
+	t.Helper()
+	if err := c.podIndexer.Add(startedPodOn(host, name, ts, false)); err != nil {
+		t.Fatalf("add pod: %v", err)
+	}
+}
 
 func TestSyncHandlerWedgesOnSustainedStorm(t *testing.T) {
 	node := swiftReadyNode(testHost)
 	c, client, _ := newTestController(t, true, node)
-	c.beginObserving(warmObserved)
 	seedStuckStorm(t, c, testHost, 3, testNow.Add(-15*time.Minute))
 
 	if err := c.syncHandler(context.Background(), testHost); err != nil {
@@ -165,7 +169,6 @@ func TestSyncHandlerWedgesOnSustainedStorm(t *testing.T) {
 func TestSyncHandlerDisabledIsNoop(t *testing.T) {
 	node := swiftReadyNode(testHost)
 	c, client, _ := newTestController(t, false, node)
-	c.beginObserving(warmObserved)
 	seedStuckStorm(t, c, testHost, 3, testNow.Add(-15*time.Minute))
 
 	if err := c.syncHandler(context.Background(), testHost); err != nil {
@@ -176,129 +179,182 @@ func TestSyncHandlerDisabledIsNoop(t *testing.T) {
 	}
 }
 
-func TestSyncHandlerColdWarmupDoesNotWedge(t *testing.T) {
+// TestFreshControllerWedgesWithoutWarmup is the regression test for the cache
+// contract: the controller keeps nothing between reconciles, so a process that
+// has just started decides from the LIST alone. There is no warm-up window in
+// which a genuinely wedged node goes unreported.
+func TestFreshControllerWedgesWithoutWarmup(t *testing.T) {
 	node := swiftReadyNode(testHost)
 	c, client, _ := newTestController(t, true, node)
-	// Observation began just now: a full window has not been watched yet.
-	c.beginObserving(testNow.Add(-1 * time.Minute))
 	seedStuckStorm(t, c, testHost, 3, testNow.Add(-15*time.Minute))
 
 	if err := c.syncHandler(context.Background(), testHost); err != nil {
 		t.Fatalf("syncHandler: %v", err)
 	}
-	if isWedged(t, client, testHost) {
-		t.Fatal("a cold controller must not invent a fresh wedge before a full window")
+	if !isWedged(t, client, testHost) {
+		t.Fatal("a freshly started controller must wedge straight off the LIST, with no warm-up")
 	}
 }
 
 func TestSyncHandlerRecoveryUnlabels(t *testing.T) {
-	// Node already carries the wedged label; a recorded success and no stuck pods
-	// must clear it.
+	// Node already carries the wedged label; a pod that got a sandbox and no
+	// stuck pods must clear it.
 	node := swiftReadyNode(testHost)
 	node.Labels[labelKey] = labelValue
 	c, client, _ := newTestController(t, true, node)
-	c.beginObserving(warmObserved)
-	c.recordPodSuccess(startedPodOn(testHost, "ok", testNow.Add(-1*time.Minute), false))
+	seedSuccess(t, c, testHost, "ok", testNow.Add(-1*time.Minute))
 
 	if err := c.syncHandler(context.Background(), testHost); err != nil {
 		t.Fatalf("syncHandler: %v", err)
 	}
 	if isWedged(t, client, testHost) {
-		t.Fatal("a recorded success with no stuck pods should unlabel the node")
+		t.Fatal("a success with no stuck pods should unlabel the node")
 	}
 }
 
-func TestShortLivedSuccessSurvivesPodDeletion(t *testing.T) {
-	// The key regression: a pod's sandbox came up (success) and the pod was then
-	// deleted, so it is no longer in the informer store, while a storm of stuck
-	// pods remains. The recorded success must still block a false wedge.
+// TestSuccessInListPreventsFalseWedge is the AROSLSRE-1643 shape: a node under a
+// real sandbox-failure storm that is nevertheless still starting pods. The
+// successes sit in the pod cache alongside the stuck pods, so the storm alone is
+// not enough to call it wedged.
+func TestSuccessInListPreventsFalseWedge(t *testing.T) {
 	node := swiftReadyNode(testHost)
 	c, client, _ := newTestController(t, true, node)
-	c.beginObserving(warmObserved)
 
-	// A short-lived success, observed via the delete handler (the pod is never
-	// added to the store, mirroring a pod already gone by reconcile time).
-	success := startedPodOn(testHost, "shortlived", testNow.Add(-2*time.Minute), false)
-	c.recordPodSuccess(cache.DeletedFinalStateUnknown{Key: "ns/shortlived", Obj: success})
+	seedStuckStorm(t, c, testHost, 3, testNow.Add(-15*time.Minute))
+	seedSuccess(t, c, testHost, "started", testNow.Add(-2*time.Minute))
 
+	if err := c.syncHandler(context.Background(), testHost); err != nil {
+		t.Fatalf("syncHandler: %v", err)
+	}
+	if isWedged(t, client, testHost) {
+		t.Fatal("a node still starting pods must not be labeled wedged")
+	}
+}
+
+// TestRestartReachesTheSameVerdict pins the property the in-memory success map
+// could not give: two controllers looking at the same LIST agree, whatever
+// either of them watched happen. A replacement process is handed the caches a
+// long-running one had and must land on the same answer with no history and no
+// warm-up.
+func TestRestartReachesTheSameVerdict(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		success    bool
+		wantWedged bool
+	}{
+		{name: "storm with no success is wedged", success: false, wantWedged: true},
+		{name: "storm with a success is not", success: true, wantWedged: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			node := swiftReadyNode(testHost)
+			before, beforeClient, _ := newTestController(t, true, node)
+			seedStuckStorm(t, before, testHost, 3, testNow.Add(-15*time.Minute))
+			if tc.success {
+				seedSuccess(t, before, testHost, "started", testNow.Add(-2*time.Minute))
+			}
+			if err := before.syncHandler(context.Background(), testHost); err != nil {
+				t.Fatalf("syncHandler before restart: %v", err)
+			}
+			if got := isWedged(t, beforeClient, testHost); got != tc.wantWedged {
+				t.Fatalf("wedged before restart = %v, want %v", got, tc.wantWedged)
+			}
+
+			// The replacement process: brand new controller, nothing remembered,
+			// same evidence.
+			after, afterClient, _ := newTestController(t, true, node)
+			seedStuckStorm(t, after, testHost, 3, testNow.Add(-15*time.Minute))
+			if tc.success {
+				seedSuccess(t, after, testHost, "started", testNow.Add(-2*time.Minute))
+			}
+			if err := after.syncHandler(context.Background(), testHost); err != nil {
+				t.Fatalf("syncHandler after restart: %v", err)
+			}
+			if got := isWedged(t, afterClient, testHost); got != tc.wantWedged {
+				t.Errorf("wedged after restart = %v, want %v (must match the pre-restart verdict)", got, tc.wantWedged)
+			}
+		})
+	}
+}
+
+// TestHotEnableDecidesImmediately covers the disabled->enabled flip. It used to
+// restart a warm-up; now there is nothing to warm up, so the first reconcile
+// after the flip acts on the evidence already in cache.
+func TestHotEnableDecidesImmediately(t *testing.T) {
+	node := swiftReadyNode(testHost)
+	c, client, _ := newTestController(t, false, node)
 	seedStuckStorm(t, c, testHost, 3, testNow.Add(-15*time.Minute))
 
 	if err := c.syncHandler(context.Background(), testHost); err != nil {
-		t.Fatalf("syncHandler: %v", err)
+		t.Fatalf("syncHandler while disabled: %v", err)
 	}
 	if isWedged(t, client, testHost) {
-		t.Fatal("a recorded success from a since-deleted pod must prevent a false wedge")
-	}
-}
-
-func TestHotEnableResetsObservation(t *testing.T) {
-	node := swiftReadyNode(testHost)
-	c, _, _ := newTestController(t, false, node)
-
-	// A disabled controller records nothing, so there is no state to carry into
-	// the enabled controller.
-	c.recordPodSuccess(startedPodOn(testHost, "ok", testNow.Add(-2*time.Minute), false))
-	if _, at := c.observation(testHost); !at.IsZero() {
-		t.Fatalf("a disabled controller must not record successes, got %v", at)
+		t.Fatal("precondition: a disabled controller must not label")
 	}
 
-	// A disabled->enabled transition must reset observedSince to now and clear the
-	// success history, so the controller re-earns a full window before it can wedge.
-	cm := &corev1.ConfigMap{
+	c.OnConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "node-health-config"},
 		Data:       map[string]string{"config.yaml": "enabled: true"},
-	}
-	c.OnConfigMap(cm, "config.yaml")
+	}, "config.yaml")
 
-	obs, at := c.observation(testHost)
-	if !obs.Equal(testNow) {
-		t.Errorf("observedSince = %v, want %v (reset on enable)", obs, testNow)
+	if err := c.syncHandler(context.Background(), testHost); err != nil {
+		t.Fatalf("syncHandler after enable: %v", err)
 	}
-	if !at.IsZero() {
-		t.Error("success history should be cleared on a disabled->enabled transition")
+	if !isWedged(t, client, testHost) {
+		t.Error("the first reconcile after a hot enable must act on the evidence already in cache")
 	}
 }
 
-func TestObservationPrunesSuccessOlderThanMaxWindow(t *testing.T) {
+// TestNonSuccessPodsDoNotSuppressAWedge pins the two pod shapes that look like a
+// success but are not. Host-network pods reach the condition without a delegated
+// NIC, which is exactly what a SWIFT wedge cannot provide, and a stuck pod is the
+// symptom rather than the cure. Counting either would mask a real wedge, and the
+// host-network case matters most: SWIFT mitigation restarts host-network pods.
+func TestNonSuccessPodsDoNotSuppressAWedge(t *testing.T) {
 	node := swiftReadyNode(testHost)
-	c, _, _ := newTestController(t, true, node)
-	c.beginObserving(warmObserved)
+	c, client, _ := newTestController(t, true, node)
+	seedStuckStorm(t, c, testHost, 3, testNow.Add(-15*time.Minute))
 
-	// A success older than the widest detector window can never matter, so it is
-	// pruned on read.
-	old := testNow.Add(-detectors.MaxWindow() - time.Minute)
-	c.recordPodSuccess(startedPodOn(testHost, "stale", old, false))
-	if _, at := c.observation(testHost); !at.IsZero() {
-		t.Errorf("stale success should be pruned, got %v", at)
+	if err := c.podIndexer.Add(startedPodOn(testHost, "hostnet", testNow.Add(-1*time.Minute), true)); err != nil {
+		t.Fatalf("add pod: %v", err)
+	}
+	if err := c.podIndexer.Add(stuckPodOn(testHost, "another-stuck", testNow.Add(-1*time.Minute))); err != nil {
+		t.Fatalf("add pod: %v", err)
+	}
+
+	if err := c.syncHandler(context.Background(), testHost); err != nil {
+		t.Fatalf("syncHandler: %v", err)
+	}
+	if !isWedged(t, client, testHost) {
+		t.Error("neither a host-network pod nor a stuck pod is a success; the wedge must still fire")
 	}
 }
 
-func TestRecordPodSuccessExcludesHostNetworkAndFailures(t *testing.T) {
-	node := swiftReadyNode(testHost)
-	c, _, _ := newTestController(t, true, node)
-	c.beginObserving(warmObserved)
+// TestOutOfWindowSuccessDoesNotSuppressAWedge covers both ends of the window.
+// The captured production node was still running 46 started pods whose freshest
+// transition was over 8 hours old, so "has ever started a pod" is always true on
+// a long-lived node. Future-dated timestamps come from kubelet clock skew and are
+// not evidence the node can attach a NIC now either.
+func TestOutOfWindowSuccessDoesNotSuppressAWedge(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		at   time.Time
+	}{
+		{name: "long stale", at: testNow.Add(-8 * time.Hour)},
+		{name: "future dated by kubelet skew", at: testNow.Add(1 * time.Hour)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			node := swiftReadyNode(testHost)
+			c, client, _ := newTestController(t, true, node)
+			seedStuckStorm(t, c, testHost, 3, testNow.Add(-15*time.Minute))
+			seedSuccess(t, c, testHost, "out-of-window", tc.at)
 
-	// Host-network pods reach the condition without a delegated NIC.
-	c.recordPodSuccess(startedPodOn(testHost, "hostnet", testNow.Add(-1*time.Minute), true))
-	// A stuck (False) pod is not a success.
-	c.recordPodSuccess(stuckPodOn(testHost, "stuck", testNow.Add(-1*time.Minute)))
-	if _, at := c.observation(testHost); !at.IsZero() {
-		t.Errorf("neither host-network nor stuck pods should record a success, got %v", at)
-	}
-}
-
-func TestRecordPodSuccessKeepsMostRecent(t *testing.T) {
-	node := swiftReadyNode(testHost)
-	c, _, _ := newTestController(t, true, node)
-	c.beginObserving(warmObserved)
-
-	c.recordPodSuccess(startedPodOn(testHost, "a", testNow.Add(-5*time.Minute), false))
-	c.recordPodSuccess(startedPodOn(testHost, "b", testNow.Add(-1*time.Minute), false))
-	// An older success arriving later must not move the timestamp backwards.
-	c.recordPodSuccess(startedPodOn(testHost, "c", testNow.Add(-8*time.Minute), false))
-
-	if _, at := c.observation(testHost); !at.Equal(testNow.Add(-1 * time.Minute)) {
-		t.Errorf("lastSuccessAt = %v, want the most recent (%v)", at, testNow.Add(-1*time.Minute))
+			if err := c.syncHandler(context.Background(), testHost); err != nil {
+				t.Fatalf("syncHandler: %v", err)
+			}
+			if !isWedged(t, client, testHost) {
+				t.Error("an out-of-window success must not suppress detection")
+			}
+		})
 	}
 }
 
@@ -496,9 +552,7 @@ func TestRestartRetainsExistingWedgedLabel(t *testing.T) {
 	node.Annotations = map[string]string{annotationDetector: "swift-vf-teardown"}
 
 	c, client, _ := newTestController(t, true, node)
-	// A freshly started controller: observation begins now, no success history,
-	// and no Events or Pods in cache.
-	c.beginObserving(testNow)
+	// A freshly started controller with no Events or Pods in cache.
 
 	if err := c.syncHandler(context.Background(), "n1"); err != nil {
 		t.Fatalf("syncHandler: %v", err)
@@ -564,32 +618,6 @@ func TestOnConfigMapHotDisableTakesEffect(t *testing.T) {
 	}
 }
 
-// TestObservationPrunesFutureDatedSuccess covers kubelet clock skew. The success
-// timestamp is a Pod condition stamped by the kubelet's own clock, so it can
-// arrive dated ahead of the controller's clock. recordPodSuccess keeps the
-// latest timestamp, so a far-future one would otherwise win permanently and
-// discard every genuine success that followed it, silently suppressing
-// detection until the wall clock caught up. It is not usable evidence, so it is
-// pruned on read like any other out-of-window entry.
-func TestObservationPrunesFutureDatedSuccess(t *testing.T) {
-	node := swiftReadyNode(testHost)
-	c, _, _ := newTestController(t, true, node)
-	c.beginObserving(warmObserved)
-
-	future := testNow.Add(detectors.MaxWindow() + time.Hour)
-	c.recordPodSuccess(startedPodOn(testHost, "skewed", future, false))
-	if _, at := c.observation(testHost); !at.IsZero() {
-		t.Errorf("future-dated success should be pruned, got %v", at)
-	}
-
-	// Skew inside the window is ordinary and stays usable.
-	near := testNow.Add(1 * time.Second)
-	c.recordPodSuccess(startedPodOn(testHost, "near", near, false))
-	if _, at := c.observation(testHost); at.IsZero() {
-		t.Error("a success within the window must be retained despite small skew")
-	}
-}
-
 // nodeWedgedSeries returns the per-node wedged gauge as a map keyed by the
 // "node|detector|signature" label tuple, so a test can assert on the exact
 // series set the vector currently exposes.
@@ -636,7 +664,6 @@ func TestResyncAllPublishesAndRetiresPerNodeWedgedSeries(t *testing.T) {
 	healthy := swiftReadyNode("swift-healthy")
 
 	c, _, factory := newTestController(t, true, wedged, healthy)
-	c.beginObserving(warmObserved)
 
 	c.resyncAll(context.Background())
 	got := nodeWedgedSeries(t)
@@ -677,7 +704,6 @@ func TestResyncAllDisabledClearsPerNodeWedgedSeries(t *testing.T) {
 	}
 
 	c, _, _ := newTestController(t, true, wedged)
-	c.beginObserving(warmObserved)
 	c.resyncAll(context.Background())
 	if got := nodeWedgedSeries(t); len(got) != 1 {
 		t.Fatalf("series set while enabled = %v, want one entry", got)

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/README.md
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/README.md
@@ -110,7 +110,9 @@ Pods that the apiserver garbage-collects:
     as a matter of course, so without this a node whose recent traffic was
     short-lived Job and CronJob pods would read as having had no success at all.
   The window comparison is absolute, so a timestamp dated ahead by kubelet clock
-  skew is discarded rather than read as an arbitrarily fresh success.
+  skew is measured by its distance from now rather than its sign. Skew inside the
+  window still counts as a success, which is harmless, and anything further out is
+  discarded rather than read as an arbitrarily fresh success.
 - **Nothing is remembered between reconciles.** Both signals come out of the
   informer caches, which is the whole point: the only state the controller keeps is
   state a `LIST` can rebuild. There is no success map to lose on restart and so no

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/README.md
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/README.md
@@ -105,10 +105,14 @@ Pods that the apiserver garbage-collects:
     timed by that transition. Keying on the transition rather than pod age means a
     container restarting inside an existing sandbox is not mistaken for success:
     the sandbox is what needs the network.
-  - a pod that reached a terminal phase with a container that actually ran, timed
-    by that container's start. A finished pod drops the condition back to `False`
-    as a matter of course, so without this a node whose recent traffic was
+  - a pod that reached a terminal phase with a container that ran exactly once,
+    timed by that container's start. A finished pod drops the condition back to
+    `False` as a matter of course, so without this a node whose recent traffic was
     short-lived Job and CronJob pods would read as having had no success at all.
+    The restart count matters: a terminated state describes the container's latest
+    run, so on a restarted container the start time belongs to a run inside the
+    sandbox the pod already had, which proves nothing. Those containers are not
+    evidence in either direction.
   The window comparison is absolute, so a timestamp dated ahead by kubelet clock
   skew is measured by its distance from now rather than its sign. Skew inside the
   window still counts as a success, which is harmless, and anything further out is

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/README.md
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/README.md
@@ -12,19 +12,18 @@ synthetic Events and Pods, no cluster required.
 
 ## The decision
 
-`Decide(node, events, pods, now, observedSince, lastSuccessAt) (Decision, Snapshot)`
+`Decide(node, events, pods, now) (Decision, Snapshot)`
 returns one of:
 
 - `DecisionWedged`: a detector fired. The controller ensures the node carries the
   wedged label.
-- `DecisionHealthy`: recovery is positively observed (a recorded per-node success
-  falls within the window). The controller ensures the node is not labeled.
+- `DecisionHealthy`: recovery is positively observed (a pod on the node got a
+  sandbox inside the window). The controller ensures the node is not labeled.
 - `DecisionUnknown`: the evidence is insufficient, so leave the label exactly as it
-  is. This covers a `NotReady` node (deferred to node lifecycle) and the cold view
-  before a full window has been observed since observation began
-  (`observedSince`). Because `Unknown` never removes a label, an existing wedged
-  label survives a restart until recovery is actually seen, and a cold view never
-  invents a fresh wedge.
+  is. This covers a `NotReady` node (deferred to node lifecycle) and a node that is
+  simply quiet: no storm and no success either. Because `Unknown` never removes a
+  label, an existing wedged label survives a restart until recovery is actually
+  seen.
 - `DecisionNotApplicable`: no detector applies to the node, so none can ever mark
   it wedged. The controller ensures the node is not labeled. This is a definitive
   statement about ownership, unlike `Unknown` which is a statement about evidence,
@@ -34,9 +33,10 @@ returns one of:
   Ready or not.
 
 `Decide` short-circuits on a wedge, only reports `Healthy` on positive success
-evidence, and otherwise stays `Unknown`. It is a pure function of the node's
-observed state and the controller's recorded per-node success history: same
-inputs, same output.
+evidence, and otherwise stays `Unknown`. It is a pure function of the node and the
+Events and Pods held for it: same inputs, same output, and nothing is carried
+between calls. Every input is something a `LIST` returns, so a controller that has
+just started decides exactly what one running for hours would, with no warm-up.
 
 ## How a detector is structured
 
@@ -57,7 +57,7 @@ is adding code in its own file, never editing the engine:
 
 `Decide` walks `registry`. For each detector it calls `Applies(node)` (skip if the
 node can't exhibit the fault), then `Evaluate(...)` to gather the evidence
-`Snapshot`, then `MeetsThreshold(snap, now, observedSince)`. The first detector that fires
+`Snapshot`, then `MeetsThreshold(snap, now)`. The first detector that fires
 wins and the node is `Wedged`; if none fires but some success was seen, the node is
 `Healthy`; otherwise `Unknown`.
 
@@ -79,8 +79,7 @@ constants, never config):
 | `requireZeroSuccess` | when true, firing requires zero fresh sandbox successes in the window |
 
 `MeetsThreshold` is: `SustainedCount >= failuresFloor` (stuck pods that have each been stuck
-at least `dwell`) **and** (`RecentSuccess == false` when `requireZeroSuccess`, and
-only once a full `window` has elapsed since `observedSince`).
+at least `dwell`) **and** `RecentSuccess == false` when `requireZeroSuccess`.
 
 Three details that matter, all of them chosen so no signal depends on Events or
 Pods that the apiserver garbage-collects:
@@ -96,21 +95,29 @@ Pods that the apiserver garbage-collects:
   only to classify which pods are failing (looked up per node by `Event.Source.Host`,
   which is deletion-safe, and correlated to a specific Pod by `InvolvedObject.UID` so
   a recycled name cannot inherit a deleted Pod's Events); they are never counted.
-- **Success presence is load-bearing, and it is a recorded history, not a scan.**
+- **Success presence is load-bearing, and it is read from the same Pods.**
   `requireZeroSuccess` is what separates a hard wedge (VF gone, no fresh sandboxes)
-  from a flap (some pods still starting). A success is a non-host-network pod whose
-  `PodReadyToStartContainers` condition transitioned to `True`; host-network pods
-  are excluded, since they reach the condition without a delegated NIC. The
-  controller records the most recent such transition per node (`SuccessAt` feeds a
-  bounded `lastSuccessAt`), advanced from pod add/update **and** the last-seen state
-  of a deleted pod, so a short-lived success survives its Pod being garbage
-  collected. `Decide` sets `RecentSuccess` when `lastSuccessAt` falls inside the
-  window; it never scans the passed-in Pods for success.
-- **No recorded success is `Unknown`, never a wedge, until the controller has
-  watched a full window.** Just after a restart or a disabled→enabled transition
-  the recorded history starts empty, so a detector does not fire until
-  `now - observedSince >= window`; before that, an empty success history is treated
-  as indeterminate, not as proof of a wedge.
+  from a flap (some pods still starting). `Evaluate` scans the node's Pods with
+  `SuccessAt` and sets `RecentSuccess` when one lands inside the window. Two shapes
+  count, and host-network pods are excluded from both since they reach a running
+  state without a delegated NIC:
+  - a live pod whose `PodReadyToStartContainers` condition transitioned to `True`,
+    timed by that transition. Keying on the transition rather than pod age means a
+    container restarting inside an existing sandbox is not mistaken for success:
+    the sandbox is what needs the network.
+  - a pod that reached a terminal phase with a container that actually ran, timed
+    by that container's start. A finished pod drops the condition back to `False`
+    as a matter of course, so without this a node whose recent traffic was
+    short-lived Job and CronJob pods would read as having had no success at all.
+  The window comparison is absolute, so a timestamp dated ahead by kubelet clock
+  skew is discarded rather than read as an arbitrarily fresh success.
+- **Nothing is remembered between reconciles.** Both signals come out of the
+  informer caches, which is the whole point: the only state the controller keeps is
+  state a `LIST` can rebuild. There is no success map to lose on restart and so no
+  warm-up window during which a genuinely wedged node goes unreported. The
+  trade-off is deliberate: a success is only visible while its Pod is still in the
+  cache, which is why the terminal-pod shape above is counted rather than relying on
+  a pod still being alive at reconcile time.
 
 ## The one detector today: `swift-vf-teardown`
 

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/decide.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/decide.go
@@ -33,8 +33,9 @@ type Decision int
 const (
 	// DecisionUnknown means the evidence is insufficient to make a call: leave
 	// the node's label exactly as it is. This covers a NotReady node (deferred to
-	// node lifecycle) and the cold view just after a controller restart, so an
-	// existing wedged label is retained until recovery is positively observed.
+	// node lifecycle) and a quiet node showing neither a sustained failure storm
+	// nor a success in the window, so an existing wedged label is retained until
+	// recovery is positively observed.
 	DecisionUnknown Decision = iota
 	// DecisionHealthy means recovery is confirmed (pods starting again): ensure
 	// the node is not labeled.

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/decide.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/decide.go
@@ -21,7 +21,6 @@ package detectors
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -82,19 +81,16 @@ type Detector interface {
 	// detector, independent of any node, so callers that only need the window do
 	// not have to evaluate the detector to learn it.
 	Window() time.Duration
-	// Evaluate reads the detector's failure signals for the node from the Events
-	// and Pods currently held for it. The success signal is not read here: it is
-	// a recorded per-node history the controller passes into Decide, since a
-	// point-in-time scan cannot see a success whose Pod was already deleted.
+	// Evaluate reads the detector's signals for the node from the Events and Pods
+	// currently held for it. Both the failure and the success signal come out of
+	// the Pods passed in, so the result depends on nothing but what a LIST
+	// returns.
 	Evaluate(events []*corev1.Event, pods []*corev1.Pod, now time.Time) Snapshot
 	// MeetsThreshold reports whether the evidence already gathered from the
 	// informers meets this detector's threshold. It is a pure predicate over that
 	// evidence, not an edge trigger: the reconcile is level-driven, so this is
-	// asked again on every pass from the current state. observedSince is when the
-	// controller began observing (caches synced, or the last disabled->enabled
-	// transition); the threshold is not met until a full window has been watched,
-	// so a cold view is never misread as zero successes.
-	MeetsThreshold(snap Snapshot, now, observedSince time.Time) bool
+	// asked again on every pass from the current state.
+	MeetsThreshold(snap Snapshot, now time.Time) bool
 }
 
 // registry is the hard-coded set of detectors. A new fault family is a new
@@ -117,22 +113,6 @@ func AnyApplies(node *corev1.Node) bool {
 	return false
 }
 
-// MaxWindow returns the longest evaluation window across all detectors. The
-// controller uses it to bound its recorded per-node success history: a success
-// older than the widest window can never affect any detector, so it can be
-// pruned. The registry is hard-coded and the windows are fixed, so the result is
-// computed once: the controller calls this on every reconcile while holding the
-// observation lock.
-var MaxWindow = sync.OnceValue(func() time.Duration {
-	var max time.Duration
-	for _, d := range registry {
-		if w := d.Window(); w > max {
-			max = w
-		}
-	}
-	return max
-})
-
 // Snapshot is the read-only evidence a detector evaluated for a node, retained
 // for logging, the reason annotation, and the firing decision. Its fields are
 // exported so the controller and labeler can render them.
@@ -154,11 +134,9 @@ type Snapshot struct {
 	// tested against, so the floor means "this many pods each stuck past the
 	// dwell", not "this many stuck right now with only the oldest one aged".
 	SustainedCount int
-	// RecentSuccess reports whether the controller has a recorded per-node success
-	// (a non-host-network PodReadyToStartContainers=True transition) inside the
-	// window. It is set by Decide from the recorded lastSuccessAt, not from a scan
-	// of the pods passed in, so a success whose Pod was already deleted still
-	// counts.
+	// RecentSuccess reports whether any pod on the node proves a sandbox was built
+	// inside the window (see SuccessAt). It is read from the same Pods the failure
+	// signal is read from, so it needs no history and survives a restart.
 	RecentSuccess bool
 	// StuckSince is the oldest PodReadyToStartContainers=False lastTransitionTime
 	// among the node's currently-stuck failing pods, a GC-independent dwell signal
@@ -185,10 +163,11 @@ func (s Snapshot) ReasonString() string {
 }
 
 // Decide is the pure core of the controller: given a node, the Events and Pods
-// currently held for it, a clock, the time the controller began observing, and
-// the node's recorded last success time, it returns the desired health state. It
-// performs no I/O and is exhaustively table-tested.
-func Decide(node *corev1.Node, events []*corev1.Event, pods []*corev1.Pod, now, observedSince, lastSuccessAt time.Time) (Decision, Snapshot) {
+// currently held for it, and a clock, it returns the desired health state. It
+// performs no I/O, keeps no state between calls, and is exhaustively
+// table-tested. Every input is something a LIST can hand back, so a controller
+// that has just restarted decides exactly what a long-running one would.
+func Decide(node *corev1.Node, events []*corev1.Event, pods []*corev1.Pod, now time.Time) (Decision, Snapshot) {
 	if node == nil {
 		return DecisionUnknown, Snapshot{}
 	}
@@ -211,27 +190,19 @@ func Decide(node *corev1.Node, events []*corev1.Event, pods []*corev1.Pod, now, 
 			continue
 		}
 		snap := d.Evaluate(events, pods, now)
-		// A recorded success counts when it falls inside this detector's window.
-		// The distance is measured in absolute terms: the timestamp comes from a
-		// Pod condition stamped by the kubelet's clock, so skew can place it in the
-		// future, and a signed comparison would read any future timestamp as an
-		// arbitrarily fresh success and suppress detection until the wall clock
-		// caught up. Skew inside the window is benign, beyond it the timestamp is
-		// not usable evidence either way.
-		if !lastSuccessAt.IsZero() && now.Sub(lastSuccessAt).Abs() < snap.Window {
-			snap.RecentSuccess = true
+		if snap.RecentSuccess {
 			sawSuccess = true
 		}
-		if d.MeetsThreshold(snap, now, observedSince) {
+		if d.MeetsThreshold(snap, now) {
 			snap.Reason = d.Reason()
 			return DecisionWedged, snap
 		}
 	}
 
-	// No detector fired. Only declare recovery on positive evidence (a recorded
-	// success in the window). An empty/insufficient view stays Unknown so an
-	// existing wedged label is retained across a restart until recovery is
-	// observed.
+	// No detector fired. Only declare recovery on positive evidence (a success in
+	// the window). An empty view stays Unknown so an existing wedged label is
+	// retained until recovery is actually observed, rather than being dropped
+	// because the node happens to be quiet.
 	if sawSuccess {
 		return DecisionHealthy, Snapshot{}
 	}

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/decide_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/decide_test.go
@@ -628,6 +628,61 @@ func TestSuccessAtCountsFinishedPods(t *testing.T) {
 	}
 }
 
+// TestSuccessAtIgnoresRestartedContainers is the false-negative guard on the
+// finished-pod path. A container's terminated state describes its latest run, so
+// on a restarted container StartedAt is the start of a run inside the sandbox the
+// pod already had. An established sandbox survives the VF teardown, so that run
+// needed no working network: counting it would let a wedged node fabricate a
+// fresh success out of a container looping in an old sandbox and suppress its own
+// detection. Only a container that ran exactly once is evidence.
+func TestSuccessAtIgnoresRestartedContainers(t *testing.T) {
+	started := ago(3 * time.Minute)
+
+	restarted := completedPod("restarted", started, false)
+	restarted.Status.ContainerStatuses[0].RestartCount = 2
+	if at, ok := SuccessAt(restarted); ok {
+		t.Errorf("SuccessAt(restarted container) = (%v, true), want false", at)
+	}
+
+	// A sidecar that never restarted still carries proof, even when another
+	// container in the same pod did.
+	mixed := completedPod("mixed", started, false)
+	mixed.Status.ContainerStatuses[0].RestartCount = 5
+	mixed.Status.ContainerStatuses = append(mixed.Status.ContainerStatuses, corev1.ContainerStatus{
+		Name: "sidecar",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+			StartedAt:  metav1.NewTime(started),
+			FinishedAt: metav1.NewTime(started.Add(1 * time.Minute)),
+		}},
+	})
+	if at, ok := SuccessAt(mixed); !ok || !at.Equal(started) {
+		t.Errorf("SuccessAt(mixed) = (%v, %v), want (%v, true)", at, ok, started)
+	}
+}
+
+// TestRestartedContainerDoesNotSuppressAWedge is the same guard at the decision
+// level: a pod looping in a sandbox built before the node wedged must not read as
+// recovery, however recent its container's latest start is.
+func TestRestartedContainerDoesNotSuppressAWedge(t *testing.T) {
+	events, pods := stuckFailing(3, ago(15*time.Minute))
+
+	looping := completedPod("looping", ago(1*time.Minute), false)
+	looping.Status.ContainerStatuses[0].RestartCount = 7
+
+	got, snap := Decide(testNode(true, true), events, pods, testNow)
+	if got != DecisionWedged {
+		t.Fatalf("precondition: Decide() = %v, want Wedged", got)
+	}
+
+	got, snap = Decide(testNode(true, true), events, append(pods, looping), testNow)
+	if got != DecisionWedged {
+		t.Errorf("Decide(with a restarting container) = %v, want Wedged", got)
+	}
+	if snap.RecentSuccess {
+		t.Error("RecentSuccess = true for a container restarting in an existing sandbox, want false")
+	}
+}
+
 // TestFinishedPodInWindowPreventsAFalseWedge is the reason the finished-pod path
 // exists: on a low-churn node the only thing that started recently may be a
 // CronJob pod that has already completed. It is still real proof the node can

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/decide_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/decide_test.go
@@ -32,14 +32,6 @@ func ago(d time.Duration) time.Time { return testNow.Add(-d) }
 // Pod correlate by UID the way they do in a live cluster.
 func podUID(name string) types.UID { return types.UID("uid-" + name) }
 
-// warm is an observedSince far enough in the past that a full detector window has
-// elapsed, so the success column is trusted. cold is recent, so the controller
-// has not yet watched a full window and a would-be wedge stays indeterminate.
-var (
-	warm = ago(30 * time.Minute)
-	cold = ago(1 * time.Minute)
-)
-
 const sig = "route ip+net: no such network interface"
 
 const nodeName = "aks-userswft2-0"
@@ -127,13 +119,11 @@ func stuckFailing(n int, since time.Time) ([]*corev1.Event, []*corev1.Pod) {
 
 func TestDecide(t *testing.T) {
 	tests := []struct {
-		name          string
-		node          *corev1.Node
-		events        []*corev1.Event
-		pods          []*corev1.Pod
-		observedSince time.Time
-		lastSuccessAt time.Time
-		want          Decision
+		name   string
+		node   *corev1.Node
+		events []*corev1.Event
+		pods   []*corev1.Pod
+		want   Decision
 	}{
 		{
 			name: "wedged: floor of stuck failing pods, zero success, dwell met",
@@ -149,7 +139,7 @@ func TestDecide(t *testing.T) {
 			want: DecisionWedged,
 		},
 		{
-			name: "flap: a recorded success in the window is not a wedge",
+			name: "flap: a started pod in the window is not a wedge",
 			node: testNode(true, true),
 			events: func() []*corev1.Event {
 				e, _ := stuckFailing(3, ago(15*time.Minute))
@@ -157,10 +147,9 @@ func TestDecide(t *testing.T) {
 			}(),
 			pods: func() []*corev1.Pod {
 				_, p := stuckFailing(3, ago(15*time.Minute))
-				return p
+				return append(p, startedPod("ok", ago(2*time.Minute), false))
 			}(),
-			lastSuccessAt: ago(2 * time.Minute),
-			want:          DecisionHealthy,
+			want: DecisionHealthy,
 		},
 		{
 			name: "below the stuck-pod floor is not wedged",
@@ -235,10 +224,10 @@ func TestDecide(t *testing.T) {
 			want: DecisionUnknown,
 		},
 		{
-			name:          "recovery: a recorded success, no stuck pods",
-			node:          testNode(true, true),
-			lastSuccessAt: ago(1 * time.Minute),
-			want:          DecisionHealthy,
+			name: "recovery: a started pod, no stuck pods",
+			node: testNode(true, true),
+			pods: []*corev1.Pod{startedPod("ok", ago(1*time.Minute), false)},
+			want: DecisionHealthy,
 		},
 		{
 			name: "cold view: no signals leaves the label unchanged",
@@ -286,7 +275,7 @@ func TestDecide(t *testing.T) {
 			want: DecisionUnknown,
 		},
 		{
-			name: "cold controller: full window not yet observed does not wedge",
+			name: "a started pod outside the window does not suppress the wedge",
 			node: testNode(true, true),
 			events: func() []*corev1.Event {
 				e, _ := stuckFailing(3, ago(15*time.Minute))
@@ -294,13 +283,12 @@ func TestDecide(t *testing.T) {
 			}(),
 			pods: func() []*corev1.Pod {
 				_, p := stuckFailing(3, ago(15*time.Minute))
-				return p
+				return append(p, startedPod("stale", ago(30*time.Minute), false))
 			}(),
-			observedSince: cold,
-			want:          DecisionUnknown,
+			want: DecisionWedged,
 		},
 		{
-			name: "recorded success not set: a host-network pod in the slice is ignored, node stays wedged",
+			name: "success not set: a host-network pod in the slice is ignored, node stays wedged",
 			node: testNode(true, true),
 			events: func() []*corev1.Event {
 				e, _ := stuckFailing(3, ago(15*time.Minute))
@@ -331,11 +319,7 @@ func TestDecide(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			obs := tc.observedSince
-			if obs.IsZero() {
-				obs = warm
-			}
-			got, _ := Decide(tc.node, tc.events, tc.pods, testNow, obs, tc.lastSuccessAt)
+			got, _ := Decide(tc.node, tc.events, tc.pods, testNow)
 			if got != tc.want {
 				t.Errorf("Decide() = %v, want %v", got, tc.want)
 			}
@@ -362,7 +346,7 @@ func TestAnyApplies(t *testing.T) {
 				t.Errorf("AnyApplies() = %v, want %v", got, tc.want)
 			}
 			if !tc.want && tc.node != nil {
-				if got, _ := Decide(tc.node, nil, nil, testNow, warm, time.Time{}); got != DecisionNotApplicable {
+				if got, _ := Decide(tc.node, nil, nil, testNow); got != DecisionNotApplicable {
 					t.Errorf("Decide() = %v, want NotApplicable to match AnyApplies", got)
 				}
 			}
@@ -371,7 +355,7 @@ func TestAnyApplies(t *testing.T) {
 }
 
 func TestDecideNilNode(t *testing.T) {
-	if got, _ := Decide(nil, nil, nil, testNow, warm, time.Time{}); got != DecisionUnknown {
+	if got, _ := Decide(nil, nil, nil, testNow); got != DecisionUnknown {
 		t.Errorf("Decide(nil) = %v, want Unknown", got)
 	}
 }
@@ -380,7 +364,7 @@ func TestDecideSnapshotOnWedge(t *testing.T) {
 	node := testNode(true, true)
 	events, pods := stuckFailing(3, ago(15*time.Minute))
 
-	got, snap := Decide(node, events, pods, testNow, warm, time.Time{})
+	got, snap := Decide(node, events, pods, testNow)
 	if got != DecisionWedged {
 		t.Fatalf("Decide() = %v, want Wedged", got)
 	}
@@ -409,7 +393,7 @@ func TestDwellReadFromOldestStuckPod(t *testing.T) {
 	// dwell, so the wedge fires on the durable Pod timestamp, not the Event age.
 	node := testNode(true, true)
 	events, pods := stuckFailing(3, ago(20*time.Minute))
-	got, _ := Decide(node, events, pods, testNow, warm, time.Time{})
+	got, _ := Decide(node, events, pods, testNow)
 	if got != DecisionWedged {
 		t.Errorf("Decide() = %v, want Wedged", got)
 	}
@@ -425,7 +409,7 @@ func TestEventsCorrelateByUIDNotName(t *testing.T) {
 	for _, p := range pods {
 		p.UID = types.UID(string(p.UID) + "-reused")
 	}
-	got, _ := Decide(node, events, pods, testNow, warm, time.Time{})
+	got, _ := Decide(node, events, pods, testNow)
 	if got != DecisionUnknown {
 		t.Errorf("Decide() = %v, want Unknown (name reuse must not inherit old Events)", got)
 	}
@@ -472,7 +456,7 @@ func TestMatchedSignatureReportsDominantFailureMode(t *testing.T) {
 			failEventFor("p1", ago(20*time.Second), msgMtpnc),
 			failEventFor("p2", ago(20*time.Second), msgMtpnc),
 		}
-		got, snap := Decide(testNode(true, true), events, pods, testNow, warm, time.Time{})
+		got, snap := Decide(testNode(true, true), events, pods, testNow)
 		if got != DecisionWedged {
 			t.Fatalf("Decide() = %v, want Wedged", got)
 		}
@@ -580,5 +564,89 @@ func TestSuccessAt(t *testing.T) {
 	// A nil pod is safe.
 	if _, ok := SuccessAt(nil); ok {
 		t.Error("SuccessAt(nil) = true, want false")
+	}
+}
+
+// completedPod is a pod that ran and finished. Its containers terminated, so a
+// sandbox existed, but PodReadyToStartContainers has dropped back to False the
+// way it does for every finished pod.
+func completedPod(name string, startedAt time.Time, hostNet bool) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: name},
+		Spec:       corev1.PodSpec{NodeName: nodeName, HostNetwork: hostNet},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodSucceeded,
+			Conditions: []corev1.PodCondition{{
+				Type:               corev1.PodReadyToStartContainers,
+				Status:             corev1.ConditionFalse,
+				LastTransitionTime: metav1.NewTime(startedAt.Add(1 * time.Minute)),
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "main",
+				State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+					StartedAt:  metav1.NewTime(startedAt),
+					FinishedAt: metav1.NewTime(startedAt.Add(1 * time.Minute)),
+				}},
+			}},
+		},
+	}
+}
+
+// TestSuccessAtCountsFinishedPods pins the Job and CronJob case. A finished pod
+// drops PodReadyToStartContainers back to False, so reading only the condition
+// would leave a node whose recent traffic was short-lived pods looking like it
+// had never started anything. A container can only terminate if it started, and
+// it can only start inside a sandbox, so the container's own start time is
+// usable proof the node could still attach a NIC.
+func TestSuccessAtCountsFinishedPods(t *testing.T) {
+	started := ago(3 * time.Minute)
+
+	if at, ok := SuccessAt(completedPod("job", started, false)); !ok || !at.Equal(started) {
+		t.Errorf("SuccessAt(completed) = (%v, %v), want (%v, true)", at, ok, started)
+	}
+
+	// Host-network is excluded here too: it never needed a delegated NIC.
+	if _, ok := SuccessAt(completedPod("hostnet-job", started, true)); ok {
+		t.Error("SuccessAt(completed host-network) = true, want false")
+	}
+
+	// A pod that failed before any container ran proves nothing: no container
+	// reached a terminated state, which is exactly the sandbox-failure shape.
+	neverRan := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "never-ran"},
+		Spec:       corev1.PodSpec{NodeName: nodeName},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "main",
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}},
+			}},
+		},
+	}
+	if _, ok := SuccessAt(neverRan); ok {
+		t.Error("SuccessAt(terminal pod whose containers never ran) = true, want false")
+	}
+}
+
+// TestFinishedPodInWindowPreventsAFalseWedge is the reason the finished-pod path
+// exists: on a low-churn node the only thing that started recently may be a
+// CronJob pod that has already completed. It is still real proof the node can
+// build a sandbox, so it must suppress the wedge exactly as a running pod does.
+func TestFinishedPodInWindowPreventsAFalseWedge(t *testing.T) {
+	events, pods := stuckFailing(3, ago(15*time.Minute))
+
+	if got, _ := Decide(testNode(true, true), events, pods, testNow); got != DecisionWedged {
+		t.Fatalf("precondition: Decide() = %v, want Wedged", got)
+	}
+
+	withJob := append(pods, completedPod("cronjob", ago(3*time.Minute), false))
+	if got, _ := Decide(testNode(true, true), events, withJob, testNow); got != DecisionHealthy {
+		t.Errorf("a finished pod inside the window must rule out a wedge: Decide() = %v, want Healthy", got)
+	}
+
+	// The same pod outside the window is not current evidence.
+	withOldJob := append(pods, completedPod("old-cronjob", ago(45*time.Minute), false))
+	if got, _ := Decide(testNode(true, true), events, withOldJob, testNow); got != DecisionWedged {
+		t.Errorf("a finished pod outside the window must not rule out a wedge: Decide() = %v, want Wedged", got)
 	}
 }

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/production_evidence_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/production_evidence_test.go
@@ -166,8 +166,7 @@ func TestProductionCompletedPodsDoNotCount(t *testing.T) {
 	}
 
 	// The node must not be declared wedged on completed-pod turnover alone.
-	observedSince := now.Add(-1 * time.Hour)
-	if got, _ := Decide(productionWedgedNode(), events, pods, now, observedSince, time.Time{}); got == DecisionWedged {
+	if got, _ := Decide(productionWedgedNode(), events, pods, now); got == DecisionWedged {
 		t.Error("completed Job and CronJob turnover must not produce a wedge")
 	}
 }
@@ -221,12 +220,12 @@ func TestProductionStaleSuccessesDoNotSuppressDetection(t *testing.T) {
 	now := time.Date(2026, 7, 27, 9, 0, 43, 0, time.UTC)
 	node := productionWedgedNode()
 	events, pods := productionWedgeEvidence(now)
-	observedSince := now.Add(-1 * time.Hour)
 
 	// Freshest success actually observed on the captured node: 500.6 minutes old,
-	// far outside the 10 minute window.
+	// far outside the 10 minute window. It is still sitting in the LIST, exactly
+	// as it was on the real node, because the pod is still running.
 	staleSuccess := now.Add(-500*time.Minute - 36*time.Second)
-	got, snap := Decide(node, events, pods, now, observedSince, staleSuccess)
+	got, snap := Decide(node, events, append(pods, startedPod("long-running", staleSuccess, false)), now)
 	if got != DecisionWedged {
 		t.Fatalf("stale success suppressed detection of the real wedge: Decide = %v (%s)", got, snap.ReasonString())
 	}
@@ -239,7 +238,7 @@ func TestProductionStaleSuccessesDoNotSuppressDetection(t *testing.T) {
 	// as Healthy and returns an empty snapshot on that path, so the decision is
 	// the assertion here.
 	freshSuccess := now.Add(-2 * time.Minute)
-	if got, _ = Decide(node, events, pods, now, observedSince, freshSuccess); got != DecisionHealthy {
+	if got, _ = Decide(node, events, append(pods, startedPod("just-started", freshSuccess, false)), now); got != DecisionHealthy {
 		t.Errorf("a success inside the window must rule out a hard wedge: Decide = %v, want %v", got, DecisionHealthy)
 	}
 }
@@ -259,12 +258,11 @@ func TestFutureDatedSuccessDoesNotSuppressDetection(t *testing.T) {
 	now := time.Date(2026, 7, 27, 9, 0, 43, 0, time.UTC)
 	node := productionWedgedNode()
 	events, pods := productionWedgeEvidence(now)
-	observedSince := now.Add(-1 * time.Hour)
 
 	// A success stamped an hour into the future by a skewed kubelet clock. It is
 	// not evidence the node can attach a NIC now, so it must not rule out a wedge.
 	future := now.Add(1 * time.Hour)
-	if got, _ := Decide(node, events, pods, now, observedSince, future); got != DecisionWedged {
+	if got, _ := Decide(node, events, append(pods, startedPod("skewed", future, false)), now); got != DecisionWedged {
 		t.Errorf("a future-dated success suppressed detection of a real wedge: Decide = %v, want %v", got, DecisionWedged)
 	}
 }

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/signature_detector.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/signature_detector.go
@@ -249,19 +249,19 @@ func stuckSince(p *corev1.Pod) (time.Time, bool) {
 //     transition. Keying on the transition, not pod age, means a container
 //     restart inside an existing sandbox is not counted: the sandbox is what
 //     needs the network, and restarting a container in one proves nothing.
-//   - A pod that has reached a terminal phase with a container that actually ran,
-//     timed by that container's start. A finished pod drops
+//   - A pod that has reached a terminal phase with a container that ran exactly
+//     once, timed by that container's start. A finished pod drops
 //     PodReadyToStartContainers back to False as a matter of course, so without
 //     this a node whose recent traffic was short-lived Job and CronJob pods would
-//     read as having had no success at all. A container can only terminate if it
-//     started, and it can only start inside a sandbox, so this cannot be reached
-//     by a pod that failed to get a network.
+//     read as having had no success at all. A container can only start inside a
+//     sandbox, so a first start is proof the sandbox was built, and this cannot be
+//     reached by a pod that failed to get a network.
 func SuccessAt(p *corev1.Pod) (time.Time, bool) {
 	if p == nil || p.Spec.HostNetwork {
 		return time.Time{}, false
 	}
 	if p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
-		return lastContainerStart(p)
+		return firstRunStart(p)
 	}
 	cond := podReadyToStartCondition(p)
 	if cond == nil || cond.Status != corev1.ConditionTrue {
@@ -270,15 +270,29 @@ func SuccessAt(p *corev1.Pod) (time.Time, bool) {
 	return cond.LastTransitionTime.Time, true
 }
 
-// lastContainerStart returns the most recent start time among a terminal pod's
-// containers that ran to termination. Only the terminated state is read: a
-// waiting container never got as far as needing a sandbox, and taking the latest
-// start keeps the timestamp as close as possible to when the node last
-// demonstrably had working networking.
-func lastContainerStart(p *corev1.Pod) (time.Time, bool) {
+// firstRunStart returns the most recent start among a terminal pod's containers
+// that ran exactly once and terminated.
+//
+// The restart count is the load-bearing part. A container's terminated state
+// describes its latest run, so on a container that restarted, StartedAt is the
+// start of a run inside the sandbox the pod already had. An established sandbox
+// survives the VF teardown, so that run needs no working network and proves
+// nothing: counting it would let a wedged node suppress its own detection, the
+// same reason kubelet Started events are unusable here. A restart count of zero
+// means the terminated state is the container's one and only run, which can only
+// have followed a sandbox the node built. Containers that did restart are simply
+// not evidence, in either direction.
+//
+// Only the terminated state is read: a waiting container never got as far as
+// needing a sandbox. Taking the latest qualifying start keeps the timestamp as
+// close as possible to when the node last demonstrably had working networking.
+func firstRunStart(p *corev1.Pod) (time.Time, bool) {
 	var latest time.Time
 	for _, css := range [][]corev1.ContainerStatus{p.Status.InitContainerStatuses, p.Status.ContainerStatuses} {
 		for _, cs := range css {
+			if cs.RestartCount != 0 {
+				continue
+			}
 			t := cs.State.Terminated
 			if t == nil || t.StartedAt.IsZero() {
 				continue

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/signature_detector.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/signature_detector.go
@@ -283,7 +283,7 @@ func lastContainerStart(p *corev1.Pod) (time.Time, bool) {
 			if t == nil || t.StartedAt.IsZero() {
 				continue
 			}
-			if latest.IsZero() || t.StartedAt.Time.After(latest) {
+			if latest.IsZero() || t.StartedAt.After(latest) {
 				latest = t.StartedAt.Time
 			}
 		}

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/signature_detector.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/signature_detector.go
@@ -73,10 +73,11 @@ func (d signatureDetector) Applies(node *corev1.Node) bool {
 	return d.appliesTo == nil || d.appliesTo(node)
 }
 
-// Evaluate reads the failure signal for this detector from the node's Events and
-// Pods within the detector window. Every number it returns comes from live Pod
-// state; Events only classify which pods are failing. The success signal is not
-// read here (see Decide and the controller's recorded success history).
+// Evaluate reads both the failure and the success signal for this detector from
+// the node's Events and Pods within the detector window. Every number it returns
+// comes from live Pod state; Events only classify which pods are failing. Both
+// signals are derived from the Pods passed in, so the whole evaluation is a pure
+// function of what a LIST returns and nothing has to be remembered between calls.
 func (d signatureDetector) Evaluate(events []*corev1.Event, pods []*corev1.Pod, now time.Time) Snapshot {
 	windowStart := now.Add(-d.window)
 	snap := Snapshot{DetectorName: d.name, Window: d.window}
@@ -118,7 +119,16 @@ func (d signatureDetector) Evaluate(events []*corev1.Event, pods []*corev1.Pod, 
 	sigCounts := make([]int, len(d.signatures))
 
 	for _, p := range pods {
-		if p == nil || p.DeletionTimestamp != nil {
+		if p == nil {
+			continue
+		}
+		// Success is read from every pod the LIST returns, including one that is
+		// terminating: a pod that got a sandbox proves the node could build one,
+		// and that stays true while it is being torn down.
+		if at, ok := SuccessAt(p); ok && now.Sub(at).Abs() < d.window {
+			snap.RecentSuccess = true
+		}
+		if p.DeletionTimestamp != nil {
 			continue
 		}
 		// Floor and dwell are per pod. A pod counts toward the floor only once it
@@ -158,27 +168,19 @@ func (d signatureDetector) Evaluate(events []*corev1.Event, pods []*corev1.Pod, 
 }
 
 // MeetsThreshold reports whether the threshold is met: the floor of pods that
-// have each individually been stuck for at least the dwell, with no recorded
-// success in the window (when required and observable). A cold view that has not
-// yet watched a full window can never meet the threshold, so an unobserved
-// success signal is treated as indeterminate, never as zero.
-func (d signatureDetector) MeetsThreshold(snap Snapshot, now, observedSince time.Time) bool {
+// have each individually been stuck for at least the dwell, with no success in
+// the window (when required). It is a pure predicate over the snapshot, which is
+// itself a pure function of the Pods and Events a LIST returns, so a restarted
+// controller reaches the same verdict as one that has been running for hours.
+func (d signatureDetector) MeetsThreshold(snap Snapshot, now time.Time) bool {
 	// The floor counts pods each sustained past the dwell (computed in Evaluate),
 	// so meeting it already proves the storm held continuously; there is no
 	// separate oldest-pod dwell check.
 	if snap.SustainedCount < d.failuresFloor {
 		return false
 	}
-	if d.requireZeroSuccess {
-		// The success signal is only trustworthy once a full window has been
-		// observed since the controller began observing; before that, treat it as
-		// indeterminate and do not fire.
-		if observedSince.IsZero() || now.Sub(observedSince) < d.window {
-			return false
-		}
-		if snap.RecentSuccess {
-			return false
-		}
+	if d.requireZeroSuccess && snap.RecentSuccess {
+		return false
 	}
 	return true
 }
@@ -235,23 +237,58 @@ func stuckSince(p *corev1.Pod) (time.Time, bool) {
 	return cond.LastTransitionTime.Time, true
 }
 
-// SuccessAt reports whether a non-host-network pod currently shows a fresh
-// sandbox (PodReadyToStartContainers=True) and, if so, when that condition last
-// transitioned to True: proof the pod's sandbox and its SWIFT network were
-// created, which a hard-wedge cannot do. Host-network pods are excluded, since
-// they reach the condition without a delegated NIC. Keying on the transition, not
-// pod age, means a container restart inside an existing sandbox is not counted as
-// success. The controller uses this to record a durable per-node lastSuccessAt,
-// so a success survives even after its short-lived pod is deleted.
+// SuccessAt reports whether a pod proves the node built it a sandbox and, if so,
+// when: proof the pod's SWIFT network was created, which a hard-wedge cannot do.
+// Host-network pods are excluded, since they reach a running state without a
+// delegated NIC.
+//
+// Two shapes count, and both are read straight off the Pod, so the signal is
+// fully reconstructible from a LIST:
+//
+//   - A live pod showing PodReadyToStartContainers=True, timed by the condition's
+//     transition. Keying on the transition, not pod age, means a container
+//     restart inside an existing sandbox is not counted: the sandbox is what
+//     needs the network, and restarting a container in one proves nothing.
+//   - A pod that has reached a terminal phase with a container that actually ran,
+//     timed by that container's start. A finished pod drops
+//     PodReadyToStartContainers back to False as a matter of course, so without
+//     this a node whose recent traffic was short-lived Job and CronJob pods would
+//     read as having had no success at all. A container can only terminate if it
+//     started, and it can only start inside a sandbox, so this cannot be reached
+//     by a pod that failed to get a network.
 func SuccessAt(p *corev1.Pod) (time.Time, bool) {
 	if p == nil || p.Spec.HostNetwork {
 		return time.Time{}, false
+	}
+	if p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
+		return lastContainerStart(p)
 	}
 	cond := podReadyToStartCondition(p)
 	if cond == nil || cond.Status != corev1.ConditionTrue {
 		return time.Time{}, false
 	}
 	return cond.LastTransitionTime.Time, true
+}
+
+// lastContainerStart returns the most recent start time among a terminal pod's
+// containers that ran to termination. Only the terminated state is read: a
+// waiting container never got as far as needing a sandbox, and taking the latest
+// start keeps the timestamp as close as possible to when the node last
+// demonstrably had working networking.
+func lastContainerStart(p *corev1.Pod) (time.Time, bool) {
+	var latest time.Time
+	for _, css := range [][]corev1.ContainerStatus{p.Status.InitContainerStatuses, p.Status.ContainerStatuses} {
+		for _, cs := range css {
+			t := cs.State.Terminated
+			if t == nil || t.StartedAt.IsZero() {
+				continue
+			}
+			if latest.IsZero() || t.StartedAt.Time.After(latest) {
+				latest = t.StartedAt.Time
+			}
+		}
+	}
+	return latest, !latest.IsZero()
 }
 
 // eventLastTime returns the latest activity time of a (possibly aggregated)


### PR DESCRIPTION
## Why

Follow-up to [#6284](https://github.com/Azure/ARO-HCP/pull/6284), addressing [this review thread](https://github.com/Azure/ARO-HCP/pull/6284#discussion_r3701996505) from @janboll, and the rule @stevekuznetsov set on the design PR: the only cache a controller is allowed to keep is one that can be re-created from the `LIST` on pod restart.

The node-health controller kept an in-memory per-node `successAt` map, advanced from the pod handlers, because a pod that got its sandbox and was then deleted leaves nothing behind for a point-in-time scan to find.

That map cannot be rebuilt from a `LIST`. It also forced a warm-up: an empty map is the absence of evidence rather than evidence of zero successes, so the controller had to refuse to label anything for a full window after every start and every disabled to enabled flip. During that window a genuinely wedged node went unreported. The warm-up existed only to work around the unreconstructable cache, so removing the cache removes the warm-up with it.

## What

Read the success signal from the Pods the detector is already handed. Two shapes count, both straight off the Pod:

- a live pod whose `PodReadyToStartContainers` condition transitioned to `True`, timed by the transition, so a container restarting inside an existing sandbox is not mistaken for success
- a pod that reached a terminal phase with a container that actually ran, timed by that container's start. A finished pod drops the condition back to `False` as a matter of course, so without this a node whose recent traffic was short-lived `Job` and `CronJob` pods would read as having had no success at all

Host-network pods stay excluded from both: they reach a running state without a delegated NIC, which is exactly what a SWIFT wedge cannot provide.

Gone as a result: `successAt`, `obsMu`, `observedSince`, `beginObserving`, `recordPodSuccess`, `observation`, `MaxWindow`, and the warm-up guard in `MeetsThreshold`. `Decide` loses two parameters.

Behaviour is otherwise unchanged. The detector config (floor 3, window 10m, dwell 10m, `requireZeroSuccess`) and the labeling path are untouched.

## Why not source success from Events

Moving the success signal onto the Event informer looks like the obvious fix and is unsound. Checked against production events on `hcp-prod-au` before writing any code:

- Kubelet `Started` fires on every container start, **including restarts inside a sandbox that already exists**, so it does not prove the CNI ran. Nine `eraser-*` pods each emitted **954** `Container started` events within a single hour.
- Events carry no `hostNetwork` flag and the involved pod may already be gone, so host-network pods cannot be excluded. `arobit-forwarder-26ckn` emitted **671**.

Either error counts a non-success as a success, which suppresses detection on a genuinely wedged node. That is a false negative, the worst direction to be wrong in, and especially dangerous because SWIFT mitigation often involves restarting host-network `azure-cns`.

## Verified against the two reference production nodes

- **Hard wedge** `aks-userswft3-34205170-vmss00000d`, 2026-07-23T10:00 to 07-24T01:00: only `FailedCreatePodSandBox` (180 events, 1 pod), zero `Started`/`Created`/`Pulled` for 15 hours straight. No new sandboxes, so a pod-LIST-only signal still fires. Detection preserved.
- **Flap** `aks-userswft2-40171262-vmss000002` (uksouth, the [AROSLSRE-1643](https://redhat.atlassian.net/browse/AROSLSRE-1643) false positive): 40 to 73 distinct pods created per hour interleaved with `FailedCreatePodSandBox`. Plenty of pods start and survive inside any 10-minute window, so the LIST sees them and the node stays unlabeled. The non-detection guard holds without the map.

## Testing

New tests pin the contract directly rather than the implementation:

- `TestRestartReachesTheSameVerdict` (both directions): two controllers looking at the same LIST agree, whatever either of them watched happen.
- `TestFreshControllerWedgesWithoutWarmup`: a just-started controller wedges straight off the LIST, no warm-up.
- `TestHotEnableDecidesImmediately`: the first reconcile after a hot enable acts on evidence already in cache.
- `TestSuccessInListPreventsFalseWedge`: the [AROSLSRE-1643](https://redhat.atlassian.net/browse/AROSLSRE-1643) shape stays unlabeled.
- `TestNonSuccessPodsDoNotSuppressAWedge`: host-network and stuck pods are not successes.
- `TestOutOfWindowSuccessDoesNotSuppressAWedge`: stale and kubelet-skew future-dated timestamps both rejected.
- `TestSuccessAtCountsFinishedPods` / `TestFinishedPodInWindowPreventsAFalseWedge`: the Job and CronJob path, including a pod that failed before any container ran.

The captured-incident tests in `production_evidence_test.go` are preserved, now feeding the successes through the pod list.

`go build`, `go vet`, `go test`, and `go test -race` are clean across `mgmt-agent`.

## Docs

`detectors/README.md` updated here. The design doc section is updated on [#6298](https://github.com/Azure/ARO-HCP/pull/6298), which is still open, so what lands there describes the shipped design rather than needing an immediate amendment.

Jira: [AROSLSRE-1588](https://redhat.atlassian.net/browse/AROSLSRE-1588)
