### PR TITLE
fix(dev-infrastructure): scope acr-replication/postgres-access/grafana-group-roles workingDir

### DIFF
--- a/dev-infrastructure/global-pipeline-stg.yaml
+++ b/dev-infrastructure/global-pipeline-stg.yaml
@@ -108,8 +108,8 @@ resourceGroups:
   # scripts/grafana-group-roles and the buildStep above.
   - name: grafana-group-roles
     action: Shell
-    command: ./scripts/grafana-group-roles/grafana-group-roles
-    workingDir: .
+    command: ./grafana-group-roles
+    workingDir: ./scripts/grafana-group-roles
     variables:
     - name: SUBSCRIPTION_ID
       input:

--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -41,8 +41,8 @@ resourceGroups:
     outputOnly: true
   - name: ocp-acr-replication
     action: Shell
-    command: ./scripts/acr-replication/acr-replication
-    workingDir: .
+    command: ./acr-replication
+    workingDir: ./scripts/acr-replication
     variables:
     - name: SUBSCRIPTION_ID
       input:
@@ -64,8 +64,8 @@ resourceGroups:
         name: globalMSIId
   - name: svc-acr-replication
     action: Shell
-    command: ./scripts/acr-replication/acr-replication
-    workingDir: .
+    command: ./acr-replication
+    workingDir: ./scripts/acr-replication
     variables:
     - name: SUBSCRIPTION_ID
       input:

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -503,8 +503,8 @@ resourceGroups:
       step: cluster
   - name: cs-postgres-access
     action: Shell
-    command: ./scripts/postgres-access/postgres-access
-    workingDir: .
+    command: ./postgres-access
+    workingDir: ./scripts/postgres-access
     shellIdentity:
       input:
         resourceGroup: global
@@ -537,8 +537,8 @@ resourceGroups:
       step: subscription-output
   - name: maestro-postgres-access
     action: Shell
-    command: ./scripts/postgres-access/postgres-access
-    workingDir: .
+    command: ./postgres-access
+    workingDir: ./scripts/postgres-access
     shellIdentity:
       input:
         resourceGroup: global


### PR DESCRIPTION
## What

Scope `workingDir` for the acr-replication, postgres-access, and grafana-group-roles Shell steps to their own `scripts/<name>` subfolder instead of the repo root (`.`), matching the existing pattern used by `housekeeping`, `upgrade-aks-cluster`, `oidc-storage-setup`, `cleanup-prometheus-pvc`, and `istio-upgrade` (which all set `workingDir: ./scripts`).

Follow-up to [AROSLSRE-1699](https://redhat.atlassian.net/browse/AROSLSRE-1699) raised on the review of #6369.

Affected steps:
- `ocp-acr-replication` / `svc-acr-replication` in `dev-infrastructure/region-pipeline.yaml`
- `cs-postgres-access` / `maestro-postgres-access` in `dev-infrastructure/svc-pipeline.yaml`
- `grafana-group-roles` in `dev-infrastructure/global-pipeline-stg.yaml`

`workingDir` changes from `.` to `./scripts/acr-replication` / `./scripts/postgres-access` / `./scripts/grafana-group-roles`, and `command` becomes relative to that.

## Why

`workingDir` has to stay non-empty, EV2 needs it set to build a scoped package archive for the step. Unsetting it falls back to the implicit whole-repo archive, which fails in EV2. With `workingDir: .` the package that gets archived and content-hashed is the entire repo, so the incremental-rollout cache key is effectively decoupled from what the step actually depends on. Scoping it down to the step's own `scripts/<name>` folder keeps the same non-empty-workingDir requirement, but makes the archived/hashed content actually reflect that step's own inputs.

## Testing

- `templatize pipeline validate --topology-config-file topology.yaml --service-config-file config/config.yaml --dev-mode --dev-region westus3` passes on all changed pipelines.
- Checked `main.go` in `scripts/acr-replication`, `scripts/postgres-access`, and `scripts/grafana-group-roles` for any relative-path assumptions beyond the working directory itself, none found (they only read env vars).
