### PR TITLE
docs(ci): design doc for the EV2 retry catcher (AROSLSRE-1726)

### DIFF
--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -132,7 +132,7 @@ ARO HCP CI is split across this repository and the OpenShift CI configuration in
 - [Design](ev2-retry-catcher.md#design)
 - [End-To-End Flow](ev2-retry-catcher.md#end-to-end-flow)
 - [E2E Tagging (ARO-HCP)](ev2-retry-catcher.md#1-e2e-tagging-aro-hcp)
-- [Writing The Retry Signal (ARO-HCP)](ev2-retry-catcher.md#2-writing-the-retry-signal-aro-hcp)
+- [Writing The Retry Facts (ARO-HCP)](ev2-retry-catcher.md#2-writing-the-retry-facts-aro-hcp)
 - [Consuming The Signal (ARO-Tools)](ev2-retry-catcher.md#3-consuming-the-signal-aro-tools)
 - [Expiration Configuration](ev2-retry-catcher.md#expiration-configuration)
 - [Where To Look](ev2-retry-catcher.md#where-to-look)

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -124,6 +124,19 @@ ARO HCP CI is split across this repository and the OpenShift CI configuration in
 - [Promotion Gating](ev2-integration.md#promotion-gating)
 - [Where To Look](ev2-integration.md#where-to-look)
 
+### [EV2 Retry Catcher](ev2-retry-catcher.md)
+
+- [Problem](ev2-retry-catcher.md#problem)
+- [Goal](ev2-retry-catcher.md#goal)
+- [Non-goals](ev2-retry-catcher.md#non-goals)
+- [Design](ev2-retry-catcher.md#design)
+- [End-To-End Flow](ev2-retry-catcher.md#end-to-end-flow)
+- [E2E Tagging (ARO-HCP)](ev2-retry-catcher.md#1-e2e-tagging-aro-hcp)
+- [Emitting The Retry Marker (ARO-HCP)](ev2-retry-catcher.md#2-emitting-the-retry-marker-aro-hcp)
+- [Consuming The Marker (ARO-Tools)](ev2-retry-catcher.md#3-consuming-the-marker-aro-tools)
+- [Expiration Configuration](ev2-retry-catcher.md#expiration-configuration)
+- [Where To Look](ev2-retry-catcher.md#where-to-look)
+
 ### [CI Cleanup](cleanup.md)
 
 - [The Three Cleanup Modes](cleanup.md#the-three-cleanup-modes)
@@ -201,6 +214,7 @@ ARO HCP CI is split across this repository and the OpenShift CI configuration in
 - [DEV CI Monitoring and Alert Response](dev-ci-monitoring.md) is the canonical Slack and PagerDuty runbook for DEV CI telemetry, alert response, exporter checks, and routing maintenance.
 - [Opstool CI Platform](opstool.md) explains the standalone AKS platform, shared monitoring infrastructure, and workload rollout model that host DEV CI tools.
 - [CI EV2 Integration](ev2-integration.md) explains how EV2 selects Prow jobs, authenticates to Gangway, and pins runs to the exact rollout commit.
+- [EV2 Retry Catcher](ev2-retry-catcher.md) explains how a narrow, deliberately labeled set of known-issue test failures triggers an automatic single retry of an EV2 gating run instead of a manual retrigger.
 - [CI Cleanup](cleanup.md) explains why cleanup is intentionally split across strict per-test teardown, targeted environment teardown, and background hygiene.
 - [E2E Testing In CI](e2e-testing.md) explains how to trigger E2E jobs from PRs and how to narrow test selection safely.
 - [Upgrade-Path Presubmit](upgrade-path-presubmit.md) explains the optional `upgrade-e2e-parallel` job that validates main-to-PR infrastructure upgrades, including how to trigger it, interpret failures, and understand its image resolution strategy.

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -132,8 +132,8 @@ ARO HCP CI is split across this repository and the OpenShift CI configuration in
 - [Design](ev2-retry-catcher.md#design)
 - [End-To-End Flow](ev2-retry-catcher.md#end-to-end-flow)
 - [E2E Tagging (ARO-HCP)](ev2-retry-catcher.md#1-e2e-tagging-aro-hcp)
-- [Emitting The Retry Marker (ARO-HCP)](ev2-retry-catcher.md#2-emitting-the-retry-marker-aro-hcp)
-- [Consuming The Marker (ARO-Tools)](ev2-retry-catcher.md#3-consuming-the-marker-aro-tools)
+- [Writing The Retry Signal (ARO-HCP)](ev2-retry-catcher.md#2-writing-the-retry-signal-aro-hcp)
+- [Consuming The Signal (ARO-Tools)](ev2-retry-catcher.md#3-consuming-the-signal-aro-tools)
 - [Expiration Configuration](ev2-retry-catcher.md#expiration-configuration)
 - [Where To Look](ev2-retry-catcher.md#where-to-look)
 

--- a/docs/ci/ev2-integration.md
+++ b/docs/ci/ev2-integration.md
@@ -154,5 +154,6 @@ When you need to change or debug EV2-to-Prow integration, start here:
 
 - [CI Overview](README.md)
 - [CI Execution](execution.md)
+- [EV2 Retry Catcher](ev2-retry-catcher.md)
 - [CI Operations](operations.md)
 - [Renew the Prow Token](../sops/renew-prow-token.md)

--- a/docs/ci/ev2-retry-catcher.md
+++ b/docs/ci/ev2-retry-catcher.md
@@ -18,7 +18,7 @@ This is scoped to EV2 Stage/Prod gating steps only. Periodic and pre-merge/PR-va
 
 - Blind retry-until-green. Every failure is still triaged; this only removes the manual retrigger latency for a pre-agreed, narrow case.
 - Retrying on infra or management-cluster failures. Those need a different, separate mechanism (see the discussion in AROSLSRE-1721).
-- A permanent allowlist. Labeled tests are expected to carry a fix commitment and come off the label once fixed (see [TTL / "timebomb" intent](#ttl--timebomb-intent) below).
+- A permanent allowlist. Labeled tests are expected to carry a fix commitment and come off the label once fixed (see [Expiration configuration](#expiration-configuration) below).
 
 ## Design
 
@@ -141,7 +141,7 @@ then the catcher writes a single, easy-to-grep line to stderr:
 EV2_RETRY_ALLOWED: N known-issue test(s) failed (max 2 allowed), all labeled "allow-retry": [test names...]
 ```
 
-Any failure outside that narrow condition - more than 2 failures, or any failure without the label mixed in - means no marker is written at all, so the gate fails exactly as it does today with no behavior change. Stderr (not stdout) is used because that's where ci-operator/Prow persist step logs into `build-log.txt`, which is what the consumer side reads back.
+Any failure outside that narrow condition - more than 2 failures, or any failure without the label mixed in - means no marker is written at all, so the gate fails exactly as it does today with no behavior change. Stderr (not stdout) is used because that's where ci-operator/Prow persists step logs into `build-log.txt`, which is what the consumer side reads back.
 
 ### 3. Consuming the marker (ARO-Tools)
 

--- a/docs/ci/ev2-retry-catcher.md
+++ b/docs/ci/ev2-retry-catcher.md
@@ -1,0 +1,201 @@
+# EV2 Retry Catcher
+
+This document describes the design behind automatically retrying an EV2 gating E2E run when it fails on a small, deliberately labeled set of known-issue tests.
+
+## Problem
+
+EV2 Stage and Prod rollouts gate promotion on an E2E run against the pinned rollout commit (see [CI EV2 Integration](ev2-integration.md)). When that gating run fails because of a single test with a known, already-tracked issue, someone still has to notice the failure, review the Prow output, and manually retrigger the run before the rollout can continue.
+
+For Stage this means starting a brand new full rollout just to retry the E2E step. For Prod it means booting up a SAW device just to click retry. Both add real latency and churn to every rollout, for a class of failure that is already understood and already has a fix in flight.
+
+## Goal
+
+Automate exactly the manual step SREs already perform today: retry the gating E2E run once when it fails narrowly on tests known to have an open issue, and leave everything else (infra errors, timeouts, broad or unexpected failures) to fail the gate and page a human as usual.
+
+This is scoped to EV2 Stage/Prod gating steps only. Periodic and pre-merge/PR-validation jobs are not affected.
+
+## Non-goals
+
+- Blind retry-until-green. Every failure is still triaged; this only removes the manual retrigger latency for a pre-agreed, narrow case.
+- Retrying on infra or management-cluster failures. Those need a different, separate mechanism (see the discussion in AROSLSRE-1721).
+- A permanent allowlist. Labeled tests are expected to carry a fix commitment and come off the label once fixed (see [TTL / "timebomb" intent](#ttl--timebomb-intent) below).
+
+## Design
+
+The mechanism is split across two repositories, each responsible for one half of the signal:
+
+```mermaid
+---
+config:
+  layout: dagre
+---
+flowchart LR
+ subgraph aro_hcp["ARO-HCP"]
+        label["allow-retry label\non known-issue tests"]
+        catcher["registerEV2RetryCatcher\n(test/cmd/aro-hcp-tests)"]
+        marker["EV2_RETRY_ALLOWED\nbuild-log marker"]
+  end
+ subgraph prow["Prow"]
+        job["E2E gating job"]
+        buildlog["build-log.txt\n(GCS)"]
+  end
+ subgraph aro_tools["ARO-Tools"]
+        executor["prow-job-executor"]
+        monitor["prowjob.Monitor"]
+        retry["single retry\n(allowEV2Retry=false)"]
+  end
+  label --> catcher
+  job -- runs --> catcher
+  catcher -- "<=2 failures, all labeled" --> marker
+  marker -- written to --> buildlog
+  executor --> monitor
+  monitor -- "job failed" --> buildlog
+  buildlog -- "marker found" --> retry
+  retry -- resubmit once --> job
+```
+
+### End-to-end flow
+
+The full sequence for a single EV2 gating attempt, from rollout to (possible) retry:
+
+```mermaid
+sequenceDiagram
+    participant EV2
+    participant executor as prow-job-executor
+    participant gangway as Gangway
+    participant job as Prow E2E job
+    participant gcs as GCS build-log.txt
+
+    EV2->>executor: execute --gate-promotion --allow-ev2-retry
+    executor->>gangway: SubmitJob (pinned to rollout commit)
+    gangway->>job: start job
+    job->>job: run e2e-parallel suite
+    job->>gcs: stream build log (incl. EV2_RETRY_ALLOWED if applicable)
+    job-->>executor: ProwJobStatus = failure
+    executor->>executor: classify as JobFailedError (FailureState)
+    executor->>gcs: fetch build-log.txt
+    gcs-->>executor: log content
+    executor->>executor: scan for EV2_RETRY_ALLOWED marker
+    alt marker found
+        executor->>gangway: SubmitJob again (retryMonitor, allowEV2Retry=false)
+        gangway->>job: start retry job
+        job-->>executor: ProwJobStatus = success/failure
+        executor-->>EV2: final result (no further retry either way)
+    else marker absent, or ErrorState/AbortedState
+        executor-->>EV2: fail the gate immediately
+    end
+```
+
+Two properties fall out of this directly:
+
+- **Only `FailureState` is inspected.** `ErrorState` (infra/tooling error) and `AbortedState` (cancellation/timeout) go straight to failing the gate; the build log is never fetched for those, since they are not the class of failure this mechanism is meant to catch.
+- **The retry is unconditional once triggered.** Whatever the retried run's outcome is (pass or fail), the executor does not evaluate the marker again and does not resubmit again - the shallow-copied `Monitor` used for the retry has `allowEV2Retry` hardcoded to `false`, so there is no code path back into the retry branch.
+
+### 1. E2E tagging (ARO-HCP)
+
+The signal starts as an ordinary Ginkgo label, using the same mechanism ARO-HCP's E2E suite already uses for other test metadata (`test/util/labels/labels.go`):
+
+```go
+// AllowRetry marks a test as safe to auto-retry during an EV2 Stage/Prod
+// gating run when it fails due to a known, actively tracked issue. This is
+// a temporary measure with a TTL: every use must have an owner and a
+// tracking issue, and the label must be removed once the underlying issue
+// is fixed. See AROSLSRE-1721.
+AllowRetry = ginkgo.Label("allow-retry")
+```
+
+A test opts in by adding `labels.AllowRetry` to its own label list on the `It(...)` call, alongside any other labels it already carries, e.g.:
+
+```go
+It("...", labels.RequireHappyPathInfra, labels.AllowRetry, func(ctx context.Context) {
+    ...
+})
+```
+
+At suite build time, `registerEV2RetryCatcher` (`test/cmd/aro-hcp-tests/main.go`) walks the full `ExtensionTestSpecs` once, before the suite runs, and precomputes the set of test names that carry the label:
+
+```go
+allowRetryNames := map[string]bool{}
+for _, spec := range specs {
+    if spec.Labels.Has(labels.AllowRetry[0]) {
+        allowRetryNames[spec.Name] = true
+    }
+}
+```
+
+It then registers `AddAfterEach` / `AddAfterAll` hooks (from `openshift-tests-extension`'s lifecycle API) that, guarded by a mutex, track every failure as it happens and check whether it's in `allowRetryNames`. This correlate-by-name approach exists because `openshift-tests-extension`'s `ExtensionTestResult` does not carry a `Labels` field on the result itself - the label set has to be captured from the pre-run spec list up front.
+
+At `AddAfterAll`, once the whole suite has finished, the accumulated counts decide whether to emit the marker (see [Emitting the retry marker](#2-emitting-the-retry-marker-aro-hcp) below).
+
+### 2. Emitting the retry marker (ARO-HCP)
+
+If, once the suite finishes:
+
+- at least one test failed, and
+- the total number of failed tests is at most `maxAutoRetryFailures` (currently `2`, a `const` in `test/cmd/aro-hcp-tests/main.go`), and
+- every failed test is in `allowRetryNames` (i.e. `nonRetriableFailures == 0`)
+
+then the catcher writes a single, easy-to-grep line to stderr:
+
+```text
+EV2_RETRY_ALLOWED: N known-issue test(s) failed (max 2 allowed), all labeled "allow-retry": [test names...]
+```
+
+Any failure outside that narrow condition - more than 2 failures, or any failure without the label mixed in - means no marker is written at all, so the gate fails exactly as it does today with no behavior change. Stderr (not stdout) is used because that's where ci-operator/Prow persist step logs into `build-log.txt`, which is what the consumer side reads back.
+
+### 3. Consuming the marker (ARO-Tools)
+
+`prow-job-executor`'s `prowjob.Monitor` gets a `allowEV2Retry bool` field (set from the new `--allow-ev2-retry` CLI flag) and a dedicated `JobFailedError` type that carries the `ProwExecutionID` and `Status.URL` of a job that ended in `FailureState`. This type only exists so `ExecuteAndWait` can distinguish "the job ran and a test failed" from any other error via `errors.As`.
+
+`ExecuteAndWait` is split into a public wrapper and a private `executeAndWaitOnce`:
+
+- `executeAndWaitOnce` is the original submit-and-poll logic, unchanged: submit through Gangway, poll `GetJobStatus` until a terminal state, return `nil`/error accordingly.
+- `ExecuteAndWait` calls `executeAndWaitOnce` once. If it returns a `JobFailedError` and `allowEV2Retry` is set, it:
+  1. converts the job's Prow "view" status URL (`https://<prow-host>/view/gs/<bucket>/<path>`) into its plain-text GCS log URL (`https://storage.googleapis.com/<bucket>/<path>/build-log.txt`), via `buildLogURLFromViewURL`,
+  2. fetches that log (bounded by a byte cap and a fetch timeout) and scans it for the `EV2_RETRY_ALLOWED` marker, via `buildLogContainsEV2RetryMarker` / `fetchLogContainsEV2RetryMarker`,
+  3. on a marker match, builds a shallow copy of the `Monitor` (`retryMonitor := *m; retryMonitor.allowEV2Retry = false`) and calls `executeAndWaitOnce` again on that copy.
+
+The shallow copy is what makes "exactly one retry" a structural guarantee rather than a counter that could be bypassed: the copy's `allowEV2Retry` is always `false`, so even if the retried run also fails with a marker present, there is no code path that resubmits a third time. The `client *Client` field is a pointer, so the copy safely shares the same HTTP client/backoff state as the original.
+
+`--allow-ev2-retry` is only wired into the `execute` subcommand's options (`RawExecuteOptions` / `completedExecuteOptions` in `options.go`); the separate read-only `monitor` subcommand always passes `false` to `NewMonitor`, since it observes a job it didn't submit and has no meaningful way to resubmit it.
+
+## Expiration configuration
+
+There is currently no automated enforcement of the TTL described below - it is a documented convention, not a CI-enforced check. This section describes what exists today and what a stronger mechanism could look like.
+
+**Current state (convention only):** the `AllowRetry` label's doc comment in `test/util/labels/labels.go` requires that every use have an owner and a tracking issue, and that the label be removed once the issue is fixed. There is no code path today that reads an expiry date, and nothing fails CI if a labeled test lingers.
+
+**Options for a stronger mechanism** (not yet implemented, tracked as a follow-up):
+
+- **Per-test expiry annotation.** Extend the label usage convention to require a comment with a tracking issue and a target removal date directly above each `labels.AllowRetry` usage, e.g. `// allow-retry until 2026-09-30, see AROSLSRE-XXXX`, and add a lint/CI check (a small Go analyzer or a grep-based presubmit check) that fails the build once that date has passed.
+- **Central manifest.** Instead of inline comments, maintain a small YAML/JSON file (e.g. `test/util/labels/allow-retry.yaml`) mapping test name -> tracking issue -> expiry date, loaded by `registerEV2RetryCatcher` to validate expiry at suite-build time and fail fast (or at least log loudly) if a label has expired.
+- **Periodic audit.** A scheduled job (or a recurring SRE Jira card) that lists all `allow-retry`-labeled tests and their age, independent of any code enforcement, as a lighter-weight starting point before investing in the above.
+
+Any of these can be layered on without changing the marker-emission or retry-consumption contract described above, since they only affect whether a test is allowed to carry the label in the first place, not how the label is consumed once present.
+
+## Naming
+
+The label and marker names went through some discussion (`flaky`, `retry-during-rollout`, `retryable-during-rollout`, `known-issue`, `ev2-retriable`) before settling on `allow-retry` / `EV2_RETRY_ALLOWED`, specifically to avoid implying anything about flakiness or root cause. The intent is purely operational: make it easy for SREs to decide when an automatic retry is reasonable, without conflating it with terms already used for other purposes (e.g. actual flaky-test quarantine).
+
+## Where to look
+
+- `test/util/labels/labels.go` - `AllowRetry` label definition
+- `test/cmd/aro-hcp-tests/main.go` - `registerEV2RetryCatcher`, `maxAutoRetryFailures`, marker emission
+- `test/e2e/README.md` - test-author-facing documentation of the label
+- ARO-Tools `tools/prow-job-executor/prowjob/monitor.go` - `JobFailedError`, `Monitor.allowEV2Retry`, single-retry `ExecuteAndWait`/`executeAndWaitOnce`
+- ARO-Tools `tools/prow-job-executor/prowjob/retrymarker.go` - `buildLogURLFromViewURL`, `buildLogContainsEV2RetryMarker`, `fetchLogContainsEV2RetryMarker`
+- ARO-Tools `tools/prow-job-executor/options.go` - `--allow-ev2-retry` flag, `AllowEV2Retry` option wiring
+- [Azure/ARO-HCP#6409](https://github.com/Azure/ARO-HCP/pull/6409) - label + marker emission implementation
+- [Azure/ARO-Tools#282](https://github.com/Azure/ARO-Tools/pull/282) - retry-catcher implementation
+
+## Follow-ups
+
+- Wire `--allow-ev2-retry=true` into the actual EV2 pipeline step definitions (`sdp-pipelines` / `openshift/release` step registry) for the environments that should use it.
+- Pick and implement one of the [expiration configuration](#expiration-configuration) options above so the TTL/timebomb intent is enforced rather than just documented.
+
+## See also
+
+- [CI EV2 Integration](ev2-integration.md)
+- [CI Execution](execution.md)
+- [E2E Testing In CI](e2e-testing.md)
+

--- a/docs/ci/ev2-retry-catcher.md
+++ b/docs/ci/ev2-retry-catcher.md
@@ -143,17 +143,19 @@ Once the suite finishes, the catcher always merges these keys into `$ARTIFACT_DI
 {
   "ev2-failed-tests": ["spec name 1", "spec name 2"],
   "ev2-allow-retry-tests": ["spec name 1"],
-  "ev2-tests-total": 42,
-  "ev2-tests-passed": 40,
-  "ev2-tests-failed": 2,
-  "ev2-tests-skipped": 0,
-  "ev2-suite-duration-seconds": 187.3
+  "ev2-suite-summary": {
+    "total": 42,
+    "passed": 40,
+    "failed": 2,
+    "skipped": 0,
+    "duration-seconds": 187.3
+  }
 }
 ```
 
 `ev2-failed-tests` is every spec that failed; `ev2-allow-retry-tests` is the subset of those that carried `labels.AllowRetry`. aro-hcp-tests reports only these raw facts - it does not decide whether the run qualifies for an automatic retry. That decision is policy (how many failures are tolerable, etc.) that belongs to prow-job-executor (see [Consuming the signal](#3-consuming-the-signal-aro-tools) below), which can evolve independently of an ARO-HCP release.
 
-The remaining `ev2-tests-*`/`ev2-suite-duration-seconds` keys aren't read by the retry decision either. They exist so anyone triaging a gating run from `finished.json` alone (a human, or a future dashboard) can see the run's basic shape (how many specs ran, how many of each result, how long the suite took wall-clock) without opening the Prow job UI.
+`ev2-suite-summary` isn't read by the retry decision either. It exists so anyone triaging a gating run from `finished.json` alone (a human, or a future dashboard) can see the run's basic shape (how many specs ran, how many of each result, how long the suite took wall-clock) without opening the Prow job UI. It's a nested object rather than more flat `ev2-*` keys so its field names don't read as confusingly similar to `ev2-failed-tests` (a name list, not a count); `duration-seconds` is rounded to one decisecond since a suite-level duration doesn't need nanosecond precision.
 
 Writing unconditionally, rather than only when a run happens to qualify, removes an ambiguity the original design had: with a conditional write, an absent key could mean either "nothing failed" or "failures happened but didn't qualify" - both looked identical from the consuming side, which caused confusion more than once while verifying this against real Prow runs. Now the keys' presence means the step ran at all; their content is the whole picture.
 

--- a/docs/ci/ev2-retry-catcher.md
+++ b/docs/ci/ev2-retry-catcher.md
@@ -137,16 +137,23 @@ At `AddAfterAll`, once the whole suite has finished, the accumulated failures an
 
 ### 2. Writing the retry facts (ARO-HCP)
 
-Once the suite finishes, the catcher always merges two keys into `$ARTIFACT_DIR/metadata.json` - even when nothing failed, in which case both are empty lists:
+Once the suite finishes, the catcher always merges these keys into `$ARTIFACT_DIR/metadata.json` - even when nothing failed, in which case the two lists are empty:
 
 ```json
 {
   "ev2-failed-tests": ["spec name 1", "spec name 2"],
-  "ev2-allow-retry-tests": ["spec name 1"]
+  "ev2-allow-retry-tests": ["spec name 1"],
+  "ev2-tests-total": 42,
+  "ev2-tests-passed": 40,
+  "ev2-tests-failed": 2,
+  "ev2-tests-skipped": 0,
+  "ev2-suite-duration-seconds": 187.3
 }
 ```
 
 `ev2-failed-tests` is every spec that failed; `ev2-allow-retry-tests` is the subset of those that carried `labels.AllowRetry`. aro-hcp-tests reports only these raw facts - it does not decide whether the run qualifies for an automatic retry. That decision is policy (how many failures are tolerable, etc.) that belongs to prow-job-executor (see [Consuming the signal](#3-consuming-the-signal-aro-tools) below), which can evolve independently of an ARO-HCP release.
+
+The remaining `ev2-tests-*`/`ev2-suite-duration-seconds` keys aren't read by the retry decision either. They exist so anyone triaging a gating run from `finished.json` alone (a human, or a future dashboard) can see the run's basic shape (how many specs ran, how many of each result, how long the suite took wall-clock) without opening the Prow job UI.
 
 Writing unconditionally, rather than only when a run happens to qualify, removes an ambiguity the original design had: with a conditional write, an absent key could mean either "nothing failed" or "failures happened but didn't qualify" - both looked identical from the consuming side, which caused confusion more than once while verifying this against real Prow runs. Now the keys' presence means the step ran at all; their content is the whole picture.
 
@@ -155,7 +162,7 @@ Writing unconditionally, rather than only when a run happens to qualify, removes
 - **A custom `finished.json` "result" value** (e.g. `RETRIABLE_FAILURE`) isn't possible - `result` is hardcoded by Prow's sidecar to `SUCCESS`/`FAILURE`/`ABORTED` based on the container exit code, and isn't something test code or ci-operator config can influence.
 - **Grepping a marker line out of `build-log.txt`** (the original design) works but is fragile: risk of truncation on multi-MB logs, needs a tail-range fetch and a chunked scan, and matches on unstructured text instead of a typed value. `metadata.json` avoids all of that.
 
-The write is merge-safe: if some other step already wrote `$ARTIFACT_DIR/metadata.json` (nothing does today, but a future step might), the existing content is read first and only the `ev2-failed-tests`/`ev2-allow-retry-tests` keys are added or overwritten. `ARTIFACT_DIR` being unset (e.g. a local, non-Prow run) is not an error - the write is simply skipped.
+The write is merge-safe: if some other step already wrote `$ARTIFACT_DIR/metadata.json` (nothing does today, but a future step might), the existing content is read first and only the `ev2-*` keys above are added or overwritten. `ARTIFACT_DIR` being unset (e.g. a local, non-Prow run) is not an error - the write is simply skipped.
 
 ### 3. Consuming the signal (ARO-Tools)
 

--- a/docs/ci/ev2-retry-catcher.md
+++ b/docs/ci/ev2-retry-catcher.md
@@ -2,7 +2,7 @@
 
 This document describes the design behind automatically retrying an EV2 gating E2E run when it fails on a small, deliberately labeled set of known-issue tests.
 
-> **Status:** the code referenced below (`labels.AllowRetry`, `registerEV2RetryCatcher`, `writeEV2RetryMetadata`, and the ARO-Tools `prowjob` changes) is not yet merged to `main`. It lives in the implementation PRs linked in [Where to look](#where-to-look). This doc describes the design those PRs implement.
+> **Status (as of 2026-08-06):** the code referenced below (`labels.AllowRetry`, `registerEV2RetryCatcher`, `writeEV2RetryMetadata`, and the ARO-Tools `prowjob` changes) is not yet merged to `main`. It lives in the implementation PRs linked in [Where to look](#where-to-look). This doc describes the design those PRs implement.
 
 ## Problem
 

--- a/docs/ci/ev2-retry-catcher.md
+++ b/docs/ci/ev2-retry-catcher.md
@@ -33,11 +33,12 @@ flowchart LR
  subgraph aro_hcp["ARO-HCP"]
         label["allow-retry label\non known-issue tests"]
         catcher["registerEV2RetryCatcher\n(test/cmd/aro-hcp-tests)"]
-        marker["EV2_RETRY_ALLOWED\nbuild-log marker"]
+        artifact["$ARTIFACT_DIR/metadata.json\nev2-retry-allowed: true"]
   end
  subgraph prow["Prow"]
         job["E2E gating job"]
-        buildlog["build-log.txt\n(GCS)"]
+        sidecar["Prow sidecar\n(combineMetadata)"]
+        finished["finished.json\n(GCS)"]
   end
  subgraph aro_tools["ARO-Tools"]
         executor["prow-job-executor"]
@@ -46,11 +47,12 @@ flowchart LR
   end
   label --> catcher
   job -- runs --> catcher
-  catcher -- "<=2 failures, all labeled" --> marker
-  marker -- written to --> buildlog
+  catcher -- "<=2 failures, all labeled" --> artifact
+  artifact -- read by --> sidecar
+  sidecar -- merges into --> finished
   executor --> monitor
-  monitor -- "job failed" --> buildlog
-  buildlog -- "marker found" --> retry
+  monitor -- "job failed" --> finished
+  finished -- "ev2-retry-allowed: true" --> retry
   retry -- resubmit once --> job
 ```
 
@@ -64,32 +66,36 @@ sequenceDiagram
     participant executor as prow-job-executor
     participant gangway as Gangway
     participant job as Prow E2E job
-    participant gcs as GCS build-log.txt
+    participant sidecar as Prow sidecar
+    participant gcs as GCS finished.json
 
     EV2->>executor: execute --gate-promotion --allow-ev2-retry
     executor->>gangway: SubmitJob (pinned to rollout commit)
     gangway->>job: start job
     job->>job: run e2e-parallel suite
-    job->>gcs: stream build log (incl. EV2_RETRY_ALLOWED if applicable)
+    job->>job: write $ARTIFACT_DIR/metadata.json (if applicable)
+    job-->>sidecar: container exits (failed)
+    sidecar->>sidecar: combineMetadata (merge metadata.json files)
+    sidecar->>gcs: upload finished.json (result=FAILURE, metadata merged in)
     job-->>executor: ProwJobStatus = failure
     executor->>executor: classify as JobFailedError (FailureState)
-    executor->>gcs: fetch build-log.txt
-    gcs-->>executor: log content
-    executor->>executor: scan for EV2_RETRY_ALLOWED marker
-    alt marker found
+    executor->>gcs: fetch finished.json
+    gcs-->>executor: finished.json content
+    executor->>executor: check metadata["ev2-retry-allowed"] == true
+    alt ev2-retry-allowed is true
         executor->>gangway: SubmitJob again (retryMonitor, allowEV2Retry=false)
         gangway->>job: start retry job
         job-->>executor: ProwJobStatus = success/failure
         executor-->>EV2: final result (no further retry either way)
-    else marker absent, or ErrorState/AbortedState
+    else ev2-retry-allowed absent/false, or ErrorState/AbortedState
         executor-->>EV2: fail the gate immediately
     end
 ```
 
 Two properties fall out of this directly:
 
-- **Only `FailureState` is inspected.** `ErrorState` (infra/tooling error) and `AbortedState` (cancellation/timeout) go straight to failing the gate; the build log is never fetched for those, since they are not the class of failure this mechanism is meant to catch.
-- **The retry is unconditional once triggered.** Whatever the retried run's outcome is (pass or fail), the executor does not evaluate the marker again and does not resubmit again - the shallow-copied `Monitor` used for the retry has `allowEV2Retry` hardcoded to `false`, so there is no code path back into the retry branch.
+- **Only `FailureState` is inspected.** `ErrorState` (infra/tooling error) and `AbortedState` (cancellation/timeout) go straight to failing the gate; `finished.json` is never fetched for those, since they are not the class of failure this mechanism is meant to catch.
+- **The retry is unconditional once triggered.** Whatever the retried run's outcome is (pass or fail), the executor does not evaluate the metadata again and does not resubmit again - the shallow-copied `Monitor` used for the retry has `allowEV2Retry` hardcoded to `false`, so there is no code path back into the retry branch.
 
 ### 1. E2E tagging (ARO-HCP)
 
@@ -125,9 +131,9 @@ for _, spec := range specs {
 
 It then registers `AddAfterEach` / `AddAfterAll` hooks (from `openshift-tests-extension`'s lifecycle API) that, guarded by a mutex, track every failure as it happens and check whether it's in `allowRetryNames`. This correlate-by-name approach exists because `openshift-tests-extension`'s `ExtensionTestResult` does not carry a `Labels` field on the result itself - the label set has to be captured from the pre-run spec list up front.
 
-At `AddAfterAll`, once the whole suite has finished, the accumulated counts decide whether to emit the marker (see [Emitting the retry marker](#2-emitting-the-retry-marker-aro-hcp) below).
+At `AddAfterAll`, once the whole suite has finished, the accumulated counts decide whether to write the retry signal (see [Writing the retry signal](#2-writing-the-retry-signal-aro-hcp) below).
 
-### 2. Emitting the retry marker (ARO-HCP)
+### 2. Writing the retry signal (ARO-HCP)
 
 If, once the suite finishes:
 
@@ -135,15 +141,25 @@ If, once the suite finishes:
 - the total number of failed tests is at most `maxAutoRetryFailures` (currently `2`, a `const` in `test/cmd/aro-hcp-tests/main.go`), and
 - every failed test is in `allowRetryNames` (i.e. `nonRetriableFailures == 0`)
 
-then the catcher writes a single, easy-to-grep line to stderr:
+then the catcher merges `ev2-retry-allowed: true` (plus the failed test names, for debugging) into `$ARTIFACT_DIR/metadata.json`:
 
-```text
-EV2_RETRY_ALLOWED: N known-issue test(s) failed (max 2 allowed), all labeled "allow-retry": [test names...]
+```json
+{
+  "ev2-retry-allowed": true,
+  "ev2-retry-allowed-tests": ["spec name 1", "spec name 2"]
+}
 ```
 
-Any failure outside that narrow condition - more than 2 failures, or any failure without the label mixed in - means no marker is written at all, so the gate fails exactly as it does today with no behavior change. Stderr (not stdout) is used because that's where ci-operator/Prow persists step logs into `build-log.txt`, which is what the consumer side reads back.
+Any failure outside that narrow condition - more than 2 failures, or any failure without the label mixed in - means the file is left untouched, so the gate fails exactly as it does today with no behavior change.
 
-### 3. Consuming the marker (ARO-Tools)
+`$ARTIFACT_DIR/metadata.json` is Prow's own, standard mechanism for a test step to attach structured data to the job's result: any Prow-decorated container can write that file, and Prow's `sidecar` reads it (if present) and merges its top-level keys into `finished.json`'s `metadata` object once the job completes (see `sigs.k8s.io/prow/pkg/sidecar`'s `combineMetadata`). This was chosen over the two alternatives considered:
+
+- **A custom `finished.json` "result" value** (e.g. `RETRIABLE_FAILURE`) isn't possible - `result` is hardcoded by Prow's sidecar to `SUCCESS`/`FAILURE`/`ABORTED` based on the container exit code, and isn't something test code or ci-operator config can influence.
+- **Grepping a marker line out of `build-log.txt`** (the original design) works but is fragile: risk of truncation on multi-MB logs, needs a tail-range fetch and a chunked scan, and matches on unstructured text instead of a typed value. `metadata.json` avoids all of that.
+
+The write is merge-safe: if some other step already wrote `$ARTIFACT_DIR/metadata.json` (nothing does today, but a future step might), the existing content is read first and only the `ev2-retry-allowed*` keys are added or overwritten. `ARTIFACT_DIR` being unset (e.g. a local, non-Prow run) is not an error - the write is simply skipped.
+
+### 3. Consuming the signal (ARO-Tools)
 
 `prow-job-executor`'s `prowjob.Monitor` gets a `allowEV2Retry bool` field (set from the new `--allow-ev2-retry` CLI flag) and a dedicated `JobFailedError` type that carries the `ProwExecutionID` and `Status.URL` of a job that ended in `FailureState`. This type only exists so `ExecuteAndWait` can distinguish "the job ran and a test failed" from any other error via `errors.As`.
 
@@ -151,11 +167,11 @@ Any failure outside that narrow condition - more than 2 failures, or any failure
 
 - `executeAndWaitOnce` is the original submit-and-poll logic, unchanged: submit through Gangway, poll `GetJobStatus` until a terminal state, return `nil`/error accordingly.
 - `ExecuteAndWait` calls `executeAndWaitOnce` once. If it returns a `JobFailedError` and `allowEV2Retry` is set, it:
-  1. converts the job's Prow "view" status URL (`https://<prow-host>/view/gs/<bucket>/<path>`) into its plain-text GCS log URL (`https://storage.googleapis.com/<bucket>/<path>/build-log.txt`), via `buildLogURLFromViewURL`,
-  2. fetches that log (bounded by a byte cap and a fetch timeout) and scans it for the `EV2_RETRY_ALLOWED` marker, via `buildLogContainsEV2RetryMarker` / `fetchLogContainsEV2RetryMarker`,
-  3. on a marker match, builds a shallow copy of the `Monitor` (`retryMonitor := *m; retryMonitor.allowEV2Retry = false`) and calls `executeAndWaitOnce` again on that copy.
+  1. converts the job's Prow "view" status URL (`https://<prow-host>/view/gs/<bucket>/<path>`) into its GCS `finished.json` URL (`https://storage.googleapis.com/<bucket>/<path>/finished.json`), via `finishedJSONURLFromViewURL`,
+  2. fetches that file (bounded by a byte cap and a fetch timeout) and checks whether its top-level `metadata` object has `ev2-retry-allowed == true`, via `jobAllowsEV2Retry` / `fetchFinishedJSONAllowsRetry`,
+  3. on a positive match, builds a shallow copy of the `Monitor` (`retryMonitor := *m; retryMonitor.allowEV2Retry = false`) and calls `executeAndWaitOnce` again on that copy.
 
-The shallow copy is what makes "exactly one retry" a structural guarantee rather than a counter that could be bypassed: the copy's `allowEV2Retry` is always `false`, so even if the retried run also fails with a marker present, there is no code path that resubmits a third time. The `client *Client` field is a pointer, so the copy safely shares the same HTTP client/backoff state as the original.
+The shallow copy is what makes "exactly one retry" a structural guarantee rather than a counter that could be bypassed: the copy's `allowEV2Retry` is always `false`, so even if the retried run also fails with the metadata key set, there is no code path that resubmits a third time. The `client *Client` field is a pointer, so the copy safely shares the same HTTP client/backoff state as the original.
 
 `--allow-ev2-retry` is only wired into the `execute` subcommand's options (`RawExecuteOptions` / `completedExecuteOptions` in `options.go`); the separate read-only `monitor` subcommand always passes `false` to `NewMonitor`, since it observes a job it didn't submit and has no meaningful way to resubmit it.
 
@@ -171,21 +187,21 @@ There is currently no automated enforcement of the TTL described below - it is a
 - **Central manifest.** Instead of inline comments, maintain a small YAML/JSON file (e.g. `test/util/labels/allow-retry.yaml`) mapping test name -> tracking issue -> expiry date, loaded by `registerEV2RetryCatcher` to validate expiry at suite-build time and fail fast (or at least log loudly) if a label has expired.
 - **Periodic audit.** A scheduled job (or a recurring SRE Jira card) that lists all `allow-retry`-labeled tests and their age, independent of any code enforcement, as a lighter-weight starting point before investing in the above.
 
-Any of these can be layered on without changing the marker-emission or retry-consumption contract described above, since they only affect whether a test is allowed to carry the label in the first place, not how the label is consumed once present.
+Any of these can be layered on without changing the metadata-write or retry-consumption contract described above, since they only affect whether a test is allowed to carry the label in the first place, not how the signal is consumed once present.
 
 ## Naming
 
-The label and marker names went through some discussion (`flaky`, `retry-during-rollout`, `retryable-during-rollout`, `known-issue`, `ev2-retriable`) before settling on `allow-retry` / `EV2_RETRY_ALLOWED`, specifically to avoid implying anything about flakiness or root cause. The intent is purely operational: make it easy for SREs to decide when an automatic retry is reasonable, without conflating it with terms already used for other purposes (e.g. actual flaky-test quarantine).
+The label and signal names went through some discussion (`flaky`, `retry-during-rollout`, `retryable-during-rollout`, `known-issue`, `ev2-retriable`) before settling on `allow-retry` / `ev2-retry-allowed`, specifically to avoid implying anything about flakiness or root cause. The intent is purely operational: make it easy for SREs to decide when an automatic retry is reasonable, without conflating it with terms already used for other purposes (e.g. actual flaky-test quarantine).
 
 ## Where to look
 
 - `test/util/labels/labels.go` - `AllowRetry` label definition
-- `test/cmd/aro-hcp-tests/main.go` - `registerEV2RetryCatcher`, `maxAutoRetryFailures`, marker emission
+- `test/cmd/aro-hcp-tests/main.go` - `registerEV2RetryCatcher`, `maxAutoRetryFailures`, `writeEV2RetryMetadata`
 - `test/e2e/README.md` - test-author-facing documentation of the label
 - ARO-Tools `tools/prow-job-executor/prowjob/monitor.go` - `JobFailedError`, `Monitor.allowEV2Retry`, single-retry `ExecuteAndWait`/`executeAndWaitOnce`
-- ARO-Tools `tools/prow-job-executor/prowjob/retrymarker.go` - `buildLogURLFromViewURL`, `buildLogContainsEV2RetryMarker`, `fetchLogContainsEV2RetryMarker`
+- ARO-Tools `tools/prow-job-executor/prowjob/retrymarker.go` - `finishedJSONURLFromViewURL`, `jobAllowsEV2Retry`, `fetchFinishedJSONAllowsRetry`
 - ARO-Tools `tools/prow-job-executor/options.go` - `--allow-ev2-retry` flag, `AllowEV2Retry` option wiring
-- [Azure/ARO-HCP#6409](https://github.com/Azure/ARO-HCP/pull/6409) - label + marker emission implementation
+- [Azure/ARO-HCP#6409](https://github.com/Azure/ARO-HCP/pull/6409) - label + metadata.json signal implementation
 - [Azure/ARO-Tools#282](https://github.com/Azure/ARO-Tools/pull/282) - retry-catcher implementation
 
 ## Follow-ups

--- a/docs/ci/ev2-retry-catcher.md
+++ b/docs/ci/ev2-retry-catcher.md
@@ -33,7 +33,7 @@ flowchart LR
  subgraph aro_hcp["ARO-HCP"]
         label["allow-retry label\non known-issue tests"]
         catcher["registerEV2RetryCatcher\n(test/cmd/aro-hcp-tests)"]
-        artifact["$ARTIFACT_DIR/metadata.json\nev2-retry-allowed: true"]
+        artifact["$ARTIFACT_DIR/metadata.json\nev2-failed-tests, ev2-allow-retry-tests"]
   end
  subgraph prow["Prow"]
         job["E2E gating job"]
@@ -41,18 +41,18 @@ flowchart LR
         finished["finished.json\n(GCS)"]
   end
  subgraph aro_tools["ARO-Tools"]
-        executor["prow-job-executor"]
+        executor["prow-job-executor\n(ev2RetryEligible)"]
         monitor["prowjob.Monitor"]
         retry["single retry\n(allowEV2Retry=false)"]
   end
   label --> catcher
   job -- runs --> catcher
-  catcher -- "<=2 failures, all labeled" --> artifact
+  catcher -- "always, even on a clean run" --> artifact
   artifact -- read by --> sidecar
   sidecar -- merges into --> finished
   executor --> monitor
   monitor -- "job failed" --> finished
-  finished -- "ev2-retry-allowed: true" --> retry
+  finished -- "eligible per ev2RetryEligible" --> retry
   retry -- resubmit once --> job
 ```
 
@@ -73,7 +73,7 @@ sequenceDiagram
     executor->>gangway: SubmitJob (pinned to rollout commit)
     gangway->>job: start job
     job->>job: run e2e-parallel suite
-    job->>job: write $ARTIFACT_DIR/metadata.json (if applicable)
+    job->>job: write $ARTIFACT_DIR/metadata.json (always)
     job-->>sidecar: container exits (failed)
     sidecar->>sidecar: combineMetadata (merge metadata.json files)
     sidecar->>gcs: upload finished.json (result=FAILURE, metadata merged in)
@@ -81,13 +81,13 @@ sequenceDiagram
     executor->>executor: classify as JobFailedError (FailureState)
     executor->>gcs: fetch finished.json
     gcs-->>executor: finished.json content
-    executor->>executor: check metadata["ev2-retry-allowed"] == true
-    alt ev2-retry-allowed is true
+    executor->>executor: ev2RetryEligible(metadata["ev2-failed-tests"], metadata["ev2-allow-retry-tests"])
+    alt eligible
         executor->>gangway: SubmitJob again (retryMonitor, allowEV2Retry=false)
         gangway->>job: start retry job
         job-->>executor: ProwJobStatus = success/failure
         executor-->>EV2: final result (no further retry either way)
-    else ev2-retry-allowed absent/false, or ErrorState/AbortedState
+    else not eligible, or ErrorState/AbortedState
         executor-->>EV2: fail the gate immediately
     end
 ```
@@ -131,49 +131,48 @@ for _, spec := range specs {
 
 It then registers `AddAfterEach` / `AddAfterAll` hooks (from `openshift-tests-extension`'s lifecycle API) that, guarded by a mutex, track every failure as it happens and check whether it's in `allowRetryNames`. This correlate-by-name approach exists because `openshift-tests-extension`'s `ExtensionTestResult` does not carry a `Labels` field on the result itself - the label set has to be captured from the pre-run spec list up front.
 
-At `AddAfterAll`, once the whole suite has finished, the accumulated counts decide whether to write the retry signal (see [Writing the retry signal](#2-writing-the-retry-signal-aro-hcp) below).
+At `AddAfterAll`, once the whole suite has finished, the accumulated failures and their allow-retry subset become the reported facts (see [Writing the retry facts](#2-writing-the-retry-facts-aro-hcp) below).
 
-### 2. Writing the retry signal (ARO-HCP)
+### 2. Writing the retry facts (ARO-HCP)
 
-If, once the suite finishes:
-
-- at least one test failed, and
-- the total number of failed tests is at most `maxAutoRetryFailures` (currently `2`, a `const` in `test/cmd/aro-hcp-tests/main.go`), and
-- every failed test is in `allowRetryNames` (i.e. `nonRetriableFailures == 0`)
-
-then the catcher merges `ev2-retry-allowed: true` (plus the failed test names, for debugging) into `$ARTIFACT_DIR/metadata.json`:
+Once the suite finishes, the catcher always merges two keys into `$ARTIFACT_DIR/metadata.json` - even when nothing failed, in which case both are empty lists:
 
 ```json
 {
-  "ev2-retry-allowed": true,
-  "ev2-retry-allowed-tests": ["spec name 1", "spec name 2"]
+  "ev2-failed-tests": ["spec name 1", "spec name 2"],
+  "ev2-allow-retry-tests": ["spec name 1"]
 }
 ```
 
-Any failure outside that narrow condition - more than 2 failures, or any failure without the label mixed in - means the file is left untouched, so the gate fails exactly as it does today with no behavior change.
+`ev2-failed-tests` is every spec that failed; `ev2-allow-retry-tests` is the subset of those that carried `labels.AllowRetry`. aro-hcp-tests reports only these raw facts - it does not decide whether the run qualifies for an automatic retry. That decision is policy (how many failures are tolerable, etc.) that belongs to prow-job-executor (see [Consuming the signal](#3-consuming-the-signal-aro-tools) below), which can evolve independently of an ARO-HCP release.
+
+Writing unconditionally, rather than only when a run happens to qualify, removes an ambiguity the original design had: with a conditional write, an absent key could mean either "nothing failed" or "failures happened but didn't qualify" - both looked identical from the consuming side, which caused confusion more than once while verifying this against real Prow runs. Now the keys' presence means the step ran at all; their content is the whole picture.
 
 `$ARTIFACT_DIR/metadata.json` is Prow's own, standard mechanism for a test step to attach structured data to the job's result: any Prow-decorated container can write that file, and Prow's `sidecar` reads it (if present) and merges its top-level keys into `finished.json`'s `metadata` object once the job completes (see `sigs.k8s.io/prow/pkg/sidecar`'s `combineMetadata`). This was chosen over the two alternatives considered:
 
 - **A custom `finished.json` "result" value** (e.g. `RETRIABLE_FAILURE`) isn't possible - `result` is hardcoded by Prow's sidecar to `SUCCESS`/`FAILURE`/`ABORTED` based on the container exit code, and isn't something test code or ci-operator config can influence.
 - **Grepping a marker line out of `build-log.txt`** (the original design) works but is fragile: risk of truncation on multi-MB logs, needs a tail-range fetch and a chunked scan, and matches on unstructured text instead of a typed value. `metadata.json` avoids all of that.
 
-The write is merge-safe: if some other step already wrote `$ARTIFACT_DIR/metadata.json` (nothing does today, but a future step might), the existing content is read first and only the `ev2-retry-allowed*` keys are added or overwritten. `ARTIFACT_DIR` being unset (e.g. a local, non-Prow run) is not an error - the write is simply skipped.
+The write is merge-safe: if some other step already wrote `$ARTIFACT_DIR/metadata.json` (nothing does today, but a future step might), the existing content is read first and only the `ev2-failed-tests`/`ev2-allow-retry-tests` keys are added or overwritten. `ARTIFACT_DIR` being unset (e.g. a local, non-Prow run) is not an error - the write is simply skipped.
 
 ### 3. Consuming the signal (ARO-Tools)
 
-`prow-job-executor`'s `prowjob.Monitor` gets a `allowEV2Retry bool` field (set from the new `--allow-ev2-retry` CLI flag) and a dedicated `JobFailedError` type that carries the `ProwExecutionID` and `Status.URL` of a job that ended in `FailureState`. This type only exists so `ExecuteAndWait` can distinguish "the job ran and a test failed" from any other error via `errors.As`.
+`prow-job-executor`'s `prowjob.Monitor` gets a `allowEV2Retry bool` field (set from the `--allow-ev2-retry` CLI flag) and a `maxAutoRetryFailures int` field (set from `--max-ev2-auto-retry-failures`, default `prowjob.DefaultMaxEV2AutoRetryFailures = 2`), plus a dedicated `JobFailedError` type that carries the `ProwExecutionID` and `Status.URL` of a job that ended in `FailureState`. This type only exists so `ExecuteAndWait` can distinguish "the job ran and a test failed" from any other error via `errors.As`.
 
 `ExecuteAndWait` is split into a public wrapper and a private `executeAndWaitOnce`:
 
 - `executeAndWaitOnce` is the original submit-and-poll logic, unchanged: submit through Gangway, poll `GetJobStatus` until a terminal state, return `nil`/error accordingly.
 - `ExecuteAndWait` calls `executeAndWaitOnce` once. If it returns a `JobFailedError` and `allowEV2Retry` is set, it:
   1. converts the job's Prow "view" status URL (`https://<prow-host>/view/gs/<bucket>/<path>`) into its GCS `finished.json` URL (`https://storage.googleapis.com/<bucket>/<path>/finished.json`), via `finishedJSONURLFromViewURL`,
-  2. fetches that file (bounded by a byte cap and a fetch timeout) and checks whether its top-level `metadata` object has `ev2-retry-allowed == true`, via `jobAllowsEV2Retry` / `fetchFinishedJSONAllowsRetry`,
-  3. on a positive match, builds a shallow copy of the `Monitor` (`retryMonitor := *m; retryMonitor.allowEV2Retry = false`) and calls `executeAndWaitOnce` again on that copy.
+  2. fetches that file (bounded by a byte cap and a fetch timeout) and reads its top-level `metadata` object's `ev2-failed-tests`/`ev2-allow-retry-tests` lists, via `jobAllowsEV2Retry` / `fetchFinishedJSONAllowsRetry`,
+  3. evaluates `ev2RetryEligible(failed, allowRetry, maxAutoRetryFailures)`: the run qualifies only when it failed at all, no more than `maxAutoRetryFailures` tests failed, and every one of them appears in the allow-retry list,
+  4. on a positive match, builds a shallow copy of the `Monitor` (`retryMonitor := *m; retryMonitor.allowEV2Retry = false`) and calls `executeAndWaitOnce` again on that copy.
 
-The shallow copy is what makes "exactly one retry" a structural guarantee rather than a counter that could be bypassed: the copy's `allowEV2Retry` is always `false`, so even if the retried run also fails with the metadata key set, there is no code path that resubmits a third time. The `client *Client` field is a pointer, so the copy safely shares the same HTTP client/backoff state as the original.
+Keeping the eligibility check (`ev2RetryEligible`) here, rather than in ARO-HCP, means the failure-count threshold can be tuned via `--max-ev2-auto-retry-failures` without an ARO-HCP rebuild, and any future policy change (e.g. weighting by which tests failed) only touches this one function.
 
-`--allow-ev2-retry` is only wired into the `execute` subcommand's options (`RawExecuteOptions` / `completedExecuteOptions` in `options.go`); the separate read-only `monitor` subcommand always passes `false` to `NewMonitor`, since it observes a job it didn't submit and has no meaningful way to resubmit it.
+The shallow copy is what makes "exactly one retry" a structural guarantee rather than a counter that could be bypassed: the copy's `allowEV2Retry` is always `false`, so even if the retried run also fails with an eligible shape, there is no code path that resubmits a third time. The `client *Client` field is a pointer, so the copy safely shares the same HTTP client/backoff state as the original.
+
+`--allow-ev2-retry` and `--max-ev2-auto-retry-failures` are only wired into the `execute` subcommand's options (`RawExecuteOptions` / `completedExecuteOptions` in `options.go`); the separate read-only `monitor` subcommand always passes `false`/the default cap to `NewMonitor`, since it observes a job it didn't submit and has no meaningful way to resubmit it.
 
 ## Expiration configuration
 
@@ -191,16 +190,16 @@ Any of these can be layered on without changing the metadata-write or retry-cons
 
 ## Naming
 
-The label and signal names went through some discussion (`flaky`, `retry-during-rollout`, `retryable-during-rollout`, `known-issue`, `ev2-retriable`) before settling on `allow-retry` / `ev2-retry-allowed`, specifically to avoid implying anything about flakiness or root cause. The intent is purely operational: make it easy for SREs to decide when an automatic retry is reasonable, without conflating it with terms already used for other purposes (e.g. actual flaky-test quarantine).
+The label and signal names went through some discussion (`flaky`, `retry-during-rollout`, `retryable-during-rollout`, `known-issue`, `ev2-retriable`) before settling on `allow-retry` for the label and `ev2-failed-tests`/`ev2-allow-retry-tests` for the reported facts, specifically to avoid implying anything about flakiness or root cause. The intent is purely operational: make it easy for SREs to decide when an automatic retry is reasonable, without conflating it with terms already used for other purposes (e.g. actual flaky-test quarantine).
 
 ## Where to look
 
 - `test/util/labels/labels.go` - `AllowRetry` label definition
-- `test/cmd/aro-hcp-tests/main.go` - `registerEV2RetryCatcher`, `maxAutoRetryFailures`, `writeEV2RetryMetadata`
+- `test/cmd/aro-hcp-tests/main.go` - `registerEV2RetryCatcher`, `writeEV2RetryMetadata`
 - `test/e2e/README.md` - test-author-facing documentation of the label
-- ARO-Tools `tools/prow-job-executor/prowjob/monitor.go` - `JobFailedError`, `Monitor.allowEV2Retry`, single-retry `ExecuteAndWait`/`executeAndWaitOnce`
-- ARO-Tools `tools/prow-job-executor/prowjob/retrymarker.go` - `finishedJSONURLFromViewURL`, `jobAllowsEV2Retry`, `fetchFinishedJSONAllowsRetry`
-- ARO-Tools `tools/prow-job-executor/options.go` - `--allow-ev2-retry` flag, `AllowEV2Retry` option wiring
+- ARO-Tools `tools/prow-job-executor/prowjob/monitor.go` - `JobFailedError`, `Monitor.allowEV2Retry`, `Monitor.maxAutoRetryFailures`, single-retry `ExecuteAndWait`/`executeAndWaitOnce`
+- ARO-Tools `tools/prow-job-executor/prowjob/retrymarker.go` - `finishedJSONURLFromViewURL`, `jobAllowsEV2Retry`, `fetchFinishedJSONAllowsRetry`, `ev2RetryEligible`
+- ARO-Tools `tools/prow-job-executor/options.go` - `--allow-ev2-retry`/`--max-ev2-auto-retry-failures` flags, `AllowEV2Retry`/`MaxEV2AutoRetryFailures` option wiring
 - [Azure/ARO-HCP#6409](https://github.com/Azure/ARO-HCP/pull/6409) - label + metadata.json signal implementation
 - [Azure/ARO-Tools#282](https://github.com/Azure/ARO-Tools/pull/282) - retry-catcher implementation
 

--- a/docs/ci/ev2-retry-catcher.md
+++ b/docs/ci/ev2-retry-catcher.md
@@ -3,6 +3,8 @@
 This document describes the design behind automatically retrying an EV2 gating E2E run when it fails on a small, deliberately labeled set of known-issue tests.
 
 > **Status (as of 2026-08-06):** the code referenced below (`labels.AllowRetry`, `registerEV2RetryCatcher`, `writeEV2RetryMetadata`, and the ARO-Tools `prowjob` changes) is not yet merged to `main`. It lives in the implementation PRs linked in [Where to look](#where-to-look). This doc describes the design those PRs implement.
+>
+> The retry mechanism itself changed after the first round of this design: rather than `prow-job-executor` resubmitting the job internally through Gangway, it now fails with a distinctly matchable error and lets EV2's own `automatedRetry` step property redrive the whole gating step. See [Consuming the signal](#3-consuming-the-signal-aro-tools) and [Retrying via EV2's automatedRetry](#4-retrying-via-ev2s-automatedretry-sdp-pipelines--aro-hcp) below.
 
 ## Problem
 
@@ -36,6 +38,7 @@ flowchart LR
         label["allow-retry label\non known-issue tests"]
         catcher["registerEV2RetryCatcher\n(test/cmd/aro-hcp-tests)"]
         artifact["$ARTIFACT_DIR/metadata.json\nev2-failed-tests, ev2-allow-retry-tests"]
+        pipeline["regionalGating step\n(test/e2e-pipeline.yaml)\nautomatedRetry.errorContainsAny"]
   end
  subgraph prow["Prow"]
         job["E2E gating job"]
@@ -45,7 +48,10 @@ flowchart LR
  subgraph aro_tools["ARO-Tools"]
         executor["prow-job-executor\n(ev2RetryEligible)"]
         monitor["prowjob.Monitor"]
-        retry["single retry\n(allowEV2Retry=false)"]
+        marker["EV2RetryableError\n(ev2-retryable-known-issue-failure)"]
+  end
+ subgraph ev2["EV2"]
+        retry["automatedRetry\n(errorContainsAny match)"]
   end
   label --> catcher
   job -- runs --> catcher
@@ -54,8 +60,10 @@ flowchart LR
   sidecar -- merges into --> finished
   executor --> monitor
   monitor -- "job failed" --> finished
-  finished -- "eligible per ev2RetryEligible" --> retry
-  retry -- resubmit once --> job
+  finished -- "eligible per ev2RetryEligible" --> marker
+  marker -- "step stdout contains marker" --> retry
+  pipeline -. "configures errorContainsAny" .-> retry
+  retry -- redrives the step --> job
 ```
 
 ### End-to-end flow
@@ -85,19 +93,22 @@ sequenceDiagram
     gcs-->>executor: finished.json content
     executor->>executor: ev2RetryEligible(metadata["ev2-failed-tests"], metadata["ev2-allow-retry-tests"])
     alt eligible
-        executor->>gangway: SubmitJob again (retryMonitor, allowEV2Retry=false)
+        executor-->>EV2: fail step, stdout/error contains ev2-retryable-known-issue-failure
+        EV2->>EV2: automatedRetry.errorContainsAny matches, redrives the step
+        EV2->>executor: execute --gate-promotion --allow-ev2-retry (retry attempt)
+        executor->>gangway: SubmitJob (retry)
         gangway->>job: start retry job
         job-->>executor: ProwJobStatus = success/failure
-        executor-->>EV2: final result (no further retry either way)
+        executor-->>EV2: final result (EV2's maximumRetryCount caps further retries)
     else not eligible, or ErrorState/AbortedState
-        executor-->>EV2: fail the gate immediately
+        executor-->>EV2: fail the gate immediately, no marker in the error
     end
 ```
 
 Two properties fall out of this directly:
 
 - **Only `FailureState` is inspected.** `ErrorState` (infra/tooling error) and `AbortedState` (cancellation/timeout) go straight to failing the gate; `finished.json` is never fetched for those, since they are not the class of failure this mechanism is meant to catch.
-- **The retry is unconditional once triggered.** Whatever the retried run's outcome is (pass or fail), the executor does not evaluate the metadata again and does not resubmit again - the shallow-copied `Monitor` used for the retry has `allowEV2Retry` hardcoded to `false`, so there is no code path back into the retry branch.
+- **`prow-job-executor` never resubmits the job itself.** On an eligible failure it returns a wrapped `EV2RetryableError`, whose `Error()` string always contains the literal marker `ev2-retryable-known-issue-failure`. The step then fails as usual; the retry is entirely EV2's doing, driven by the `automatedRetry.errorContainsAny` list configured directly on the `regionalGating` step in `test/e2e-pipeline.yaml` (see [Retrying via EV2's automatedRetry](#4-retrying-via-ev2s-automatedretry-sdp-pipelines--aro-hcp) below). How many times EV2 retries, and how long it waits between attempts, is controlled entirely by that step's `maximumRetryCount`/`durationBetweenRetries`, not by anything in `prow-job-executor`.
 
 ### 1. E2E tagging (ARO-HCP)
 
@@ -168,22 +179,41 @@ The write is merge-safe: if some other step already wrote `$ARTIFACT_DIR/metadat
 
 ### 3. Consuming the signal (ARO-Tools)
 
-`prow-job-executor`'s `prowjob.Monitor` gets an `allowEV2Retry bool` field (set from the `--allow-ev2-retry` CLI flag) and a `maxAutoRetryFailures int` field (set from `--max-ev2-auto-retry-failures`, default `prowjob.DefaultMaxEV2AutoRetryFailures = 2`), plus a dedicated `JobFailedError` type that carries the `ProwExecutionID` and `Status.URL` of a job that ended in `FailureState`. This type only exists so `ExecuteAndWait` can distinguish "the job ran and a test failed" from any other error via `errors.As`.
+`prow-job-executor`'s `prowjob.Monitor` gets an `allowEV2Retry bool` field (set from the `--allow-ev2-retry` CLI flag). `ExecuteAndWait` submits the job through Gangway exactly once and polls `GetJobStatus` until a terminal state, same as before. The change is entirely in what happens after a `FailureState`:
 
-`ExecuteAndWait` is split into a public wrapper and a private `executeAndWaitOnce`:
-
-- `executeAndWaitOnce` is the original submit-and-poll logic, unchanged: submit through Gangway, poll `GetJobStatus` until a terminal state, return `nil`/error accordingly.
-- `ExecuteAndWait` calls `executeAndWaitOnce` once. If it returns a `JobFailedError` and `allowEV2Retry` is set, it:
-  1. converts the job's Prow "view" status URL (`https://<prow-host>/view/gs/<bucket>/<path>`) into its GCS `finished.json` URL (`https://storage.googleapis.com/<bucket>/<path>/finished.json`), via `finishedJSONURLFromViewURL`,
-  2. fetches that file (bounded by a byte cap and a fetch timeout) and reads its top-level `metadata` object's `ev2-failed-tests`/`ev2-allow-retry-tests` lists, via `jobAllowsEV2Retry` / `fetchFinishedJSONAllowsRetry`,
-  3. evaluates `ev2RetryEligible(failed, allowRetry, maxAutoRetryFailures)`: the run qualifies only when it failed at all, no more than `maxAutoRetryFailures` tests failed, and every one of them appears in the allow-retry list,
-  4. on a positive match, builds a shallow copy of the `Monitor` (`retryMonitor := *m; retryMonitor.allowEV2Retry = false`) and calls `executeAndWaitOnce` again on that copy.
+1. it fetches `finished.json` from GCS (via `finishedJSONURLFromViewURL`, bounded by a byte cap and a fetch timeout) and reads its top-level `metadata` object's `ev2-failed-tests`/`ev2-allow-retry-tests` lists, via `jobAllowsEV2Retry` / `fetchFinishedJSONAllowsRetry`,
+2. it evaluates `ev2RetryEligible(failed, allowRetry, maxAutoRetryFailures)`: the run qualifies only when it failed at all, no more than `maxAutoRetryFailures` tests failed, and every one of them appears in the allow-retry list (`maxAutoRetryFailures` is set from `--max-ev2-auto-retry-failures`, default `prowjob.DefaultMaxEV2AutoRetryFailures = 2`),
+3. on a positive match, it returns `&EV2RetryableError{Cause: err}` instead of the original error. `EV2RetryableError.Error()` always contains the literal `EV2RetryableMarker` constant (`ev2-retryable-known-issue-failure`), so the step's stdout/failure output substring-matches EV2's `automatedRetry.errorContainsAny` (see [Retrying via EV2's automatedRetry](#4-retrying-via-ev2s-automatedretry-sdp-pipelines--aro-hcp) below). `EV2RetryableError` wraps the original cause via `Unwrap()`, so callers using `errors.Is`/`errors.As` on the underlying failure still work.
+4. on a non-match (ineligible failure, or `ErrorState`/`AbortedState`), the original error is returned unchanged - no marker, so EV2's `automatedRetry` condition never matches and the gate fails immediately.
 
 Keeping the eligibility check (`ev2RetryEligible`) here, rather than in ARO-HCP, means the failure-count threshold can be tuned via `--max-ev2-auto-retry-failures` without an ARO-HCP rebuild, and any future policy change (e.g. weighting by which tests failed) only touches this one function.
 
-The shallow copy is what makes "exactly one retry" a structural guarantee rather than a counter that could be bypassed: the copy's `allowEV2Retry` is always `false`, so even if the retried run also fails with an eligible shape, there is no code path that resubmits a third time. The `client *Client` field is a pointer, so the copy safely shares the same HTTP client/backoff state as the original.
+`prow-job-executor` itself never resubmits anything - the earlier design (an internal Gangway resubmit with a shallow-copied `Monitor` guarded by `allowEV2Retry=false`) was replaced with this fail-with-a-marker approach specifically so the number of retry attempts, the backoff between them, and the actual redrive mechanism are all owned by EV2's own step configuration, not duplicated in ARO-Tools.
 
-`--allow-ev2-retry` and `--max-ev2-auto-retry-failures` are only wired into the `execute` subcommand's options (`RawExecuteOptions` / `completedExecuteOptions` in `options.go`); the separate read-only `monitor` subcommand always passes `false`/the default cap to `NewMonitor`, since it observes a job it didn't submit and has no meaningful way to resubmit it.
+`--allow-ev2-retry` and `--max-ev2-auto-retry-failures` are only wired into the `execute` subcommand's options (`RawExecuteOptions` / `completedExecuteOptions` in `options.go`); the separate read-only `monitor` subcommand always passes `false`/the default cap to `NewMonitor`, since it observes a job it didn't submit and has no meaningful way to trigger a retry for it.
+
+### 4. Retrying via EV2's automatedRetry (sdp-pipelines / ARO-HCP)
+
+The actual retry is driven entirely by EV2's native step-level `automatedRetry` property, set directly on the `regionalGating` `ProwJob` validation step in `test/e2e-pipeline.yaml`:
+
+```yaml
+automatedRetry:
+  errorContainsAny:
+  - "failed to establish a new connection"
+  - "failed to get token"
+  - "Failed to connect to MSI"
+  - "ev2-retryable-known-issue-failure"
+  maximumRetryCount: 1
+  durationBetweenRetries: 1m
+```
+
+EV2 substring-scans the step's output for any of the `errorContainsAny` strings and, on a match, redrives the whole step up to `maximumRetryCount` times, waiting `durationBetweenRetries` in between. Setting `automatedRetry` explicitly on a step **replaces** sdp-pipelines' default retry policy for that step (which only covers the three MSI/connection-failure phrases above) rather than extending it - so the three default phrases have to be repeated here alongside the new marker, or the gate would lose its existing infra-retry behavior.
+
+`sdp-pipelines`'s `tooling/pkg/types/pipeline/prow.go` passes `--allow-ev2-retry` to every generated `ProwJob` step's command unconditionally; this is safe because the flag is inert unless `gate-promotion` is also set on the step, which is only true for the Stage/Prod EV2 gating steps and never for periodic or pre-merge jobs.
+
+**This currently only takes effect in prod.** `stg` and `int` both set `useExclusiveLocks: true` in sdp-pipelines' `hcp/stages.yaml`, which makes the generator treat those stages as fail-fast. `orchestratedStepFor` (`tooling/pkg/ev2/manifests/generate/graph_step.go`) ignores any explicit `automatedRetry` whenever a stage is fail-fast, falling back to the default MSI-only policy instead - so today, a stage gating run still needs a manual retry. Extending the generator to honor a custom `automatedRetry` even under fail-fast (while still forcing `FallbackToManualMitigation: false`, preserving the "don't hold the exclusive lock for a week" intent behind fail-fast) is a shared code path used by roughly 30 other pipelines and is tracked as a separate follow-up in AROSLSRE-1764, rather than bundled into this change.
+
+> ⚠️ Do not reproduce the literal string `ev2-retryable-known-issue-failure` anywhere else that could end up in a gating step's stdout (comments in `common.sh`, other steps' `automatedRetry` lists, etc.). EV2's substring scan is applied to the whole step output, and a stray match would cause a genuinely failed, non-eligible run to be spuriously retried - exactly the class of bug described in AROSLSRE-1292.
 
 ## Expiration configuration
 
@@ -208,15 +238,19 @@ The label and signal names went through some discussion (`flaky`, `retry-during-
 - `test/util/labels/labels.go` - `AllowRetry` label definition
 - `test/cmd/aro-hcp-tests/main.go` - `registerEV2RetryCatcher`, `writeEV2RetryMetadata`
 - `test/e2e/README.md` - test-author-facing documentation of the label
-- ARO-Tools `tools/prow-job-executor/prowjob/monitor.go` - `JobFailedError`, `Monitor.allowEV2Retry`, `Monitor.maxAutoRetryFailures`, single-retry `ExecuteAndWait`/`executeAndWaitOnce`
+- `test/e2e-pipeline.yaml` - `regionalGating` step's `automatedRetry` configuration
+- ARO-Tools `tools/prow-job-executor/prowjob/monitor.go` - `EV2RetryableError`, `EV2RetryableMarker`, `Monitor.allowEV2Retry`, `Monitor.maxAutoRetryFailures`, `ExecuteAndWait`
 - ARO-Tools `tools/prow-job-executor/prowjob/retrymarker.go` - `finishedJSONURLFromViewURL`, `jobAllowsEV2Retry`, `fetchFinishedJSONAllowsRetry`, `ev2RetryEligible`
 - ARO-Tools `tools/prow-job-executor/options.go` - `--allow-ev2-retry`/`--max-ev2-auto-retry-failures` flags, `AllowEV2Retry`/`MaxEV2AutoRetryFailures` option wiring
+- sdp-pipelines `tooling/pkg/types/pipeline/prow.go` - `--allow-ev2-retry` wired into the generated `ProwJob` step command
+- sdp-pipelines `tooling/pkg/ev2/manifests/generate/graph_step.go` - `orchestratedStepFor`/`buildOnFailure`, how `automatedRetry` becomes EV2's `onFailure.retry`
 - [Azure/ARO-HCP#6409](https://github.com/Azure/ARO-HCP/pull/6409) - label + metadata.json signal implementation
-- [Azure/ARO-Tools#282](https://github.com/Azure/ARO-Tools/pull/282) - retry-catcher implementation
+- [Azure/ARO-HCP#6464](https://github.com/Azure/ARO-HCP/pull/6464) - `regionalGating` `automatedRetry` step configuration
+- [Azure/ARO-Tools#282](https://github.com/Azure/ARO-Tools/pull/282) - retry-catcher implementation (fail-with-marker design)
 
 ## Follow-ups
 
-- Wire `--allow-ev2-retry=true` into the actual EV2 pipeline step definitions (`sdp-pipelines` / `openshift/release` step registry) for the environments that should use it.
+- Extend EV2 automated retry to `stg`/`int`: today it only takes effect in prod, since those stages fail fast and the generator ignores custom `automatedRetry` in that mode. Tracked in AROSLSRE-1764.
 - Pick and implement one of the [expiration configuration](#expiration-configuration) options above so the TTL/timebomb intent is enforced rather than just documented.
 
 ## See also

--- a/docs/ci/ev2-retry-catcher.md
+++ b/docs/ci/ev2-retry-catcher.md
@@ -2,6 +2,8 @@
 
 This document describes the design behind automatically retrying an EV2 gating E2E run when it fails on a small, deliberately labeled set of known-issue tests.
 
+> **Status:** the code referenced below (`labels.AllowRetry`, `registerEV2RetryCatcher`, `writeEV2RetryMetadata`, and the ARO-Tools `prowjob` changes) is not yet merged to `main`. It lives in the implementation PRs linked in [Where to look](#where-to-look). This doc describes the design those PRs implement.
+
 ## Problem
 
 EV2 Stage and Prod rollouts gate promotion on an E2E run against the pinned rollout commit (see [CI EV2 Integration](ev2-integration.md)). When that gating run fails because of a single test with a known, already-tracked issue, someone still has to notice the failure, review the Prow output, and manually retrigger the run before the rollout can continue.

--- a/docs/ci/ev2-retry-catcher.md
+++ b/docs/ci/ev2-retry-catcher.md
@@ -157,7 +157,7 @@ The write is merge-safe: if some other step already wrote `$ARTIFACT_DIR/metadat
 
 ### 3. Consuming the signal (ARO-Tools)
 
-`prow-job-executor`'s `prowjob.Monitor` gets a `allowEV2Retry bool` field (set from the `--allow-ev2-retry` CLI flag) and a `maxAutoRetryFailures int` field (set from `--max-ev2-auto-retry-failures`, default `prowjob.DefaultMaxEV2AutoRetryFailures = 2`), plus a dedicated `JobFailedError` type that carries the `ProwExecutionID` and `Status.URL` of a job that ended in `FailureState`. This type only exists so `ExecuteAndWait` can distinguish "the job ran and a test failed" from any other error via `errors.As`.
+`prow-job-executor`'s `prowjob.Monitor` gets an `allowEV2Retry bool` field (set from the `--allow-ev2-retry` CLI flag) and a `maxAutoRetryFailures int` field (set from `--max-ev2-auto-retry-failures`, default `prowjob.DefaultMaxEV2AutoRetryFailures = 2`), plus a dedicated `JobFailedError` type that carries the `ProwExecutionID` and `Status.URL` of a job that ended in `FailureState`. This type only exists so `ExecuteAndWait` can distinguish "the job ran and a test failed" from any other error via `errors.As`.
 
 `ExecuteAndWait` is split into a public wrapper and a private `executeAndWaitOnce`:
 


### PR DESCRIPTION
Jira: [AROSLSRE-1726](https://redhat.atlassian.net/browse/AROSLSRE-1726)

### What

Adds `docs/ci/ev2-retry-catcher.md`, a design/architecture doc for the EV2 auto-retry mechanism ([AROSLSRE-1721](https://redhat.atlassian.net/browse/AROSLSRE-1721)), and links it from `docs/ci/README.md` and `docs/ci/ev2-integration.md`.

### Why

The EV2 auto-retry mechanism spans two repos (this one and ARO-Tools) and was designed over a Slack thread. There was no single written place covering the end-to-end flow, how the `allow-retry` label and marker work, or the (currently unenforced) expiration intent behind the label. This doc fills that gap so the design is reviewable and discoverable outside of the PRs that implemented it.

### Testing

Docs-only change. Verified locally that the Mermaid flowchart and sequence diagram blocks parse (extracted and checked with a small Node script) and that all internal links resolve to existing anchors/files.

### Special notes for your reviewer

Covers, in order: problem/goal/non-goals, the design and a full end-to-end sequence diagram, the `allow-retry` E2E tagging convention, marker emission rules, `prow-job-executor`'s single-retry consumption path, and expiration configuration (current comment-only convention plus a few options for a stronger, enforced mechanism, none of which are implemented yet).

References the implementation PRs: [#6409](https://github.com/Azure/ARO-HCP/pull/6409) and [Azure/ARO-Tools#282](https://github.com/Azure/ARO-Tools/pull/282).

### PR Checklist
- [x] Docs-only change, no code affected
- [x] Links verified against existing `docs/ci/` files
