### PR TITLE
fix(dev-infrastructure): unset workingDir on postgres-access reconcile steps

### DIFF
--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -504,7 +504,9 @@ resourceGroups:
   - name: cs-postgres-access
     action: Shell
     command: ./scripts/postgres-access/postgres-access
-    workingDir: .
+    # workingDir intentionally left unset: this step reconciles postgres access grants and
+    # must always run on incremental rollouts, not be skipped by content-hash caching, which
+    # setting workingDir would opt it into (see AROSLSRE-1699).
     shellIdentity:
       input:
         resourceGroup: global
@@ -538,7 +540,9 @@ resourceGroups:
   - name: maestro-postgres-access
     action: Shell
     command: ./scripts/postgres-access/postgres-access
-    workingDir: .
+    # workingDir intentionally left unset: this step reconciles postgres access grants and
+    # must always run on incremental rollouts, not be skipped by content-hash caching, which
+    # setting workingDir would opt it into (see AROSLSRE-1699).
     shellIdentity:
       input:
         resourceGroup: global


### PR DESCRIPTION
## Why

`cs-postgres-access` and `maestro-postgres-access` are Shell steps in `svc-pipeline.yaml` that reconcile postgres access grants, they need to run on every rollout to catch drift, not just when their pipeline step changes.

They were both set to `workingDir: .`. Per `ARO-Tools/pipelines/types/shell.go`:

```go
func (s *ShellStep) IsWellFormedOverInputs() bool {
	// raw shell steps capture the whole repository as an archive input, so they are not well-formed
	return s.WorkingDir != ""
}
```

Any non-empty `workingDir` (including `.`) opts a Shell step into content-hash caching under incremental rollouts (`runShellStep` in `shell.go` skips execution when `IsWellFormedOverInputs()` is true, keyed on `{command, workingDir, envVars}` against a persistent `.step-cache` dir). A step only always reruns when `workingDir` is left fully unset.

Since `svc-pipeline.yaml` lives at `dev-infrastructure/`'s root, `workingDir: .` and an unset `workingDir` compute to the exact same working directory at execution time (`filepath.Join(PipelineDirectory, ".")` == `PipelineDirectory`), so removing the field changes only caching eligibility, not actual runtime behavior.

## What

Removed `workingDir: .` from `cs-postgres-access` and `maestro-postgres-access`, with a comment explaining why, so both steps always execute on incremental rollouts as intended.

Raised by roivaz in [PR #6369 review](https://github.com/Azure/ARO-HCP/pull/6369#discussion_r3705131376), tracked in [AROSLSRE-1699](https://redhat.atlassian.net/browse/AROSLSRE-1699).

Note: the same issue affects the new `ocp-acr-replication`/`svc-acr-replication` steps being added in #6369 (also `workingDir: .`), those aren't on `main` yet so aren't part of this PR, they'll be fixed directly in #6369 before merge.

## Testing

Validated with `templatize pipeline validate --topology-config-file topology.yaml --service-config-file config/config.yaml --dev-mode --dev-region westus3` (exit 0, no schema/topology errors). `workingDir` is optional in the pipeline schema and not in any step's required-fields list, confirmed removing it is safe. No functional change to the step's working directory since it already resolved to the pipeline directory.
