### PR TITLE
do not merge: OCPBUGS-98213 Verification - #6033

### DIFF
--- a/test/e2e/cluster_create_cpo_override_20240610.go
+++ b/test/e2e/cluster_create_cpo_override_20240610.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+
+	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+	"github.com/Azure/ARO-HCP/test/util/verifiers"
+)
+
+var _ = FDescribe("Create HCPOpenShiftCluster with CPO override (v20240610preview)", func() {
+	It("should create a 4.21 cluster with CPO image override using v20240610preview API",
+		labels.RequireNothing,
+		labels.Critical,
+		labels.Positive,
+		labels.AroRpApiCompatible,
+		labels.CreateCluster,
+		labels.MIContainers(1),
+		func(ctx context.Context) {
+			const customerClusterName = "cpo-override-2406"
+
+			tc := framework.NewTestContext()
+
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
+			}
+
+			By("creating a resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "cpo-override-2406", tc.Location())
+			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for CPO override test")
+
+			const channelGroup = "candidate"
+
+			By("resolving 4.21 install version")
+			cpVersion, err := framework.GetLatestInstallVersion(ctx, channelGroup, "4.21")
+			Expect(err).NotTo(HaveOccurred(), "failed to resolve 4.21 install version")
+
+			By("creating cluster parameters")
+			clusterParams := framework.NewDefaultClusterParams20240610()
+			clusterParams.ClusterName = customerClusterName
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.ManagedResourceGroupName = managedResourceGroupName
+			clusterParams.OpenshiftVersionId = cpVersion
+			clusterParams.ChannelGroup = channelGroup
+			clusterParams.Tags[metadataapi.TagClusterCPOImageOverride] = to.Ptr(cpoOverrideImage)
+
+			By("creating customer resources (infrastructure and managed identities)")
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
+				resourceGroup,
+				clusterParams,
+				map[string]interface{}{},
+				TestArtifactsFS,
+				framework.RBACScopeResourceGroup,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for CPO override cluster")
+
+			By("creating the HCP cluster")
+			err = tc.CreateHCPClusterFromParam20240610(ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				framework.ClusterCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with CPO override", customerClusterName)
+
+			By("creating the node pool")
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
+			nodePoolParams.ClusterName = customerClusterName
+			nodePoolParams.NodePoolName = "np-1"
+			nodePoolParams.Replicas = int32(2)
+			nodePoolParams.OpenshiftVersionId = cpVersion
+			nodePoolParams.ChannelGroup = channelGroup
+
+			err = tc.CreateNodePoolFromParam20240610(ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				managedResourceGroupName,
+				customerClusterName,
+				nodePoolParams,
+				framework.NodePoolCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create node pool for CPO override cluster %q", customerClusterName)
+
+			By("getting admin credentials for the cluster")
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
+				ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				*resourceGroup.Name,
+				customerClusterName,
+				framework.GetAdminRESTConfigTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for CPO override cluster %q", customerClusterName)
+
+			By("verifying the cluster is viable")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to verify CPO override cluster %q is viable", customerClusterName)
+		})
+})

--- a/test/e2e/cluster_create_cpo_override_20251223.go
+++ b/test/e2e/cluster_create_cpo_override_20251223.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+
+	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+	"github.com/Azure/ARO-HCP/test/util/verifiers"
+)
+
+var _ = FDescribe("Create HCPOpenShiftCluster with CPO override (v20251223preview)", func() {
+	It("should create a 4.21 cluster with CPO image override using v20251223preview API",
+		labels.RequireNothing,
+		labels.Critical,
+		labels.Positive,
+		labels.AroRpApiCompatible,
+		labels.CreateCluster,
+		labels.MIContainers(1),
+		func(ctx context.Context) {
+			const customerClusterName = "cpo-override-2512"
+
+			tc := framework.NewTestContext()
+
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
+			}
+
+			By("creating a resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "cpo-override-2512", tc.Location())
+			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for CPO override test")
+
+			const channelGroup = "candidate"
+
+			By("resolving 4.21 install version")
+			cpVersion, err := framework.GetLatestInstallVersion(ctx, channelGroup, "4.21")
+			Expect(err).NotTo(HaveOccurred(), "failed to resolve 4.21 install version")
+
+			By("creating cluster parameters")
+			clusterParams := framework.NewDefaultClusterParams20251223()
+			clusterParams.ClusterName = customerClusterName
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.ManagedResourceGroupName = managedResourceGroupName
+			clusterParams.OpenshiftVersionId = cpVersion
+			clusterParams.ChannelGroup = channelGroup
+			clusterParams.Tags[metadataapi.TagClusterCPOImageOverride] = to.Ptr(cpoOverrideImage)
+
+			By("creating customer resources (infrastructure and managed identities)")
+			clusterParams, err = tc.CreateClusterCustomerResources20251223(ctx,
+				resourceGroup,
+				clusterParams,
+				map[string]interface{}{},
+				TestArtifactsFS,
+				framework.RBACScopeResourceGroup,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for CPO override cluster")
+
+			By("creating the HCP cluster")
+			err = tc.CreateHCPClusterFromParam20251223(
+				ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				nil,
+				framework.ClusterCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with CPO override", customerClusterName)
+
+			By("creating the node pool")
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
+			nodePoolParams.ClusterName = customerClusterName
+			nodePoolParams.NodePoolName = "np-1"
+			nodePoolParams.Replicas = int32(2)
+			nodePoolParams.OpenshiftVersionId = cpVersion
+			nodePoolParams.ChannelGroup = channelGroup
+
+			err = tc.CreateNodePoolFromParam20240610(ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				managedResourceGroupName,
+				customerClusterName,
+				nodePoolParams,
+				framework.NodePoolCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create node pool for CPO override cluster %q", customerClusterName)
+
+			By("getting admin credentials for the cluster")
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
+				ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				*resourceGroup.Name,
+				customerClusterName,
+				framework.GetAdminRESTConfigTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for CPO override cluster %q", customerClusterName)
+
+			By("verifying the cluster is viable")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to verify CPO override cluster %q is viable", customerClusterName)
+		})
+})

--- a/test/e2e/cluster_create_private_kv.go
+++ b/test/e2e/cluster_create_private_kv.go
@@ -23,13 +23,14 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
+	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
 	hcpsdk20251223preview "github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
 )
 
-var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
+var _ = FDescribe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 	BeforeEach(func() {
 		// do nothing. per test initialization usually ages better than shared.
 	})
@@ -55,12 +56,21 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			resourceGroup, err := tc.NewResourceGroup(ctx, "private-keyvault", tc.Location())
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for private keyvault test")
 
+			const channelGroup = "candidate"
+
+			By("resolving 4.21 install version")
+			cpVersion, err := framework.GetLatestInstallVersion(ctx, channelGroup, "4.21")
+			Expect(err).NotTo(HaveOccurred(), "failed to resolve 4.21 install version")
+
 			By("creating cluster parameters")
 			clusterParams := framework.NewDefaultClusterParams20251223()
 			clusterParams.ClusterName = customerClusterName
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
 			clusterParams.KeyVaultVisibility = "Private"
+			clusterParams.OpenshiftVersionId = cpVersion
+			clusterParams.ChannelGroup = channelGroup
+			clusterParams.Tags[metadataapi.TagClusterCPOImageOverride] = to.Ptr(cpoOverrideImage)
 
 			By("creating customer resources (infrastructure and managed identities)")
 			clusterParams, err = tc.CreateClusterCustomerResources20251223(ctx,
@@ -125,6 +135,8 @@ var _ = Describe("Create HCPOpenShiftCluster with Private KeyVault", func() {
 			nodePoolParams.ClusterName = customerClusterName
 			nodePoolParams.NodePoolName = "np-1"
 			nodePoolParams.Replicas = int32(2)
+			nodePoolParams.OpenshiftVersionId = cpVersion
+			nodePoolParams.ChannelGroup = channelGroup
 
 			err = tc.CreateNodePoolFromParam20240610(ctx,
 				GinkgoLogr,

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -27,6 +27,8 @@ import (
 	"github.com/Azure/ARO-HCP/test/util/log"
 )
 
+const cpoOverrideImage = "arohcpocpdev.azurecr.io/control-plane-operator@sha256:bb471a00fcb61e8dc8a8c4abfebb16f15f282e2cb7df792514fdfc66a5891a1a"
+
 var (
 	e2eSetup integration.SetupModel
 )

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -7,6 +7,8 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 4.21 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 4.21 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -6,6 +6,8 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 4.21 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 4.21 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -6,6 +6,8 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 4.21 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 4.21 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -9,6 +9,8 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 4.21 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 4.21 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -6,6 +6,8 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 4.21 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 4.21 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -6,6 +6,8 @@ Authorized CIDRs Connectivity should allow API access only from authorized VM IP
 Customer should be able to create an HCP cluster with custom autoscaling and update the autoscaling configuration
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
+Create HCPOpenShiftCluster with CPO override (v20240610preview) should create a 4.21 cluster with CPO image override using v20240610preview API
+Create HCPOpenShiftCluster with CPO override (v20251223preview) should create a 4.21 cluster with CPO image override using v20251223preview API
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public


### PR DESCRIPTION
What

Help verify router pod doesn't get deployed until all route are able to be rendered in the router configmap.
Why
Testing

    Build and push https://github.com/openshift/hypershift/pull/8971 out of band to ACR
    FDescribe on private key vault test so only that e2e runs.
    Look at kusto for the run in question
        Check events to validate there's only ever a single replicaset of the private-router pod in the hostedcluster namespace
        Check mgmt-agent logs and kube-apiserver logs to validate the configmap is created, then updated later with the ignition route, then the router pod is created