### PR TITLE
feat: report hcpctl token usage

### DIFF
--- a/docs/snapshot-analysis.md
+++ b/docs/snapshot-analysis.md
@@ -85,6 +85,8 @@ directory (defaults to the data directory, overridable with `--output`):
   pricing dimensions. Token counts distinguish uncached input, cache reads,
   cache writes, and output. Cache writes include a TTL breakdown when the
   provider reports one (for example, Anthropic's `5m` and `1h` tiers).
+  Copilot usage is captured from the live SDK event stream and includes
+  automatic conversation-compaction requests.
 
 Once an LLM session has been created, `usage.json` is also written on a
 best-effort basis when analysis fails or is cancelled. This preserves usage

--- a/docs/snapshot-analysis.md
+++ b/docs/snapshot-analysis.md
@@ -74,13 +74,39 @@ The agent runs through several phases:
 
 ### Analyze output
 
-The command writes three files to the output directory (defaults to the data
-directory, overridable with `--output`):
+After a successful analysis, the command writes four files to the output
+directory (defaults to the data directory, overridable with `--output`):
 
 - `analysis.json` — the fully hydrated causal chain as structured JSON.
 - `analysis.md` — the chain rendered as a readable markdown document.
 - `conversation.json` — the full conversation history with the agent,
   including all prompts, responses, and tool calls.
+- `usage.json` — aggregate LLM usage with a breakdown by provider, model, and
+  pricing dimensions. Token counts distinguish uncached input, cache reads,
+  cache writes, and output. Cache writes include a TTL breakdown when the
+  provider reports one (for example, Anthropic's `5m` and `1h` tiers).
+
+Once an LLM session has been created, `usage.json` is also written on a
+best-effort basis when analysis fails or is cancelled. This preserves usage
+from completed requests that may already be billable. `conversation.json` is
+likewise saved best-effort on unsuccessful runs; `analysis.json` and
+`analysis.md` are success-only outputs.
+
+The report also preserves provider-reported billing units and non-token usage,
+such as server-side tool requests. The token categories are normalized to be
+mutually exclusive, so a cost calculator can apply the appropriate rate to
+each category without double-counting cached input. Pricing is intentionally
+not embedded in hcpctl because it varies by provider, model, backend, service
+tier, region, contract, and date. The `breakdown` entries preserve the pricing
+dimensions reported by the selected provider and backend. The top-level
+`startedAt` and `endedAt` fields identify the usage interval so a consumer can
+select rates effective at that time. Contract-specific rates and any pricing
+context that the provider does not report must be supplied by the external
+price book.
+
+The aggregate token categories, additional units, and provider-reported costs
+are also logged in the `Analysis complete` message at the default verbosity
+level.
 
 ## Debugging with conversation.json
 

--- a/tooling/hcpctl/cmd/snapshot/analyze_cmd.go
+++ b/tooling/hcpctl/cmd/snapshot/analyze_cmd.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
@@ -255,7 +256,7 @@ func (o *RawAnalyzeOptions) validate() (*validatedAnalyzeOptions, error) {
 	return validated, nil
 }
 
-func (o *validatedAnalyzeOptions) run(ctx context.Context) error {
+func (o *validatedAnalyzeOptions) run(ctx context.Context) (runErr error) {
 	logger := logr.FromContextOrDiscard(ctx)
 
 	// Read manifest.
@@ -371,18 +372,9 @@ func (o *validatedAnalyzeOptions) run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create LLM session: %w", err)
 	}
-	var analysisErr error
+	usageStartedAt := time.Now().UTC()
 	defer func() {
-		session.SaveConversation(filepath.Join(o.outputDir, "conversation.json"))
-		if analysisErr == nil {
-			if err := session.Delete(ctx); err != nil {
-				logger.Error(err, "Failed to delete LLM session.")
-			}
-		} else {
-			if err := session.Disconnect(); err != nil {
-				logger.Error(err, "Failed to disconnect LLM session.")
-			}
-		}
+		finalizeAnalysisSession(ctx, logger, session, o.outputDir, usageStartedAt, time.Now().UTC(), &runErr)
 	}()
 
 	result, err := agent.Analyze(ctx, logger, session, cachedKustoClient, agent.AnalyzeOptions{
@@ -401,39 +393,94 @@ func (o *validatedAnalyzeOptions) run(ctx context.Context) error {
 		NodeConsoleLogURLs:  nodeConsoleLogURLs,
 	})
 	if err != nil {
-		analysisErr = err
-		return analysisErr
+		return err
 	}
 	hydratedChain := result.HydratedChain
 
 	// Write output.
 	logger.Info("Writing analysis output.")
 	if err := os.MkdirAll(o.outputDir, 0o755); err != nil {
-		analysisErr = fmt.Errorf("failed to create output directory: %w", err)
-		return analysisErr
+		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
 	analysisJSON, err := json.MarshalIndent(hydratedChain, "", "  ")
 	if err != nil {
-		analysisErr = fmt.Errorf("failed to marshal analysis: %w", err)
-		return analysisErr
+		return fmt.Errorf("failed to marshal analysis: %w", err)
 	}
 	if err := os.WriteFile(filepath.Join(o.outputDir, "analysis.json"), analysisJSON, 0o644); err != nil {
-		analysisErr = fmt.Errorf("failed to write analysis.json: %w", err)
-		return analysisErr
+		return fmt.Errorf("failed to write analysis.json: %w", err)
 	}
 
 	rendered := agent.RenderMarkdown(hydratedChain, manifest.TestName)
 	if err := os.WriteFile(filepath.Join(o.outputDir, "analysis.md"), []byte(rendered), 0o644); err != nil {
-		analysisErr = fmt.Errorf("failed to write analysis.md: %w", err)
-		return analysisErr
+		return fmt.Errorf("failed to write analysis.md: %w", err)
 	}
 
-	logger.Info("Analysis complete.",
-		"outputDir", o.outputDir,
-		"analysisJSON", filepath.Join(o.outputDir, "analysis.json"),
-		"analysisMarkdown", filepath.Join(o.outputDir, "analysis.md"),
-	)
+	return nil
+}
+
+func finalizeAnalysisSession(ctx context.Context, logger logr.Logger, session agent.LLMSession, outputDir string, startedAt, endedAt time.Time, runErr *error) {
+	usage := session.Usage()
+	usage.StartedAt = startedAt
+	usage.EndedAt = endedAt
+	usagePath := filepath.Join(outputDir, "usage.json")
+	if err := writeUsageReport(usagePath, usage); err != nil {
+		if *runErr == nil {
+			*runErr = err
+		} else {
+			logger.Error(err, "Failed to preserve LLM usage after unsuccessful analysis.", "path", usagePath)
+		}
+	} else if *runErr == nil {
+		logger.Info("Analysis complete.",
+			"outputDir", outputDir,
+			"analysisJSON", filepath.Join(outputDir, "analysis.json"),
+			"analysisMarkdown", filepath.Join(outputDir, "analysis.md"),
+			"usageJSON", usagePath,
+			"usageStartedAt", usage.StartedAt,
+			"usageEndedAt", usage.EndedAt,
+			"uncachedInputTokens", usage.Tokens.UncachedInputTokens,
+			"cacheReadInputTokens", usage.Tokens.CacheReadInputTokens,
+			"cacheWriteInputTokens", usage.Tokens.CacheWriteInputTokens,
+			"outputTokens", usage.Tokens.OutputTokens,
+			"totalTokens", usage.Tokens.TotalTokens,
+			"llmRequests", usage.Requests,
+			"additionalUnits", usage.AdditionalUnits,
+			"providerReportedCosts", usage.ProviderReportedCosts,
+		)
+	} else {
+		logger.Info("Preserved LLM usage after unsuccessful analysis.",
+			"usageJSON", usagePath,
+			"usageStartedAt", usage.StartedAt,
+			"usageEndedAt", usage.EndedAt,
+			"llmRequests", usage.Requests,
+			"totalTokens", usage.Tokens.TotalTokens,
+		)
+	}
+
+	session.SaveConversation(filepath.Join(outputDir, "conversation.json"))
+	if *runErr == nil {
+		if err := session.Delete(ctx); err != nil {
+			logger.Error(err, "Failed to delete LLM session.")
+		}
+	} else {
+		if err := session.Disconnect(); err != nil {
+			logger.Error(err, "Failed to disconnect LLM session.")
+		}
+	}
+}
+
+func writeUsageReport(path string, usage agent.UsageReport) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("failed to create usage output directory: %w", err)
+	}
+
+	usageJSON, err := json.MarshalIndent(usage, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal usage: %w", err)
+	}
+	if err := os.WriteFile(path, usageJSON, 0o644); err != nil {
+		return fmt.Errorf("failed to write usage.json: %w", err)
+	}
 
 	return nil
 }

--- a/tooling/hcpctl/cmd/snapshot/analyze_cmd_test.go
+++ b/tooling/hcpctl/cmd/snapshot/analyze_cmd_test.go
@@ -1,0 +1,190 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/agent"
+	"github.com/go-logr/logr"
+)
+
+type fakeAnalysisSession struct {
+	usage               agent.UsageReport
+	savedPath           string
+	disconnectWasCalled bool
+	deleteWasCalled     bool
+}
+
+func (s *fakeAnalysisSession) SendAndWait(context.Context, string) (string, error) {
+	return "", nil
+}
+
+func (s *fakeAnalysisSession) Usage() agent.UsageReport {
+	return s.usage.Clone()
+}
+
+func (s *fakeAnalysisSession) SaveConversation(path string) {
+	s.savedPath = path
+}
+
+func (s *fakeAnalysisSession) SessionID() string {
+	return "test-session"
+}
+
+func (s *fakeAnalysisSession) Disconnect() error {
+	s.disconnectWasCalled = true
+	return nil
+}
+
+func (s *fakeAnalysisSession) Delete(context.Context) error {
+	s.deleteWasCalled = true
+	return nil
+}
+
+func TestWriteUsageReport(t *testing.T) {
+	startedAt := time.Date(2026, time.August, 3, 17, 0, 0, 0, time.UTC)
+	endedAt := startedAt.Add(5 * time.Minute)
+	want := agent.UsageReport{
+		StartedAt: startedAt,
+		EndedAt:   endedAt,
+		Requests:  1,
+		Tokens: agent.TokenUsage{
+			UncachedInputTokens:   100,
+			CacheReadInputTokens:  200,
+			CacheWriteInputTokens: 300,
+			OutputTokens:          25,
+			TotalTokens:           625,
+		},
+		Breakdown: []agent.UsageBreakdown{{
+			Provider:   "anthropic",
+			Model:      "claude-test",
+			Dimensions: map[string]string{"backend": "api"},
+			Requests:   1,
+		}},
+	}
+
+	path := filepath.Join(t.TempDir(), "nested", "usage.json")
+	if err := writeUsageReport(path, want); err != nil {
+		t.Fatalf("writeUsageReport() error = %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading usage report: %v", err)
+	}
+	var got agent.UsageReport
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshaling usage report: %v", err)
+	}
+
+	if !got.StartedAt.Equal(startedAt) || !got.EndedAt.Equal(endedAt) {
+		t.Errorf("usage interval = %s..%s, want %s..%s", got.StartedAt, got.EndedAt, startedAt, endedAt)
+	}
+	if got.Requests != want.Requests || !reflect.DeepEqual(got.Tokens, want.Tokens) {
+		t.Errorf("usage totals = %+v, want %+v", got, want)
+	}
+	if len(got.Breakdown) != 1 || got.Breakdown[0].Dimensions["backend"] != "api" {
+		t.Errorf("usage breakdown = %+v, want Anthropic API entry", got.Breakdown)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat usage report: %v", err)
+	}
+	if gotMode := info.Mode().Perm(); gotMode != 0o644 {
+		t.Errorf("usage report mode = %o, want 644", gotMode)
+	}
+}
+
+func TestWriteUsageReportReturnsDirectoryError(t *testing.T) {
+	parentFile := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(parentFile, []byte("content"), 0o600); err != nil {
+		t.Fatalf("creating parent file: %v", err)
+	}
+
+	err := writeUsageReport(filepath.Join(parentFile, "usage.json"), agent.UsageReport{})
+	if err == nil {
+		t.Fatal("writeUsageReport() error = nil, want directory creation error")
+	}
+}
+
+func TestFinalizeAnalysisSessionPreservesUsageOnError(t *testing.T) {
+	startedAt := time.Date(2026, time.August, 3, 17, 0, 0, 0, time.UTC)
+	endedAt := startedAt.Add(5 * time.Minute)
+	session := &fakeAnalysisSession{usage: agent.UsageReport{
+		Requests: 2,
+		Tokens: agent.TokenUsage{
+			UncachedInputTokens: 100,
+			OutputTokens:        25,
+			TotalTokens:         125,
+		},
+	}}
+	originalErr := errors.New("analysis failed")
+	runErr := originalErr
+	outputDir := t.TempDir()
+
+	finalizeAnalysisSession(context.Background(), logr.Discard(), session, outputDir, startedAt, endedAt, &runErr)
+
+	if !errors.Is(runErr, originalErr) {
+		t.Fatalf("finalizeAnalysisSession() error = %v, want original analysis error", runErr)
+	}
+	if !session.disconnectWasCalled || session.deleteWasCalled {
+		t.Errorf("session cleanup = disconnect:%t delete:%t, want disconnect only", session.disconnectWasCalled, session.deleteWasCalled)
+	}
+	if wantPath := filepath.Join(outputDir, "conversation.json"); session.savedPath != wantPath {
+		t.Errorf("conversation path = %q, want %q", session.savedPath, wantPath)
+	}
+
+	data, err := os.ReadFile(filepath.Join(outputDir, "usage.json"))
+	if err != nil {
+		t.Fatalf("reading preserved usage report: %v", err)
+	}
+	var got agent.UsageReport
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshaling preserved usage report: %v", err)
+	}
+	if got.Requests != 2 || got.Tokens.TotalTokens != 125 {
+		t.Errorf("preserved usage = %+v, want requests=2 totalTokens=125", got)
+	}
+	if !got.StartedAt.Equal(startedAt) || !got.EndedAt.Equal(endedAt) {
+		t.Errorf("preserved interval = %s..%s, want %s..%s", got.StartedAt, got.EndedAt, startedAt, endedAt)
+	}
+}
+
+func TestFinalizeAnalysisSessionReturnsUsageWriteError(t *testing.T) {
+	outputDir := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(outputDir, []byte("content"), 0o600); err != nil {
+		t.Fatalf("creating output path: %v", err)
+	}
+
+	session := &fakeAnalysisSession{}
+	var runErr error
+	finalizeAnalysisSession(context.Background(), logr.Discard(), session, outputDir, time.Now(), time.Now(), &runErr)
+
+	if runErr == nil {
+		t.Fatal("finalizeAnalysisSession() error = nil, want usage write error")
+	}
+	if !session.disconnectWasCalled || session.deleteWasCalled {
+		t.Errorf("session cleanup = disconnect:%t delete:%t, want disconnect only", session.disconnectWasCalled, session.deleteWasCalled)
+	}
+}

