### PR TITLE
fix(hcp): add automatedRetry for region rollout ARM propagation-lag failures

### DIFF
--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -71,6 +71,20 @@ resourceGroups:
     dependsOn:
     - resourceGroup: regional
       step: rpRegistration
+    # On a first-time region rollout this deploys shortly after the geography
+    # pipeline creates the Kusto cluster/database it targets (they are separate
+    # service groups with no cross-pipeline dependsOn), so it can race ahead of
+    # ARM RP propagation and fail with a transient Internal Server Error (the
+    # observed failure was error.code=BadInput with that message text, already
+    # covered by the patterns below without a separate BadInput matcher).
+    # See AROSLSRE-1707.
+    automatedRetry:
+      errorContainsAny:
+      - "InternalServerError"
+      - "Internal server error"
+      - "500 Internal Server Error"
+      maximumRetryCount: 3
+      durationBetweenRetries: 1m
     variables:
     - name: auditLogsEventHubId
       input:
@@ -85,6 +99,14 @@ resourceGroups:
     dependsOn:
     - resourceGroup: regional
       step: rpRegistration
+    # Same transient-failure risk as kustoDataConnection above. See AROSLSRE-1707.
+    automatedRetry:
+      errorContainsAny:
+      - "InternalServerError"
+      - "Internal server error"
+      - "500 Internal Server Error"
+      maximumRetryCount: 3
+      durationBetweenRetries: 1m
     variables:
     - name: alertEventsEventHubId
       input:
@@ -129,9 +151,16 @@ resourceGroups:
     template: templates/region.bicep
     parameters: configurations/region.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    # errorContainsAny is widened beyond "Internal error" because on a
+    # first-time region rollout this can also fail with the ARM RP
+    # propagation-lag variants seen elsewhere in this repo (e.g. shortly after
+    # rpRegistration completes for a brand new subscription). See AROSLSRE-1708.
     automatedRetry:
       errorContainsAny:
       - "Internal error"
+      - "InternalServerError"
+      - "Internal server error"
+      - "500 Internal Server Error"
       maximumRetryCount: 4
       durationBetweenRetries: 2m
     variables:


### PR DESCRIPTION
## Why

The westus3 stg region rollout ([AROSLSRE-1689](https://redhat.atlassian.net/browse/AROSLSRE-1689)) hit two transient failures in the same pipeline run, both caused by an ARM deploy running too soon after a dependency it needs was just created/registered. Neither was a real config or capacity problem, both went away on a plain retry, but we're about to bring up several more new regions and don't want every rollout to need a manual retry.

## What

- `kustoDataConnection`/`alertEventsDataConnection` in `region-pipeline.yaml` had no `automatedRetry` at all, so an Internal Server Error right after the geography pipeline creates the target Kusto cluster/database (a separate service group with no cross-pipeline `dependsOn`) failed the whole rollout. The observed failure was `error.code=BadInput` with that message text, already covered by the `InternalServerError`/`Internal server error`/`500 Internal Server Error` patterns without needing a separate `BadInput` matcher (which would be too broad and risk masking real config mistakes). Added `automatedRetry` to both steps ([AROSLSRE-1707](https://redhat.atlassian.net/browse/AROSLSRE-1707)).
- `regional/infra`'s `automatedRetry` only matched `"Internal error"`, missing the `InternalServerError`/`500 Internal Server Error` variants seen right after `rpRegistration` completes for a brand new subscription. Widened the error match list ([AROSLSRE-1708](https://redhat.atlassian.net/browse/AROSLSRE-1708)).

Not changing dependency ordering or adding cross-pipeline waits, just widening retry coverage to match the transient error signatures we actually saw.

[AROSLSRE-1706](https://redhat.atlassian.net/browse/AROSLSRE-1706)
