### PR TITLE
ci: add upgrade/in-place infrastructure with dedicated ci02 environment

### DIFF
--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -273,7 +273,7 @@ clouds:
               appBaseName: "aro-dev-arm-helper-pool"
               certBaseName: "armHelperPoolCert"
               certBaseDns: "armhelperpool.hcp.osadev.cloud"
-              size: 40
+              size: 50
             msiMock:
               applicationName: "aro-dev-msi-mock2"
               certName: "msiMockCert2"
@@ -282,7 +282,7 @@ clouds:
               appBaseName: "aro-dev-msi-mock-pool"
               certBaseName: "msiMockPoolCert"
               certBaseDns: "msimockpool.hcp.osadev.cloud"
-              size: 20
+              size: 50
         int:
           bot:
             applicationName: "OpenShift Release Bot - INT"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1880,3 +1880,110 @@ clouds:
                 vmSize: Standard_D4ds_v6
             jaeger:
               deploy: true
+      ci02:
+        # prow upgrade infra - deploys into "ARO HCP E2E Infrastructure" subscription
+        # Sized for 10 concurrent HCPs (1/5 of ci01)
+        defaults:
+          customExporter:
+            clusterNameFilter: "{{ .ctx.environment }}-{{ .ctx.regionShort }}"
+          auditLogsEventHub:
+            enabled: true
+          kusto:
+            manageInstance: false
+          # Service Key Vault
+          serviceKeyVault:
+            assignNSP: false
+          # Cluster Service
+          clustersService:
+            postgres:
+              deploy: false
+              password: 'TheBlurstOfTimes'
+              containerizedDb:
+                image: "docker.io/library/postgres:14.2"
+                pvcCapacity: 512Mi
+            tracing:
+              address: "http://ingest.observability:4318"
+              exporter: "otlp"
+          # Geneva
+          geneva:
+            logs:
+              manage: Disabled
+          # DNS
+          dns:
+            regionalSubdomain: '{{ .ctx.regionShort }}'
+          # Maestro
+          maestro:
+            postgres:
+              deploy: false
+              password: 'TheBlurstOfTimes'
+              containerizedDb:
+                image: "docker.io/library/postgres:14.2"
+                pvcCapacity: 512Mi
+            server:
+              mqttClientName: 'maestro-server-{{ .ctx.regionShort }}'
+              certSAN: 'maestro-server-{{ .ctx.regionShort }}.maestro.{{ .ctx.regionShort }}.hcpsvc.osadev.cloud'
+              certCN: 'server.maestro.{{ .ctx.regionShort }}.hcpsvc.osadev.cloud'
+              tracing:
+                address: "http://ingest.observability:4318"
+                exporter: "otlp"
+            agent:
+              certSAN: 'hcp-underlay-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}.maestro.{{ .ctx.regionShort }}.hcpsvc.osadev.cloud'
+              certCN: 'mgmt-{{ .ctx.stamp }}.maestro.{{ .ctx.regionShort }}.hcpsvc.osadev.cloud'
+          # Backend
+          backend:
+            tracing:
+              address: "http://ingest.observability:4318"
+              exporter: "otlp"
+          # Frontend
+          frontend:
+            audit:
+              connectSocket: false
+            cosmosDB:
+              private: false
+              zoneRedundantMode: 'Disabled'
+            tracing:
+              address: "http://ingest.observability:4318"
+              exporter: "otlp"
+          # MC - sized for 10 concurrent HCPs (1/5 of ci01)
+          mgmt:
+            subscription:
+              key: ARO HCP E2E Infrastructure (EA Subscription)
+            rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}"
+            aks:
+              name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-mgmt-{{ .ctx.stamp }}"
+              systemAgentPool:
+                maxCount: 4
+                osDiskSizeGB: 32
+                vmSize: Standard_D8ds_v6
+              userAgentPool:
+                maxCount: 9
+                minCount: 5
+                osDiskSizeGB: 100
+                vmSize: Standard_E16ds_v6
+                poolCount: 1
+                secondaryNicCount: 7
+              infraAgentPool:
+                vmSize: Standard_D8ds_v6
+                osDiskSizeGB: 64
+                poolCount: 1
+                maxCount: 2
+            jaeger:
+              deploy: false
+            applyKubeletFixes: false
+          # SVC - same as ci01
+          svc:
+            subscription:
+              key: ARO HCP E2E Infrastructure (EA Subscription)
+            rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
+            aks:
+              name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
+              systemAgentPool:
+                vmSize: Standard_D4ds_v6
+              userAgentPool:
+                name: 'u64d8dsv6'
+                vmSize: Standard_D8ds_v6
+                osDiskSizeGB: 64
+              infraAgentPool:
+                vmSize: Standard_D4ds_v6
+            jaeger:
+              deploy: true

