### PR TITLE
chore(config): remove unused STG V2 Grafana version (AROSLSRE-1713)

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -107,8 +107,6 @@ clouds:
             kustoName: "hcp-{{ .ctx.environment }}-uk-3"
             # V2 Grafana workspace (globally unique, differs from the live name).
             grafanaName: "arohcp-{{ .ctx.environment }}2"
-            # v13: Azure only accepts major 12/13 for new workspaces since 2026-06-15.
-            grafanaMajorVersion: "13"
             # Dedicated stg billing Kusto in hcp-stg-global (E8a_v4; E8ads_v5 is not
             # offered in uksouth). Consumed by the transient Billing.StgGlobal bicepparam.
             billingKustoName: "arohcpHoBo{{ .ctx.environment }}"

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -3557,9 +3557,6 @@
           "description": "A space-separated list of Service Principals IDs, Types and their desired grafana roles The format is: <principalId>/<principalType>/<role>, e.g. 12345678-1234-1234-1234-123456789012/Group/Admin",
           "pattern": "^$|^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\\/(Group|ServicePrincipal|User)\\/(Contributor|Admin|Viewer)\\s*)+$"
         },
-        "grafanaMajorVersion": {
-          "type": "string"
-        },
         "billingKustoName": {
           "type": "string"
         },
@@ -3581,7 +3578,6 @@
         "kustoName",
         "grafanaName",
         "grafanaRoles",
-        "grafanaMajorVersion",
         "billingKustoName",
         "billingKustoSku"
       ]

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -133,7 +133,6 @@ defaults:
     # monitoring.grafanaRoles so assigning a role on arohcp-stg2 never touches
     # the shared arohcp-stg (which already holds the grant manually).
     grafanaRoles: ""
-    grafanaMajorVersion: "empty-sentinel"
     billingKustoName: "empty-sentinel"
     billingKustoSku: "empty-sentinel"
   # Image Registry Policy

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -962,7 +962,6 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
-  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   grafanaRoles: ""
   kustoName: empty-sentinel

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -962,7 +962,6 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
-  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   grafanaRoles: ""
   kustoName: empty-sentinel

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -960,7 +960,6 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
-  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   grafanaRoles: ""
   kustoName: empty-sentinel

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -960,7 +960,6 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
-  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   grafanaRoles: ""
   kustoName: empty-sentinel

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -960,7 +960,6 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
-  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   grafanaRoles: ""
   kustoName: empty-sentinel

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -962,7 +962,6 @@ stgGlobalV2:
   frontDoorName: empty-sentinel
   genevaKeyVaultName: empty-sentinel
   globalKeyVaultName: empty-sentinel
-  grafanaMajorVersion: empty-sentinel
   grafanaName: empty-sentinel
   grafanaRoles: ""
   kustoName: empty-sentinel


### PR DESCRIPTION
[AROSLSRE-1713](https://redhat.atlassian.net/browse/AROSLSRE-1713)

### What

Remove the unused `stgGlobalV2.grafanaMajorVersion` default, STG override, schema entry, and rendered values.

The active shared `monitoring.grafanaMajorVersion` remains unchanged at version 12.

### Why

Since [#6044](https://github.com/Azure/ARO-HCP/pull/6044), the STG V2 Grafana reconciliation pipeline reads `monitoring.grafanaMajorVersion`. The remaining V2-specific version field is unused and misleading because it renders as 13 while the pipeline actually requests the shared version 12.

### Testing

- `make -C config materialize`
- `make validate-config-pipelines`
- `make verify-materialize`
- `make verify-schema`

No unit or E2E tests were added because this removes an unused configuration field without changing pipeline behavior.

### Special notes for your reviewer

The STG V2 workspace still uses its separate `stgGlobalV2.grafanaName`. Only the unused version field is removed.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
