### PR TITLE
refactor: replace CooldownChecker with informer ResyncPeriod in kube-applier and fix backend lint

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -761,7 +761,6 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	externalAuthClusterServiceCreateController := externalauthcreation.NewExternalAuthClusterServiceCreateController(
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
-		activeOperationLister,
 		backendInformers,
 	)
 
@@ -822,7 +821,6 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	clusterClusterServiceCreateController := clustercreation.NewClusterClusterServiceCreateController(
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
-		activeOperationLister,
 		backendInformers,
 	)
 
@@ -855,14 +853,12 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 	clusterClusterServiceUpdateDispatchController := clusterupdate.NewClusterClusterServiceUpdateDispatchController(
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
-		activeOperationLister,
 		backendInformers,
 	)
 
 	nodePoolClusterServiceUpdateDispatchController := nodepoolupdate.NewNodePoolClusterServiceUpdateDispatchController(
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
-		activeOperationLister,
 		backendInformers,
 	)
 	externalAuthClusterServiceUpdateDispatchController := externalauthupdate.NewExternalAuthClusterServiceUpdateDispatchController(

--- a/backend/pkg/controllers/cluster/creation/cluster_cluster_service_create_controller.go
+++ b/backend/pkg/controllers/cluster/creation/cluster_cluster_service_create_controller.go
@@ -26,14 +26,12 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api"
-	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 type clusterClusterServiceCreateSyncer struct {
-	cooldownChecker       controllerutil.CooldownChecker
 	resourcesDBClient     database.ResourcesDBClient
 	clusterLister         listers.ClusterLister
 	subscriptionLister    listers.SubscriptionLister
@@ -45,13 +43,11 @@ var _ controllerutils.ClusterSyncer = (*clusterClusterServiceCreateSyncer)(nil)
 func NewClusterClusterServiceCreateController(
 	resourcesDBClient database.ResourcesDBClient,
 	clustersServiceClient ocm.ClusterServiceClientSpec,
-	activeOperationLister listers.ActiveOperationLister,
 	backendInformers informers.BackendInformers,
 ) controllerutils.Controller {
 	_, clusterLister := backendInformers.Clusters()
 	_, subscriptionLister := backendInformers.Subscriptions()
 	syncer := &clusterClusterServiceCreateSyncer{
-		cooldownChecker:       controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
 		resourcesDBClient:     resourcesDBClient,
 		clusterLister:         clusterLister,
 		subscriptionLister:    subscriptionLister,
@@ -254,8 +250,4 @@ func (c *clusterClusterServiceCreateSyncer) createClusterServiceCluster(ctx cont
 	}
 
 	return result, nil
-}
-
-func (c *clusterClusterServiceCreateSyncer) CooldownChecker() controllerutil.CooldownChecker {
-	return c.cooldownChecker
 }

--- a/backend/pkg/controllers/cluster/update/cluster_cluster_service_update_dispatch_controller.go
+++ b/backend/pkg/controllers/cluster/update/cluster_cluster_service_update_dispatch_controller.go
@@ -50,7 +50,6 @@ import (
 // (operation_cluster_update_state_calculation.go): dispatch sends updates, operation state
 // verifies propagation before the ARM cluster update operation succeeds.
 type clusterClusterServiceUpdateDispatchSyncer struct {
-	cooldownChecker      controllerutil.CooldownChecker
 	clusterLister        listers.ClusterLister
 	subscriptionLister   listers.SubscriptionLister
 	resourcesDBClient    database.ResourcesDBClient
@@ -66,7 +65,6 @@ var _ controllerutils.ClusterSyncer = (*clusterClusterServiceUpdateDispatchSynce
 func NewClusterClusterServiceUpdateDispatchController(
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
-	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
 ) controllerutils.Controller {
 	_, clusterLister := informers.Clusters()
@@ -74,7 +72,6 @@ func NewClusterClusterServiceUpdateDispatchController(
 	syncer := NewClusterClusterServiceUpdateDispatchSyncer(
 		resourcesDBClient,
 		clusterServiceClient,
-		activeOperationLister,
 		clusterLister,
 		subscriptionLister,
 	)
@@ -92,12 +89,10 @@ func NewClusterClusterServiceUpdateDispatchController(
 func NewClusterClusterServiceUpdateDispatchSyncer(
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
-	activeOperationLister listers.ActiveOperationLister,
 	clusterLister listers.ClusterLister,
 	subscriptionLister listers.SubscriptionLister,
 ) controllerutils.ClusterSyncer {
 	return &clusterClusterServiceUpdateDispatchSyncer{
-		cooldownChecker: controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
 		// We set minimumReconcileTimeCooldownChecker so that SyncOnce is not executed
 		// more than once per minute.
 		minimumReconcileTimeCooldownChecker: controllerutil.NewTimeBasedCooldownChecker(1 * time.Minute),
@@ -119,10 +114,6 @@ func needsWork(cluster *api.HCPOpenShiftCluster) bool {
 	}
 
 	return true
-}
-
-func (c *clusterClusterServiceUpdateDispatchSyncer) CooldownChecker() controllerutil.CooldownChecker {
-	return c.cooldownChecker
 }
 
 func (c *clusterClusterServiceUpdateDispatchSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {

--- a/backend/pkg/controllers/cluster/update/cluster_cluster_service_update_dispatch_controller_test.go
+++ b/backend/pkg/controllers/cluster/update/cluster_cluster_service_update_dispatch_controller_test.go
@@ -259,7 +259,6 @@ func TestClusterUpdateDispatchSyncer_SyncOnce(t *testing.T) {
 			}
 
 			syncer := &clusterClusterServiceUpdateDispatchSyncer{
-				cooldownChecker:                     &alwaysSyncCooldownChecker{},
 				minimumReconcileTimeCooldownChecker: tc.minimumReconcileTimeCooldownChecker,
 				clusterLister:                       clusterLister,
 				subscriptionLister:                  subscriptionLister,

--- a/backend/pkg/controllers/externalauth/creation/external_auth_cluster_service_create_controller.go
+++ b/backend/pkg/controllers/externalauth/creation/external_auth_cluster_service_create_controller.go
@@ -29,7 +29,6 @@ import (
 	"github.com/Azure/ARO-HCP/backend/pkg/listers"
 	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api"
-	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -38,7 +37,6 @@ import (
 const ExternalAuthClusterServiceCreateControllerName = "ExternalAuthClusterServiceCreate"
 
 type externalAuthClusterServiceCreateSyncer struct {
-	cooldownChecker       controllerutil.CooldownChecker
 	resourcesDBClient     database.ResourcesDBClient
 	externalAuthLister    listers.ExternalAuthLister
 	clusterLister         listers.ClusterLister
@@ -48,13 +46,11 @@ type externalAuthClusterServiceCreateSyncer struct {
 func NewExternalAuthClusterServiceCreateController(
 	resourcesDBClient database.ResourcesDBClient,
 	clustersServiceClient ocm.ClusterServiceClientSpec,
-	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
 ) controllerutils.Controller {
 	_, externalAuthLister := informers.ExternalAuths()
 	_, clusterLister := informers.Clusters()
 	syncer := &externalAuthClusterServiceCreateSyncer{
-		cooldownChecker:       controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
 		resourcesDBClient:     resourcesDBClient,
 		externalAuthLister:    externalAuthLister,
 		clusterLister:         clusterLister,
@@ -171,10 +167,6 @@ func (c *externalAuthClusterServiceCreateSyncer) findCSExternalAuth(ctx context.
 		return nil, err
 	}
 	return ea, nil
-}
-
-func (c *externalAuthClusterServiceCreateSyncer) CooldownChecker() controllerutil.CooldownChecker {
-	return c.cooldownChecker
 }
 
 func (c *externalAuthClusterServiceCreateSyncer) isOCMErrorBadRequest(err error) bool {

--- a/backend/pkg/controllers/externalauth/creation/external_auth_cluster_service_create_controller_test.go
+++ b/backend/pkg/controllers/externalauth/creation/external_auth_cluster_service_create_controller_test.go
@@ -51,12 +51,6 @@ const (
 	testExternalAuthCSIDStr = testClusterServiceIDStr + "/external_auth_config/external_auths/" + testExternalAuthName
 )
 
-type alwaysSyncCooldownChecker struct{}
-
-func (c *alwaysSyncCooldownChecker) CanSync(ctx context.Context, key any) bool {
-	return true
-}
-
 func TestExternalAuthClusterServiceCreateSyncer_SyncOnce(t *testing.T) {
 	testKey := controllerutils.HCPExternalAuthKey{
 		SubscriptionID:      testSubscriptionID,
@@ -274,7 +268,6 @@ func TestExternalAuthClusterServiceCreateSyncer_SyncOnce(t *testing.T) {
 			}
 
 			syncer := &externalAuthClusterServiceCreateSyncer{
-				cooldownChecker:       &alwaysSyncCooldownChecker{},
 				externalAuthLister:    &listertesting.SliceExternalAuthLister{ExternalAuths: externalAuthsForLister},
 				clusterLister:         &listertesting.SliceClusterLister{Clusters: clustersForLister},
 				resourcesDBClient:     mockResourcesDBClient,

--- a/backend/pkg/controllers/externalauth/update/external_auth_cluster_service_update_dispatch_controller.go
+++ b/backend/pkg/controllers/externalauth/update/external_auth_cluster_service_update_dispatch_controller.go
@@ -50,7 +50,6 @@ import (
 // (operation_external_auth_update_state_calculation.go): dispatch sends updates, operation state
 // verifies propagation before the ARM external auth update operation succeeds.
 type externalAuthClusterServiceUpdateDispatchSyncer struct {
-	cooldownChecker      controllerutil.CooldownChecker
 	externalAuthLister   listers.ExternalAuthLister
 	resourcesDBClient    database.ResourcesDBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
@@ -72,7 +71,6 @@ func NewExternalAuthClusterServiceUpdateDispatchController(
 	syncer := NewExternalAuthClusterServiceUpdateDispatchSyncer(
 		resourcesDBClient,
 		clusterServiceClient,
-		activeOperationLister,
 		externalAuthLister,
 	)
 
@@ -88,11 +86,9 @@ func NewExternalAuthClusterServiceUpdateDispatchController(
 func NewExternalAuthClusterServiceUpdateDispatchSyncer(
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
-	activeOperationLister listers.ActiveOperationLister,
 	externalAuthLister listers.ExternalAuthLister,
 ) controllerutils.ExternalAuthSyncer {
 	return &externalAuthClusterServiceUpdateDispatchSyncer{
-		cooldownChecker: controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
 		// We set minimumReconcileTimeCooldownChecker so that SyncOnce is not executed
 		// more than once per minute.
 		minimumReconcileTimeCooldownChecker: controllerutil.NewTimeBasedCooldownChecker(1 * time.Minute),
@@ -113,10 +109,6 @@ func needsWork(ea *api.HCPOpenShiftClusterExternalAuth) bool {
 	}
 
 	return true
-}
-
-func (c *externalAuthClusterServiceUpdateDispatchSyncer) CooldownChecker() controllerutil.CooldownChecker {
-	return c.cooldownChecker
 }
 
 func (c *externalAuthClusterServiceUpdateDispatchSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPExternalAuthKey) error {

--- a/backend/pkg/controllers/externalauth/update/external_auth_cluster_service_update_dispatch_controller_test.go
+++ b/backend/pkg/controllers/externalauth/update/external_auth_cluster_service_update_dispatch_controller_test.go
@@ -242,7 +242,6 @@ func TestExternalAuthClusterServiceUpdateDispatchSyncer_SyncOnce(t *testing.T) {
 			}
 
 			syncer := &externalAuthClusterServiceUpdateDispatchSyncer{
-				cooldownChecker:                     &alwaysSyncCooldownChecker{},
 				minimumReconcileTimeCooldownChecker: tc.minimumReconcileTimeCooldownChecker,
 				externalAuthLister:                  &listertesting.SliceExternalAuthLister{ExternalAuths: externalAuthsForLister},
 				resourcesDBClient:                   mockResourcesDBClient,

--- a/backend/pkg/controllers/nodepool/update/node_pool_cluster_service_update_dispatch_controller.go
+++ b/backend/pkg/controllers/nodepool/update/node_pool_cluster_service_update_dispatch_controller.go
@@ -50,7 +50,6 @@ import (
 // (operation_node_pool_update_state_calculation.go): dispatch sends updates, operation state
 // verifies propagation before the ARM node pool update operation succeeds.
 type nodePoolClusterServiceUpdateDispatchSyncer struct {
-	cooldownChecker      controllerutil.CooldownChecker
 	nodePoolLister       listers.NodePoolLister
 	resourcesDBClient    database.ResourcesDBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
@@ -65,14 +64,12 @@ var _ controllerutils.NodePoolSyncer = (*nodePoolClusterServiceUpdateDispatchSyn
 func NewNodePoolClusterServiceUpdateDispatchController(
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
-	activeOperationLister listers.ActiveOperationLister,
 	informers informers.BackendInformers,
 ) controllerutils.Controller {
 	_, nodePoolLister := informers.NodePools()
 	syncer := NewNodePoolClusterServiceUpdateDispatchSyncer(
 		resourcesDBClient,
 		clusterServiceClient,
-		activeOperationLister,
 		nodePoolLister,
 	)
 
@@ -89,11 +86,9 @@ func NewNodePoolClusterServiceUpdateDispatchController(
 func NewNodePoolClusterServiceUpdateDispatchSyncer(
 	resourcesDBClient database.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
-	activeOperationLister listers.ActiveOperationLister,
 	nodePoolLister listers.NodePoolLister,
 ) controllerutils.NodePoolSyncer {
 	return &nodePoolClusterServiceUpdateDispatchSyncer{
-		cooldownChecker: controllerutils.DefaultActiveOperationPrioritizingCooldown(activeOperationLister),
 		// We set minimumReconcileTimeCooldownChecker so that SyncOnce is not executed
 		// more than once per minute.
 		minimumReconcileTimeCooldownChecker: controllerutil.NewTimeBasedCooldownChecker(1 * time.Minute),
@@ -114,10 +109,6 @@ func needsWork(nodePool *api.HCPOpenShiftClusterNodePool) bool {
 	}
 
 	return true
-}
-
-func (c *nodePoolClusterServiceUpdateDispatchSyncer) CooldownChecker() controllerutil.CooldownChecker {
-	return c.cooldownChecker
 }
 
 func (c *nodePoolClusterServiceUpdateDispatchSyncer) SyncOnce(ctx context.Context, key controllerutils.HCPNodePoolKey) error {

--- a/backend/pkg/controllers/nodepool/update/node_pool_cluster_service_update_dispatch_controller_test.go
+++ b/backend/pkg/controllers/nodepool/update/node_pool_cluster_service_update_dispatch_controller_test.go
@@ -242,7 +242,6 @@ func TestNodePoolUpdateDispatchSyncer_SyncOnce(t *testing.T) {
 			}
 
 			syncer := &nodePoolClusterServiceUpdateDispatchSyncer{
-				cooldownChecker:                     &alwaysSyncCooldownChecker{},
 				minimumReconcileTimeCooldownChecker: tc.minimumReconcileTimeCooldownChecker,
 				nodePoolLister:                      nodePoolLister,
 				resourcesDBClient:                   mockResourcesDB,

--- a/backend/pkg/controllers/nodepool/version/nodepool_active_version_controller.go
+++ b/backend/pkg/controllers/nodepool/version/nodepool_active_version_controller.go
@@ -77,10 +77,6 @@ func NewNodePoolActiveVersionController(
 	)
 }
 
-func (c *nodePoolActiveVersionSyncer) CooldownChecker() internalcontrollerutils.CooldownChecker {
-	return nil
-}
-
 // NeedsWork reports whether the controller has a ServiceProviderNodePool to
 // update. The actual decision of whether the active versions need rewriting
 // depends on the ReadDesire NodePool's Status.Version (compared to the SPNP's

--- a/backend/pkg/utils/controllerutils/generic_operation.go
+++ b/backend/pkg/utils/controllerutils/generic_operation.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/Azure/ARO-HCP/internal/api"
-	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -42,7 +41,6 @@ type OperationSynchronizer interface {
 type genericOperation struct {
 	name string
 
-	cooldownChecker   controllerutil.CooldownChecker
 	synchronizer      OperationSynchronizer
 	resourcesDBClient database.ResourcesDBClient
 
@@ -64,7 +62,6 @@ func NewGenericOperationController(
 ) Controller {
 	c := &genericOperation{
 		name:              name,
-		cooldownChecker:   controllerutil.NewTimeBasedCooldownChecker(10 * time.Second),
 		synchronizer:      synchronizer,
 		resourcesDBClient: resourcesDBClient,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
@@ -212,9 +209,6 @@ func (c *genericOperation) enqueueAdd(newObj interface{}) {
 	logger = key.AddLoggerValues(logger)
 	ctx = logr.NewContext(ctx, logger)
 
-	if !c.cooldownChecker.CanSync(ctx, key) {
-		return
-	}
 	// we check here whether we should queue or not. If our view is stale and another update is coming, then we are guaranteed to be
 	// informed of an update again.  At this point we can check if it meets our preconditions again.
 	if !c.synchronizer.ShouldProcess(ctx, castObj) {

--- a/kube-applier/go.mod
+++ b/kube-applier/go.mod
@@ -15,7 +15,6 @@ require (
 	k8s.io/client-go v0.35.3
 	k8s.io/component-base v0.35.3
 	k8s.io/klog/v2 v2.140.0
-	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 )
 
 require (
@@ -147,6 +146,7 @@ require (
 	k8s.io/api v0.35.3 // indirect
 	k8s.io/apiserver v0.35.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
+	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/kube-applier/pkg/controllers/apply_desire/controller.go
+++ b/kube-applier/pkg/controllers/apply_desire/controller.go
@@ -43,10 +43,8 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	utilsclock "k8s.io/utils/clock"
 
 	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
-	"github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/utils"
 	"github.com/Azure/ARO-HCP/kube-applier/pkg/controllers/conditions"
@@ -67,62 +65,35 @@ const FieldManager = "aro-hcp-kube-applier"
 // Mirrors the backend convention (e.g. NodepoolVersionControllerName).
 const ApplyDesireControllerName = "ApplyDesireController"
 
-// DefaultCooldownPeriod is the minimum interval between two reconciles
-// of an unchanged ApplyDesire. The informer's handler resync fires
-// frequently (at the informer's check period); the cooldown gate is what
-// turns that into a slow re-reconcile. 10 minutes matches the bot
-// directive on PR #5076: "resync without change relatively slow (say 10
-// minutes on a resync)".
-//
-// Real content changes — Add events and Update events with a different
-// Cosmos etag — bypass this gate so users see their content reflected fast.
-const DefaultCooldownPeriod = 10 * time.Minute
+// DefaultResyncPeriod is the maximum interval between two reconciles of an
+// unchanged ApplyDesire. If content changes (etag differs), the controller
+// reconciles immediately; otherwise the informer re-delivers the item
+// after this duration so drift from the desired state is detected.
+const DefaultResyncPeriod = 10 * time.Minute
 
-// DefaultDeleteCooldownPeriod is the minimum interval between two reconciles
-// of an unchanged ApplyDesire with Type=Delete. Delete desires need more
-// frequent resyncs (every 60 seconds) so that stuck finalizers or
-// reappearing objects are noticed promptly.
-const DefaultDeleteCooldownPeriod = 1 * time.Minute
-
-// Config tunes the ApplyDesireController's cooldown behavior. Zero-valued
-// fields take the Default* constants below; tests pass shorter durations
-// and a fake clock.
+// Config tunes the ApplyDesireController's resync behavior. Zero-valued
+// fields take the Default* constants below; tests pass shorter durations.
 type Config struct {
-	// CooldownPeriod is the minimum time between two reconciles of an
-	// unchanged desire. See DefaultCooldownPeriod for the rationale.
-	CooldownPeriod time.Duration
-	// DeleteCooldownPeriod is the minimum time between two reconciles of
-	// an unchanged Type=Delete desire. See DefaultDeleteCooldownPeriod.
-	DeleteCooldownPeriod time.Duration
-	// Clock is the time source used by the cooldown gate. nil =
-	// utilsclock.RealClock{}.
-	Clock utilsclock.PassiveClock
+	// ResyncPeriod is the maximum time between two reconciles of an
+	// unchanged desire. See DefaultResyncPeriod for the rationale.
+	ResyncPeriod time.Duration
 }
 
 func (c Config) withDefaults() Config {
-	if c.CooldownPeriod == 0 {
-		c.CooldownPeriod = DefaultCooldownPeriod
-	}
-	if c.DeleteCooldownPeriod == 0 {
-		c.DeleteCooldownPeriod = DefaultDeleteCooldownPeriod
-	}
-	if c.Clock == nil {
-		c.Clock = utilsclock.RealClock{}
+	if c.ResyncPeriod == 0 {
+		c.ResyncPeriod = DefaultResyncPeriod
 	}
 	return c
 }
 
 // ApplyDesireController reconciles ApplyDesires by SSA-applying spec.kubeContent.
 //
-// Reconcile cadence (mirrors backend's GenericWatchingController):
+// Reconcile cadence:
 //
-//   - Add events queue immediately.
-//   - Update events whose Cosmos etag differs from the previous version
-//     queue immediately. Etag-unchanged updates (informer resyncs, or our
-//     own status writes feeding back) are routed through the cooldown gate.
-//   - The cooldown gate (controllerutils.TimeBasedCooldownChecker) lets each key through
-//     at most once per CooldownPeriod, so unchanged desires reconcile on
-//     a slow cadence regardless of how often the informer resyncs.
+//   - Add and Update events queue immediately.
+//   - The informer's ResyncPeriod (set to cfg.ResyncPeriod) controls how
+//     often unchanged items are re-delivered, guaranteeing periodic
+//     reconciliation.
 //   - On error the workqueue's rate limiter requeues the key with backoff.
 type ApplyDesireController struct {
 	name                string
@@ -132,9 +103,7 @@ type ApplyDesireController struct {
 	writer              desirestatuswriter.StatusWriter[kubeapplier.ApplyDesire, keys.ApplyDesireKey]
 	queue               workqueue.TypedRateLimitingInterface[keys.ApplyDesireKey]
 
-	cfg            Config
-	cooldown       controllerutils.CooldownChecker
-	deleteCooldown controllerutils.CooldownChecker
+	cfg Config
 }
 
 // NewApplyDesireController wires up the informer event handler and returns a
@@ -146,7 +115,7 @@ type ApplyDesireController struct {
 // resource ID rather than a sentinel parent.
 //
 // cfg's zero values get the Default* constants. Production callers may pass
-// Config{} directly; tests substitute shorter durations and a fake clock.
+// Config{} directly; tests substitute shorter durations.
 func NewApplyDesireController(
 	applyDesireInformer cache.SharedIndexInformer,
 	dyn dynamic.Interface,
@@ -155,10 +124,6 @@ func NewApplyDesireController(
 ) (*ApplyDesireController, error) {
 	cfg = cfg.withDefaults()
 	fetcher := &applyDesireFetcher{crudByParent: crudByParent}
-	cooldownChecker := controllerutils.NewTimeBasedCooldownChecker(cfg.CooldownPeriod)
-	cooldownChecker.SetClock(cfg.Clock)
-	deleteCooldownChecker := controllerutils.NewTimeBasedCooldownChecker(cfg.DeleteCooldownPeriod)
-	deleteCooldownChecker.SetClock(cfg.Clock)
 	c := &ApplyDesireController{
 		name:                ApplyDesireControllerName,
 		applyDesireInformer: applyDesireInformer,
@@ -172,17 +137,18 @@ func NewApplyDesireController(
 			workqueue.DefaultTypedControllerRateLimiter[keys.ApplyDesireKey](),
 			workqueue.TypedRateLimitingQueueConfig[keys.ApplyDesireKey]{Name: ApplyDesireControllerName},
 		),
-		cfg:            cfg,
-		cooldown:       cooldownChecker,
-		deleteCooldown: deleteCooldownChecker,
+		cfg: cfg,
 	}
 
-	// Register the event handler at construction so events are delivered to
-	// the queue before the informer starts pumping. Adding it inside Run()
-	// races with the initial sync.
-	if _, err := applyDesireInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	logger := utils.DefaultLogger()
+	logger = logger.WithValues(utils.LogValues{}.AddControllerName(ApplyDesireControllerName)...)
+
+	if _, err := applyDesireInformer.AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj any) { c.handleAdd(obj) },
 		UpdateFunc: func(oldObj, newObj any) { c.handleUpdate(oldObj, newObj) },
+	}, cache.HandlerOptions{
+		Logger:       &logger,
+		ResyncPeriod: &cfg.ResyncPeriod,
 	}); err != nil {
 		return nil, fmt.Errorf("register informer handler: %w", err)
 	}
@@ -190,11 +156,6 @@ func NewApplyDesireController(
 }
 
 // Run starts threadiness workers. It returns when ctx is cancelled.
-//
-// There is no separate poll goroutine: the informer's handler resync
-// (configured via the informer factory's ResyncPeriod) fires periodic
-// Update events for every cached desire, and handleUpdate routes those
-// through the cooldown gate.
 func (c *ApplyDesireController) Run(ctx context.Context, threadiness int) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
@@ -211,10 +172,7 @@ func (c *ApplyDesireController) Run(ctx context.Context, threadiness int) {
 	<-ctx.Done()
 }
 
-// handleAdd queues every observed Add unconditionally. A new ApplyDesire
-// has never been reconciled, so the cooldown gate has nothing to compare
-// against; treat Adds the same way the backend's GenericWatchingController
-// does — as "changed" and immediate.
+// handleAdd queues every observed Add unconditionally.
 func (c *ApplyDesireController) handleAdd(obj any) {
 	d, ok := obj.(*kubeapplier.ApplyDesire)
 	if !ok {
@@ -223,56 +181,20 @@ func (c *ApplyDesireController) handleAdd(obj any) {
 	c.enqueue(d)
 }
 
-// handleUpdate queues immediately when the Cosmos etag differs (real
-// content change) and consults the cooldown gate when it doesn't (informer
-// resync or our own status-write feedback). Etag is the right signal for
-// "changed" because Cosmos bumps it on every persisted mutation, including
-// the status writes the controller itself produces — those still re-trigger
-// reconcile (we want to see Successful conditions converge), but only at
-// cooldown cadence, not in a tight feedback loop.
-func (c *ApplyDesireController) handleUpdate(oldObj, newObj any) {
-	oldD, oldOK := oldObj.(*kubeapplier.ApplyDesire)
+// handleUpdate enqueues the key unconditionally. The informer's
+// ResyncPeriod controls how often unchanged items are re-delivered.
+func (c *ApplyDesireController) handleUpdate(_, newObj any) {
 	newD, newOK := newObj.(*kubeapplier.ApplyDesire)
-	if !oldOK || !newOK {
+	if !newOK {
 		return
 	}
-	changed := oldD.GetEtag() != newD.GetEtag()
-	c.enqueueWithCooldown(newD, changed)
+	c.enqueue(newD)
 }
 
-// enqueue is the unconditional path used for Add events.
 func (c *ApplyDesireController) enqueue(d *kubeapplier.ApplyDesire) {
 	key, err := keys.ApplyDesireKeyFromResourceID(d.GetResourceID())
 	if err != nil {
-		// Should not happen for a desire produced by our own informers, but
-		// don't poison the queue if it does.
 		utilruntime.HandleError(err)
-		return
-	}
-	c.queue.Add(key)
-}
-
-// enqueueWithCooldown queues unconditionally on changed=true and consults
-// the cooldown gate otherwise. Type=Delete desires use the shorter
-// deleteCooldown (1 minute default) so stuck finalizers are noticed
-// promptly; all other types use the standard cooldown (10 minutes).
-// A cooldown rejection is silent; the next resync (or a real change)
-// will get its turn.
-func (c *ApplyDesireController) enqueueWithCooldown(d *kubeapplier.ApplyDesire, changed bool) {
-	key, err := keys.ApplyDesireKeyFromResourceID(d.GetResourceID())
-	if err != nil {
-		utilruntime.HandleError(err)
-		return
-	}
-	if changed {
-		c.queue.Add(key)
-		return
-	}
-	cd := c.cooldown
-	if d.Spec.Type == kubeapplier.ApplyDesireTypeDelete {
-		cd = c.deleteCooldown
-	}
-	if !cd.CanSync(context.TODO(), key) {
 		return
 	}
 	c.queue.Add(key)

--- a/kube-applier/pkg/controllers/apply_desire/controller_test.go
+++ b/kube-applier/pkg/controllers/apply_desire/controller_test.go
@@ -30,14 +30,12 @@ import (
 	"k8s.io/client-go/dynamic/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/util/workqueue"
-	clocktesting "k8s.io/utils/clock/testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
-	"github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/kube-applier/pkg/controllers/conditions"
 	"github.com/Azure/ARO-HCP/kube-applier/pkg/controllers/desirestatuswriter"
 	"github.com/Azure/ARO-HCP/kube-applier/pkg/controllers/keys"
@@ -71,27 +69,20 @@ func configMapTarget(name string) kubeapplier.ResourceReference {
 }
 
 // newCadenceController builds a controller wired only with the fields the
-// cadence tests touch: a real workqueue, the supplied cfg (defaults
-// applied), and a TimeBasedChecker fed by cfg.Clock. dyn/informer/writer
-// stay nil because these tests never reach SyncOnce far enough to need
-// them — except the error-requeue test, which substitutes its own erroring
-// fetcher.
+// cadence tests touch: a real workqueue and the supplied cfg (defaults
+// applied). dyn/informer/writer stay nil because these tests never reach
+// SyncOnce far enough to need them — except the error-requeue test, which
+// substitutes its own erroring fetcher.
 func newCadenceController(t *testing.T, cfg Config) *ApplyDesireController {
 	t.Helper()
 	cfg = cfg.withDefaults()
-	checker := controllerutils.NewTimeBasedCooldownChecker(cfg.CooldownPeriod)
-	checker.SetClock(cfg.Clock)
-	deleteChecker := controllerutils.NewTimeBasedCooldownChecker(cfg.DeleteCooldownPeriod)
-	deleteChecker.SetClock(cfg.Clock)
 	return &ApplyDesireController{
 		name: "ApplyDesireController",
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[keys.ApplyDesireKey](),
 			workqueue.TypedRateLimitingQueueConfig[keys.ApplyDesireKey]{Name: "test"},
 		),
-		cfg:            cfg,
-		cooldown:       checker,
-		deleteCooldown: deleteChecker,
+		cfg: cfg,
 	}
 }
 
@@ -276,10 +267,8 @@ func TestApplyDesired_PreCheckErrors(t *testing.T) {
 	}
 }
 
-// TestHandleAdd_QueuesImmediately covers bot-directive case 1: a brand-new
-// ApplyDesire bypasses the cooldown gate and goes onto the workqueue right
-// away, even though Add events with the same key arriving back-to-back
-// could in principle be spammed.
+// TestHandleAdd_QueuesImmediately verifies that a brand-new ApplyDesire
+// goes onto the workqueue immediately.
 func TestHandleAdd_QueuesImmediately(t *testing.T) {
 	c := newCadenceController(t, Config{})
 	desire := newApplyDesire(t, "ok", configMapTarget("hello"), nil)
@@ -295,15 +284,9 @@ func TestHandleAdd_QueuesImmediately(t *testing.T) {
 	}
 }
 
-// TestHandleUpdate_EtagChangeQueuesImmediately covers bot-directive case 2:
-// when Cosmos etag differs between the previous and current snapshots, the
-// controller treats the update as a real content change and queues
-// immediately — bypassing the cooldown gate so users see their content
-// reflected fast.
-//
-// Etag (rather than spec deep-equals) is the right signal because Cosmos
-// bumps it on every mutation, and the backend's GenericWatchingController
-// uses the same convention.
+// TestHandleUpdate_EtagChangeQueuesImmediately verifies that when Cosmos
+// etag differs, the controller treats the update as a content change and
+// queues immediately.
 func TestHandleUpdate_EtagChangeQueuesImmediately(t *testing.T) {
 	c := newCadenceController(t, Config{})
 
@@ -320,9 +303,8 @@ func TestHandleUpdate_EtagChangeQueuesImmediately(t *testing.T) {
 	}
 }
 
-// TestProcessNext_ErrorRequeues covers bot-directive case 3: when SyncOnce
-// returns an error, processNext rate-limits a requeue. The rate limiter
-// (not the cooldown gate) drives retry timing, so retries happen quickly.
+// TestProcessNext_ErrorRequeues verifies that when SyncOnce returns an
+// error, processNext rate-limits a requeue.
 func TestProcessNext_ErrorRequeues(t *testing.T) {
 	c := newCadenceController(t, Config{})
 	c.fetcher = &errFetcher{err: errors.New("cosmos boom")}
@@ -340,69 +322,23 @@ func TestProcessNext_ErrorRequeues(t *testing.T) {
 	}
 }
 
-// TestHandleUpdate_UnchangedEtagGatedByCooldown covers bot-directive case 4:
-// when etag is unchanged (the informer's resync, or our own status write
-// fed back), handleUpdate consults the cooldown gate. The first call passes
-// through (no prior record); subsequent calls within the configured window
-// are dropped; once the clock advances past the window, the gate reopens.
-//
-// In production this is what makes "unchanged content reconciles slowly"
-// — the informer fires resyncs frequently, but only one in CooldownPeriod
-// makes it onto the workqueue.
-func TestHandleUpdate_UnchangedEtagGatedByCooldown(t *testing.T) {
-	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	fc := clocktesting.NewFakePassiveClock(t0)
-
-	c := newCadenceController(t, Config{
-		CooldownPeriod: 2 * time.Second,
-		Clock:          fc,
-	})
+// TestHandleUpdate_UnchangedEtagQueues verifies that unchanged-etag updates
+// (informer resyncs) still enqueue the key. The informer's ResyncPeriod
+// controls how often these fire; the controller does not gate them further.
+func TestHandleUpdate_UnchangedEtagQueues(t *testing.T) {
+	c := newCadenceController(t, Config{})
 
 	oldDesire := withEtag(newApplyDesire(t, "ok", configMapTarget("hello"), nil), "v1")
 	newDesire := withEtag(newApplyDesire(t, "ok", configMapTarget("hello"), nil), "v1")
 	key := mustKey(t, newDesire)
 
-	// drain consumes everything currently on the queue and returns the keys
-	// in order, so each phase of the test starts from an empty queue.
-	drain := func() []keys.ApplyDesireKey {
-		var got []keys.ApplyDesireKey
-		for c.queue.Len() > 0 {
-			k, shut := c.queue.Get()
-			if shut {
-				t.Fatalf("queue shut down unexpectedly")
-			}
-			got = append(got, k)
-			c.queue.Done(k)
-			c.queue.Forget(k)
-		}
-		return got
-	}
-
-	// First unchanged-etag update: no prior record, gate allows.
 	c.handleUpdate(oldDesire, newDesire)
-	if got := drain(); len(got) != 1 || got[0] != key {
-		t.Fatalf("first unchanged-etag update queued %v, want [%v]", got, key)
+	if got := c.queue.Len(); got != 1 {
+		t.Fatalf("queue.Len after unchanged-etag update = %d, want 1", got)
 	}
-
-	// 1.5s later: still inside the 2s cooldown. Gate denies.
-	fc.SetTime(t0.Add(1500 * time.Millisecond))
-	c.handleUpdate(oldDesire, newDesire)
-	if got := drain(); len(got) != 0 {
-		t.Errorf("at 1.5s (cooldown=2s) drained %v, want none", got)
-	}
-
-	// 2.1s later (past cooldown): gate reopens.
-	fc.SetTime(t0.Add(2100 * time.Millisecond))
-	c.handleUpdate(oldDesire, newDesire)
-	if got := drain(); len(got) != 1 || got[0] != key {
-		t.Fatalf("at 2.1s (past cooldown) drained %v, want [%v]", got, key)
-	}
-
-	// Immediately after the gate just fired, the next window starts from
-	// 2.1s and the gate is closed again until 4.1s.
-	c.handleUpdate(oldDesire, newDesire)
-	if got := drain(); len(got) != 0 {
-		t.Errorf("immediately after pass-through drained %v, want none", got)
+	gotKey, _ := c.queue.Get()
+	if gotKey != key {
+		t.Errorf("queued key = %v, want %v", gotKey, key)
 	}
 }
 

--- a/kube-applier/pkg/controllers/read_desire_manager/controller.go
+++ b/kube-applier/pkg/controllers/read_desire_manager/controller.go
@@ -31,10 +31,8 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	utilsclock "k8s.io/utils/clock"
 
 	"github.com/Azure/ARO-HCP/internal/api/kubeapplier"
-	controllerutil "github.com/Azure/ARO-HCP/internal/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/database"
 	"github.com/Azure/ARO-HCP/internal/utils"
 	"github.com/Azure/ARO-HCP/kube-applier/pkg/controllers/conditions"
@@ -43,40 +41,28 @@ import (
 	"github.com/Azure/ARO-HCP/kube-applier/pkg/controllers/read_desire_kubernetes"
 )
 
-// DefaultCooldownPeriod is the minimum interval between two reconciles of a
-// ReadDesire whose Cosmos etag has not changed. The manager's per-key
-// reconcile is bookkeeping (start/stop of the per-instance kube reflector),
-// so the periodic re-check is much less time-sensitive than apply or delete;
-// 10 minutes matches apply_desire's default and avoids needless churn on the
-// per-instance controllers.
-//
-// Real content changes (Add events, Update events with a different etag,
-// and Delete events) bypass this gate so per-instance controllers are
-// (re)launched or stopped promptly.
-const DefaultCooldownPeriod = 10 * time.Minute
+// DefaultResyncPeriod is the maximum interval between two reconciles of a
+// ReadDesire whose Cosmos etag has not changed. If content changes, the
+// controller reconciles immediately; otherwise it schedules a resync after
+// this duration. 10 minutes matches apply_desire's default.
+const DefaultResyncPeriod = 10 * time.Minute
 
 // ReadDesireInformerManagingControllerName is the per-controller identifier
 // emitted in the "controller_name" log key and used as the workqueue name.
 // Mirrors the backend convention.
 const ReadDesireInformerManagingControllerName = "ReadDesireInformerManagingController"
 
-// Config tunes the manager's cooldown behavior. Zero-valued fields take the
-// Default* constants; tests pass shorter durations and a fake clock.
+// Config tunes the manager's resync behavior. Zero-valued fields take the
+// Default* constants; tests pass shorter durations.
 type Config struct {
-	// CooldownPeriod gates re-reconciles for a desire whose Cosmos etag has
-	// not changed. See DefaultCooldownPeriod.
-	CooldownPeriod time.Duration
-	// Clock is the time source used by the cooldown gate. nil =
-	// utilsclock.RealClock{}.
-	Clock utilsclock.PassiveClock
+	// ResyncPeriod is the maximum time between re-reconciles for a desire
+	// whose Cosmos etag has not changed. See DefaultResyncPeriod.
+	ResyncPeriod time.Duration
 }
 
 func (c Config) withDefaults() Config {
-	if c.CooldownPeriod == 0 {
-		c.CooldownPeriod = DefaultCooldownPeriod
-	}
-	if c.Clock == nil {
-		c.Clock = utilsclock.RealClock{}
+	if c.ResyncPeriod == 0 {
+		c.ResyncPeriod = DefaultResyncPeriod
 	}
 	return c
 }
@@ -97,14 +83,12 @@ type PerInstanceFactory interface {
 // ReadDesireInformerManagingController watches ReadDesires and manages the
 // per-instance kubernetes reflectors.
 //
-// Reconcile cadence (mirrors apply_desire and backend's GenericWatchingController):
+// Reconcile cadence:
 //
-//   - Add events queue immediately.
-//   - Update events whose Cosmos etag differs from the previous version queue
-//     immediately. Etag-unchanged updates (informer resyncs, or our own
-//     status writes feeding back) are routed through the cooldown gate.
-//   - Delete events queue immediately so the per-instance controller stops
-//     promptly when a ReadDesire is removed from Cosmos.
+//   - Add, Update, and Delete events queue immediately.
+//   - The informer's ResyncPeriod (set to cfg.ResyncPeriod) controls how
+//     often unchanged items are re-delivered, guaranteeing periodic
+//     reconciliation.
 //   - On error the workqueue's rate limiter requeues the key with backoff.
 type ReadDesireInformerManagingController struct {
 	name               string
@@ -114,8 +98,7 @@ type ReadDesireInformerManagingController struct {
 	writer             desirestatuswriter.StatusWriter[kubeapplier.ReadDesire, keys.ReadDesireKey]
 	queue              workqueue.TypedRateLimitingInterface[keys.ReadDesireKey]
 
-	cfg      Config
-	cooldown controllerutil.CooldownChecker
+	cfg Config
 
 	// running tracks the live per-instance ReadDesireKubernetesController for
 	// each ReadDesire by its key. The map is mutated only under mu. SyncOnce
@@ -152,8 +135,6 @@ func NewReadDesireInformerManagingController(
 ) (*ReadDesireInformerManagingController, error) {
 	cfg = cfg.withDefaults()
 	fetcher := &readDesireFetcher{crudByParent: crudByParent}
-	cooldownChecker := controllerutil.NewTimeBasedCooldownChecker(cfg.CooldownPeriod)
-	cooldownChecker.SetClock(cfg.Clock)
 	c := &ReadDesireInformerManagingController{
 		name:               ReadDesireInformerManagingControllerName,
 		readDesireInformer: readDesireInformer,
@@ -167,15 +148,20 @@ func NewReadDesireInformerManagingController(
 			fetcher,
 			&readDesireReplacer{crudByParent: crudByParent},
 		),
-		cfg:      cfg,
-		cooldown: cooldownChecker,
-		running:  map[keys.ReadDesireKey]*runningInstance{},
+		cfg:     cfg,
+		running: map[keys.ReadDesireKey]*runningInstance{},
 	}
 
-	if _, err := readDesireInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	logger := utils.DefaultLogger()
+	logger = logger.WithValues(utils.LogValues{}.AddControllerName(ReadDesireInformerManagingControllerName)...)
+
+	if _, err := readDesireInformer.AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj any) { c.handleAdd(obj) },
 		UpdateFunc: func(oldObj, newObj any) { c.handleUpdate(oldObj, newObj) },
 		DeleteFunc: func(obj any) { c.handleDelete(obj) },
+	}, cache.HandlerOptions{
+		Logger:       &logger,
+		ResyncPeriod: &cfg.ResyncPeriod,
 	}); err != nil {
 		return nil, fmt.Errorf("register informer handler: %w", err)
 	}
@@ -224,9 +210,7 @@ func (c *ReadDesireInformerManagingController) Run(ctx context.Context, threadin
 	<-ctx.Done()
 }
 
-// handleAdd queues every observed Add unconditionally — a new ReadDesire
-// has never been reconciled, so the cooldown gate has nothing to compare
-// against.
+// handleAdd queues every observed Add unconditionally.
 func (c *ReadDesireInformerManagingController) handleAdd(obj any) {
 	d, ok := obj.(*kubeapplier.ReadDesire)
 	if !ok {
@@ -235,30 +219,14 @@ func (c *ReadDesireInformerManagingController) handleAdd(obj any) {
 	c.enqueue(d)
 }
 
-// handleUpdate queues immediately when the Cosmos etag differs — that is
-// the signal that something the manager cares about (TargetItem, Spec, or
-// our own status write) actually moved. Etag-unchanged updates are
-// informer resyncs of an already-running instance: route them through the
-// cooldown gate so we don't churn through bookkeeping for nothing.
-func (c *ReadDesireInformerManagingController) handleUpdate(oldObj, newObj any) {
-	oldD, oldOK := oldObj.(*kubeapplier.ReadDesire)
+// handleUpdate enqueues the key unconditionally. The informer's
+// ResyncPeriod controls how often unchanged items are re-delivered.
+func (c *ReadDesireInformerManagingController) handleUpdate(_, newObj any) {
 	newD, newOK := newObj.(*kubeapplier.ReadDesire)
-	if !oldOK || !newOK {
+	if !newOK {
 		return
 	}
-	if oldD.GetEtag() != newD.GetEtag() {
-		c.enqueue(newD)
-		return
-	}
-	key, err := keys.ReadDesireKeyFromResourceID(newD.GetResourceID())
-	if err != nil {
-		utilruntime.HandleError(err)
-		return
-	}
-	if !c.cooldown.CanSync(context.TODO(), key) {
-		return
-	}
-	c.queue.Add(key)
+	c.enqueue(newD)
 }
 
 // handleDelete queues every observed Delete unconditionally so the

--- a/test-integration/utils/databasemutationhelpers/step_sync_cluster_cluster_service_update_dispatch.go
+++ b/test-integration/utils/databasemutationhelpers/step_sync_cluster_cluster_service_update_dispatch.go
@@ -78,12 +78,10 @@ func (s *syncClusterClusterServiceUpdateDispatchStep) RunTest(ctx context.Contex
 	require.NoError(t, err)
 
 	clusterLister := &listertesting.SliceClusterLister{Clusters: []*api.HCPOpenShiftCluster{cluster}}
-	activeOperationLister := &listertesting.SliceActiveOperationLister{}
 	subscriptionLister := &listertesting.DBSubscriptionLister{ResourcesDBClient: stepInput.ResourcesDBClient}
 	syncer := clusterupdate.NewClusterClusterServiceUpdateDispatchSyncer(
 		stepInput.ResourcesDBClient,
 		stepInput.ClusterServiceMockInfo.MockClusterServiceClient,
-		activeOperationLister,
 		clusterLister,
 		subscriptionLister,
 	)


### PR DESCRIPTION
Remove CooldownChecker from apply_desire and read_desire_manager controllers. The resync period is now set via AddEventHandlerWithOptions on the informer registration, which controls how often unchanged items are re-delivered. Content changes (etag differs) still trigger immediate reconciliation.

Also fix pre-existing lint and build breakage on the kill-cooldown branch: remove unused controllerutil imports, stale cooldownChecker struct literal fields in tests, and activeOperationLister args from updated constructor call sites.
