### PR TITLE
feat: report hcpctl token usage

### DIFF
--- a/docs/snapshot-analysis.md
+++ b/docs/snapshot-analysis.md
@@ -74,13 +74,18 @@ The agent runs through several phases:
 
 ### Analyze output
 
-The command writes three files to the output directory (defaults to the data
+The command writes four files to the output directory (defaults to the data
 directory, overridable with `--output`):
 
 - `analysis.json` — the fully hydrated causal chain as structured JSON.
 - `analysis.md` — the chain rendered as a readable markdown document.
 - `conversation.json` — the full conversation history with the agent,
   including all prompts, responses, and tool calls.
+- `usage.json` — aggregate LLM input, output, and total token counts, plus the
+  number of completed LLM requests.
+
+The same token usage fields are logged in the `Analysis complete` message at
+the default verbosity level.
 
 ## Debugging with conversation.json
 

--- a/tooling/hcpctl/cmd/snapshot/analyze_cmd.go
+++ b/tooling/hcpctl/cmd/snapshot/analyze_cmd.go
@@ -429,10 +429,25 @@ func (o *validatedAnalyzeOptions) run(ctx context.Context) error {
 		return analysisErr
 	}
 
+	usageJSON, err := json.MarshalIndent(result.Usage, "", "  ")
+	if err != nil {
+		analysisErr = fmt.Errorf("failed to marshal usage: %w", err)
+		return analysisErr
+	}
+	if err := os.WriteFile(filepath.Join(o.outputDir, "usage.json"), usageJSON, 0o644); err != nil {
+		analysisErr = fmt.Errorf("failed to write usage.json: %w", err)
+		return analysisErr
+	}
+
 	logger.Info("Analysis complete.",
 		"outputDir", o.outputDir,
 		"analysisJSON", filepath.Join(o.outputDir, "analysis.json"),
 		"analysisMarkdown", filepath.Join(o.outputDir, "analysis.md"),
+		"usageJSON", filepath.Join(o.outputDir, "usage.json"),
+		"inputTokens", result.Usage.InputTokens,
+		"outputTokens", result.Usage.OutputTokens,
+		"totalTokens", result.Usage.TotalTokens,
+		"llmRequests", result.Usage.Requests,
 	)
 
 	return nil

--- a/tooling/hcpctl/pkg/agent/agent.go
+++ b/tooling/hcpctl/pkg/agent/agent.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	copilot "github.com/github/copilot-sdk/go"
@@ -156,6 +157,8 @@ type Session struct {
 	client       *CopilotClient
 	logger       logr.Logger
 	lastMessages json.RawMessage
+	usageMu      sync.RWMutex
+	usage        TokenUsage
 }
 
 // CreateSession creates a new Copilot session for an analysis run.
@@ -300,6 +303,14 @@ func (s *Session) SessionID() string {
 	return s.inner.SessionID
 }
 
+// Usage returns the aggregate token usage observed in the most recent
+// conversation snapshot.
+func (s *Session) Usage() TokenUsage {
+	s.usageMu.RLock()
+	defer s.usageMu.RUnlock()
+	return s.usage
+}
+
 // SendAndWait sends a prompt to the session and blocks until the agent is idle.
 // If ctx is cancelled, the in-flight work is aborted.
 // Returns the final assistant message content.
@@ -379,12 +390,40 @@ func (s *Session) snapshotMessages() {
 		s.logger.Error(err, "Failed to snapshot session messages.")
 		return
 	}
+	usage := tokenUsageFromCopilotEvents(events)
+	s.usageMu.Lock()
+	s.usage = usage
+	s.usageMu.Unlock()
 	data, err := json.MarshalIndent(events, "", "  ")
 	if err != nil {
 		s.logger.Error(err, "Failed to marshal session messages for snapshot.")
 		return
 	}
 	s.lastMessages = data
+}
+
+// tokenUsageFromCopilotEvents extracts all completed assistant LLM requests
+// from a Copilot conversation history. Recomputing from the full history keeps
+// the aggregate correct across multiple SendAndWait calls and avoids counting
+// the same event more than once.
+func tokenUsageFromCopilotEvents(events []copilot.SessionEvent) TokenUsage {
+	var usage TokenUsage
+	for _, event := range events {
+		data, ok := event.Data.(*copilot.AssistantUsageData)
+		if !ok {
+			continue
+		}
+
+		var inputTokens, outputTokens int64
+		if data.InputTokens != nil {
+			inputTokens = *data.InputTokens
+		}
+		if data.OutputTokens != nil {
+			outputTokens = *data.OutputTokens
+		}
+		usage.Add(inputTokens, outputTokens)
+	}
+	return usage
 }
 
 // SaveConversation writes the most recent conversation snapshot to a JSON

--- a/tooling/hcpctl/pkg/agent/analyze.go
+++ b/tooling/hcpctl/pkg/agent/analyze.go
@@ -74,6 +74,10 @@ type AnalyzeResult struct {
 
 	// DraftChain is the last validated draft before the final hydration.
 	DraftChain *DraftChain
+
+	// Usage is the aggregate token usage from all LLM requests made during
+	// the analysis.
+	Usage TokenUsage
 }
 
 // Analyze runs the full agentic analysis loop: initial prompt, validate-draft,
@@ -171,6 +175,7 @@ func Analyze(ctx context.Context, logger logr.Logger, session LLMSession, kustoC
 	return &AnalyzeResult{
 		HydratedChain: hydratedChain,
 		DraftChain:    draftChain,
+		Usage:         session.Usage(),
 	}, nil
 }
 

