### PR TITLE
feat(mgmt-agent): enable node-health detection by default (AROSLSRE-1588)

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1453,13 +1453,25 @@
         "managedIdentityName": {
           "type": "string",
           "description": "The name of the MSI that will be used by the mgmt-agent to interact with Azure"
+        },
+        "nodeHealth": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether the mgmt-agent node-health detection controller is enabled. On by default. It only labels and annotates a node it believes is wedged and emits a metric; set this to false per environment to opt out."
+            }
+          },
+          "additionalProperties": false,
+          "required": ["enabled"]
         }
       },
       "additionalProperties": false,
       "required": [
         "image",
         "k8s",
-        "managedIdentityName"
+        "managedIdentityName",
+        "nodeHealth"
       ]
     },
     "kubeApplier": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -213,6 +213,12 @@ defaults:
   # Mgmt Agent Controller
   mgmtAgent:
     managedIdentityName: mgmt-agent
+    # Node-health detection controller. On by default. It only labels and
+    # annotates a node it believes is wedged and emits a metric; it never
+    # cordons, drains, deletes, or reboots anything. Set this to false per
+    # environment to opt out.
+    nodeHealth:
+      enabled: true
     image:
       registry: arohcpsvcdev.azurecr.io
       repository: mgmt-agent

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -760,6 +760,8 @@ mgmtAgent:
         memory: 768Mi
     serviceAccountName: mgmt-agent
   managedIdentityName: mgmt-agent
+  nodeHealth:
+    enabled: true
 mgmtKeyVault:
   name: ah-ci00-mg-j7654321-1
   private: false

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -760,6 +760,8 @@ mgmtAgent:
         memory: 768Mi
     serviceAccountName: mgmt-agent
   managedIdentityName: mgmt-agent
+  nodeHealth:
+    enabled: true
 mgmtKeyVault:
   name: ah-ci01-mg-j7654321-1
   private: false

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -758,6 +758,8 @@ mgmtAgent:
         memory: 768Mi
     serviceAccountName: mgmt-agent
   managedIdentityName: mgmt-agent
+  nodeHealth:
+    enabled: true
 mgmtKeyVault:
   name: ah-cspr-mg-usw3-1
   private: false

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -758,6 +758,8 @@ mgmtAgent:
         memory: 768Mi
     serviceAccountName: mgmt-agent
   managedIdentityName: mgmt-agent
+  nodeHealth:
+    enabled: true
 mgmtKeyVault:
   name: ah-dev-mg-usw3-1
   private: false

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -758,6 +758,8 @@ mgmtAgent:
         memory: 768Mi
     serviceAccountName: mgmt-agent
   managedIdentityName: mgmt-agent
+  nodeHealth:
+    enabled: true
 mgmtKeyVault:
   name: ah-perf-mg-usw3ptest-1
   private: false

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -760,6 +760,8 @@ mgmtAgent:
         memory: 768Mi
     serviceAccountName: mgmt-agent
   managedIdentityName: mgmt-agent
+  nodeHealth:
+    enabled: true
 mgmtKeyVault:
   name: ah-pers-mg-usw3test-1
   private: false

--- a/mgmt-agent/values.yaml
+++ b/mgmt-agent/values.yaml
@@ -19,15 +19,17 @@ nodeHealth:
   configKey: config.yaml
   # Rendered into the ConfigMap the controller watches. Detection logic,
   # thresholds, and the SWIFT-v2 node scoping are hard-coded; the only runtime
-  # config is this switch.
+  # config is this switch, and its value comes from
+  # config/config.yaml (mgmtAgent.nodeHealth.enabled), which defaults to true.
+  # An environment that wants the controller off overrides the key to false.
   #
-  # This file is the authoritative source for the ConfigMap's contents. The
-  # controller hot-reloads a live edit to the ConfigMap within one resync, which
-  # makes `kubectl edit` a valid break-glass to switch the controller off during
-  # an incident, but that edit is not durable: the next mgmt-agent rollout runs
-  # helm and restores the value from here. A change meant to stick goes in git.
+  # The controller hot-reloads a live edit to the ConfigMap within one resync,
+  # which makes `kubectl edit` a valid break-glass to switch the controller off
+  # during an incident, but that edit is not durable: the next mgmt-agent
+  # rollout runs helm and restores the rendered value. A change meant to stick
+  # goes in git.
   config:
-    enabled: false
+    enabled: {{ .mgmtAgent.nodeHealth.enabled }}
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/mgmt-agent/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mgmt_agent.yaml
+++ b/mgmt-agent/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mgmt_agent.yaml
@@ -34,7 +34,7 @@ metadata:
     app.kubernetes.io/name: mgmt-agent
 data:
   config.yaml: |
-    enabled: false
+    enabled: true
 ---
 # Source: mgmt-agent/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## What

Enables the mgmt-agent node-health detection controller by default.

Jira: [AROSLSRE-1715](https://redhat.atlassian.net/browse/AROSLSRE-1715) (epic [AROSLSRE-1588](https://redhat.atlassian.net/browse/AROSLSRE-1588))

## Why

The controller merged in [#6284](https://github.com/Azure/ARO-HCP/pull/6284) but `mgmt-agent/values.yaml` hard-coded `enabled: false`, so it loads and then sits idle in every environment. It has never actually detected anything. This turns it on.

It also had no config knob at all, so there was no way to turn it on or off per environment. This adds one.

## How

`mgmtAgent.nodeHealth.enabled` is a new config key with a default of `true`, and `mgmt-agent/values.yaml` now renders the ConfigMap flag from it instead of the hard-coded value. An environment that wants the controller off sets the key to `false`. None do today, so every environment gets it.

| File | Change |
| --- | --- |
| `config/config.yaml` | New `mgmtAgent.nodeHealth.enabled`, default `true` |
| `config/config.schema.json` | Schema for the new key, required under `mgmtAgent` |
| `mgmt-agent/values.yaml` | Renders the flag from config instead of hard-coding `false` |
| `config/rendered/dev/*` | Re-materialized |
| `mgmt-agent/zz_fixture_TestHelmTemplate_*` | Re-materialized |

## Risk

Low by construction, not by convention. The controller only labels and annotates a node it believes is wedged, and emits a metric.

- Its ClusterRole grants `get`, `list`, `watch`, `patch` on nodes and nothing else.
- The only write is a metadata-only RFC 7386 merge patch (`labeler.go`, `metadataPatch`), which touches `metadata.labels` and `metadata.annotations` only.
- There is no cordon, drain, evict, delete, or reboot anywhere in the package.

The worst case for a false positive is a stray label on a node.

## Verification

Rendered value per public environment, via `make render-partial-config`:

```
int   mgmtAgent.nodeHealth.enabled: true
stg   mgmtAgent.nodeHealth.enabled: true
prod  mgmtAgent.nodeHealth.enabled: true
```

Chart output, from the updated helm fixture:

```yaml
data:
  config.yaml: |
    enabled: true
```

The value renders as an unquoted YAML boolean, which the controller's strict config parser requires.

Local checks, all on a clean committed tree:

- `make -C config detect-change`
- `make verify-schema`
- `make verify-json-format`
- `make verify-yamlfmt`
- `make validate-config-pipelines`
- `go build ./...` and `go test ./pkg/controller/nodehealth/...` in `mgmt-agent`
- EV2 resolve-mode manifest generation against sdp-pipelines `main`

## Follow-up

Once this is live I will check the emitted `nodehealth_*` series against real node state and attach that to [AROSLSRE-1715](https://redhat.atlassian.net/browse/AROSLSRE-1715).