--- a/config/rendered/dev/ci02/centralus.yaml
+++ b/config/rendered/dev/ci02/centralus.yaml
@@ -1,0 +1,1130 @@
+acm:
+  mce:
+    bundle:
+      digest: sha256:bc1c8b78956c1ac1f80427869391c210c0827e18e92b57546cc81174f1eaa666
+      registry: quay.io
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
+  operator:
+    bundle:
+      digest: sha256:219d7a80b0c0945624b8c30b12c561c13cfa22f5597362974d28b73be2d78709
+      registry: quay.io
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
+acr:
+  ocp:
+    name: arohcpocpdev
+    replicationState: true
+    untaggedImagesRetention:
+      days: 90
+      enabled: true
+    zoneRedundantMode: Disabled
+  svc:
+    name: arohcpsvcdev
+    untaggedImagesRetention:
+      days: 90
+      enabled: true
+    zoneRedundantMode: Disabled
+acrDNSSuffix: azurecr.io
+acrPull:
+  image:
+    digest: sha256:b0cbba7044d5142f8545758e5a69b7b35e7f8c6af596bc972e164d2b345978a7
+    registry: mcr.microsoft.com
+    repository: aks/msi-acrpull
+adminApi:
+  audit:
+    connectSocket: false
+  cert:
+    contentType: x-pkcs12
+    issuer: Self
+    name: admin-api-cert-ci02-j7654321
+    san: admin.j7654321.hcpsvc.osadev.cloud
+  image:
+    digest: sha256:6f7cd7e77ae5ca7cf9231b9479211a0430a071c763d9540d769a2f40d9d78c57
+    registry: arohcpsvcdev.azurecr.io
+    repository: arohcpadminapi
+  k8s:
+    namespace: aro-hcp-admin-api
+    replicas: 2
+    resources:
+      limits:
+        memory: unlimited
+      requests:
+        cpu: 200m
+        memory: 512Mi
+    serviceAccountName: admin-api
+  managedIdentityName: admin-api
+administration:
+  readerGroupId: ""
+  releaseManagementGroupId: ""
+  sreServiceTag: CorpNetSaw
+aksCommandRuntime:
+  image:
+    digest: sha256:d01328a795b25e53de454b3a5fe987302d5df608ef286550f0eadab48881334f
+    registry: mcr.microsoft.com
+    repository: aks/command/runtime
+alertEventsEventHub:
+  kustoConsumerGroupName: AlertEventsToKusto
+  kustoDataConnectionName: ci02-centralus-alert-events
+  name: metric-alerts
+armHelperCertName: armHelperCert2
+armHelperClientId: 3331e670-0804-48e8-a086-6241671ddc93
+armHelperFPAPrincipalId: 47f69502-0065-4d9a-b19b-d403e183d2f4
+armHelperTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
+arobit:
+  forwarder:
+    image:
+      digest: sha256:e8df41b2461b466e5f1d28157f7931f7c68b4b0917258e12de4d7922fd283703
+      registry: mcr.microsoft.com
+      repository: oss/v2/fluent/fluent-bit
+    resources:
+      limits:
+        memory: 1248Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+  kusto:
+    buffering: true
+    enabled: true
+    environmentName: dev
+  mdsd:
+    enabled: false
+    image:
+      digest: sha256:83b9cbd2662c56a6d6858210bfb375e81a5d6bea5462786d5005a473ad2ee657
+      registry: mcr.microsoft.com
+      repository: geneva/distroless/mdsd
+auditLogsEventHub:
+  authRuleName: SendRule
+  enabled: true
+  kustoConsumerGroupName: AuditLogsToKusto
+  kustoDataConnectionName: ci02-centralus-auditlogs
+  name: aks-auditlogs
+  namespace: hcp-ci02-centralus-auditlogs-eh
+  rg: centralus-shared-resources
+automationDryRun: false
+azureGeoShortId: us
+azureRegionAvailabilityZoneCount: 3
+backend:
+  azureRuntimeConfig:
+    tlsCertificatesIssuer: Self
+  clusterScopedIdentitiesConfig:
+    roleSetName: dev
+  exitOnPanic: true
+  image:
+    digest: sha256:1403f55f7616aac0d2c676f6669cce518f1e72d0e315358fb0d4d1e3b0804f6b
+    registry: arohcpsvcdev.azurecr.io
+    repository: arohcpbackend
+  k8s:
+    namespace: aro-hcp
+    replicas: 2
+    resources:
+      limits:
+        memory: unlimited
+      requests:
+        cpu: 100m
+        memory: 1Gi
+    serviceAccountName: backend
+  logVerbosity: 4
+  maestro:
+    sourceEnvironmentIdentifier: arohcpci02
+  managedIdentityName: backend
+  tracing:
+    address: http://ingest.observability:4318
+    exporter: otlp
+billing:
+  aub:
+    accountName: ""
+    cloudSuffix: ""
+  eventHub:
+    namespace: ""
+    resourceGroupName: ""
+    subscriptionId: ""
+  imageArtifact:
+    adoProject: ""
+    artifactName: ""
+    buildId: 0
+  kusto:
+    clusterName: ""
+    clusterPrincipals:
+    - id: ""
+      name: ""
+      role: ""
+      tenantId: ""
+      type: ""
+    dstsGroups:
+    - description: ""
+      name: ""
+    sku: ""
+    vmUsageStaleThreshold: ""
+  pav2:
+    cloudName: ""
+    endpoint: ""
+  rg: placeholder
+cloud: Public
+cloudEnvironmentName: AzurePublicCloud
+clustersService:
+  azureOperatorsManagedIdentities:
+    roleSetName: dev
+  azureRuntimeConfig:
+    tlsCertificatesIssuer: Self
+  batchProcesses: ""
+  batchProcessesDryRun: true
+  dataPlaneHAProxyImage: ""
+  denyAssignments: disabled
+  deployDebugJobs: false
+  environment: arohcpci02
+  image:
+    digest: sha256:5931b36242ac61b69a2c0628f2291aaf38220ab9e41b3c33e227387359103cfa
+    registry: quay.io
+    repository: app-sre/aro-hcp-clusters-service
+  k8s:
+    deploymentStrategy:
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+    namespace: clusters-service
+    replicas: 3
+    resources:
+      limits:
+        memory: unlimited
+      requests:
+        cpu: 50m
+        memory: 150Mi
+    serviceAccountName: clusters-service
+  managedIdentityName: clusters-service
+  postgres:
+    backupRetentionDays: 7
+    containerizedDb:
+      image: docker.io/library/postgres:14.2
+      pvcCapacity: 512Mi
+    databaseName: clusters-service
+    deploy: false
+    enhancedMetricsEnabled: true
+    geoRedundantBackup: false
+    minTLSVersion: TLSV1.2
+    name: arohcp-ci02-dbcs-j7654321
+    password: TheBlurstOfTimes
+    private: false
+    serverSku: Standard_D8s_v3
+    serverStorageSizeGB: 128
+    serverVersion: "17"
+    zoneRedundantMode: Auto
+  provisionShardClusterLimit: 100
+  provisionShardStatus: active
+  tracing:
+    address: http://ingest.observability:4318
+    exporter: otlp
+customExporter:
+  clusterNameFilter: ci02-j7654321
+  clusterTypes: svc-cluster,mgmt-cluster
+  enabledCollectors: service-tag-usage,kusto-logs-current
+  image:
+    digest: sha256:335a5217890f8137c8bce97c212762dcf584ffb8d5c193499880dcbb4acd4673
+    registry: arohcpsvcdev.azurecr.io
+    repository: arohcpmetrics
+  k8s:
+    namespace: aro-hcp-exporter
+    resources:
+      limits:
+        memory: unlimited
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    serviceAccountName: aro-hcp-exporter
+  managedIdentityName: aro-hcp-exporter
+cxKeyVault:
+  name: ah-ci02-cx-j7654321-1
+  private: false
+  softDelete: false
+  tagKey: aroHCPPurpose
+  tagValue: cx
+dns:
+  baseDnsZoneRG: global
+  cxParentZoneName: hcp.osadev.cloud
+  globalCertificatesDomain: hcp-global.osadev.cloud
+  parentZoneName: osadev.cloud
+  regionalSubdomain: j7654321
+  svcParentZoneName: hcpsvc.osadev.cloud
+e2e:
+  prow:
+    globalKeyVaultTokenSecret: prow-token
+  regionTest:
+    allowedSubscriptions: ""
+    gatePromotion: true
+    prowJobName: ""
+entraAppOwnerIds: d8837611-f550-4f0a-af48-575a7178adfb,16ea1e12-7ef3-4613-bea4-3d4a20cbc38c,770ce6b0-5afe-472d-ac0d-1fae72acc4e4
+environmentName: ci02
+ev2:
+  assistedId:
+    applicationId: ""
+    certificate:
+      keyVault: empty-sentinel
+      name: ""
+    dstsHost: usnorth-dsts.dsts.core.windows.net
+firstPartyAppCertificate:
+  contentType: x-pkcs12
+  issuer: Self
+  manage: Disabled
+  name: firstPartyCert2
+  san: firstPartyCert2.hcpsvc.osadev.cloud
+firstPartyAppClientId: b3cb2fab-15cb-4583-ad06-f91da9bfe2d1
+fleet:
+  image:
+    digest: ""
+    registry: arohcpsvcdev.azurecr.io
+    repository: fleet
+  k8s:
+    namespace: fleet
+    replicas: 2
+    resources:
+      limits:
+        memory: 1Gi
+      requests:
+        cpu: 200m
+        memory: 512Mi
+    serviceAccountName: fleet
+  managedIdentityName: fleet
+  registration:
+    autoApproveStamps: true
+    stampIdentifier: "1"
+frontend:
+  audit:
+    connectSocket: false
+  cert:
+    contentType: x-pkcs12
+    issuer: Self
+    name: frontend-cert-ci02-j7654321
+    san: rp.j7654321.hcpsvc.osadev.cloud
+  cosmosDB:
+    billingContainerMaxScale: 4000
+    disableLocalAuth: true
+    fleetContainerMaxScale: 4000
+    locksContainerMaxScale: 4000
+    name: arohcpci02-rp-j7654321
+    private: false
+    resourceContainerMaxScale: 8000
+    zoneRedundantMode: Disabled
+  exitOnPanic: true
+  image:
+    digest: sha256:af0620c11338f6b5a878363529dfb4b740515385a6ab4c6a486bcb78e4de4ced
+    registry: arohcpsvcdev.azurecr.io
+    repository: arohcpfrontend
+  k8s:
+    namespace: aro-hcp
+    replicas: 2
+    resources:
+      limits:
+        memory: unlimited
+      requests:
+        cpu: 100m
+        memory: 512Mi
+    serviceAccountName: frontend
+  logVerbosity: 0
+  managedIdentityName: frontend
+  tracing:
+    address: http://ingest.observability:4318
+    exporter: otlp
+geneva:
+  actions:
+    allowedAcisExtensions: AzureRedHatHypershiftExtension,Azure Red Hat Hypershift
+    application:
+      applicationId: empty-sentinel
+      manage: true
+      name: arohcp-ga-dev
+      useSNI: false
+    certificate:
+      contentType: x-pkcs12
+      issuer: Self
+      manage: Enabled
+      name: genevaAction
+      san: genevaAction.hcp-global.osadev.cloud
+    endpointName: centralus
+    endpointUrl: ""
+    genevaActionsPrincipalId: ""
+    keyVault:
+      name: arohcpdev-geneva-kv
+      private: false
+      softDelete: true
+      tagKey: aroHCPPurpose
+      tagValue: geneva-actions
+    publish:
+      betaCertificate:
+        keyVault: empty-sentinel
+        name: empty-sentinel
+      betaPackageName: empty-sentinel
+      buildId: 0
+      packageName: empty-sentinel
+    serviceTag: GenevaActions
+    targetRegion: Central US
+  logs:
+    adminCertName: geneva-logs-admin
+    adminCertSan: geneva-logs-admin.geneva.keyvault.aro-hcp-global.azure.com
+    adminCertificateDomain: geneva.keyvault.aro-hcp-global.azure.com
+    administrators:
+      alias:
+      - AME\WEINONGW
+      securityGroup: AME\TM-AzureRedHatOpenShift-Leads
+    certificateDomain: geneva.keyvault.aro-hcp.azure.com
+    certificateIssuer: Self
+    cluster:
+      accountName: placeholder
+      configVersion: "1"
+      namespace: ""
+      san: empty-sentinel
+      secretName: clusterlogs
+    contentType: x-pkcs12
+    environment: Test
+    manage: Disabled
+    rp:
+      accountName: placeholder
+      configVersion: "1"
+      namespace: ""
+      san: empty-sentinel
+      secretName: rplogs
+    typeName: ""
+  metrics:
+    cluster:
+      account: AzureRedHatOpenShiftCluster
+    rp:
+      account: AzureRedHatOpenShiftRP
+  principalId: ""
+  resourceContributor: ""
+global:
+  billing:
+    digest: placeholder
+    repository: billing
+    rg: placeholder
+    subscriptionKey: hcp-billng-ci02
+  globalMSIName: global-rollout-identity
+  groupQuota:
+    displayName: empty-sentinel
+    id: empty-sentinel
+  keyVault:
+    encryptionKeyName: secretSyncKey
+    name: arohcpdev-global
+    private: false
+    softDelete: true
+    tagKey: aroHCPPurpose
+    tagValue: global
+  managementGroup:
+    id: empty-sentinel
+  nsp:
+    accessMode: Learning
+    name: nsp-global
+  region: westus3
+  rg: global
+  safeDnsIntAppObjectId: ""
+  subscription:
+    displayName: Azure Red Hat OpenShift HCP - ci02 - Global
+    key: ARO Hosted Control Planes (EA Subscription 1)
+    providers:
+      Microsoft.Cdn:
+        poll: true
+      Microsoft.Compute:
+        features:
+        - name: EncryptionAtHost
+          poll: true
+        poll: true
+      Microsoft.ContainerService:
+        features:
+        - name: IstioNativeSidecarModePreview
+          poll: true
+        poll: true
+      Microsoft.Dashboard:
+        poll: true
+      Microsoft.Kusto:
+        poll: true
+      Microsoft.Network:
+        features:
+        - name: AllowBringYourOwnPublicIpAddress
+          poll: true
+        poll: true
+      Microsoft.Support:
+        poll: true
+hcpRecovery:
+  image:
+    digest: ""
+    registry: arohcpsvcdev.azurecr.io
+    repository: arohcprecovery
+  k8s:
+    namespace: hcp-recovery
+    replicas: 2
+    serviceAccountName: hcp-recovery
+hypershift:
+  additionalInstallArg: --enable-cpo-overrides
+  image:
+    digest: sha256:f74ffb720e622ff79fed6eb9f47b3af09b112fd3fc1e5b8406503130eeb40c2a
+    registry: quay.io
+    repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
+  limitClusterSizes: true
+  metricsSet:
+    performanceMetrics: false
+  namespace: hypershift
+  sharedIngressIPTag: ""
+  sharedIngressImage:
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+imageRegistryPolicy:
+  extraAllowedRegistries: docker.io/jaegertracing,docker.io/grafana,docker.io/otel,docker.io/library/postgres
+  validationActions: Deny
+imageSync:
+  environmentName: aro-hcp-image-sync
+  ocMirror:
+    enabled: true
+    image:
+      digest: sha256:81441ace3a179898bb1a5eb9012a76f552e6e5b9107005d5e17aba0c186d88c1
+      registry: arohcpsvcdev.azurecr.io
+      repository: image-sync/oc-mirror
+    jobNamePrefix: ""
+    operatorVersionsToMirror: 4.18,4.19,4.20,4.21,4.22
+    pullSecretName: ocmirror-pull-secret
+  ondemandSync:
+    pullSecretName: component-sync-pull-secret
+  outboundServiceTags: ""
+keyVaultDNSSuffix: vault.azure.net
+kubeApplier:
+  cosmosContainerMaxScale: 8000
+  cosmosContainerName: Manifests-MC-1
+  image:
+    digest: sha256:bf05fa14daa56bd1275fd28da3c9348fdaa232b7f1f7cfe7e9cfa83072c63894
+    registry: arohcpsvcdev.azurecr.io
+    repository: kube-applier
+  k8s:
+    namespace: kube-applier
+    replicas: 2
+    resources:
+      limits:
+        memory: unlimited
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    serviceAccountName: kube-applier
+  managedIdentityName: kube-applier
+  partitionKey: /providers/microsoft.redhatopenshift/stamps/1/managementclusters/default
+kubeEvents:
+  enabled: true
+  image:
+    digest: sha256:dea4ec46b0d97261cedd62ab6235e6aa6002e5aac8fab87b80d41e57f9658f82
+    registry: kubernetesshared.azurecr.io
+    repository: shared/kube-events
+  k8s:
+    namespace: monitoring
+    resources:
+      limits:
+        memory: unlimited
+      requests:
+        cpu: 200m
+        memory: 512Mi
+    serviceAccountName: ke-serviceaccount
+kusto:
+  adminGroups: ""
+  autoScaleMax: 10
+  autoScaleMin: 2
+  enableAutoScale: true
+  hostedControlPlaneLogsDatabase: HostedControlPlaneLogs
+  kustoName: hcp-dev-us-2
+  location: eastus2
+  manageInstance: false
+  monitoringEventsDatabase: MonitoringEvents
+  rg: hcp-kusto-us
+  serviceLogsDatabase: ServiceLogs
+  sku: Standard_E16ads_v5
+  tier: Standard
+  viewerGroups: 64dc69e4-d083-49fc-9569-ebece1dd1408/6b6d3adf-8476-4727-9812-20ffdef2b85c
+  viewerIdentities: 64dc69e4-d083-49fc-9569-ebece1dd1408/5990dc26-1b73-4547-9bba-9a5bd64a0165
+kvCertAccessPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
+kvCertAccessRoleId: ""
+kvCertOfficerPrincipalId: c9b1819d-bb29-4ac2-9abe-39e4fe9b59eb
+logs:
+  mdsd:
+    cert:
+      issuer: ""
+      name: ""
+      type: ""
+    msiName: logs-mdsd
+    namespace: arobit
+    serviceAccountName: arobit-forwarder
+    subscriptions: []
+maestro:
+  agent:
+    certCN: mgmt-1.maestro.j7654321.hcpsvc.osadev.cloud
+    certSAN: hcp-underlay-j7654321-mgmt-1.maestro.j7654321.hcpsvc.osadev.cloud
+    consumerName: hcp-underlay-j7654321-mgmt-1
+    k8s:
+      namespace: maestro
+      replicas: 1
+      serviceAccountName: maestro
+    loglevel: 2
+    managedIdentityName: maestro-consumer
+    sidecar:
+      image:
+        digest: sha256:2c0ba08f2ebb48b3938b103cdce87450110a2f8ad76dd6a082d0dcd3e02c289e
+        registry: mcr.microsoft.com
+        repository: azurelinux/base/nginx
+  certIssuer: Self
+  eventGrid:
+    maxClientSessionsPerAuthName: 6
+    name: arohcp-ci02-maestro-j7654321
+    private: false
+  image:
+    digest: sha256:f70df67b0e2125b9809f551fc608c057d9aa970935da6c58265ac3c622eb4802
+    registry: quay.io
+    repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
+  postgres:
+    backupRetentionDays: 7
+    containerizedDb:
+      image: docker.io/library/postgres:14.2
+      pvcCapacity: 512Mi
+    databaseName: maestro
+    deploy: false
+    enhancedMetricsEnabled: true
+    geoRedundantBackup: false
+    minTLSVersion: TLSV1.2
+    name: arohcp-ci02-dbmaestro-j7654321
+    password: TheBlurstOfTimes
+    private: false
+    serverSku: Standard_D2s_v3
+    serverStorageSizeGB: 32
+    serverVersion: "15"
+    zoneRedundantMode: Auto
+  restrictIstioIngress: true
+  server:
+    certCN: server.maestro.j7654321.hcpsvc.osadev.cloud
+    certSAN: maestro-server-j7654321.maestro.j7654321.hcpsvc.osadev.cloud
+    k8s:
+      namespace: maestro
+      replicas: 2
+      resources:
+        limits:
+          memory: unlimited
+        requests:
+          cpu: 200m
+          memory: 512Mi
+      serviceAccountName: maestro
+    loglevel: 2
+    managedIdentityName: maestro-server
+    mqttClientName: maestro-server-j7654321
+    tracing:
+      address: http://ingest.observability:4318
+      exporter: otlp
+mgmt:
+  aks:
+    clusterOutboundIPAddressIPTags: ""
+    etcd:
+      name: ah-ci02-me-j7654321-1
+      private: true
+      softDelete: false
+      tagKey: aroHCPPurpose
+      tagValue: etcd-encryption
+    infraAgentPool:
+      maxCount: 2
+      minCount: 1
+      name: infra
+      osDiskSizeGB: 64
+      poolCount: 1
+      vmSize: Standard_D8ds_v6
+      zoneRedundantMode: Auto
+      zones: ""
+    kubernetesVersion: "1.35"
+    name: ci02-j7654321-mgmt-1
+    networkDataplane: azure
+    networkPolicy: azure
+    podSubnetPrefix: 10.128.64.0/18
+    subnetPrefix: 10.128.8.0/21
+    systemAgentPool:
+      maxCount: 4
+      minCount: 1
+      name: system
+      osDiskSizeGB: 32
+      poolCount: 1
+      vmSize: Standard_D8ds_v6
+      zoneRedundantMode: Auto
+      zones: ""
+    tags: clusterType=mgmt-cluster,persist=true
+    upgradeSettings:
+      maxSurge: 10%
+      maxUnavailable: "0"
+    userAgentPool:
+      maxCount: 9
+      minCount: 5
+      name: userswft
+      osDiskSizeGB: 100
+      poolCount: 1
+      secondaryNicCount: 7
+      vmSize: Standard_E16ds_v6
+      zoneRedundantMode: Auto
+      zones: ""
+    vnetAddressPrefix: 10.128.0.0/14
+  applyKubeletFixes: false
+  defaultStorageClassSkuName: PremiumV2_LRS
+  hcpBackups:
+    storageAccount:
+      name: oadpci02j76543211
+      public: false
+      zoneRedundantMode: Auto
+    storageAccountContainerName: backups
+  jaeger:
+    deploy: false
+  nsp:
+    accessMode: Learning
+    name: nsp-j7654321-mgmt-1
+  prometheus:
+    admissionWebhook:
+      patch:
+        image:
+          registry: arohcpsvcdev.azurecr.io
+          repository: k8s-cache/ingress-nginx/kube-webhook-certgen
+          sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
+    kubeStateMetrics:
+      image:
+        digest: sha256:bcd0475c8f223ffe01a78b35446583584a691356327da0eeeb19a2c4e7755a21
+        registry: mcr.microsoft.com/oss/v2
+        repository: kubernetes/kube-state-metrics
+    namespace: prometheus
+    namespaceNetworkPolicyGroup: monitoring
+    prometheusConfigReloader:
+      image:
+        registry: mcr.microsoft.com/oss/v2
+        repository: prometheus/prometheus-config-reloader
+        sha: e502320119de5f35c2fbc803bab5b78ba3a7ed177dd45b5493dd9130b7760da7
+    prometheusOperator:
+      image:
+        registry: mcr.microsoft.com/oss/v2
+        repository: prometheus/prometheus-operator
+        sha: 5d7972807c5809c4dcb5ddb73782d9e1ac5933ff6d4d9b70e8baf9b97bfc98ab
+      version: ""
+    prometheusSpec:
+      image:
+        registry: mcr.microsoft.com/oss/v2
+        repository: prometheus/prometheus
+        sha: addf21a90b6d1af9c3e3b8bf3242209a307880ce93daa354b7c6e4cf08e4c95d
+      replicas: 2
+      resources:
+        limits:
+          memory: NONE
+        requests:
+          cpu: NONE
+          memory: NONE
+      shards: 1
+    thanos:
+      image:
+        registry: arohcpsvcdev.azurecr.io
+        repository: thanos/thanos
+        sha: b567818fe608067eb0f1d7c2c4fe361e7ad83c8a256234c97685f1d0bf670cc8
+        tag: v0.41.0
+  rg: hcp-underlay-ci02-j7654321-mgmt-1
+  stampIdentifier: "1"
+  stamps:
+    count: 1
+  subscription:
+    certificateDomains:
+    - '*.hcp.osadev.cloud'
+    - '*.hcpsvc.osadev.cloud'
+    displayName: Azure Red Hat OpenShift HCP - Central US - MGMT - 1
+    key: ARO HCP E2E Infrastructure (EA Subscription)
+    providers:
+      Microsoft.Compute:
+        features:
+        - name: EncryptionAtHost
+          poll: true
+        poll: true
+      Microsoft.ContainerInstance:
+        poll: true
+      Microsoft.ContainerService:
+        features:
+        - name: IstioNativeSidecarModePreview
+          poll: true
+        poll: true
+      Microsoft.Insights:
+        poll: true
+      Microsoft.Network:
+        features:
+        - name: AllowBringYourOwnPublicIpAddress
+          poll: true
+        poll: true
+      Microsoft.Quota:
+        poll: true
+      Microsoft.Storage:
+        poll: true
+    usePlannedQuota: true
+mgmtAgent:
+  image:
+    digest: sha256:a046f8e9dc974b0b76bad0ad16ce19bba44dda5fddc48998adec64009b6dfb7b
+    registry: arohcpsvcdev.azurecr.io
+    repository: mgmt-agent
+  k8s:
+    namespace: mgmt-agent
+    replicas: 2
+    resources:
+      requests:
+        cpu: 50m
+        memory: 768Mi
+    serviceAccountName: mgmt-agent
+  managedIdentityName: mgmt-agent
+  nodeHealth:
+    enabled: true
+mgmtKeyVault:
+  name: ah-ci02-mg-j7654321-1
+  private: false
+  softDelete: false
+  tagKey: aroHCPPurpose
+  tagValue: mgmt
+miMockCertName: msiMockCert2
+miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
+miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
+mise:
+  applicationName: arohcp-mise-ci02
+  arm:
+    applicationId: e2c2ff5c-e5b4-4e79-8c3e-1da8c48461e7
+    audienceFQDN: management.azure.com
+    authorityFQDN: login.microsoftonline.com
+    policyLabel: ARM Policy
+    tenantId: 33e01921-4d64-4f8c-a055-5bdaffd5e33d
+  audit:
+    connectSocket: false
+  deploy: false
+  genevaActions:
+    audienceFQDN: management.azure.com
+    authorityFQDN: sts.windows.net
+    policyLabel: Geneva Actions
+  image:
+    digest: ""
+    repository: mise-1p-container-image
+  imageV2:
+    digest: ""
+    repository: mise-1p-container-image
+  sessiongate:
+    audience: 6dae42f8-4368-4678-94ff-3960e28e3630
+    authorityFQDN: sts.windows.net
+    policyLabel: Session Gate
+  tracing:
+    address: ""
+    exporter: ""
+monitoring:
+  alertRuleOwningTeamTag: ""
+  alertSeverityCeiling: 0
+  alertsEnabled: true
+  amwScaling:
+    pollInterval: 30s
+  crossTenantSecurityGroup: ""
+  eventHubAlerting:
+    enabled: true
+  grafanaMajorVersion: "12"
+  grafanaName: arohcp-dev
+  grafanaRoles: 6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
+  grafanaSku: Standard
+  grafanaZoneRedundantMode: Disabled
+  hcpWorkspaceName: hcps-j7654321
+  icm:
+    connectionId: ""
+    connectionName: ""
+    environment: ""
+    manageConnection: false
+    msft:
+      actionGroupName: ""
+      actionGroupShortName: ""
+      automitigationEnabled: ""
+      enabled: true
+      routingId: ""
+    rp:
+      actionGroupName: ""
+      actionGroupShortName: ""
+      automitigationEnabled: ""
+      enabled: true
+      routingId: ""
+    sl:
+      actionGroupName: ""
+      actionGroupShortName: ""
+      automitigationEnabled: ""
+      enabled: true
+      routingId: ""
+    sre:
+      actionGroupName: ""
+      actionGroupShortName: ""
+      automitigationEnabled: ""
+      enabled: true
+      routingId: ""
+  svcWorkspaceName: services-j7654321
+msiCredentialsRefresher:
+  certificate:
+    commonName: ""
+    issuer: OneCertV2-PrivateCA
+    manage: false
+    name: msi-refresher
+    sanDnsNames: []
+  earlyRefreshFrequency: "0"
+  firstPartyAppClientId: ""
+  image:
+    digest: ""
+    registry: empty-sentinel
+    repository: empty-sentinel
+  imageArtifact:
+    adoProject: ""
+    artifactName: ""
+    buildId: 0
+  k8s:
+    namespace: msi-credential-refresher
+    serviceAccountName: msi-credential-refresher
+  managedIdentityName: msi-credential-refresher
+msiKeyVault:
+  name: ah-ci02-mi-j7654321-1
+  private: false
+  softDelete: false
+  tagKey: aroHCPPurpose
+  tagValue: msi
+msiRp:
+  dataPlaneAudienceResource: https://dummy.org
+oidc:
+  frontdoor:
+    keyVault:
+      name: ah-ci02-afd
+      private: false
+      softDelete: true
+      tagKey: aroHCPPurpose
+      tagValue: afd
+    manage: false
+    msiName: arohcp-afd
+    name: arohcpdev
+    sku: Premium_AzureFrontDoor
+    subdomain: oic
+    useManagedCertificates: true
+  storageAccount:
+    name: arohcpci02oidcj7654321
+    privateLinkLocation: centralus
+    public: true
+    zoneRedundantMode: Auto
+quotaizer:
+  dryRun: false
+  image:
+    digest: ""
+    registry: empty-sentinel
+    repository: empty-sentinel
+  imageArtifact:
+    adoProject: empty-sentinel
+    artifactName: empty-sentinel
+    buildId: 0
+  managedIdentityName: aro-quotaizer
+  quotaGroup:
+    displayName: HCP - ci02 centralus
+    id: aro-ci02-centralus
+region: centralus
+regionRG: hcp-underlay-ci02-j7654321
+secretSyncController:
+  image:
+    digest: sha256:72abeb657cfbdd6a5891fc102a16429875d70c5932ad5994524d0246db914013
+    registry: registry.k8s.io
+    repository: secrets-store-sync/controller
+  k8s:
+    namespace: secret-sync-controller
+    resources:
+      limits:
+        memory: unlimited
+      requests:
+        cpu: 50m
+        memory: 100Mi
+    serviceAccountName: secrets-store-sync-controller-manager
+  providerImage:
+    digest: sha256:517fb8c67ca4114b8f86950306b46eb2a8ba7757970e3c8976f5bd418d81e45b
+    registry: mcr.microsoft.com
+    repository: oss/v2/azure/secrets-store/provider-azure
+serviceKeyVault:
+  assignNSP: false
+  name: aro-hcp-dev-svc-kv
+  private: false
+  region: westus3
+  rg: global
+  softDelete: true
+  subscription:
+    displayName: ARO Hosted Control Planes (EA Subscription 1)
+    key: ARO Hosted Control Planes (EA Subscription 1)
+  tagKey: aroHCPPurpose
+  tagValue: service
+sessiongate:
+  cert:
+    contentType: x-pkcs12
+    issuer: Self
+    name: sessiongate-cert-ci02-j7654321
+    san: sessiongate.j7654321.hcpsvc.osadev.cloud
+  image:
+    digest: sha256:df780df7ce54fbf58824258c44fdb1d135687c24f232440355f4e317c3af3cde
+    registry: arohcpsvcdev.azurecr.io
+    repository: arohcpsessiongate
+  k8s:
+    namespace: sessiongate
+    replicas: 2
+    serviceAccountName: sessiongate
+  managedIdentityName: sessiongate
+stgGlobalV2:
+  acrOcpName: empty-sentinel
+  acrSvcName: empty-sentinel
+  billingKustoName: empty-sentinel
+  billingKustoSku: empty-sentinel
+  cxParentZoneName: empty-sentinel
+  frontDoorKeyVaultName: empty-sentinel
+  frontDoorName: empty-sentinel
+  genevaKeyVaultName: empty-sentinel
+  globalKeyVaultName: empty-sentinel
+  grafanaName: empty-sentinel
+  grafanaRoles: ""
+  kustoName: empty-sentinel
+  oidcStorageAccountName: empty-sentinel
+  svcParentZoneName: empty-sentinel
+svc:
+  aks:
+    clusterOutboundIPAddressIPTags: ""
+    etcd:
+      name: ah-ci02-se-j7654321-1
+      private: true
+      softDelete: false
+      tagKey: aroHCPPurpose
+      tagValue: etcd-encryption
+    infraAgentPool:
+      maxCount: 3
+      minCount: 1
+      name: infra
+      osDiskSizeGB: 32
+      poolCount: 1
+      vmSize: Standard_D4ds_v6
+      zoneRedundantMode: Auto
+      zones: ""
+    kubernetesVersion: "1.35"
+    name: ci02-j7654321-svc
+    networkDataplane: cilium
+    networkPolicy: cilium
+    podSubnetPrefix: 10.128.64.0/18
+    subnetPrefix: 10.128.8.0/21
+    systemAgentPool:
+      maxCount: 3
+      minCount: 1
+      name: system
+      osDiskSizeGB: 32
+      poolCount: 1
+      vmSize: Standard_D4ds_v6
+      zoneRedundantMode: Auto
+      zones: ""
+    tags: clusterType=svc-cluster,persist=true
+    upgradeSettings:
+      maxSurge: 10%
+      maxUnavailable: "0"
+    userAgentPool:
+      maxCount: 3
+      minCount: 1
+      name: u64d8dsv6
+      osDiskSizeGB: 64
+      poolCount: 3
+      vmSize: Standard_D8ds_v6
+      zoneRedundantMode: Auto
+      zones: ""
+    vnetAddressPrefix: 10.128.0.0/14
+  istio:
+    ingressGatewayIPAddressIPTags: ""
+    ingressGatewayIPAddressName: aro-hcp-istio-ingress
+    istioctlVersion: 1.30.3
+    tag: prod-stable
+    targetVersion: asm-1-28
+    versions: asm-1-28
+  jaeger:
+    deploy: true
+  nsp:
+    accessMode: Learning
+    name: nsp-j7654321-svc
+  opsIngress:
+    gateway:
+      ipAddressName: aro-hcp-ops-ingress
+      ipAddressTags: ""
+  prometheus:
+    admissionWebhook:
+      patch:
+        image:
+          registry: arohcpsvcdev.azurecr.io
+          repository: k8s-cache/ingress-nginx/kube-webhook-certgen
+          sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
+    kubeStateMetrics:
+      image:
+        digest: sha256:bcd0475c8f223ffe01a78b35446583584a691356327da0eeeb19a2c4e7755a21
+        registry: mcr.microsoft.com/oss/v2
+        repository: kubernetes/kube-state-metrics
+    namespace: prometheus
+    namespaceNetworkPolicyGroup: ""
+    prometheusConfigReloader:
+      image:
+        registry: mcr.microsoft.com/oss/v2
+        repository: prometheus/prometheus-config-reloader
+        sha: e502320119de5f35c2fbc803bab5b78ba3a7ed177dd45b5493dd9130b7760da7
+    prometheusOperator:
+      image:
+        registry: mcr.microsoft.com/oss/v2
+        repository: prometheus/prometheus-operator
+        sha: 5d7972807c5809c4dcb5ddb73782d9e1ac5933ff6d4d9b70e8baf9b97bfc98ab
+      version: ""
+    prometheusSpec:
+      image:
+        registry: mcr.microsoft.com/oss/v2
+        repository: prometheus/prometheus
+        sha: addf21a90b6d1af9c3e3b8bf3242209a307880ce93daa354b7c6e4cf08e4c95d
+      replicas: 2
+      resources:
+        limits:
+          memory: NONE
+        requests:
+          cpu: NONE
+          memory: NONE
+      shards: 1
+      version: ""
+    thanos:
+      image:
+        registry: arohcpsvcdev.azurecr.io
+        repository: thanos/thanos
+        sha: b567818fe608067eb0f1d7c2c4fe361e7ad83c8a256234c97685f1d0bf670cc8
+        tag: v0.41.0
+  rg: hcp-underlay-ci02-j7654321-svc
+  subscription:
+    certificateDomains:
+    - '*.hcpsvc.osadev.cloud'
+    displayName: Azure Red Hat OpenShift HCP - Central US - SVC
+    key: ARO HCP E2E Infrastructure (EA Subscription)
+    providers:
+      Microsoft.Compute:
+        features:
+        - name: EncryptionAtHost
+          poll: true
+        poll: true
+      Microsoft.ContainerService:
+        features:
+        - name: IstioNativeSidecarModePreview
+          poll: true
+        - name: ManagedGatewayAPIPreview
+          poll: true
+        - name: IdentityBindingPreview
+          poll: true
+        poll: true
+      Microsoft.Dashboard:
+        poll: true
+      Microsoft.DbForPostgreSQL:
+        poll: true
+      Microsoft.Insights:
+        poll: true
+      Microsoft.Kusto:
+        poll: true
+      Microsoft.Network:
+        features:
+        - name: AllowBringYourOwnPublicIpAddress
+          poll: true
+        poll: true
+      Microsoft.Quota:
+        poll: true
+    usePlannedQuota: true
+tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
+velero:
+  azurePlugin:
+    digest: sha256:6c9a836847b7992bf4b62e4abbcf1abca396c8766b4736cbeecf43c85921dfeb
+    registry: registry.stage.redhat.io
+    repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
+  hypershiftPlugin:
+    digest: sha256:1e959bed1cbfaf165fef00818235110674327c568d93fafa2027233aa331a9cc
+    registry: registry.stage.redhat.io
+    repository: oadp/oadp-hypershift-velero-plugin-rhel9
+  server:
+    digest: sha256:a611f6c4f62b7f9a281bda0ae7390264e8f4be21f4751710e1feb90956ffad23
+    registry: registry.stage.redhat.io
+    repository: oadp/oadp-velero-rhel9

