### PR TITLE
chore: automate tenant-quota image updates

### DIFF
--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -161,7 +161,7 @@ clouds:
           image:
             registry: "arohcpsvcdev.azurecr.io"
             repository: "tenant-quota-collector"
-            tag: "latest"
+            digest: "sha256:e550b375a6110ec600fa8fa097cffe05de8a53f3e8f4d8452232116baa8fbc56"
           tenants:
           - tenantId: "64dc69e4-d083-49fc-9569-ebece1dd1408"
             tenantName: "RedHat0"

--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -154,6 +154,17 @@ images:
     targets:
     - jsonPath: defaults.imageSync.ocMirror.image.digest
       filePath: ../../config/config.yaml
+  # Tenant Quota Collector image
+  tenant-quota:
+    group: aro-ci-images
+    source:
+      image: arohcpsvcdev.azurecr.io/tenant-quota-collector
+      tagPattern: "^[a-f0-9]{7}$"
+      versionLabel: vcs-ref
+      useAuth: true
+    targets:
+    - jsonPath: clouds.dev.defaults.opstool.tenantQuota.image.digest
+      filePath: ../../config/config-dev-ci.yaml
   # Prometheus images
   prometheus-operator:
     group: prom-stack

--- a/tooling/tenant-quota/deploy/values.yaml
+++ b/tooling/tenant-quota/deploy/values.yaml
@@ -4,6 +4,7 @@
 imageRegistry: ""
 imageRepository: "tenant-quota-collector"
 imageTag: ""
+imageDigest: ""
 msiClientId: ""
 secretProvider:
   keyVault: ""

--- a/tooling/tenant-quota/deploy/values.yaml.tmpl
+++ b/tooling/tenant-quota/deploy/values.yaml.tmpl
@@ -1,6 +1,6 @@
 imageRegistry: "{{ .opstool.tenantQuota.image.registry }}"
 imageRepository: "{{ .opstool.tenantQuota.image.repository }}"
-imageTag: "{{ .opstool.tenantQuota.image.tag }}"
+imageDigest: "{{ .opstool.tenantQuota.image.digest }}"
 msiClientId: "__tenantQuotaUAMIClientId__"
 secretProvider:
   keyVault: "__keyVaultName__"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-28205
Follow-up to https://github.com/openshift/release/pull/82787
### What

- Register the tenant-quota collector with the image-updater using immutable seven-character commit tags from ACR.
- Replace the DEV-CI `latest` tag with the current image digest.
- Pass the digest through the tenant-quota Helm values so deployments use `repository@sha256:...`.

### Why

The collector previously used a mutable `latest` tag with `IfNotPresent`, which allowed AKS nodes to reuse stale cached images. Digest pinning makes deployments deterministic, while the existing image-updater periodic will keep the digest current through automated PRs.

### Testing

- `make -C config materialize`
- `AZURE_TOKEN_CREDENTIALS=dev go test ./tooling/image-updater/...`
- Rendered the DEV-CI tenant-quota values and verified Helm emits `arohcpsvcdev.azurecr.io/tenant-quota-collector@sha256:...`.

### Special notes for your reviewer

The release postsubmit publishes immutable seven-character commit tags whenever `tooling/tenant-quota/` changes. This PR itself will produce the first such tag after merge; the seeded digest is the currently published collector image.