--- a/tooling/hcpctl/cmd/snapshot/analyze_cmd_test.go
+++ b/tooling/hcpctl/cmd/snapshot/analyze_cmd_test.go
@@ -40,6 +40,8 @@ func (s *fakeAnalysisSession) SendAndWait(context.Context, string) (string, erro
 	return "", nil
 }
 
+func (s *fakeAnalysisSession) ResetHistory() {}
+
 func (s *fakeAnalysisSession) Usage() agent.UsageReport {
 	return s.usage.Clone()
 }
@@ -112,8 +114,12 @@ func TestWriteUsageReport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat usage report: %v", err)
 	}
-	if gotMode := info.Mode().Perm(); gotMode != 0o644 {
-		t.Errorf("usage report mode = %o, want 644", gotMode)
+	gotMode := info.Mode().Perm()
+	if gotMode&0o600 != 0o600 {
+		t.Errorf("usage report mode = %o, want owner read/write permissions", gotMode)
+	}
+	if unexpected := gotMode &^ 0o644; unexpected != 0 {
+		t.Errorf("usage report mode = %o, includes unexpected permissions %o", gotMode, unexpected)
 	}
 }
 

--- a/tooling/hcpctl/cmd/snapshot/analyze_cmd_test.go
+++ b/tooling/hcpctl/cmd/snapshot/analyze_cmd_test.go
@@ -24,8 +24,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/agent"
 	"github.com/go-logr/logr"