--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -43,6 +43,29 @@ environments:
       identity_container_prefix: aro-hcp-msi-container-dev
       identity_container_count: 20
       identity_provisioning: unmanaged
+  # dev-upgrade is a separate environment for the upgrade/in-place test suite
+  # and CAPZ on-demand testing. It uses deploy_env ci02 so upgrade jobs and
+  # e2e-parallel jobs (ci00/ci01) never compete for the same Boskos pools.
+  # ci02 maps to a dedicated templatize environment with cluster sizing tuned
+  # for upgrade workloads (10 concurrent HCPs vs 50 in e2e-parallel).
+  dev-upgrade:
+    deploy_envs:
+    - ci02
+    pools:
+    # Dedicated subscription for upgrade and CAPZ on-demand testing.
+    # 30 slots support peak concurrent PR activity + merge pool.
+    # Each slot supports up to 10 concurrent HCPs (matching ci02 MGMT sizing).
+    # After the 10th spec is merged, no additional specs can be added without
+    # first increasing identity_container_count here (and resyncing the boskos
+    # config) — otherwise excess specs block waiting for a free identity
+    # container and the suite eventually times out.
+    - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 04"
+      region: westus3
+      region_mode: runtime-selected
+      resource_type: aro-hcp-dev-shard4-slot
+      slot_count: 30
+      identity_container_prefix: aro-hcp-msi-container-dev-shard4
+      identity_container_count: 10
   int:
     deploy_envs:
     - int

