### PR TITLE
 [WIP] Add HO/CPO deployments to CI artifacts and snapshot analize

### DIFF
--- a/tooling/hcpctl/pkg/snapshot/gatherer.go
+++ b/tooling/hcpctl/pkg/snapshot/gatherer.go
@@ -17,6 +17,7 @@ package snapshot
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -29,6 +30,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+
+	"sigs.k8s.io/yaml"
 
 	"github.com/Azure/azure-kusto-go/azkustodata"
 	"github.com/Azure/azure-kusto-go/azkustodata/kql"
@@ -749,6 +752,18 @@ func (g *Gatherer) gatherPhase(
 					verificationSuite: phase.name + "/" + key,
 				})
 			}
+
+			// Deployments queries
+			deploymentsDir := filepath.Join(resDir, "deployments")
+			for _, q := range queriesByCategory(categoryDeployments) {
+				poolItems = append(poolItems, workItem{
+					query:             q,
+					data:              phaseDataPtr,
+					mu:                phaseMu,
+					outputDir:         deploymentsDir,
+					verificationSuite: phase.name + "/" + key,
+				})
+			}
 		}
 
 		// Per-request trace queries — only for requests in this phase.
@@ -1060,21 +1075,26 @@ func (g *Gatherer) executeQuery(ctx context.Context, q querySpec, data *queryDat
 		return nil, fmt.Errorf("query %s failed: %w", q.key(), err)
 	}
 
-	// Write combined output file: README + query + results.
 	outDir := filepath.Join(baseDir, q.component)
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create output directory: %w", err)
 	}
 
-	readme := readQueryReadme(q)
-	md := composeOutput(readme, rendered, rows)
-	mdFile := filepath.Join(outDir, q.queryName+".md")
-	if err := os.WriteFile(mdFile, []byte(md), 0o644); err != nil {
-		return nil, fmt.Errorf("failed to write output: %w", err)
+	if q.outputFormat == "yaml" {
+		if err := writeYAMLOutput(outDir, q, rows); err != nil {
+			return nil, err
+		}
+	} else {
+		readme := readQueryReadme(q)
+		md := composeOutput(readme, rendered, rows)
+		mdFile := filepath.Join(outDir, q.queryName+".md")
+		if err := os.WriteFile(mdFile, []byte(md), 0o644); err != nil {
+			return nil, fmt.Errorf("failed to write output: %w", err)
+		}
 	}
 
 	if len(rows) > 0 {
-		logger.V(1).Info("Wrote query output", "query", q.key(), "rows", len(rows), "file", mdFile)
+		logger.V(1).Info("Wrote query output", "query", q.key(), "rows", len(rows))
 	} else {
 		logger.V(1).Info("Query returned no results", "query", q.key())
 	}
@@ -1123,11 +1143,43 @@ func writeQueryOutput(q querySpec, data queryData, baseDir string, cachedRows []
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
+	if q.outputFormat == "yaml" {
+		return writeYAMLOutput(outDir, q, cachedRows)
+	}
+
 	readme := readQueryReadme(q)
 	md := composeOutput(readme, rendered, cachedRows)
 	mdFile := filepath.Join(outDir, q.queryName+".md")
 	if err := os.WriteFile(mdFile, []byte(md), 0o644); err != nil {
 		return fmt.Errorf("failed to write output: %w", err)
+	}
+
+	return nil
+}
+
+// writeYAMLOutput extracts the first column of the first result row (expected
+// to be a JSON object from a Kusto dynamic column), converts it to YAML, and
+// writes it as <queryName>.yaml. If there are no results, no file is written.
+func writeYAMLOutput(outDir string, q querySpec, rows []resultRow) error {
+	if len(rows) == 0 || len(rows[0].values) == 0 {
+		return nil
+	}
+
+	jsonStr := rows[0].values[0]
+
+	var obj interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &obj); err != nil {
+		return fmt.Errorf("query %s: failed to parse JSON from Kusto result: %w", q.key(), err)
+	}
+
+	yamlBytes, err := yaml.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("query %s: failed to convert to YAML: %w", q.key(), err)
+	}
+
+	outFile := filepath.Join(outDir, q.queryName+".yaml")
+	if err := os.WriteFile(outFile, yamlBytes, 0o644); err != nil {
+		return fmt.Errorf("failed to write YAML output: %w", err)
 	}
 
 	return nil