--- a/tooling/hcpctl/pkg/agent/claude_provider.go
+++ b/tooling/hcpctl/pkg/agent/claude_provider.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -173,11 +174,20 @@ type ClaudeSession struct {
 	messages     []anthropic.MessageParam
 	sessionID    string
 	logger       logr.Logger
+	usageMu      sync.RWMutex
+	usage        TokenUsage
 }
 
 // SessionID returns the unique identifier for this session.
 func (s *ClaudeSession) SessionID() string {
 	return s.sessionID
+}
+
+// Usage returns the aggregate token usage observed by this session.
+func (s *ClaudeSession) Usage() TokenUsage {
+	s.usageMu.RLock()
+	defer s.usageMu.RUnlock()
+	return s.usage
 }
 
 // SendAndWait sends a user prompt and blocks until Claude finishes responding,
@@ -218,6 +228,9 @@ func (s *ClaudeSession) SendAndWait(ctx context.Context, prompt string) (string,
 			"inputTokens", resp.Usage.InputTokens,
 			"outputTokens", resp.Usage.OutputTokens,
 		)
+		s.usageMu.Lock()
+		s.usage.Add(resp.Usage.InputTokens, resp.Usage.OutputTokens)
+		s.usageMu.Unlock()
 
 		// Add assistant response to conversation history.
 		s.messages = append(s.messages, resp.ToParam())

--- a/tooling/hcpctl/pkg/agent/provider.go
+++ b/tooling/hcpctl/pkg/agent/provider.go
@@ -46,6 +46,11 @@ type LLMSession interface {
 	// assistant text content.
 	SendAndWait(ctx context.Context, prompt string) (string, error)
 
+	// Usage returns the aggregate token usage observed by this session.
+	// Implementations include every completed LLM request made while handling
+	// SendAndWait calls, including requests made during tool-use loops.
+	Usage() TokenUsage
+
 	// SaveConversation writes the conversation history to a JSON file at
 	// the given path. This is best-effort: implementations should log
 	// errors rather than return them.
@@ -102,6 +107,27 @@ type ProviderSessionConfig struct {
 	// Model overrides the provider's default model for this session.
 	// When empty, the provider uses its configured default.
 	Model string
+}
+
+// TokenUsage contains aggregate token usage for an LLM session.
+//
+// TotalTokens is the sum of InputTokens and OutputTokens. Requests is the
+// number of completed LLM requests, so a single SendAndWait call may
+// contribute more than one request when the provider performs tool-use turns
+// internally.
+type TokenUsage struct {
+	InputTokens  int64 `json:"inputTokens"`
+	OutputTokens int64 `json:"outputTokens"`
+	TotalTokens  int64 `json:"totalTokens"`
+	Requests     int64 `json:"requests"`
+}
+
+// Add records one completed LLM request in the aggregate.
+func (u *TokenUsage) Add(inputTokens, outputTokens int64) {
+	u.InputTokens += inputTokens
+	u.OutputTokens += outputTokens
+	u.TotalTokens += inputTokens + outputTokens
+	u.Requests++
 }
 
 // ToolDefinition is a provider-neutral description of a tool that can be

--- a/tooling/hcpctl/pkg/agent/provider_test.go
+++ b/tooling/hcpctl/pkg/agent/provider_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"testing"
+
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func TestTokenUsageAdd(t *testing.T) {
+	var usage TokenUsage
+
+	usage.Add(100, 25)
+	usage.Add(10, 5)
+
+	if usage.InputTokens != 110 {
+		t.Errorf("InputTokens = %d, want 110", usage.InputTokens)
+	}
+	if usage.OutputTokens != 30 {
+		t.Errorf("OutputTokens = %d, want 30", usage.OutputTokens)
+	}
+	if usage.TotalTokens != 140 {
+		t.Errorf("TotalTokens = %d, want 140", usage.TotalTokens)
+	}
+	if usage.Requests != 2 {
+		t.Errorf("Requests = %d, want 2", usage.Requests)
+	}
+}
+
+func TestTokenUsageFromCopilotEvents(t *testing.T) {
+	input1, output1 := int64(100), int64(25)
+	input2, output2 := int64(10), int64(5)
+
+	usage := tokenUsageFromCopilotEvents([]copilot.SessionEvent{
+		{Data: &copilot.AssistantUsageData{InputTokens: &input1, OutputTokens: &output1}},
+		{Data: &copilot.AssistantUsageData{InputTokens: &input2, OutputTokens: &output2}},
+		{Data: &copilot.SessionInfoData{}},
+	})
+
+	if usage.InputTokens != 110 || usage.OutputTokens != 30 || usage.TotalTokens != 140 || usage.Requests != 2 {
+		t.Errorf("usage = %+v, want input=110 output=30 total=140 requests=2", usage)
+	}
+}


### PR DESCRIPTION
## Why

Snapshot analysis can make multiple LLM requests, including tool-use rounds, but hcpctl did not expose aggregate token consumption. This made it difficult to understand the usage of an analysis run.

## What changed

- aggregate input, output, total token, and request counts across Claude and Copilot sessions
- write the aggregate to `usage.json` with the other analysis artifacts
- include the usage fields in the completion log
- document the new artifact and cover aggregation with unit tests

## Impact

Users gain a machine-readable usage artifact and an at-a-glance usage summary in normal command output. Existing analysis artifacts and behavior remain unchanged.

## Validation

```text
cd tooling/hcpctl
go test ./pkg/agent ./cmd/snapshot
```

Related issue: none provided.
