### PR TITLE
feat(e2e): pin eastus2 PROD gating to Test-Tenant sub

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -147,6 +147,17 @@ clouds:
             audit:
               connectSocket: true
         regions:
+          eastus2:
+            e2e:
+              regionTest:
+                # eastus2 is pinned to the Test-Tenant sub ("ARO HCP E2E") because
+                # the RH-tenant PROD subs (Prod-00/Prod-01) have every RP-allowed
+                # x64 general-purpose VM SKU restricted (NotAvailableForSubscription)
+                # in this region, which makes node pool creation fail there. The
+                # Test-Tenant sub is unrestricted in eastus2 (it also backs the
+                # eastus2euap canary), so routing eastus2 to it unblocks the gating
+                # job. Revert once the RH subs' SKU restriction is lifted (ARO-28614).
+                allowedSubscriptions: "ARO HCP E2E"
           eastus2euap:
             e2e:
               regionTest:


### PR DESCRIPTION
## Why

The single slot-manager PROD e2e gating job (`branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel`) picks its runtime region at lease time. When it selected **eastus2**, node pool creation failed because the RH-tenant PROD e2e subscriptions (`ARO HCP E2E Hosted Clusters - Prod - 00` / `- 01`) have **every RP-allowlisted x64 general-purpose VM SKU restricted** (`NotAvailableForSubscription` across all availability zones) in that region. This caused the revert of openshift/release#82812.

I verified via the Resource SKUs API that this affects **only eastus2** on both RH PROD subs — all other PROD regions (uksouth, switzerlandnorth, canadacentral, australiaeast, westeurope, centralindia, brazilsouth) have the RP-allowed D/E-series SKUs available.

## What

Add a per-region `e2e.regionTest.allowedSubscriptions` override for **eastus2** pinning it to the **Test-Tenant sub** (`ARO HCP E2E`), mirroring the existing `eastus2euap` canary override. The Test-Tenant sub is unrestricted in eastus2 (it already backs the eastus2euap canary, which is physically the same hardware region), so routing eastus2 to it unblocks the gating job.

This is an interim unblock. In parallel, an Azure support case is being pursued to lift the SKU restriction (enable the `DSv5` family + quota) on the RH PROD subs in eastus2. **Revert this override once that restriction is lifted.**

Ref: [ARO-28614](https://redhat.atlassian.net/browse/ARO-28614)

## Testing

`cd config && make materialize` — no rendered/fixture drift (prod-overlay region override does not affect dev-rendered configs); validate + helmtest pass.