--- a/tooling/hcpctl/pkg/snapshot/manifest.go
+++ b/tooling/hcpctl/pkg/snapshot/manifest.go
@@ -192,6 +192,7 @@ func directoryLayout() map[string]string {
 		"state":          "<phase>/resources/<type>/<name>/state/ — time-windowed raw resource state dumps (ARM state, CS state, Maestro logs, etc.)",
 		"conditions":     "<phase>/resources/<type>/<name>/conditions/ — status condition transition summaries (HyperShift conditions, controller conditions)",
 		"logs":           "<phase>/resources/<type>/<name>/logs/ — filtered or aggregated container and audit logs (operator logs, Maestro server/agent logs)",
+		"deployments":    "<phase>/resources/<type>/<name>/deployments/ — Kubernetes resource snapshots (e.g. Deployment manifests) from Kusto, written as YAML",
 		"requests":       "<phase>/resources/<type>/<name>/requests/<METHOD>-<client_request_id>/ — per-request trace data with state/ and logs/ subdirectories",
 		"node_boot_logs": "node_boot_logs/ — VM serial console output (boot diagnostics) from nodes in the test. Files are named <node-name>-console.log. Each entry in manifest.json node_console_logs includes an artifact_url for downloading the original from the Prow job artifacts.",
 		"azure_sdk_log":  "azure_sdk_log/azure.log — client-side Azure SDK request/response log. Present only when manifest.json azure_log is set.",

--- a/tooling/hcpctl/pkg/snapshot/queries.go
+++ b/tooling/hcpctl/pkg/snapshot/queries.go
@@ -74,6 +74,11 @@ const (
 	// (e.g. control plane events for a cluster). They are written to
 	// resources/<type>/<name>/events/<component>/<queryName>.md.
 	categoryResourceEvents queryCategory = "resourceEvents"
+
+	// categoryDeployments queries extract Kubernetes resource snapshots (e.g. Deployment
+	// manifests). They run once per unique resource and are written to
+	// resources/<type>/<name>/deployments/<component>/<queryName>.yaml.
+	categoryDeployments queryCategory = "deployments"
 )
 
 // querySpec describes a single KQL query in the dependency chain.
@@ -102,6 +107,11 @@ type querySpec struct {
 	// are ambiguous (e.g. multiple distinct values for a single-valued field),
 	// storeResult should return an error.
 	storeResult func(*queryData, []resultRow) error
+	// outputFormat controls how results are written. Empty (default) produces
+	// a markdown file (.md) with query text and a results table. "yaml"
+	// extracts the first column of the first row, converts it from JSON to
+	// YAML, and writes a .yaml file.
+	outputFormat string
 }
 
 // key returns the "component/queryName" identifier for this query.
@@ -746,6 +756,30 @@ var allQueries = []querySpec{
 		templatePath: "queries/hypershift/clusterAPIProviderLogs/query.kql",
 		database:     "hcp",
 		category:     categoryLogs,
+		ready: func(d queryData) bool {
+			return d.HostedControlPlaneNamespace != "" && strings.EqualFold(d.ResourceType, "microsoft.redhatopenshift/hcpopenshiftclusters")
+		},
+		prerequisites: "HostedControlPlaneNamespace, ResourceType is cluster",
+	},
+	{
+		component:    "hypershift",
+		queryName:    "hypershiftOperatorDeployment",
+		templatePath: "queries/hypershift/hypershiftOperatorDeployment/query.kql",
+		database:     "service",
+		category:     categoryDeployments,
+		outputFormat: "yaml",
+		ready: func(d queryData) bool {
+			return strings.EqualFold(d.ResourceType, "microsoft.redhatopenshift/hcpopenshiftclusters")
+		},
+		prerequisites: "ResourceType is cluster",
+	},
+	{
+		component:    "hypershift",
+		queryName:    "controlPlaneOperatorDeployment",
+		templatePath: "queries/hypershift/controlPlaneOperatorDeployment/query.kql",
+		database:     "service",
+		category:     categoryDeployments,
+		outputFormat: "yaml",
 		ready: func(d queryData) bool {
 			return d.HostedControlPlaneNamespace != "" && strings.EqualFold(d.ResourceType, "microsoft.redhatopenshift/hcpopenshiftclusters")
 		},

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/controlPlaneOperatorDeployment/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/controlPlaneOperatorDeployment/query.kql
@@ -1,0 +1,10 @@
+cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubernetesResourceSnapshots')
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
+| where objectKind == 'Deployment'
+| where namespace == '{{ .HostedControlPlaneNamespace }}'
+| where name == 'control-plane-operator'
+| summarize arg_max(timestamp, object) by namespace, name
+| project object

--- a/tooling/hcpctl/pkg/snapshot/queries/hypershift/hypershiftOperatorDeployment/query.kql
+++ b/tooling/hcpctl/pkg/snapshot/queries/hypershift/hypershiftOperatorDeployment/query.kql
@@ -1,0 +1,10 @@
+cluster('{{ .ClusterURI }}').database('{{ .ServiceDatabase }}').table('kubernetesResourceSnapshots')
+| where timestamp between ({{ kqlDatetime .PhaseStartTime }} .. {{ kqlDatetime .PhaseEndTime }})
+{{- if and .ServiceClusterName .ManagementClusterName }}
+| where cluster in ('{{ .ServiceClusterName }}', '{{ .ManagementClusterName }}')
+{{- end }}
+| where objectKind == 'Deployment'
+| where namespace == 'hypershift'
+| where name == 'operator'
+| summarize arg_max(timestamp, object) by namespace, name
+| project object


### PR DESCRIPTION
  Do not review it yet. This requires PR #6270 to be tested/validated.
  
  Jira: [ARO-28661](https://redhat.atlassian.net/browse/ARO-28661)

  *Summary*

  - Add HyperShift Operator (HO) and Control Plane Operator (CPO) Deployment object snapshots to the gather-snapshot CI artifacts
  - New KQL queries fetch the latest Deployment from the kubernetesResourceSnapshots Kusto table and write them as YAML files per test phase
  - Introduce a categoryDeployments query category and a yaml output format to the snapshot gatherer, enabling raw YAML output alongside the existing
  markdown format

  *New CI artifacts*

  <phase>/resources/<type>/<name>/deployments/hypershift/hypershiftOperatorDeployment.yaml
  <phase>/resources/<type>/<name>/deployments/hypershift/controlPlaneOperatorDeployment.yaml

  *Dependencies*

  This depends on the DeploymentWatcher (PR #6270) to populate the kubernetesResourceSnapshots Kusto table with Deployment events from management
  clusters.

  *Test plan*
  - [ ] Verify deployment YAML files appear in snapshot artifacts after PR #6270 is deployed