+
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/agent"
 )
 
 type fakeAnalysisSession struct {

--- a/tooling/hcpctl/pkg/agent/agent.go
+++ b/tooling/hcpctl/pkg/agent/agent.go
@@ -161,6 +161,8 @@ type Session struct {
 	usage           UsageReport
 	usageProvider   string
 	usageDimensions map[string]string
+	usageModel      string
+	seenUsageKeys   map[string]struct{}
 }
 
 // CreateSession creates a new Copilot session for an analysis run.
@@ -219,7 +221,13 @@ func (c *CopilotClient) CreateSession(ctx context.Context, logger logr.Logger, c
 		logger:          logger,
 		usageProvider:   usageProvider,
 		usageDimensions: usageDimensions,
+		usageModel:      sessionCfg.Model,
+		seenUsageKeys:   make(map[string]struct{}),
 	}
+	// Register before the first SendAndWait. The SDK dispatches handlers in
+	// registration order, so all preceding usage events are recorded before
+	// SendAndWait's temporary session.idle handler returns to the caller.
+	s.inner.On(s.recordUsageEvent)
 
 	// When verbosity is high enough, trace every session event for debugging.
 	if c.cfg.Verbosity >= 5 {
@@ -317,8 +325,7 @@ func (s *Session) SessionID() string {
 // manages conversation context internally within the CLI subprocess.
 func (s *Session) ResetHistory() {}
 
-// Usage returns the aggregate token usage observed in the most recent
-// conversation snapshot.
+// Usage returns the aggregate token usage observed from live session events.
 func (s *Session) Usage() UsageReport {
 	s.usageMu.RLock()
 	defer s.usageMu.RUnlock()
@@ -404,10 +411,11 @@ func (s *Session) snapshotMessages() {
 		s.logger.Error(err, "Failed to snapshot session messages.")
 		return
 	}
-	usage := usageReportFromCopilotEvents(events, s.usageProvider, s.usageDimensions)
-	s.usageMu.Lock()
-	s.usage = usage
-	s.usageMu.Unlock()
+	// Replay any persisted usage-bearing events as a fallback. Live events have
+	// already been recorded, so stable request/event identities suppress them.
+	for _, event := range events {
+		s.recordUsageEvent(event)
+	}
 	data, err := json.MarshalIndent(events, "", "  ")
 	if err != nil {
 		s.logger.Error(err, "Failed to marshal session messages for snapshot.")
@@ -416,40 +424,62 @@ func (s *Session) snapshotMessages() {
 	s.lastMessages = data
 }
 
-// usageReportFromCopilotEvents extracts all completed assistant LLM requests
-// from a Copilot conversation history. Recomputing from the full history keeps
-// the aggregate correct across multiple SendAndWait calls and avoids counting
-// the same event more than once.
+// recordUsageEvent aggregates billable requests from the live event stream.
+// assistant.usage events are ephemeral and unavailable through GetEvents, so
+// they must be captured as they are delivered. Compaction usage is emitted on
+// a distinct session.compaction_complete event and represents a separate LLM
+// request.
+func (s *Session) recordUsageEvent(event copilot.SessionEvent) {
+	switch event.Data.(type) {
+	case *copilot.AssistantUsageData, *copilot.SessionCompactionCompleteData:
+	default:
+		return
+	}
+
+	keys := copilotUsageEventKeys(event)
+	s.usageMu.Lock()
+	defer s.usageMu.Unlock()
+	entry, ok := usageBreakdownFromCopilotEvent(event, s.usageProvider, s.usageDimensions, s.usageModel)
+	if !ok {
+		return
+	}
+	if s.seenUsageKeys == nil {
+		s.seenUsageKeys = make(map[string]struct{})
+	}
+	duplicate := false
+	for _, key := range keys {
+		if _, seen := s.seenUsageKeys[key]; seen {
+			duplicate = true
+		}
+		s.seenUsageKeys[key] = struct{}{}
+	}
+	if duplicate {
+		return
+	}
+	if entry.Model != "" {
+		s.usageModel = entry.Model
+	}
+	s.usage.Add(entry)
+}
+
+// usageReportFromCopilotEvents aggregates a supplied event stream. Production
+// sessions call recordUsageEvent from Session.On; this helper keeps conversion
+// and deduplication directly testable without starting the Copilot CLI.
 func usageReportFromCopilotEvents(events []copilot.SessionEvent, provider string, baseDimensions map[string]string) UsageReport {
-	var usage UsageReport
+	s := &Session{
+		usageProvider:   provider,
+		usageDimensions: baseDimensions,
+		seenUsageKeys:   make(map[string]struct{}),
+	}
 	for _, event := range events {
-		data, ok := event.Data.(*copilot.AssistantUsageData)
-		if !ok {
-			continue
-		}
+		s.recordUsageEvent(event)
+	}
+	return s.Usage()
+}
 
-		var inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens int64
-		if data.InputTokens != nil {
-			inputTokens = *data.InputTokens
-		}
-		if data.OutputTokens != nil {
-			outputTokens = *data.OutputTokens
-		}
-		if data.CacheReadTokens != nil {
-			cacheReadTokens = *data.CacheReadTokens
-		}
-		if data.CacheWriteTokens != nil {
-			cacheWriteTokens = *data.CacheWriteTokens
-		}
-
-		// Copilot reports cache reads as part of inputTokens. Normalize the
-		// common schema into mutually exclusive input categories so consumers
-		// can apply different input and cache-read rates without double billing.
-		uncachedInputTokens := inputTokens - cacheReadTokens
-		if uncachedInputTokens < 0 {
-			uncachedInputTokens = 0
-		}
-
+func usageBreakdownFromCopilotEvent(event copilot.SessionEvent, provider string, baseDimensions map[string]string, fallbackModel string) (UsageBreakdown, bool) {
+	switch data := event.Data.(type) {
+	case *copilot.AssistantUsageData:
 		dimensions := cloneStringMap(baseDimensions)
 		if dimensions == nil {
 			dimensions = make(map[string]string)
@@ -476,23 +506,102 @@ func usageReportFromCopilotEvents(events []copilot.SessionEvent, provider string
 		if len(providerReportedCosts) == 0 {
 			providerReportedCosts = nil
 		}
+		tokens := normalizedCopilotTokenUsage(data.InputTokens, data.OutputTokens, data.CacheReadTokens, data.CacheWriteTokens)
+		tokens.OutputTokenDetails = outputDetails
 
-		usage.Add(UsageBreakdown{
-			Provider:   provider,
-			Model:      data.Model,
-			Dimensions: dimensions,
-			Requests:   1,
-			Tokens: TokenUsage{
-				UncachedInputTokens:   uncachedInputTokens,
-				CacheReadInputTokens:  cacheReadTokens,
-				CacheWriteInputTokens: cacheWriteTokens,
-				OutputTokens:          outputTokens,
-				OutputTokenDetails:    outputDetails,
-			},
+		return UsageBreakdown{
+			Provider:              provider,
+			Model:                 data.Model,
+			Dimensions:            dimensions,
+			Requests:              1,
+			Tokens:                tokens,
 			ProviderReportedCosts: providerReportedCosts,
-		})
+		}, true
+
+	case *copilot.SessionCompactionCompleteData:
+		if data.CompactionTokensUsed == nil {
+			return UsageBreakdown{}, false
+		}
+		// Count reported usage even when compaction itself failed: the model
+		// request completed far enough to report usage and may still be billed.
+		compaction := data.CompactionTokensUsed
+		model := fallbackModel
+		if compaction.Model != nil {
+			model = *compaction.Model
+		}
+		providerReportedCosts := make(map[string]float64)
+		if compaction.CopilotUsage != nil {
+			providerReportedCosts["nanoAIU"] = compaction.CopilotUsage.TotalNanoAiu
+		}
+		if len(providerReportedCosts) == 0 {
+			providerReportedCosts = nil
+		}
+
+		return UsageBreakdown{
+			Provider:              provider,
+			Model:                 model,
+			Dimensions:            cloneStringMap(baseDimensions),
+			Requests:              1,
+			Tokens:                normalizedCopilotTokenUsage(compaction.InputTokens, compaction.OutputTokens, compaction.CacheReadTokens, compaction.CacheWriteTokens),
+			ProviderReportedCosts: providerReportedCosts,
+		}, true
 	}
-	return usage
+
+	return UsageBreakdown{}, false
+}
+
+func normalizedCopilotTokenUsage(input, output, cacheRead, cacheWrite *int64) TokenUsage {
+	inputTokens := int64Value(input)
+	cacheReadTokens := int64Value(cacheRead)
+	uncachedInputTokens := inputTokens - cacheReadTokens
+	if uncachedInputTokens < 0 {
+		uncachedInputTokens = 0
+	}
+
+	return TokenUsage{
+		UncachedInputTokens:   uncachedInputTokens,
+		CacheReadInputTokens:  cacheReadTokens,
+		CacheWriteInputTokens: int64Value(cacheWrite),
+		OutputTokens:          int64Value(output),
+	}
+}
+
+func int64Value(value *int64) int64 {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+func copilotUsageEventKeys(event copilot.SessionEvent) []string {
+	keys := make([]string, 0, 4)
+	addKey := func(kind, value string) {
+		if value != "" {
+			keys = append(keys, kind+":"+value)
+		}
+	}
+
+	switch data := event.Data.(type) {
+	case *copilot.AssistantUsageData:
+		if data.APICallID != nil {
+			addKey("api-call", *data.APICallID)
+		}
+		if data.ServiceRequestID != nil {
+			addKey("service-request", *data.ServiceRequestID)
+		}
+		if data.ProviderCallID != nil {
+			addKey("provider-request", *data.ProviderCallID)
+		}
+	case *copilot.SessionCompactionCompleteData:
+		if data.ServiceRequestID != nil {
+			addKey("service-request", *data.ServiceRequestID)
+		}
+		if data.RequestID != nil {
+			addKey("provider-request", *data.RequestID)
+		}
+	}
+	addKey("event", event.ID)
+	return keys
 }
 
 // SaveConversation writes the most recent conversation snapshot to a JSON

--- a/tooling/hcpctl/pkg/agent/agent.go
+++ b/tooling/hcpctl/pkg/agent/agent.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	copilot "github.com/github/copilot-sdk/go"
@@ -152,10 +153,14 @@ type SessionConfig struct {
 // the conversation can be saved even if the CLI process is no longer
 // available (e.g. after ctrl-C kills the subprocess).
 type Session struct {
-	inner        *copilot.Session
-	client       *CopilotClient
-	logger       logr.Logger
-	lastMessages json.RawMessage
+	inner           *copilot.Session
+	client          *CopilotClient
+	logger          logr.Logger
+	lastMessages    json.RawMessage
+	usageMu         sync.RWMutex
+	usage           UsageReport
+	usageProvider   string
+	usageDimensions map[string]string
 }
 
 // CreateSession creates a new Copilot session for an analysis run.
@@ -201,11 +206,19 @@ func (c *CopilotClient) CreateSession(ctx context.Context, logger logr.Logger, c
 
 	logger = logger.WithValues("sessionID", session.SessionID)
 	logger.Info("Created Copilot session.")
+	usageProvider := "github-copilot"
+	usageDimensions := map[string]string{"backend": "github"}
+	if c.cfg.AuthMode == CopilotAuthModeBYOK {
+		usageProvider = "azure-ai-foundry"
+		usageDimensions["backend"] = "byok"
+	}
 
 	s := &Session{
-		inner:  session,
-		client: c,
-		logger: logger,
+		inner:           session,
+		client:          c,
+		logger:          logger,
+		usageProvider:   usageProvider,
+		usageDimensions: usageDimensions,
 	}
 
 	// When verbosity is high enough, trace every session event for debugging.
@@ -300,6 +313,14 @@ func (s *Session) SessionID() string {
 	return s.inner.SessionID
 }
 
+// Usage returns the aggregate token usage observed in the most recent
+// conversation snapshot.
+func (s *Session) Usage() UsageReport {
+	s.usageMu.RLock()
+	defer s.usageMu.RUnlock()
+	return s.usage.Clone()
+}
+
 // SendAndWait sends a prompt to the session and blocks until the agent is idle.
 // If ctx is cancelled, the in-flight work is aborted.
 // Returns the final assistant message content.
@@ -379,12 +400,95 @@ func (s *Session) snapshotMessages() {
 		s.logger.Error(err, "Failed to snapshot session messages.")
 		return
 	}
+	usage := usageReportFromCopilotEvents(events, s.usageProvider, s.usageDimensions)
+	s.usageMu.Lock()
+	s.usage = usage
+	s.usageMu.Unlock()
 	data, err := json.MarshalIndent(events, "", "  ")
 	if err != nil {
 		s.logger.Error(err, "Failed to marshal session messages for snapshot.")
 		return
 	}
 	s.lastMessages = data
+}
+
+// usageReportFromCopilotEvents extracts all completed assistant LLM requests
+// from a Copilot conversation history. Recomputing from the full history keeps
+// the aggregate correct across multiple SendAndWait calls and avoids counting
+// the same event more than once.
+func usageReportFromCopilotEvents(events []copilot.SessionEvent, provider string, baseDimensions map[string]string) UsageReport {
+	var usage UsageReport
+	for _, event := range events {
+		data, ok := event.Data.(*copilot.AssistantUsageData)
+		if !ok {
+			continue
+		}
+
+		var inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens int64
+		if data.InputTokens != nil {
+			inputTokens = *data.InputTokens
+		}
+		if data.OutputTokens != nil {
+			outputTokens = *data.OutputTokens
+		}
+		if data.CacheReadTokens != nil {
+			cacheReadTokens = *data.CacheReadTokens
+		}
+		if data.CacheWriteTokens != nil {
+			cacheWriteTokens = *data.CacheWriteTokens
+		}
+
+		// Copilot reports cache reads as part of inputTokens. Normalize the
+		// common schema into mutually exclusive input categories so consumers
+		// can apply different input and cache-read rates without double billing.
+		uncachedInputTokens := inputTokens - cacheReadTokens
+		if uncachedInputTokens < 0 {
+			uncachedInputTokens = 0
+		}
+
+		dimensions := cloneStringMap(baseDimensions)
+		if dimensions == nil {
+			dimensions = make(map[string]string)
+		}
+		if data.APIEndpoint != nil {
+			dimensions["apiEndpoint"] = string(*data.APIEndpoint)
+		}
+
+		outputDetails := make(map[string]int64)
+		if data.ReasoningTokens != nil && *data.ReasoningTokens > 0 {
+			outputDetails["reasoning"] = *data.ReasoningTokens
+		}
+		if len(outputDetails) == 0 {
+			outputDetails = nil
+		}
+
+		providerReportedCosts := make(map[string]float64)
+		if data.Cost != nil {
+			providerReportedCosts["modelMultiplier"] = *data.Cost
+		}
+		if data.CopilotUsage != nil {
+			providerReportedCosts["nanoAIU"] = data.CopilotUsage.TotalNanoAiu
+		}
+		if len(providerReportedCosts) == 0 {
+			providerReportedCosts = nil
+		}
+
+		usage.Add(UsageBreakdown{
+			Provider:   provider,
+			Model:      data.Model,
+			Dimensions: dimensions,
+			Requests:   1,
+			Tokens: TokenUsage{
+				UncachedInputTokens:   uncachedInputTokens,
+				CacheReadInputTokens:  cacheReadTokens,
+				CacheWriteInputTokens: cacheWriteTokens,
+				OutputTokens:          outputTokens,
+				OutputTokenDetails:    outputDetails,
+			},
+			ProviderReportedCosts: providerReportedCosts,
+		})
+	}
+	return usage
 }
 
 // SaveConversation writes the most recent conversation snapshot to a JSON

--- a/tooling/hcpctl/pkg/agent/agent.go
+++ b/tooling/hcpctl/pkg/agent/agent.go
@@ -161,6 +161,8 @@ type Session struct {
 	usage           UsageReport
 	usageProvider   string
 	usageDimensions map[string]string
+	usageModel      string
+	seenUsageKeys   map[string]struct{}
 }
 
 // CreateSession creates a new Copilot session for an analysis run.
@@ -219,7 +221,13 @@ func (c *CopilotClient) CreateSession(ctx context.Context, logger logr.Logger, c
 		logger:          logger,
 		usageProvider:   usageProvider,
 		usageDimensions: usageDimensions,
+		usageModel:      sessionCfg.Model,
+		seenUsageKeys:   make(map[string]struct{}),
 	}
+	// Register before the first SendAndWait. The SDK dispatches handlers in
+	// registration order, so all preceding usage events are recorded before
+	// SendAndWait's temporary session.idle handler returns to the caller.
+	s.inner.On(s.recordUsageEvent)
 
 	// When verbosity is high enough, trace every session event for debugging.
 	if c.cfg.Verbosity >= 5 {
@@ -313,8 +321,7 @@ func (s *Session) SessionID() string {
 	return s.inner.SessionID
 }
 
-// Usage returns the aggregate token usage observed in the most recent
-// conversation snapshot.
+// Usage returns the aggregate token usage observed from live session events.
 func (s *Session) Usage() UsageReport {
 	s.usageMu.RLock()
 	defer s.usageMu.RUnlock()
@@ -400,10 +407,11 @@ func (s *Session) snapshotMessages() {
 		s.logger.Error(err, "Failed to snapshot session messages.")
 		return
 	}
-	usage := usageReportFromCopilotEvents(events, s.usageProvider, s.usageDimensions)
-	s.usageMu.Lock()
-	s.usage = usage
-	s.usageMu.Unlock()
+	// Replay any persisted usage-bearing events as a fallback. Live events have
+	// already been recorded, so stable request/event identities suppress them.
+	for _, event := range events {
+		s.recordUsageEvent(event)
+	}
 	data, err := json.MarshalIndent(events, "", "  ")
 	if err != nil {
 		s.logger.Error(err, "Failed to marshal session messages for snapshot.")
@@ -412,40 +420,62 @@ func (s *Session) snapshotMessages() {
 	s.lastMessages = data
 }
 
-// usageReportFromCopilotEvents extracts all completed assistant LLM requests
-// from a Copilot conversation history. Recomputing from the full history keeps
-// the aggregate correct across multiple SendAndWait calls and avoids counting
-// the same event more than once.
+// recordUsageEvent aggregates billable requests from the live event stream.
+// assistant.usage events are ephemeral and unavailable through GetEvents, so
+// they must be captured as they are delivered. Compaction usage is emitted on
+// a distinct session.compaction_complete event and represents a separate LLM
+// request.
+func (s *Session) recordUsageEvent(event copilot.SessionEvent) {
+	switch event.Data.(type) {
+	case *copilot.AssistantUsageData, *copilot.SessionCompactionCompleteData:
+	default:
+		return
+	}
+
+	keys := copilotUsageEventKeys(event)
+	s.usageMu.Lock()
+	defer s.usageMu.Unlock()
+	entry, ok := usageBreakdownFromCopilotEvent(event, s.usageProvider, s.usageDimensions, s.usageModel)
+	if !ok {
+		return
+	}
+	if s.seenUsageKeys == nil {
+		s.seenUsageKeys = make(map[string]struct{})
+	}
+	duplicate := false
+	for _, key := range keys {
+		if _, seen := s.seenUsageKeys[key]; seen {
+			duplicate = true
+		}
+		s.seenUsageKeys[key] = struct{}{}
+	}
+	if duplicate {
+		return
+	}
+	if entry.Model != "" {
+		s.usageModel = entry.Model
+	}
+	s.usage.Add(entry)
+}
+
+// usageReportFromCopilotEvents aggregates a supplied event stream. Production
+// sessions call recordUsageEvent from Session.On; this helper keeps conversion
+// and deduplication directly testable without starting the Copilot CLI.
 func usageReportFromCopilotEvents(events []copilot.SessionEvent, provider string, baseDimensions map[string]string) UsageReport {
-	var usage UsageReport
+	s := &Session{
+		usageProvider:   provider,
+		usageDimensions: baseDimensions,
+		seenUsageKeys:   make(map[string]struct{}),
+	}
 	for _, event := range events {
-		data, ok := event.Data.(*copilot.AssistantUsageData)
-		if !ok {
-			continue
-		}
+		s.recordUsageEvent(event)
+	}
+	return s.Usage()
+}
 
-		var inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens int64
-		if data.InputTokens != nil {
-			inputTokens = *data.InputTokens
-		}
-		if data.OutputTokens != nil {
-			outputTokens = *data.OutputTokens
-		}
-		if data.CacheReadTokens != nil {
-			cacheReadTokens = *data.CacheReadTokens
-		}
-		if data.CacheWriteTokens != nil {
-			cacheWriteTokens = *data.CacheWriteTokens
-		}
-
-		// Copilot reports cache reads as part of inputTokens. Normalize the
-		// common schema into mutually exclusive input categories so consumers
-		// can apply different input and cache-read rates without double billing.
-		uncachedInputTokens := inputTokens - cacheReadTokens
-		if uncachedInputTokens < 0 {
-			uncachedInputTokens = 0
-		}
-
+func usageBreakdownFromCopilotEvent(event copilot.SessionEvent, provider string, baseDimensions map[string]string, fallbackModel string) (UsageBreakdown, bool) {
+	switch data := event.Data.(type) {
+	case *copilot.AssistantUsageData:
 		dimensions := cloneStringMap(baseDimensions)
 		if dimensions == nil {
 			dimensions = make(map[string]string)
@@ -472,23 +502,102 @@ func usageReportFromCopilotEvents(events []copilot.SessionEvent, provider string
 		if len(providerReportedCosts) == 0 {
 			providerReportedCosts = nil
 		}
+		tokens := normalizedCopilotTokenUsage(data.InputTokens, data.OutputTokens, data.CacheReadTokens, data.CacheWriteTokens)
+		tokens.OutputTokenDetails = outputDetails
 
-		usage.Add(UsageBreakdown{
-			Provider:   provider,
-			Model:      data.Model,
-			Dimensions: dimensions,
-			Requests:   1,
-			Tokens: TokenUsage{
-				UncachedInputTokens:   uncachedInputTokens,
-				CacheReadInputTokens:  cacheReadTokens,
-				CacheWriteInputTokens: cacheWriteTokens,
-				OutputTokens:          outputTokens,
-				OutputTokenDetails:    outputDetails,
-			},
+		return UsageBreakdown{
+			Provider:              provider,
+			Model:                 data.Model,
+			Dimensions:            dimensions,
+			Requests:              1,
+			Tokens:                tokens,
 			ProviderReportedCosts: providerReportedCosts,
-		})
+		}, true
+
+	case *copilot.SessionCompactionCompleteData:
+		if data.CompactionTokensUsed == nil {
+			return UsageBreakdown{}, false
+		}
+		// Count reported usage even when compaction itself failed: the model
+		// request completed far enough to report usage and may still be billed.
+		compaction := data.CompactionTokensUsed
+		model := fallbackModel
+		if compaction.Model != nil {
+			model = *compaction.Model
+		}
+		providerReportedCosts := make(map[string]float64)
+		if compaction.CopilotUsage != nil {
+			providerReportedCosts["nanoAIU"] = compaction.CopilotUsage.TotalNanoAiu
+		}
+		if len(providerReportedCosts) == 0 {
+			providerReportedCosts = nil
+		}
+
+		return UsageBreakdown{
+			Provider:              provider,
+			Model:                 model,
+			Dimensions:            cloneStringMap(baseDimensions),
+			Requests:              1,
+			Tokens:                normalizedCopilotTokenUsage(compaction.InputTokens, compaction.OutputTokens, compaction.CacheReadTokens, compaction.CacheWriteTokens),
+			ProviderReportedCosts: providerReportedCosts,
+		}, true
 	}
-	return usage
+
+	return UsageBreakdown{}, false
+}
+
+func normalizedCopilotTokenUsage(input, output, cacheRead, cacheWrite *int64) TokenUsage {
+	inputTokens := int64Value(input)
+	cacheReadTokens := int64Value(cacheRead)
+	uncachedInputTokens := inputTokens - cacheReadTokens
+	if uncachedInputTokens < 0 {
+		uncachedInputTokens = 0
+	}
+
+	return TokenUsage{
+		UncachedInputTokens:   uncachedInputTokens,
+		CacheReadInputTokens:  cacheReadTokens,
+		CacheWriteInputTokens: int64Value(cacheWrite),
+		OutputTokens:          int64Value(output),
+	}
+}
+
+func int64Value(value *int64) int64 {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+func copilotUsageEventKeys(event copilot.SessionEvent) []string {
+	keys := make([]string, 0, 4)
+	addKey := func(kind, value string) {
+		if value != "" {
+			keys = append(keys, kind+":"+value)
+		}
+	}
+
+	switch data := event.Data.(type) {
+	case *copilot.AssistantUsageData:
+		if data.APICallID != nil {
+			addKey("api-call", *data.APICallID)
+		}
+		if data.ServiceRequestID != nil {
+			addKey("service-request", *data.ServiceRequestID)
+		}
+		if data.ProviderCallID != nil {
+			addKey("provider-request", *data.ProviderCallID)
+		}
+	case *copilot.SessionCompactionCompleteData:
+		if data.ServiceRequestID != nil {
+			addKey("service-request", *data.ServiceRequestID)
+		}
+		if data.RequestID != nil {
+			addKey("provider-request", *data.RequestID)
+		}
+	}
+	addKey("event", event.ID)
+	return keys
 }
 
 // SaveConversation writes the most recent conversation snapshot to a JSON

--- a/tooling/hcpctl/pkg/agent/agent.go
+++ b/tooling/hcpctl/pkg/agent/agent.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	copilot "github.com/github/copilot-sdk/go"
@@ -152,10 +153,14 @@ type SessionConfig struct {
 // the conversation can be saved even if the CLI process is no longer
 // available (e.g. after ctrl-C kills the subprocess).
 type Session struct {
-	inner        *copilot.Session
-	client       *CopilotClient
-	logger       logr.Logger
-	lastMessages json.RawMessage
+	inner           *copilot.Session
+	client          *CopilotClient
+	logger          logr.Logger
+	lastMessages    json.RawMessage
+	usageMu         sync.RWMutex
+	usage           UsageReport
+	usageProvider   string
+	usageDimensions map[string]string
 }
 
 // CreateSession creates a new Copilot session for an analysis run.
@@ -201,11 +206,19 @@ func (c *CopilotClient) CreateSession(ctx context.Context, logger logr.Logger, c
 
 	logger = logger.WithValues("sessionID", session.SessionID)
 	logger.Info("Created Copilot session.")
+	usageProvider := "github-copilot"
+	usageDimensions := map[string]string{"backend": "github"}
+	if c.cfg.AuthMode == CopilotAuthModeBYOK {
+		usageProvider = "azure-ai-foundry"
+		usageDimensions["backend"] = "byok"
+	}
 
 	s := &Session{
-		inner:  session,
-		client: c,
-		logger: logger,
+		inner:           session,
+		client:          c,
+		logger:          logger,
+		usageProvider:   usageProvider,
+		usageDimensions: usageDimensions,
 	}
 
 	// When verbosity is high enough, trace every session event for debugging.
@@ -304,6 +317,14 @@ func (s *Session) SessionID() string {
 // manages conversation context internally within the CLI subprocess.
 func (s *Session) ResetHistory() {}
 
+// Usage returns the aggregate token usage observed in the most recent
+// conversation snapshot.
+func (s *Session) Usage() UsageReport {
+	s.usageMu.RLock()
+	defer s.usageMu.RUnlock()
+	return s.usage.Clone()
+}
+
 // SendAndWait sends a prompt to the session and blocks until the agent is idle.
 // If ctx is cancelled, the in-flight work is aborted.
 // Returns the final assistant message content.
@@ -383,12 +404,95 @@ func (s *Session) snapshotMessages() {
 		s.logger.Error(err, "Failed to snapshot session messages.")
 		return
 	}
+	usage := usageReportFromCopilotEvents(events, s.usageProvider, s.usageDimensions)
+	s.usageMu.Lock()
+	s.usage = usage
+	s.usageMu.Unlock()
 	data, err := json.MarshalIndent(events, "", "  ")
 	if err != nil {
 		s.logger.Error(err, "Failed to marshal session messages for snapshot.")
 		return
 	}
 	s.lastMessages = data
+}
+
+// usageReportFromCopilotEvents extracts all completed assistant LLM requests
+// from a Copilot conversation history. Recomputing from the full history keeps
+// the aggregate correct across multiple SendAndWait calls and avoids counting
+// the same event more than once.
+func usageReportFromCopilotEvents(events []copilot.SessionEvent, provider string, baseDimensions map[string]string) UsageReport {
+	var usage UsageReport
+	for _, event := range events {
+		data, ok := event.Data.(*copilot.AssistantUsageData)
+		if !ok {
+			continue
+		}
+
+		var inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens int64
+		if data.InputTokens != nil {
+			inputTokens = *data.InputTokens
+		}
+		if data.OutputTokens != nil {
+			outputTokens = *data.OutputTokens
+		}
+		if data.CacheReadTokens != nil {
+			cacheReadTokens = *data.CacheReadTokens
+		}
+		if data.CacheWriteTokens != nil {
+			cacheWriteTokens = *data.CacheWriteTokens
+		}
+
+		// Copilot reports cache reads as part of inputTokens. Normalize the
+		// common schema into mutually exclusive input categories so consumers
+		// can apply different input and cache-read rates without double billing.
+		uncachedInputTokens := inputTokens - cacheReadTokens
+		if uncachedInputTokens < 0 {
+			uncachedInputTokens = 0
+		}
+
+		dimensions := cloneStringMap(baseDimensions)
+		if dimensions == nil {
+			dimensions = make(map[string]string)
+		}
+		if data.APIEndpoint != nil {
+			dimensions["apiEndpoint"] = string(*data.APIEndpoint)
+		}
+
+		outputDetails := make(map[string]int64)
+		if data.ReasoningTokens != nil && *data.ReasoningTokens > 0 {
+			outputDetails["reasoning"] = *data.ReasoningTokens
+		}
+		if len(outputDetails) == 0 {
+			outputDetails = nil
+		}
+
+		providerReportedCosts := make(map[string]float64)
+		if data.Cost != nil {
+			providerReportedCosts["modelMultiplier"] = *data.Cost
+		}
+		if data.CopilotUsage != nil {
+			providerReportedCosts["nanoAIU"] = data.CopilotUsage.TotalNanoAiu
+		}
+		if len(providerReportedCosts) == 0 {
+			providerReportedCosts = nil
+		}
+
+		usage.Add(UsageBreakdown{
+			Provider:   provider,
+			Model:      data.Model,
+			Dimensions: dimensions,
+			Requests:   1,
+			Tokens: TokenUsage{
+				UncachedInputTokens:   uncachedInputTokens,
+				CacheReadInputTokens:  cacheReadTokens,
+				CacheWriteInputTokens: cacheWriteTokens,
+				OutputTokens:          outputTokens,
+				OutputTokenDetails:    outputDetails,
+			},
+			ProviderReportedCosts: providerReportedCosts,
+		})
+	}
+	return usage
 }
 
 // SaveConversation writes the most recent conversation snapshot to a JSON

--- a/tooling/hcpctl/pkg/agent/analyze.go
+++ b/tooling/hcpctl/pkg/agent/analyze.go
@@ -74,6 +74,10 @@ type AnalyzeResult struct {
 
 	// DraftChain is the last validated draft before the final hydration.
 	DraftChain *DraftChain
+
+	// Usage is the aggregate token usage from all LLM requests made during
+	// the analysis.
+	Usage UsageReport
 }
 
 // Analyze runs the full agentic analysis loop: initial prompt, validate-draft,
@@ -189,6 +193,7 @@ func Analyze(ctx context.Context, logger logr.Logger, session LLMSession, kustoC
 	return &AnalyzeResult{
 		HydratedChain: hydratedChain,
 		DraftChain:    draftChain,
+		Usage:         session.Usage(),
 	}, nil
 }
 

--- a/tooling/hcpctl/pkg/agent/analyze.go
+++ b/tooling/hcpctl/pkg/agent/analyze.go
@@ -74,6 +74,10 @@ type AnalyzeResult struct {
 
 	// DraftChain is the last validated draft before the final hydration.
 	DraftChain *DraftChain
+
+	// Usage is the aggregate token usage from all LLM requests made during
+	// the analysis.
+	Usage UsageReport
 }
 
 // Analyze runs the full agentic analysis loop: initial prompt, validate-draft,
@@ -171,6 +175,7 @@ func Analyze(ctx context.Context, logger logr.Logger, session LLMSession, kustoC
 	return &AnalyzeResult{
 		HydratedChain: hydratedChain,
 		DraftChain:    draftChain,
+		Usage:         session.Usage(),
 	}, nil
 }
 

--- a/tooling/hcpctl/pkg/agent/claude_provider.go
+++ b/tooling/hcpctl/pkg/agent/claude_provider.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -142,16 +143,30 @@ func (p *ClaudeProvider) CreateProviderSession(ctx context.Context, logger logr.
 	sessionID := fmt.Sprintf("claude-%d", time.Now().UnixNano())
 	logger = logger.WithValues("sessionID", sessionID)
 	logger.Info("Created Claude session.", "model", model)
+	backend := p.cfg.Backend
+	if backend == "" {
+		backend = ClaudeBackendAPI
+	}
+	provider := "anthropic"
+	dimensions := map[string]string{"backend": backend}
+	if backend == ClaudeBackendVertex {
+		provider = "google-vertex-ai"
+		if p.cfg.VertexRegion != "" {
+			dimensions["region"] = p.cfg.VertexRegion
+		}
+	}
 
 	return &ClaudeSession{
-		client:       p.client,
-		model:        model,
-		systemPrompt: fullSystemPrompt,
-		tools:        tools,
-		toolHandlers: buildToolHandlerMap(cfg.Tools),
-		messages:     nil,
-		sessionID:    sessionID,
-		logger:       logger,
+		client:          p.client,
+		model:           model,
+		systemPrompt:    fullSystemPrompt,
+		tools:           tools,
+		toolHandlers:    buildToolHandlerMap(cfg.Tools),
+		messages:        nil,
+		sessionID:       sessionID,
+		logger:          logger,
+		usageProvider:   provider,
+		usageDimensions: dimensions,
 	}, nil
 }
 
@@ -179,11 +194,22 @@ type ClaudeSession struct {
 	archivedMessages []anthropic.MessageParam
 	sessionID        string
 	logger           logr.Logger
+	usageMu          sync.RWMutex
+	usage            UsageReport
+	usageProvider    string
+	usageDimensions  map[string]string
 }
 
 // SessionID returns the unique identifier for this session.
 func (s *ClaudeSession) SessionID() string {
 	return s.sessionID
+}
+
+// Usage returns the aggregate token usage observed by this session.
+func (s *ClaudeSession) Usage() UsageReport {
+	s.usageMu.RLock()
+	defer s.usageMu.RUnlock()
+	return s.usage.Clone()
 }
 
 // SendAndWait sends a user prompt and blocks until Claude finishes responding,
@@ -233,8 +259,13 @@ func (s *ClaudeSession) SendAndWait(ctx context.Context, prompt string) (string,
 		s.logger.V(3).Info("Claude API responded.",
 			"stopReason", resp.StopReason,
 			"inputTokens", resp.Usage.InputTokens,
+			"cacheReadInputTokens", resp.Usage.CacheReadInputTokens,
+			"cacheWriteInputTokens", resp.Usage.CacheCreationInputTokens,
 			"outputTokens", resp.Usage.OutputTokens,
 		)
+		s.usageMu.Lock()
+		s.usage.Add(usageBreakdownFromClaudeResponse(s.usageProvider, s.usageDimensions, resp))
+		s.usageMu.Unlock()
 
 		// Add assistant response to both the active context and the archive.
 		assistantMsg := resp.ToParam()
@@ -257,6 +288,65 @@ func (s *ClaudeSession) SendAndWait(ctx context.Context, prompt string) (string,
 		toolResultMsg := anthropic.NewUserMessage(toolResults...)
 		s.messages = append(s.messages, toolResultMsg)
 		s.archivedMessages = append(s.archivedMessages, toolResultMsg)
+	}
+}
+
+func usageBreakdownFromClaudeResponse(provider string, baseDimensions map[string]string, resp *anthropic.Message) UsageBreakdown {
+	dimensions := cloneStringMap(baseDimensions)
+	if dimensions == nil {
+		dimensions = make(map[string]string)
+	}
+	if resp.Usage.ServiceTier != "" {
+		dimensions["serviceTier"] = string(resp.Usage.ServiceTier)
+	}
+	if resp.Usage.InferenceGeo != "" {
+		dimensions["inferenceGeo"] = resp.Usage.InferenceGeo
+	}
+
+	cacheWriteByTTL := make(map[string]int64)
+	if resp.Usage.CacheCreation.Ephemeral5mInputTokens > 0 {
+		cacheWriteByTTL["5m"] = resp.Usage.CacheCreation.Ephemeral5mInputTokens
+	}
+	if resp.Usage.CacheCreation.Ephemeral1hInputTokens > 0 {
+		cacheWriteByTTL["1h"] = resp.Usage.CacheCreation.Ephemeral1hInputTokens
+	}
+	if len(cacheWriteByTTL) == 0 {
+		cacheWriteByTTL = nil
+	}
+
+	outputDetails := make(map[string]int64)
+	if resp.Usage.OutputTokensDetails.ThinkingTokens > 0 {
+		outputDetails["reasoning"] = resp.Usage.OutputTokensDetails.ThinkingTokens
+	}
+	if len(outputDetails) == 0 {
+		outputDetails = nil
+	}
+
+	additionalUnits := make(map[string]float64)
+	if resp.Usage.ServerToolUse.WebSearchRequests > 0 {
+		additionalUnits["webSearchRequests"] = float64(resp.Usage.ServerToolUse.WebSearchRequests)
+	}
+	if resp.Usage.ServerToolUse.WebFetchRequests > 0 {
+		additionalUnits["webFetchRequests"] = float64(resp.Usage.ServerToolUse.WebFetchRequests)
+	}
+	if len(additionalUnits) == 0 {
+		additionalUnits = nil
+	}
+
+	return UsageBreakdown{
+		Provider:   provider,
+		Model:      string(resp.Model),
+		Dimensions: dimensions,
+		Requests:   1,
+		Tokens: TokenUsage{
+			UncachedInputTokens:        resp.Usage.InputTokens,
+			CacheReadInputTokens:       resp.Usage.CacheReadInputTokens,
+			CacheWriteInputTokens:      resp.Usage.CacheCreationInputTokens,
+			CacheWriteInputTokensByTTL: cacheWriteByTTL,
+			OutputTokens:               resp.Usage.OutputTokens,
+			OutputTokenDetails:         outputDetails,
+		},
+		AdditionalUnits: additionalUnits,
 	}
 }
 

--- a/tooling/hcpctl/pkg/agent/claude_provider.go
+++ b/tooling/hcpctl/pkg/agent/claude_provider.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -142,16 +143,30 @@ func (p *ClaudeProvider) CreateProviderSession(ctx context.Context, logger logr.
 	sessionID := fmt.Sprintf("claude-%d", time.Now().UnixNano())
 	logger = logger.WithValues("sessionID", sessionID)
 	logger.Info("Created Claude session.", "model", model)
+	backend := p.cfg.Backend
+	if backend == "" {
+		backend = ClaudeBackendAPI
+	}
+	provider := "anthropic"
+	dimensions := map[string]string{"backend": backend}
+	if backend == ClaudeBackendVertex {
+		provider = "google-vertex-ai"
+		if p.cfg.VertexRegion != "" {
+			dimensions["region"] = p.cfg.VertexRegion
+		}
+	}
 
 	return &ClaudeSession{
-		client:       p.client,
-		model:        model,
-		systemPrompt: fullSystemPrompt,
-		tools:        tools,
-		toolHandlers: buildToolHandlerMap(cfg.Tools),
-		messages:     nil,
-		sessionID:    sessionID,
-		logger:       logger,
+		client:          p.client,
+		model:           model,
+		systemPrompt:    fullSystemPrompt,
+		tools:           tools,
+		toolHandlers:    buildToolHandlerMap(cfg.Tools),
+		messages:        nil,
+		sessionID:       sessionID,
+		logger:          logger,
+		usageProvider:   provider,
+		usageDimensions: dimensions,
 	}, nil
 }
 
@@ -165,19 +180,30 @@ func (p *ClaudeProvider) Stop() error {
 // It maintains the conversation history and handles the tool-use loop
 // internally within SendAndWait.
 type ClaudeSession struct {
-	client       anthropic.Client
-	model        string
-	systemPrompt string
-	tools        []anthropic.ToolUnionParam
-	toolHandlers map[string]func(ctx context.Context, params json.RawMessage) (string, error)
-	messages     []anthropic.MessageParam
-	sessionID    string
-	logger       logr.Logger
+	client          anthropic.Client
+	model           string
+	systemPrompt    string
+	tools           []anthropic.ToolUnionParam
+	toolHandlers    map[string]func(ctx context.Context, params json.RawMessage) (string, error)
+	messages        []anthropic.MessageParam
+	sessionID       string
+	logger          logr.Logger
+	usageMu         sync.RWMutex
+	usage           UsageReport
+	usageProvider   string
+	usageDimensions map[string]string
 }
 
 // SessionID returns the unique identifier for this session.
 func (s *ClaudeSession) SessionID() string {
 	return s.sessionID
+}
+
+// Usage returns the aggregate token usage observed by this session.
+func (s *ClaudeSession) Usage() UsageReport {
+	s.usageMu.RLock()
+	defer s.usageMu.RUnlock()
+	return s.usage.Clone()
 }
 
 // SendAndWait sends a user prompt and blocks until Claude finishes responding,
@@ -216,8 +242,13 @@ func (s *ClaudeSession) SendAndWait(ctx context.Context, prompt string) (string,
 		s.logger.V(3).Info("Claude API responded.",
 			"stopReason", resp.StopReason,
 			"inputTokens", resp.Usage.InputTokens,
+			"cacheReadInputTokens", resp.Usage.CacheReadInputTokens,
+			"cacheWriteInputTokens", resp.Usage.CacheCreationInputTokens,
 			"outputTokens", resp.Usage.OutputTokens,
 		)
+		s.usageMu.Lock()
+		s.usage.Add(usageBreakdownFromClaudeResponse(s.usageProvider, s.usageDimensions, resp))
+		s.usageMu.Unlock()
 
 		// Add assistant response to conversation history.
 		s.messages = append(s.messages, resp.ToParam())
@@ -235,6 +266,65 @@ func (s *ClaudeSession) SendAndWait(ctx context.Context, prompt string) (string,
 
 		// Add tool results as user message and continue the loop.
 		s.messages = append(s.messages, anthropic.NewUserMessage(toolResults...))
+	}
+}
+
+func usageBreakdownFromClaudeResponse(provider string, baseDimensions map[string]string, resp *anthropic.Message) UsageBreakdown {
+	dimensions := cloneStringMap(baseDimensions)
+	if dimensions == nil {
+		dimensions = make(map[string]string)
+	}
+	if resp.Usage.ServiceTier != "" {
+		dimensions["serviceTier"] = string(resp.Usage.ServiceTier)
+	}
+	if resp.Usage.InferenceGeo != "" {
+		dimensions["inferenceGeo"] = resp.Usage.InferenceGeo
+	}
+
+	cacheWriteByTTL := make(map[string]int64)
+	if resp.Usage.CacheCreation.Ephemeral5mInputTokens > 0 {
+		cacheWriteByTTL["5m"] = resp.Usage.CacheCreation.Ephemeral5mInputTokens
+	}
+	if resp.Usage.CacheCreation.Ephemeral1hInputTokens > 0 {
+		cacheWriteByTTL["1h"] = resp.Usage.CacheCreation.Ephemeral1hInputTokens
+	}
+	if len(cacheWriteByTTL) == 0 {
+		cacheWriteByTTL = nil
+	}
+
+	outputDetails := make(map[string]int64)
+	if resp.Usage.OutputTokensDetails.ThinkingTokens > 0 {
+		outputDetails["reasoning"] = resp.Usage.OutputTokensDetails.ThinkingTokens
+	}
+	if len(outputDetails) == 0 {
+		outputDetails = nil
+	}
+
+	additionalUnits := make(map[string]float64)
+	if resp.Usage.ServerToolUse.WebSearchRequests > 0 {
+		additionalUnits["webSearchRequests"] = float64(resp.Usage.ServerToolUse.WebSearchRequests)
+	}
+	if resp.Usage.ServerToolUse.WebFetchRequests > 0 {
+		additionalUnits["webFetchRequests"] = float64(resp.Usage.ServerToolUse.WebFetchRequests)
+	}
+	if len(additionalUnits) == 0 {
+		additionalUnits = nil
+	}
+
+	return UsageBreakdown{
+		Provider:   provider,
+		Model:      string(resp.Model),
+		Dimensions: dimensions,
+		Requests:   1,
+		Tokens: TokenUsage{
+			UncachedInputTokens:        resp.Usage.InputTokens,
+			CacheReadInputTokens:       resp.Usage.CacheReadInputTokens,
+			CacheWriteInputTokens:      resp.Usage.CacheCreationInputTokens,
+			CacheWriteInputTokensByTTL: cacheWriteByTTL,
+			OutputTokens:               resp.Usage.OutputTokens,
+			OutputTokenDetails:         outputDetails,
+		},
+		AdditionalUnits: additionalUnits,
 	}
 }
 

--- a/tooling/hcpctl/pkg/agent/provider.go
+++ b/tooling/hcpctl/pkg/agent/provider.go
@@ -17,6 +17,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/go-logr/logr"
 )
@@ -51,6 +52,11 @@ type LLMSession interface {
 	// manage conversation state server-side (e.g. Copilot SDK) may
 	// implement this as a no-op.
 	ResetHistory()
+
+	// Usage returns the aggregate usage observed by this session.
+	// Implementations include every completed LLM request made while handling
+	// SendAndWait calls, including requests made during tool-use loops.
+	Usage() UsageReport
 
 	// SaveConversation writes the conversation history to a JSON file at
 	// the given path. This is best-effort: implementations should log
@@ -108,6 +114,189 @@ type ProviderSessionConfig struct {
 	// Model overrides the provider's default model for this session.
 	// When empty, the provider uses its configured default.
 	Model string
+}
+
+// UsageReport contains the billable usage dimensions for an LLM session.
+// Totals make the report convenient for operational telemetry, while Breakdown
+// preserves the provider, model, backend, service tier, and other dimensions
+// needed to apply an external price book accurately. StartedAt and EndedAt
+// bound the reporting interval so consumers can select time-dependent rates.
+type UsageReport struct {
+	StartedAt             time.Time          `json:"startedAt"`
+	EndedAt               time.Time          `json:"endedAt"`
+	Requests              int64              `json:"requests"`
+	Tokens                TokenUsage         `json:"tokens"`
+	AdditionalUnits       map[string]float64 `json:"additionalUnits,omitempty"`
+	ProviderReportedCosts map[string]float64 `json:"providerReportedCosts,omitempty"`
+	Breakdown             []UsageBreakdown   `json:"breakdown,omitempty"`
+}
+
+// UsageBreakdown aggregates requests with the same pricing identity.
+// Dimensions is deliberately open-ended so providers can expose pricing
+// attributes without changing the common schema.
+type UsageBreakdown struct {
+	Provider              string             `json:"provider"`
+	Model                 string             `json:"model"`
+	Dimensions            map[string]string  `json:"dimensions,omitempty"`
+	Requests              int64              `json:"requests"`
+	Tokens                TokenUsage         `json:"tokens"`
+	AdditionalUnits       map[string]float64 `json:"additionalUnits,omitempty"`
+	ProviderReportedCosts map[string]float64 `json:"providerReportedCosts,omitempty"`
+}
+
+// TokenUsage separates the token categories that may have different prices.
+// The input categories are normalized to be mutually exclusive, even when a
+// provider reports cache reads as part of its input token count.
+type TokenUsage struct {
+	UncachedInputTokens        int64            `json:"uncachedInputTokens"`
+	CacheReadInputTokens       int64            `json:"cacheReadInputTokens"`
+	CacheWriteInputTokens      int64            `json:"cacheWriteInputTokens"`
+	CacheWriteInputTokensByTTL map[string]int64 `json:"cacheWriteInputTokensByTTL,omitempty"`
+	OutputTokens               int64            `json:"outputTokens"`
+	OutputTokenDetails         map[string]int64 `json:"outputTokenDetails,omitempty"`
+	TotalTokens                int64            `json:"totalTokens"`
+}
+
+// Add merges token usage and recomputes TotalTokens from the mutually
+// exclusive top-level token categories. Token details are subsets and are not
+// added to the total.
+func (u *TokenUsage) Add(other TokenUsage) {
+	u.UncachedInputTokens += other.UncachedInputTokens
+	u.CacheReadInputTokens += other.CacheReadInputTokens
+	u.CacheWriteInputTokens += other.CacheWriteInputTokens
+	u.OutputTokens += other.OutputTokens
+	addInt64Values(&u.CacheWriteInputTokensByTTL, other.CacheWriteInputTokensByTTL)
+	addInt64Values(&u.OutputTokenDetails, other.OutputTokenDetails)
+	u.TotalTokens = u.UncachedInputTokens + u.CacheReadInputTokens + u.CacheWriteInputTokens + u.OutputTokens
+}
+
+// Add merges one pricing-homogeneous usage entry into the report.
+func (u *UsageReport) Add(entry UsageBreakdown) {
+	u.Requests += entry.Requests
+	u.Tokens.Add(entry.Tokens)
+	addFloat64Values(&u.AdditionalUnits, entry.AdditionalUnits)
+	addFloat64Values(&u.ProviderReportedCosts, entry.ProviderReportedCosts)
+
+	for i := range u.Breakdown {
+		if u.Breakdown[i].Provider == entry.Provider &&
+			u.Breakdown[i].Model == entry.Model &&
+			stringMapsEqual(u.Breakdown[i].Dimensions, entry.Dimensions) {
+			u.Breakdown[i].Requests += entry.Requests
+			u.Breakdown[i].Tokens.Add(entry.Tokens)
+			addFloat64Values(&u.Breakdown[i].AdditionalUnits, entry.AdditionalUnits)
+			addFloat64Values(&u.Breakdown[i].ProviderReportedCosts, entry.ProviderReportedCosts)
+			return
+		}
+	}
+
+	entry.Tokens.TotalTokens = entry.Tokens.UncachedInputTokens + entry.Tokens.CacheReadInputTokens + entry.Tokens.CacheWriteInputTokens + entry.Tokens.OutputTokens
+	entry.Dimensions = cloneStringMap(entry.Dimensions)
+	entry.Tokens.CacheWriteInputTokensByTTL = cloneInt64Map(entry.Tokens.CacheWriteInputTokensByTTL)
+	entry.Tokens.OutputTokenDetails = cloneInt64Map(entry.Tokens.OutputTokenDetails)
+	entry.AdditionalUnits = cloneFloat64Map(entry.AdditionalUnits)
+	entry.ProviderReportedCosts = cloneFloat64Map(entry.ProviderReportedCosts)
+	u.Breakdown = append(u.Breakdown, entry)
+}
+
+// Clone returns a deep copy suitable for returning while a provider may still
+// be recording usage in another goroutine.
+func (u UsageReport) Clone() UsageReport {
+	clone := UsageReport{
+		StartedAt:             u.StartedAt,
+		EndedAt:               u.EndedAt,
+		Requests:              u.Requests,
+		Tokens:                u.Tokens.clone(),
+		AdditionalUnits:       cloneFloat64Map(u.AdditionalUnits),
+		ProviderReportedCosts: cloneFloat64Map(u.ProviderReportedCosts),
+		Breakdown:             make([]UsageBreakdown, len(u.Breakdown)),
+	}
+	for i := range u.Breakdown {
+		clone.Breakdown[i] = UsageBreakdown{
+			Provider:              u.Breakdown[i].Provider,
+			Model:                 u.Breakdown[i].Model,
+			Dimensions:            cloneStringMap(u.Breakdown[i].Dimensions),
+			Requests:              u.Breakdown[i].Requests,
+			Tokens:                u.Breakdown[i].Tokens.clone(),
+			AdditionalUnits:       cloneFloat64Map(u.Breakdown[i].AdditionalUnits),
+			ProviderReportedCosts: cloneFloat64Map(u.Breakdown[i].ProviderReportedCosts),
+		}
+	}
+	return clone
+}
+
+func (u TokenUsage) clone() TokenUsage {
+	u.CacheWriteInputTokensByTTL = cloneInt64Map(u.CacheWriteInputTokensByTTL)
+	u.OutputTokenDetails = cloneInt64Map(u.OutputTokenDetails)
+	return u
+}
+
+func addInt64Values(destination *map[string]int64, source map[string]int64) {
+	if len(source) == 0 {
+		return
+	}
+	if *destination == nil {
+		*destination = make(map[string]int64, len(source))
+	}
+	for key, value := range source {
+		(*destination)[key] += value
+	}
+}
+
+func addFloat64Values(destination *map[string]float64, source map[string]float64) {
+	if len(source) == 0 {
+		return
+	}
+	if *destination == nil {
+		*destination = make(map[string]float64, len(source))
+	}
+	for key, value := range source {
+		(*destination)[key] += value
+	}
+}
+
+func stringMapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, value := range a {
+		if b[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneStringMap(source map[string]string) map[string]string {
+	if source == nil {
+		return nil
+	}
+	clone := make(map[string]string, len(source))
+	for key, value := range source {
+		clone[key] = value
+	}
+	return clone
+}
+
+func cloneInt64Map(source map[string]int64) map[string]int64 {
+	if source == nil {
+		return nil
+	}
+	clone := make(map[string]int64, len(source))
+	for key, value := range source {
+		clone[key] = value
+	}
+	return clone
+}
+
+func cloneFloat64Map(source map[string]float64) map[string]float64 {
+	if source == nil {
+		return nil
+	}
+	clone := make(map[string]float64, len(source))
+	for key, value := range source {
+		clone[key] = value
+	}
+	return clone
 }
 
 // ToolDefinition is a provider-neutral description of a tool that can be

--- a/tooling/hcpctl/pkg/agent/provider.go
+++ b/tooling/hcpctl/pkg/agent/provider.go
@@ -17,6 +17,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/go-logr/logr"
 )
@@ -45,6 +46,11 @@ type LLMSession interface {
 	// responding, including any tool-use rounds. Returns the final
 	// assistant text content.
 	SendAndWait(ctx context.Context, prompt string) (string, error)
+
+	// Usage returns the aggregate usage observed by this session.
+	// Implementations include every completed LLM request made while handling
+	// SendAndWait calls, including requests made during tool-use loops.
+	Usage() UsageReport
 
 	// SaveConversation writes the conversation history to a JSON file at
 	// the given path. This is best-effort: implementations should log
@@ -102,6 +108,189 @@ type ProviderSessionConfig struct {
 	// Model overrides the provider's default model for this session.
 	// When empty, the provider uses its configured default.
 	Model string
+}
+
+// UsageReport contains the billable usage dimensions for an LLM session.
+// Totals make the report convenient for operational telemetry, while Breakdown
+// preserves the provider, model, backend, service tier, and other dimensions
+// needed to apply an external price book accurately. StartedAt and EndedAt
+// bound the reporting interval so consumers can select time-dependent rates.
+type UsageReport struct {
+	StartedAt             time.Time          `json:"startedAt"`
+	EndedAt               time.Time          `json:"endedAt"`
+	Requests              int64              `json:"requests"`
+	Tokens                TokenUsage         `json:"tokens"`
+	AdditionalUnits       map[string]float64 `json:"additionalUnits,omitempty"`
+	ProviderReportedCosts map[string]float64 `json:"providerReportedCosts,omitempty"`
+	Breakdown             []UsageBreakdown   `json:"breakdown,omitempty"`
+}
+
+// UsageBreakdown aggregates requests with the same pricing identity.
+// Dimensions is deliberately open-ended so providers can expose pricing
+// attributes without changing the common schema.
+type UsageBreakdown struct {
+	Provider              string             `json:"provider"`
+	Model                 string             `json:"model"`
+	Dimensions            map[string]string  `json:"dimensions,omitempty"`
+	Requests              int64              `json:"requests"`
+	Tokens                TokenUsage         `json:"tokens"`
+	AdditionalUnits       map[string]float64 `json:"additionalUnits,omitempty"`
+	ProviderReportedCosts map[string]float64 `json:"providerReportedCosts,omitempty"`
+}
+
+// TokenUsage separates the token categories that may have different prices.
+// The input categories are normalized to be mutually exclusive, even when a
+// provider reports cache reads as part of its input token count.
+type TokenUsage struct {
+	UncachedInputTokens        int64            `json:"uncachedInputTokens"`
+	CacheReadInputTokens       int64            `json:"cacheReadInputTokens"`
+	CacheWriteInputTokens      int64            `json:"cacheWriteInputTokens"`
+	CacheWriteInputTokensByTTL map[string]int64 `json:"cacheWriteInputTokensByTTL,omitempty"`
+	OutputTokens               int64            `json:"outputTokens"`
+	OutputTokenDetails         map[string]int64 `json:"outputTokenDetails,omitempty"`
+	TotalTokens                int64            `json:"totalTokens"`
+}
+
+// Add merges token usage and recomputes TotalTokens from the mutually
+// exclusive top-level token categories. Token details are subsets and are not
+// added to the total.
+func (u *TokenUsage) Add(other TokenUsage) {
+	u.UncachedInputTokens += other.UncachedInputTokens
+	u.CacheReadInputTokens += other.CacheReadInputTokens
+	u.CacheWriteInputTokens += other.CacheWriteInputTokens
+	u.OutputTokens += other.OutputTokens
+	addInt64Values(&u.CacheWriteInputTokensByTTL, other.CacheWriteInputTokensByTTL)
+	addInt64Values(&u.OutputTokenDetails, other.OutputTokenDetails)
+	u.TotalTokens = u.UncachedInputTokens + u.CacheReadInputTokens + u.CacheWriteInputTokens + u.OutputTokens
+}
+
+// Add merges one pricing-homogeneous usage entry into the report.
+func (u *UsageReport) Add(entry UsageBreakdown) {
+	u.Requests += entry.Requests
+	u.Tokens.Add(entry.Tokens)
+	addFloat64Values(&u.AdditionalUnits, entry.AdditionalUnits)
+	addFloat64Values(&u.ProviderReportedCosts, entry.ProviderReportedCosts)
+
+	for i := range u.Breakdown {
+		if u.Breakdown[i].Provider == entry.Provider &&
+			u.Breakdown[i].Model == entry.Model &&
+			stringMapsEqual(u.Breakdown[i].Dimensions, entry.Dimensions) {
+			u.Breakdown[i].Requests += entry.Requests
+			u.Breakdown[i].Tokens.Add(entry.Tokens)
+			addFloat64Values(&u.Breakdown[i].AdditionalUnits, entry.AdditionalUnits)
+			addFloat64Values(&u.Breakdown[i].ProviderReportedCosts, entry.ProviderReportedCosts)
+			return
+		}
+	}
+
+	entry.Tokens.TotalTokens = entry.Tokens.UncachedInputTokens + entry.Tokens.CacheReadInputTokens + entry.Tokens.CacheWriteInputTokens + entry.Tokens.OutputTokens
+	entry.Dimensions = cloneStringMap(entry.Dimensions)
+	entry.Tokens.CacheWriteInputTokensByTTL = cloneInt64Map(entry.Tokens.CacheWriteInputTokensByTTL)
+	entry.Tokens.OutputTokenDetails = cloneInt64Map(entry.Tokens.OutputTokenDetails)
+	entry.AdditionalUnits = cloneFloat64Map(entry.AdditionalUnits)
+	entry.ProviderReportedCosts = cloneFloat64Map(entry.ProviderReportedCosts)
+	u.Breakdown = append(u.Breakdown, entry)
+}
+
+// Clone returns a deep copy suitable for returning while a provider may still
+// be recording usage in another goroutine.
+func (u UsageReport) Clone() UsageReport {
+	clone := UsageReport{
+		StartedAt:             u.StartedAt,
+		EndedAt:               u.EndedAt,
+		Requests:              u.Requests,
+		Tokens:                u.Tokens.clone(),
+		AdditionalUnits:       cloneFloat64Map(u.AdditionalUnits),
+		ProviderReportedCosts: cloneFloat64Map(u.ProviderReportedCosts),
+		Breakdown:             make([]UsageBreakdown, len(u.Breakdown)),
+	}
+	for i := range u.Breakdown {
+		clone.Breakdown[i] = UsageBreakdown{
+			Provider:              u.Breakdown[i].Provider,
+			Model:                 u.Breakdown[i].Model,
+			Dimensions:            cloneStringMap(u.Breakdown[i].Dimensions),
+			Requests:              u.Breakdown[i].Requests,
+			Tokens:                u.Breakdown[i].Tokens.clone(),
+			AdditionalUnits:       cloneFloat64Map(u.Breakdown[i].AdditionalUnits),
+			ProviderReportedCosts: cloneFloat64Map(u.Breakdown[i].ProviderReportedCosts),
+		}
+	}
+	return clone
+}
+
+func (u TokenUsage) clone() TokenUsage {
+	u.CacheWriteInputTokensByTTL = cloneInt64Map(u.CacheWriteInputTokensByTTL)
+	u.OutputTokenDetails = cloneInt64Map(u.OutputTokenDetails)
+	return u
+}
+
+func addInt64Values(destination *map[string]int64, source map[string]int64) {
+	if len(source) == 0 {
+		return
+	}
+	if *destination == nil {
+		*destination = make(map[string]int64, len(source))
+	}
+	for key, value := range source {
+		(*destination)[key] += value
+	}
+}
+
+func addFloat64Values(destination *map[string]float64, source map[string]float64) {
+	if len(source) == 0 {
+		return
+	}
+	if *destination == nil {
+		*destination = make(map[string]float64, len(source))
+	}
+	for key, value := range source {
+		(*destination)[key] += value
+	}
+}
+
+func stringMapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for key, value := range a {
+		if b[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneStringMap(source map[string]string) map[string]string {
+	if source == nil {
+		return nil
+	}
+	clone := make(map[string]string, len(source))
+	for key, value := range source {
+		clone[key] = value
+	}
+	return clone
+}
+
+func cloneInt64Map(source map[string]int64) map[string]int64 {
+	if source == nil {
+		return nil
+	}
+	clone := make(map[string]int64, len(source))
+	for key, value := range source {
+		clone[key] = value
+	}
+	return clone
+}
+
+func cloneFloat64Map(source map[string]float64) map[string]float64 {
+	if source == nil {
+		return nil
+	}
+	clone := make(map[string]float64, len(source))
+	for key, value := range source {
+		clone[key] = value
+	}
+	return clone
 }
 
 // ToolDefinition is a provider-neutral description of a tool that can be

--- a/tooling/hcpctl/pkg/agent/provider_test.go
+++ b/tooling/hcpctl/pkg/agent/provider_test.go
@@ -15,6 +15,8 @@
 package agent
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/anthropics/anthropic-sdk-go"
@@ -96,42 +98,122 @@ func TestUsageReportFromCopilotEvents(t *testing.T) {
 	input1, output1 := int64(100), int64(25)
 	cacheRead1, cacheWrite1, reasoning1 := int64(20), int64(10), int64(5)
 	input2, output2 := int64(10), int64(5)
+	compactionInput, compactionOutput := int64(50), int64(4)
+	compactionCacheRead, compactionCacheWrite := int64(40), int64(3)
 	cost1, cost2 := 1.5, 0.5
 	endpoint := copilot.AssistantUsageAPIEndpointResponses
+	apiCallID := "api-call-1"
+	compactionServiceRequestID := "compaction-service-request"
+	model := "gpt-test"
+	firstUsage := &copilot.AssistantUsageData{
+		Model:            model,
+		APICallID:        &apiCallID,
+		APIEndpoint:      &endpoint,
+		InputTokens:      &input1,
+		OutputTokens:     &output1,
+		CacheReadTokens:  &cacheRead1,
+		CacheWriteTokens: &cacheWrite1,
+		ReasoningTokens:  &reasoning1,
+		Cost:             &cost1,
+		CopilotUsage:     &rpc.AssistantUsageCopilotUsage{TotalNanoAiu: 7},
+	}
+	compaction := &copilot.SessionCompactionCompleteData{
+		Success:          true,
+		ServiceRequestID: &compactionServiceRequestID,
+		// Model is intentionally omitted to verify that compaction inherits the
+		// most recently observed model when the optional SDK field is absent.
+		CompactionTokensUsed: &copilot.CompactionCompleteCompactionTokensUsed{
+			InputTokens:      &compactionInput,
+			OutputTokens:     &compactionOutput,
+			CacheReadTokens:  &compactionCacheRead,
+			CacheWriteTokens: &compactionCacheWrite,
+			CopilotUsage:     &rpc.CompactionCompleteCompactionTokensUsedCopilotUsage{TotalNanoAiu: 3},
+		},
+	}
 
 	usage := usageReportFromCopilotEvents([]copilot.SessionEvent{
-		{Data: &copilot.AssistantUsageData{
-			Model:            "gpt-test",
-			APIEndpoint:      &endpoint,
-			InputTokens:      &input1,
-			OutputTokens:     &output1,
-			CacheReadTokens:  &cacheRead1,
-			CacheWriteTokens: &cacheWrite1,
-			ReasoningTokens:  &reasoning1,
-			Cost:             &cost1,
-			CopilotUsage:     &rpc.AssistantUsageCopilotUsage{TotalNanoAiu: 7},
-		}},
-		{Data: &copilot.AssistantUsageData{Model: "gpt-test", APIEndpoint: &endpoint, InputTokens: &input2, OutputTokens: &output2, Cost: &cost2}},
+		{ID: "usage-event-1", Data: firstUsage},
+		// The same API call may be replayed with a different event ID. It must
+		// still be counted only once.
+		{ID: "usage-event-1-replayed", Data: firstUsage},
+		{ID: "usage-event-2", Data: &copilot.AssistantUsageData{Model: model, APIEndpoint: &endpoint, InputTokens: &input2, OutputTokens: &output2, Cost: &cost2}},
+		{ID: "compaction-event", Data: compaction},
+		// Compaction events use their request IDs for cross-delivery deduplication.
+		{ID: "compaction-event-replayed", Data: compaction},
 		{Data: &copilot.SessionInfoData{}},
 	}, "github-copilot", map[string]string{"backend": "github"})
 
-	if usage.Requests != 2 {
-		t.Errorf("Requests = %d, want 2", usage.Requests)
+	if usage.Requests != 3 {
+		t.Errorf("Requests = %d, want 3", usage.Requests)
 	}
-	if usage.Tokens.UncachedInputTokens != 90 || usage.Tokens.CacheReadInputTokens != 20 || usage.Tokens.CacheWriteInputTokens != 10 || usage.Tokens.OutputTokens != 30 {
-		t.Errorf("Tokens = %+v, want input=90 cacheRead=20 cacheWrite=10 output=30", usage.Tokens)
+	if usage.Tokens.UncachedInputTokens != 100 || usage.Tokens.CacheReadInputTokens != 60 || usage.Tokens.CacheWriteInputTokens != 13 || usage.Tokens.OutputTokens != 34 {
+		t.Errorf("Tokens = %+v, want input=100 cacheRead=60 cacheWrite=13 output=34", usage.Tokens)
 	}
-	if usage.Tokens.TotalTokens != 150 {
-		t.Errorf("TotalTokens = %d, want 150", usage.Tokens.TotalTokens)
+	if usage.Tokens.TotalTokens != 207 {
+		t.Errorf("TotalTokens = %d, want 207", usage.Tokens.TotalTokens)
 	}
 	if usage.Tokens.OutputTokenDetails["reasoning"] != 5 {
 		t.Errorf("OutputTokenDetails = %+v, want reasoning=5", usage.Tokens.OutputTokenDetails)
 	}
-	if usage.ProviderReportedCosts["modelMultiplier"] != 2 || usage.ProviderReportedCosts["nanoAIU"] != 7 {
-		t.Errorf("ProviderReportedCosts = %+v, want modelMultiplier=2 nanoAIU=7", usage.ProviderReportedCosts)
+	if usage.ProviderReportedCosts["modelMultiplier"] != 2 || usage.ProviderReportedCosts["nanoAIU"] != 10 {
+		t.Errorf("ProviderReportedCosts = %+v, want modelMultiplier=2 nanoAIU=10", usage.ProviderReportedCosts)
 	}
-	if len(usage.Breakdown) != 1 || usage.Breakdown[0].Dimensions["apiEndpoint"] != "/responses" {
-		t.Errorf("Breakdown = %+v, want one /responses entry", usage.Breakdown)
+	if len(usage.Breakdown) != 2 || usage.Breakdown[0].Dimensions["apiEndpoint"] != "/responses" || usage.Breakdown[1].Requests != 1 || usage.Breakdown[1].Model != model {
+		t.Errorf("Breakdown = %+v, want normal and compaction entries", usage.Breakdown)
+	}
+}
+
+func TestCopilotCompactionUsageRequiresReportedTokens(t *testing.T) {
+	input := int64(12)
+	model := "gpt-test"
+	usage := usageReportFromCopilotEvents([]copilot.SessionEvent{
+		{ID: "failed-compaction-with-usage", Data: &copilot.SessionCompactionCompleteData{
+			Success: false,
+			CompactionTokensUsed: &copilot.CompactionCompleteCompactionTokensUsed{
+				Model:       &model,
+				InputTokens: &input,
+			},
+		}},
+		{ID: "failed-compaction-without-usage", Data: &copilot.SessionCompactionCompleteData{Success: false}},
+	}, "github-copilot", map[string]string{"backend": "github"})
+
+	if usage.Requests != 1 || usage.Tokens.TotalTokens != input {
+		t.Errorf("Usage() = requests:%d totalTokens:%d, want requests:1 totalTokens:%d", usage.Requests, usage.Tokens.TotalTokens, input)
+	}
+}
+
+func TestRecordCopilotUsageEventConcurrent(t *testing.T) {
+	session := &Session{
+		usageProvider:   "github-copilot",
+		usageDimensions: map[string]string{"backend": "github"},
+		seenUsageKeys:   make(map[string]struct{}),
+	}
+
+	const requests = 50
+	var wg sync.WaitGroup
+	for i := 0; i < requests; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			input, output := int64(1), int64(1)
+			apiCallID := fmt.Sprintf("api-call-%d", i)
+			session.recordUsageEvent(copilot.SessionEvent{
+				ID: fmt.Sprintf("usage-event-%d", i),
+				Data: &copilot.AssistantUsageData{
+					Model:        "gpt-test",
+					APICallID:    &apiCallID,
+					InputTokens:  &input,
+					OutputTokens: &output,
+				},
+			})
+			_ = session.Usage()
+		}(i)
+	}
+	wg.Wait()
+
+	usage := session.Usage()
+	if usage.Requests != requests || usage.Tokens.TotalTokens != requests*2 {
+		t.Errorf("Usage() = requests:%d totalTokens:%d, want requests:%d totalTokens:%d", usage.Requests, usage.Tokens.TotalTokens, requests, requests*2)
 	}
 }
 

--- a/tooling/hcpctl/pkg/agent/provider_test.go
+++ b/tooling/hcpctl/pkg/agent/provider_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	copilot "github.com/github/copilot-sdk/go"
+	"github.com/github/copilot-sdk/go/rpc"
+)
+
+func TestUsageReportAdd(t *testing.T) {
+	var report UsageReport
+	report.Add(UsageBreakdown{
+		Provider:   "anthropic",
+		Model:      "claude-test",
+		Dimensions: map[string]string{"backend": "api", "serviceTier": "standard"},
+		Requests:   1,
+		Tokens: TokenUsage{
+			UncachedInputTokens:        100,
+			CacheReadInputTokens:       20,
+			CacheWriteInputTokens:      30,
+			CacheWriteInputTokensByTTL: map[string]int64{"5m": 30},
+			OutputTokens:               25,
+			OutputTokenDetails:         map[string]int64{"reasoning": 5},
+		},
+		AdditionalUnits:       map[string]float64{"webSearchRequests": 1},
+		ProviderReportedCosts: map[string]float64{"credits": 1.5},
+	})
+	report.Add(UsageBreakdown{
+		Provider:   "anthropic",
+		Model:      "claude-test",
+		Dimensions: map[string]string{"backend": "api", "serviceTier": "standard"},
+		Requests:   1,
+		Tokens: TokenUsage{
+			UncachedInputTokens:        10,
+			CacheReadInputTokens:       2,
+			CacheWriteInputTokens:      4,
+			CacheWriteInputTokensByTTL: map[string]int64{"1h": 4},
+			OutputTokens:               5,
+			OutputTokenDetails:         map[string]int64{"reasoning": 1},
+		},
+		AdditionalUnits:       map[string]float64{"webSearchRequests": 2},
+		ProviderReportedCosts: map[string]float64{"credits": 0.5},
+	})
+	report.Add(UsageBreakdown{
+		Provider:   "anthropic",
+		Model:      "claude-test",
+		Dimensions: map[string]string{"backend": "api", "serviceTier": "priority"},
+		Requests:   1,
+	})
+
+	if report.Requests != 3 {
+		t.Errorf("Requests = %d, want 3", report.Requests)
+	}
+	if report.Tokens.UncachedInputTokens != 110 || report.Tokens.CacheReadInputTokens != 22 || report.Tokens.CacheWriteInputTokens != 34 || report.Tokens.OutputTokens != 30 {
+		t.Errorf("Tokens = %+v, want input=110 cacheRead=22 cacheWrite=34 output=30", report.Tokens)
+	}
+	if report.Tokens.TotalTokens != 196 {
+		t.Errorf("TotalTokens = %d, want 196", report.Tokens.TotalTokens)
+	}
+	if report.Tokens.CacheWriteInputTokensByTTL["5m"] != 30 || report.Tokens.CacheWriteInputTokensByTTL["1h"] != 4 {
+		t.Errorf("CacheWriteInputTokensByTTL = %+v, want 5m=30 1h=4", report.Tokens.CacheWriteInputTokensByTTL)
+	}
+	if report.Tokens.OutputTokenDetails["reasoning"] != 6 {
+		t.Errorf("OutputTokenDetails = %+v, want reasoning=6", report.Tokens.OutputTokenDetails)
+	}
+	if report.AdditionalUnits["webSearchRequests"] != 3 {
+		t.Errorf("AdditionalUnits = %+v, want webSearchRequests=3", report.AdditionalUnits)
+	}
+	if report.ProviderReportedCosts["credits"] != 2 {
+		t.Errorf("ProviderReportedCosts = %+v, want credits=2", report.ProviderReportedCosts)
+	}
+	if len(report.Breakdown) != 2 {
+		t.Fatalf("len(Breakdown) = %d, want 2", len(report.Breakdown))
+	}
+	if report.Breakdown[0].Requests != 2 {
+		t.Errorf("Breakdown[0].Requests = %d, want 2", report.Breakdown[0].Requests)
+	}
+}
+
+func TestUsageReportFromCopilotEvents(t *testing.T) {
+	input1, output1 := int64(100), int64(25)
+	cacheRead1, cacheWrite1, reasoning1 := int64(20), int64(10), int64(5)
+	input2, output2 := int64(10), int64(5)
+	cost1, cost2 := 1.5, 0.5
+	endpoint := copilot.AssistantUsageAPIEndpointResponses
+
+	usage := usageReportFromCopilotEvents([]copilot.SessionEvent{
+		{Data: &copilot.AssistantUsageData{
+			Model:            "gpt-test",
+			APIEndpoint:      &endpoint,
+			InputTokens:      &input1,
+			OutputTokens:     &output1,
+			CacheReadTokens:  &cacheRead1,
+			CacheWriteTokens: &cacheWrite1,
+			ReasoningTokens:  &reasoning1,
+			Cost:             &cost1,
+			CopilotUsage:     &rpc.AssistantUsageCopilotUsage{TotalNanoAiu: 7},
+		}},
+		{Data: &copilot.AssistantUsageData{Model: "gpt-test", APIEndpoint: &endpoint, InputTokens: &input2, OutputTokens: &output2, Cost: &cost2}},
+		{Data: &copilot.SessionInfoData{}},
+	}, "github-copilot", map[string]string{"backend": "github"})
+
+	if usage.Requests != 2 {
+		t.Errorf("Requests = %d, want 2", usage.Requests)
+	}
+	if usage.Tokens.UncachedInputTokens != 90 || usage.Tokens.CacheReadInputTokens != 20 || usage.Tokens.CacheWriteInputTokens != 10 || usage.Tokens.OutputTokens != 30 {
+		t.Errorf("Tokens = %+v, want input=90 cacheRead=20 cacheWrite=10 output=30", usage.Tokens)
+	}
+	if usage.Tokens.TotalTokens != 150 {
+		t.Errorf("TotalTokens = %d, want 150", usage.Tokens.TotalTokens)
+	}
+	if usage.Tokens.OutputTokenDetails["reasoning"] != 5 {
+		t.Errorf("OutputTokenDetails = %+v, want reasoning=5", usage.Tokens.OutputTokenDetails)
+	}
+	if usage.ProviderReportedCosts["modelMultiplier"] != 2 || usage.ProviderReportedCosts["nanoAIU"] != 7 {
+		t.Errorf("ProviderReportedCosts = %+v, want modelMultiplier=2 nanoAIU=7", usage.ProviderReportedCosts)
+	}
+	if len(usage.Breakdown) != 1 || usage.Breakdown[0].Dimensions["apiEndpoint"] != "/responses" {
+		t.Errorf("Breakdown = %+v, want one /responses entry", usage.Breakdown)
+	}
+}
+
+func TestUsageBreakdownFromClaudeResponse(t *testing.T) {
+	response := &anthropic.Message{
+		Model: "claude-test",
+		Usage: anthropic.Usage{
+			InputTokens:              100,
+			CacheReadInputTokens:     200,
+			CacheCreationInputTokens: 300,
+			CacheCreation: anthropic.CacheCreation{
+				Ephemeral5mInputTokens: 250,
+				Ephemeral1hInputTokens: 50,
+			},
+			OutputTokens: 25,
+			OutputTokensDetails: anthropic.OutputTokensDetails{
+				ThinkingTokens: 5,
+			},
+			ServerToolUse: anthropic.ServerToolUsage{
+				WebSearchRequests: 2,
+				WebFetchRequests:  1,
+			},
+			ServiceTier:  anthropic.UsageServiceTierPriority,
+			InferenceGeo: "us",
+		},
+	}
+
+	entry := usageBreakdownFromClaudeResponse("anthropic", map[string]string{"backend": "api"}, response)
+	if entry.Provider != "anthropic" || entry.Model != "claude-test" || entry.Requests != 1 {
+		t.Errorf("identity = provider=%q model=%q requests=%d", entry.Provider, entry.Model, entry.Requests)
+	}
+	if entry.Dimensions["serviceTier"] != "priority" || entry.Dimensions["inferenceGeo"] != "us" {
+		t.Errorf("Dimensions = %+v, want serviceTier=priority inferenceGeo=us", entry.Dimensions)
+	}
+	if entry.Tokens.UncachedInputTokens != 100 || entry.Tokens.CacheReadInputTokens != 200 || entry.Tokens.CacheWriteInputTokens != 300 || entry.Tokens.OutputTokens != 25 {
+		t.Errorf("Tokens = %+v, want input=100 cacheRead=200 cacheWrite=300 output=25", entry.Tokens)
+	}
+	if entry.Tokens.CacheWriteInputTokensByTTL["5m"] != 250 || entry.Tokens.CacheWriteInputTokensByTTL["1h"] != 50 {
+		t.Errorf("CacheWriteInputTokensByTTL = %+v, want 5m=250 1h=50", entry.Tokens.CacheWriteInputTokensByTTL)
+	}
+	if entry.Tokens.OutputTokenDetails["reasoning"] != 5 {
+		t.Errorf("OutputTokenDetails = %+v, want reasoning=5", entry.Tokens.OutputTokenDetails)
+	}
+	if entry.AdditionalUnits["webSearchRequests"] != 2 || entry.AdditionalUnits["webFetchRequests"] != 1 {
+		t.Errorf("AdditionalUnits = %+v, want webSearchRequests=2 webFetchRequests=1", entry.AdditionalUnits)
+	}
+}


### PR DESCRIPTION
## Why

Snapshot analysis can make multiple LLM requests, including tool-use rounds, but hcpctl did not expose aggregate token consumption. This made it difficult to understand the usage of an analysis run.

## What changed

- aggregate input, output, total token, and request counts across Claude and Copilot sessions
- write the aggregate to `usage.json` with the other analysis artifacts
- include the usage fields in the completion log
- document the new artifact and cover aggregation with unit tests

## Impact

Users gain a machine-readable usage artifact and an at-a-glance usage summary in normal command output. Existing analysis artifacts and behavior remain unchanged.

## Validation

```text
cd tooling/hcpctl
go test ./pkg/agent ./cmd/snapshot
```