### PR TITLE
feat: update velero config for hosted cluster backups

### DIFF
--- a/velero/deploy/templates/install-job.yaml
+++ b/velero/deploy/templates/install-job.yaml
@@ -50,6 +50,11 @@ spec:
             --backup-location-config useAAD="true",resourceGroup={{ .Values.resourceGroup }},storageAccount={{ .Values.storageAccount }},subscriptionId={{ .Values.subscriptionId }} \
             --snapshot-location-config subscriptionId={{ .Values.subscriptionId }} \
             --image {{ .Values.imageRegistry }}/{{ .Values.veleroServer.repository }}@{{ .Values.veleroServer.digest }} \
+            --concurrent-backups 4 \
+            --velero-pod-mem-limit 0 \
+            --velero-pod-mem-request 1024Mi \
+            --velero-pod-cpu-limit 0 \
+            --velero-pod-cpu-request 1000m \
             --dry-run -o yaml > /manifest/velero.yaml
 
           echo "Manifest generated successfully."

--- a/velero/deploy/templates/kustomize-patch.yaml
+++ b/velero/deploy/templates/kustomize-patch.yaml
@@ -22,6 +22,7 @@ data:
     spec:
       template:
         spec:
+          priorityClassName: service-lifecycle-critical
           nodeSelector:
             aro-hcp.azure.com/role: infra
           tolerations:
@@ -39,10 +40,3 @@ data:
       template:
         spec:
           priorityClassName: service-lifecycle-critical
-          nodeSelector:
-            aro-hcp.azure.com/role: infra
-          tolerations:
-          - key: "infra"
-            operator: "Equal"
-            value: "true"
-            effect: "NoSchedule"

--- a/velero/deploy/templates/velero-rbac.yaml
+++ b/velero/deploy/templates/velero-rbac.yaml
@@ -138,6 +138,11 @@ rules:
 - apiGroups: ["discovery.k8s.io"]
   resources: ["*"]
   verbs: ["*"]
+- apiGroups: ["multitenancy.acn.azure.com"]
+  resources:
+  - multitenantpodnetworkconfigs
+  - podnetworkinstances
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/velero/deploy/templates/volumesnapshotclass.yaml
+++ b/velero/deploy/templates/volumesnapshotclass.yaml
@@ -8,3 +8,5 @@ driver: disk.csi.azure.com
 deletionPolicy: Retain
 parameters:
   incremental: "true"
+  # instantAccessDurationMinutes documented here https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/36e24171a3ed6ffa4a5c515e194e00e08c059da5/docs/driver-parameters.md?plain=1#L101
+  instantAccessDurationMinutes: "60" # 60 minutes is the minimum duration for instant access snapshots

--- a/velero/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_velero.yaml
+++ b/velero/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_velero.yaml
@@ -225,6 +225,11 @@ rules:
 - apiGroups: ["discovery.k8s.io"]
   resources: ["*"]
   verbs: ["*"]
+- apiGroups: ["multitenancy.acn.azure.com"]
+  resources:
+  - multitenantpodnetworkconfigs
+  - podnetworkinstances
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
 ---
 # Source: velero-hcp-cli/templates/installer-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -323,6 +328,8 @@ driver: disk.csi.azure.com
 deletionPolicy: Retain
 parameters:
   incremental: "true"
+  # instantAccessDurationMinutes documented here https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/36e24171a3ed6ffa4a5c515e194e00e08c059da5/docs/driver-parameters.md?plain=1#L101
+  instantAccessDurationMinutes: "60" # 60 minutes is the minimum duration for instant access snapshots
 
 ---
 # Source: velero-hcp-cli/templates/kustomize-patch.yaml
@@ -350,6 +357,7 @@ data:
     spec:
       template:
         spec:
+          priorityClassName: service-lifecycle-critical
           nodeSelector:
             aro-hcp.azure.com/role: infra
           tolerations:
@@ -367,13 +375,6 @@ data:
       template:
         spec:
           priorityClassName: service-lifecycle-critical
-          nodeSelector:
-            aro-hcp.azure.com/role: infra
-          tolerations:
-          - key: "infra"
-            operator: "Equal"
-            value: "true"
-            effect: "NoSchedule"
 ---
 # Source: velero-hcp-cli/templates/install-job.yaml
 apiVersion: batch/v1
@@ -427,6 +428,11 @@ spec:
             --backup-location-config useAAD="true",resourceGroup=hcp-underlay-dev-westus3-mgmt-1,storageAccount=__storageAccountName__,subscriptionId=__subscriptionId__ \
             --snapshot-location-config subscriptionId=__subscriptionId__ \
             --image arohcpsvcdev.azurecr.io/oadp/oadp-velero-rhel9@sha256:1234567890 \
+            --concurrent-backups 4 \
+            --velero-pod-mem-limit 0 \
+            --velero-pod-mem-request 1024Mi \
+            --velero-pod-cpu-limit 0 \
+            --velero-pod-cpu-request 1000m \
             --dry-run -o yaml > /manifest/velero.yaml
 
           echo "Manifest generated successfully."


### PR DESCRIPTION
- increase velero cpu/memory requests and remove limits
- set concurrent backups to 4
- add node-agents to all nodes for csi snapshot uploads
- set instantaccessdurationminutes on volumesnapshotclass (requires aks v1.35.4)
- update velero RBAC to allow backup/restore of swift CRs

<!-- Link to Jira issue -->

### What

Updates velero helm deployment to address gaps found during backup controller buildout.

### Why
Required to support Hosted Cluster disaster recovery

### Testing
Found while testing backups in https://github.com/Azure/ARO-HCP/pull/6261 so that PR will validate this change once this is merged.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