--- a/tooling/templatize/settings.yaml
+++ b/tooling/templatize/settings.yaml
@@ -46,6 +46,16 @@ environments:
     ev2Cloud: public
     cxStamp: 1
     regionShortOverride: "j${BUILD_ID: -7}"
+- name: ci02
+  description: |
+    CI infra for upgrade/in-place tests.
+    Sized for 10 concurrent HCPs (1/5 of ci01).
+  defaults:
+    region: centralus
+    cloud: dev
+    ev2Cloud: public
+    cxStamp: 1
+    regionShortOverride: "j${BUILD_ID: -7}"
 - name: perf
   description: |
     Used for performance testing.


### PR DESCRIPTION
[ARO-28000](https://redhat.atlassian.net/browse/ARO-28000)

## What

- Adds a dedicated `dev-upgrade` slot environment in `e2e-slots.yaml` with 30 upgrade slots on a new "ARO HCP E2E Hosted Clusters - Dev - 04" subscription, each with 10 identity containers
- Creates a new `ci02` templatize environment with MGMT cluster sizing tuned for 10 concurrent HCPs (1/5 of ci01):
  - user: 1 pool × E16ds_v6, min:5/max:9 (vs ci01: 3 pools, min:7/max:14)
  - system: 1 pool × D8ds_v6, min:1/max:4 (vs ci01: 1 pool D16ds_v6, min:1/max:4)
  - infra: 1 pool × D8ds_v6, min:1/max:2 (vs ci01: 2 pools, min:1/max:3)
- Bumps the MSI mock pool and ARM helper pool sizes to 50 in `config-dev-ci.yaml`

## Why

The upgrade/in-place test suite (and CAPZ on-demand testing) needs dedicated CI infrastructure to run alongside e2e-parallel on PRs without contending for the same Boskos pools. Per slot-manager design (`test/cmd/aro-hcp-tests/slot-manager/DESIGN.md`), a separate `deploy_env` (`ci02`) ensures upgrade jobs never receive a pool from the larger e2e-parallel environment, and cluster sizing can be tuned independently for the lighter workload (10 vs 50 concurrent HCPs).

A dedicated customer subscription ("Dev - 04") isolates the upgrade/CAPZ workload from the existing 4 e2e-parallel shards (shard0–shard3). The 30 slots support peak concurrent PR activity plus merge pool.

The MSI mock and ARM helper pool bumps cover the combined 50 max concurrent infrastructures (20 e2e-parallel + 30 upgrade/CAPZ).

**Quota impact analysis (Infrastructure subscription, West US 3):**

| Scenario | Ddsv6 | vs 3,000 | Edsv6 | vs 10,000 | AKS clusters | vs 100 |
|---|---|---|---|---|---|---|
| 20 ci01 + 30 ci02 min | 3,040 | 101% | 10,080 | 101% | 120 | 120% |

## Testing

No new tests — this is infrastructure configuration only. The slot catalog is validated by existing unit tests in `test/cmd/aro-hcp-tests/slot-manager/slots/`. The rendered ci02 config is auto-generated by `cd config && make materialize`.

## Special notes for your reviewer

- The "ARO HCP E2E Hosted Clusters - Dev - 04" subscription does not exist yet — it must be created and onboarded before the upgrade pools can be provisioned
- The upgrade identity pools are not yet provisioned — `slot-manager apply-identity-pool` must be run after the subscription is available
- The openshift/release Boskos config needs a corresponding update (`slot-manager sync-boskos-config`)
- The CI job in openshift/release needs `ARO_HCP_DEPLOY_ENV: ci02`
- Infrastructure subscription quota increase requests are a prerequisite for the full 20+30 capacity

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge