### PR TITLE
OCPBUGS-99304: chore: backend/pkg/controllers/controlplaneversion: Scaffold install/update version selection

### DIFF
--- a/backend/pkg/controllers/controlplaneversion/aro.go
+++ b/backend/pkg/controllers/controlplaneversion/aro.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/blang/semver/v4"
+	configv1 "github.com/openshift/api/config/v1"
+	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"k8s.io/klog/v2"
+)
+
+// ARO-HCP specific user agent; put whatever you like in here to identify yourself.
+var userAgent = "AROHCPFixme/0.1"
+
+// SelectControlPlaneVersion must run at a scale of an estimated 100 qps
+// SelectControlPlaneVersion must return a z-stream that always has a path for 4.y+1 up to 4.y(latest) and then the latest 4.y(latest).latest.
+// The selected z-stream must be the most recent available z-stream that meets those criteria
+// The hostedCluster may not be present in all scenarios, since cases like install doesn't have a hostedCluster.
+// The hostedCluster may never have achieved any stable level, but must still select the best z-stream.
+// The z-steam chosen for 4.y, must be able to upgrade to a 4.y+1.z that can itself upgrade to a 4.y+2.z.
+// This ensures that we can always upgrade to the latest level.
+// When a particular channelStability 4.y+1 has no upgrade paths from 4.y, then we select the latest z-stream for that 4.y.
+// We move from 4.22 to 5.0 in our numbering scheme, so 5.0 is considered the 4.y+1 for 4.22.
+// If the hostedCluster has previous values in .status.controlPlaneVersion.history that are partially or fully installed,
+// be sure to only select levels that have upgrade paths from *all* present versions.
+// To the implementer: if you cannot honor conditional edges yet, know that future bugs will press on being able to provide
+// that value on HostedCluster upgrade decisions.
+// Remember that edges can be removed and if an edge from 4.20.12 to 4.21.4 is removed.  This diverges into two cases
+//  1. no level of 4.20 can upgrade to 4.21.  In this case, upgrade to the latest 4.20.z
+//  2. some levels of 4.20 can upgrade to 4.21.  In this case, select the 4.20.12 clusters must wait to upgrade until a new z-stream
+//     can move to 4.21.  During this time, this function must return nil for the targetVersion and a structured error until
+//     a new edge from 4.20 to 4.21 appears and we can upgrade to that later 4.20.z.
+func SelectControlPlaneVersion(ctx context.Context, channelStability string, desiredYVersion semver.Version, roundTripper RoundTrip, updateService *url.URL, hostedCluster *hypershiftv1beta1.HostedCluster) (*semver.Version, error) {
+	channel := fmt.Sprintf("%s-%d.%d", channelStability, desiredYVersion.Major, desiredYVersion.Minor)
+	if hostedCluster == nil {
+		connectivityRanker := preferFeatureConnectivityOverPatchFixes(ctx, roundTripper, updateService, userAgent, channelStability, channel)
+		rankRelease := func(release configv1.Release) (float32, error) {
+			if err := aroInstallAcceptable(release); err != nil {
+				return 0, err
+			}
+			return connectivityRanker(release)
+		}
+		return defaultInstall(ctx, roundTripper, updateService, userAgent, channel, rankRelease)
+	}
+	clusterUpdateService := hostedCluster.Spec.UpdateService
+	if len(clusterUpdateService) == 0 {
+		clusterUpdateService = configv1.URL(defaultUpstreamUpdateService)
+	}
+	if updateService != nil && configv1.URL(updateService.String()) != clusterUpdateService {
+		return nil, fmt.Errorf("HostedCluster spec.updateService %q diverges from the explicitly-requested update service %q.  Call SelectControlPlaneVersion with a nil update service to defer to the current HostedCluster configuration, or update the HostedCluster spec.updateService to match the update service you want that cluster to use.", hostedCluster.Spec.UpdateService, updateService)
+	}
+	updateService, err := url.Parse(string(clusterUpdateService))
+	if err != nil {
+		return nil, err
+	}
+	if channel != hostedCluster.Spec.Channel {
+		return nil, fmt.Errorf("HostedCluster spec.channel %q diverges from the explicitly-requested channel %q.  Call SelectControlPlaneVersion with a channel stability and desired X.Y version that matches the current HostedCluster channel configuration, or update the HostedCluster spec.channel to %q.", hostedCluster.Spec.Channel, channel, channel)
+	}
+	connectivityRanker := preferFeatureConnectivityOverPatchFixes(ctx, roundTripper, updateService, userAgent, channelStability, channel)
+	return defaultUpdate(ctx, hostedCluster, connectivityRanker)
+}
+
+// aroInstallAcceptable is maintained by ARO maintainers, not by OCP, to track things that ARO considers install-blocking bugs.
+func aroInstallAcceptable(release configv1.Release) error {
+	aroInstallBugs := map[string]error{
+		"4.22.6": errors.New("FIXME: example ARO-maintainer concerns with 4.22.6 installs"),
+	}
+
+	return aroInstallBugs[release.Version] // Perhaps ARO maintainers have more keys to make this concern conditional on specific install-config choices.  If so, they can update this function or use a closure that understands this specific installation request's configuration.
+}
+
+// preferFeatureConnectivityOverPatchFixes ranks releases to
+// prioritize connections to future features, to keep those updates
+// reliably available for the fraction of clusters that decide they want
+// those new features.  In exchange, this can leave clusters exposed to
+// bug and CVE fixes that have shipped into the configured channel.
+//
+// Each call to preferFeatureConnectivityOverPatchFixes returns a closure with
+// its own update-service cache state.  Create a new closure whenever you want
+// to clear that cache.
+func preferFeatureConnectivityOverPatchFixes(ctx context.Context, roundTripper RoundTrip, updateService *url.URL, userAgent string, channelStability string, initialChannel string) rankRelease {
+	graphs := make(map[string]*graph)
+	return func(release configv1.Release) (float32, error) {
+		rank, err := walkHighestFeature(ctx, graphs, roundTripper, updateService, userAgent, channelStability, initialChannel, release)
+		klog.V(4).Infof("ranked %g for %v with %v (%v)", rank, release.Version, release.Channels, err)
+		return rank, err
+	}
+}
+
+// walkHighestFeature recursively retrieves update-service advice and
+// walks from the initial channel through later channels, searching
+// for the highest feature reachable from the initial release.  Both
+// unconditional and conditionally-recommended updates are treated as
+// walkable connections.  A mutable 'graphs' cache can be passed to
+// make performance manageable.
+func walkHighestFeature(ctx context.Context, graphs map[string]*graph, roundTripper RoundTrip, updateService *url.URL, userAgent string, channelStability string, initialChannel string, release configv1.Release) (float32, error) {
+	largestRank, maxChannel := rankReleaseByHighestChannel(release, channelStability)
+	if maxChannel == "" || maxChannel == initialChannel { // there's no way to walk from here to a higher channel
+		return largestRank, nil
+	}
+
+	if graphs == nil {
+		graphs = make(map[string]*graph)
+	}
+	var err error
+	var releases []configv1.Release
+	graph, ok := graphs[maxChannel]
+	if ok {
+		releases, err = nodesToReleases(graph.Nodes)
+		if err != nil {
+			return 0, err
+		}
+	} else {
+		releases, graph, _, err = cincinnati(ctx, roundTripper, updateService, userAgent, maxChannel)
+		if err != nil {
+			return 0, err
+		}
+		graphs[maxChannel] = graph // cache to save later repeat requests
+	}
+
+	currentReleaseIndex := -1
+	for i, r := range releases {
+		if r.Version == release.Version {
+			currentReleaseIndex = i
+			break
+		}
+	}
+	if currentReleaseIndex == -1 {
+		return 0, fmt.Errorf("%q not found in channel %q", release.Version, maxChannel)
+	}
+
+	for _, edge := range graph.Edges {
+		if edge.Origin == currentReleaseIndex {
+			rank, err := walkHighestFeature(ctx, graphs, roundTripper, updateService, userAgent, channelStability, maxChannel, releases[edge.Destination])
+			if err != nil {
+				klog.Errorf("failure walking %q in %q while ranking: %v", releases[edge.Destination].Version, maxChannel, err)
+			}
+			if rank > largestRank {
+				largestRank = rank
+			}
+		}
+	}
+
+	for _, conditionalEdge := range graph.ConditionalEdges {
+		for _, edge := range conditionalEdge.Edges {
+			if edge.From == release.Version {
+				found := false
+				for _, r := range releases {
+					if r.Version == edge.To {
+						found = true
+						rank, err := walkHighestFeature(ctx, graphs, roundTripper, updateService, userAgent, channelStability, maxChannel, r)
+						if err != nil {
+							klog.Errorf("failure walking %q in %q while ranking: %v", r.Version, maxChannel, err)
+						}
+						if rank > largestRank {
+							largestRank = rank
+						}
+						break
+					}
+				}
+				if !found {
+					riskNames := make([]string, 0, len(conditionalEdge.Risks))
+					for _, risk := range conditionalEdge.Risks {
+						riskNames = append(riskNames, risk.Name)
+					}
+					klog.Errorf("unable to find target %q, referenced by conditional update %v in %q", edge.To, riskNames, maxChannel)
+				}
+			}
+		}
+	}
+
+	return largestRank, nil
+}
+
+// rankReleaseByHighestChannel ranks a release by the highest
+// channelStability MAJOR.MINOR channel that release is a direct member
+// of, returning both the rank and that maximum channel.
+func rankReleaseByHighestChannel(release configv1.Release, channelStability string) (float32, string) {
+	var rank float32
+	maxChannel := ""
+	for _, channel := range release.Channels {
+		stability, major, minor, err := parseChannel(channel)
+		if err != nil {
+			klog.Errorf("failed to parse channel from %v while generating an ARO rank for %q: %v", release.Channels, release.Version, err)
+			major = 0
+			minor = 0
+		}
+		if stability == channelStability {
+			var r float32
+			r = float32(major) + float32(minor)/1000 // there will never be more than 1k minor releases in any given major release
+			if r > rank {
+				rank = r
+				maxChannel = channel
+			}
+		}
+	}
+	return rank, maxChannel
+}
+
+// parseChannel parses a channel string like "stable-4.20" into
+// channel stability ("stable"), major (4), and minor (20) components.
+func parseChannel(channel string) (string, uint, uint, error) {
+	i := strings.LastIndex(channel, "-")
+	if i == -1 {
+		return "", 0, 0, fmt.Errorf("no - delimiter found in channel %q", channel)
+	}
+	if i == 0 {
+		return "", 0, 0, fmt.Errorf("no channel stability found before the - delimiter in channel %q", channel)
+	}
+	if i == len(channel)-1 {
+		return "", 0, 0, fmt.Errorf("no target version found after the final - delimiter in channel %q", channel)
+	}
+	channelStability := channel[:i]
+	versionString := channel[i+1:]
+	versionSegments := strings.Split(versionString, ".")
+	if len(versionSegments) != 2 {
+		return channelStability, 0, 0, fmt.Errorf("expected a MAJOR.MINOR version in the %q portion of channel %q, but did not get two segments in %v", versionString, channel, versionSegments)
+	}
+
+	major, err := strconv.ParseUint(versionSegments[0], 10, 32)
+	if err != nil {
+		return channelStability, 0, 0, fmt.Errorf("expected a major version in the %q portion of channel %q: %w", versionSegments[0], channel, err)
+	}
+
+	minor, err := strconv.ParseUint(versionSegments[1], 10, 32)
+	if err != nil {
+		return channelStability, uint(major), 0, fmt.Errorf("expected a minor version in the %q portion of channel %q: %w", versionSegments[1], channel, err)
+	}
+
+	return channelStability, uint(major), uint(minor), nil
+}

--- a/backend/pkg/controllers/controlplaneversion/aro_test.go
+++ b/backend/pkg/controllers/controlplaneversion/aro_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestPreferFeatureConnectivityOverPatchFixes(t *testing.T) {
+	tests := []struct {
+		name          string
+		release       configv1.Release
+		graphs        map[string]graph
+		expectedRank  float32
+		expectedError string
+	}{
+		{
+			name:         "no channels gets rank 0",
+			release:      configv1.Release{},
+			expectedRank: 0,
+		},
+		{
+			name:    "multiple channels ranks the highest major.minor in the target stability set",
+			release: configv1.Release{Version: "4.22.0", Channels: []string{"stable-4.22", "stable-5.0", "stable-4.23"}},
+			graphs: map[string]graph{
+				"stable-5.0": {
+					Nodes: []node{
+						makeNode("4.22.0", ""),
+					},
+				},
+			},
+			expectedRank: 5,
+		},
+		{
+			name:    "alternative stability sets are ignored",
+			release: configv1.Release{Version: "4.22.0", Channels: []string{"stable-4.22", "stable-5.0", "stable-4.23", "candidate-5.2"}},
+			graphs: map[string]graph{
+				"stable-5.0": {
+					Nodes: []node{
+						makeNode("4.22.0", ""),
+					},
+				},
+			},
+			expectedRank: 5,
+		},
+		{
+			name:    "minor versions up to 999 are ranked appropriately",
+			release: configv1.Release{Version: "4.22.0", Channels: []string{"stable-4.22", "stable-4.999"}},
+			graphs: map[string]graph{
+				"stable-4.999": {
+					Nodes: []node{
+						makeNode("4.22.0", ""),
+					},
+				},
+			},
+			expectedRank: 4.999,
+		},
+		{
+			name:    "minor versions up to 999 are ranked appropriately vs higher majors",
+			release: configv1.Release{Version: "4.22.0", Channels: []string{"stable-4.22", "stable-4.999", "stable-5.0"}},
+			graphs: map[string]graph{
+				"stable-5.0": {
+					Nodes: []node{
+						makeNode("4.22.0", ""),
+					},
+				},
+			},
+			expectedRank: 5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			roundTripper := testRoundTripper(tt.graphs)
+			rank, err := preferFeatureConnectivityOverPatchFixes(context.Background(), roundTripper, nil, userAgent, "stable", "stable-4.22")(tt.release)
+			if len(tt.expectedError) == 0 && err != nil {
+				t.Error(err)
+			} else if len(tt.expectedError) > 0 && err == nil {
+				t.Errorf("expected error %q, but got %v", tt.expectedError, err)
+			} else if err != nil && err.Error() != tt.expectedError {
+				t.Errorf("expected error %q, but got %q", tt.expectedError, err)
+			}
+			if rank != tt.expectedRank {
+				t.Errorf("expected rank %g, but got %g", tt.expectedRank, rank)
+			}
+		})
+	}
+}
+
+func TestParseChannel(t *testing.T) {
+	tests := []struct {
+		channel           string
+		expectedStability string
+		expectedMajor     uint
+		expectedMinor     uint
+		expectedError     string
+	}{
+		{
+			channel:       "",
+			expectedError: `no - delimiter found in channel ""`,
+		},
+		{
+			channel:       "-",
+			expectedError: `no channel stability found before the - delimiter in channel "-"`,
+		},
+		{
+			channel:       "-4.20",
+			expectedError: `no channel stability found before the - delimiter in channel "-4.20"`,
+		},
+		{
+			channel:       "stable-",
+			expectedError: `no target version found after the final - delimiter in channel "stable-"`,
+		},
+		{
+			channel:           "stable-a",
+			expectedStability: "stable",
+			expectedError:     `expected a MAJOR.MINOR version in the "a" portion of channel "stable-a", but did not get two segments in [a]`,
+		},
+		{
+			channel:           "stable-a.b.c",
+			expectedStability: "stable",
+			expectedError:     `expected a MAJOR.MINOR version in the "a.b.c" portion of channel "stable-a.b.c", but did not get two segments in [a b c]`,
+		},
+		{
+			channel:           "stable-a.b",
+			expectedStability: "stable",
+			expectedError:     `expected a major version in the "a" portion of channel "stable-a.b": strconv.ParseUint: parsing "a": invalid syntax`,
+		},
+		{
+			channel:           "stable-10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.a",
+			expectedStability: "stable",
+			expectedError:     `expected a major version in the "10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" portion of channel "stable-10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.a": strconv.ParseUint: parsing "10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000": value out of range`,
+		},
+		{
+			channel:           "stable-4.a",
+			expectedStability: "stable",
+			expectedMajor:     4,
+			expectedError:     `expected a minor version in the "a" portion of channel "stable-4.a": strconv.ParseUint: parsing "a": invalid syntax`,
+		},
+		{
+			channel:           "stable-4.20",
+			expectedStability: "stable",
+			expectedMajor:     4,
+			expectedMinor:     20,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.channel, func(t *testing.T) {
+			stability, major, minor, err := parseChannel(tt.channel)
+			if len(tt.expectedError) == 0 && err != nil {
+				t.Error(err)
+			} else if len(tt.expectedError) > 0 && err == nil {
+				t.Errorf("expected error %q, but got %v", tt.expectedError, err)
+			} else if err != nil && err.Error() != tt.expectedError {
+				t.Errorf("expected error %q, but got %q", tt.expectedError, err)
+			}
+			if stability != tt.expectedStability {
+				t.Errorf("expected %q stability, got %q", tt.expectedStability, stability)
+			}
+			if major != tt.expectedMajor {
+				t.Errorf("expected %d major, got %d", tt.expectedMajor, major)
+			}
+			if minor != tt.expectedMinor {
+				t.Errorf("expected %d minor, got %d", tt.expectedMinor, minor)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/controlplaneversion/cincinnati.go
+++ b/backend/pkg/controllers/controlplaneversion/cincinnati.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// RoundTrip allows customizing the RoundTripper (e.g. to support
+// testing or proxy/TLS configuration) without having to create a local
+// struct supplying the RoundTripper interface.  The interface only
+// requires a RoundTrip function, and it is easier to just pass the
+// function around.  https://github.com/golang/go/issues/38479 is
+// proposing the type become a stdlib declaration, but until then,
+// declare it locally.
+type RoundTrip func(*http.Request) (*http.Response, error)
+
+// metadata represents release metadata for a single node in the update graph.
+type metadata struct {
+	ChannelsString string `json:"io.openshift.upgrades.graph.release.channels,omitempty"`
+}
+
+// node represents a single cluster version in the update graph.
+type node struct {
+	// Version is the semantic version of this release.
+	Version string `json:"version"`
+
+	// Payload is the release image pullspec (payload) for this version.
+	Payload string `json:"payload"`
+
+	// Metadata contains additional release information such as URL, architecture,
+	// and supported update channels.
+	Metadata metadata `json:"metadata,omitempty"`
+}
+
+// edge represents an unconditional upgrade path between two versions in the graph.
+// It is serialized as a two-element array [origin, destination] in JSON.
+type edge struct {
+	// Origin is the index of the source version node.
+	Origin int
+
+	// Destination is the index of the target version node.
+	Destination int
+}
+
+// conditionalEdge represents a conditional update path between two versions in the graph.
+type conditionalEdge struct {
+	// From is the semantic version string of the source release.
+	From string `json:"from"`
+
+	// To is the semantic version string of the target release.
+	To string `json:"to"`
+}
+
+// conditionalEdges groups a set of conditional upgrade edges with their shared risks.
+// All edges in this group are subject to the same risk conditions.
+type conditionalEdges struct {
+	// Edges contains the conditional upgrade paths sharing these risks.
+	Edges []conditionalEdge `json:"edges"`
+
+	// Risks defines the conditions that must be evaluated to determine if
+	// these conditional updates are recommended for a particular cluster.
+	Risks []configv1.ConditionalUpdateRisk `json:"risks"`
+}
+
+// graph represents the update graph structure returned by the Cincinnati service.
+// It defines all available cluster versions and the valid upgrade paths between them.
+type graph struct {
+	// Nodes contains all cluster version releases available in this channel.
+	Nodes []node `json:"nodes"`
+
+	// Edges defines unconditional upgrade paths as index pairs referencing Nodes.
+	// Each edge indicates a recommended upgrade from one version to another.
+	Edges []edge `json:"edges"`
+
+	// ConditionalEdges defines upgrade paths that require risk evaluation.
+	// These upgrades are only recommended if their associated risks are acceptable.
+	ConditionalEdges []conditionalEdges `json:"conditionalEdges"`
+}
+
+// UnmarshalJSON deserializes an edge from its JSON representation.
+// Edges are represented in JSON as two-element arrays [origin, destination],
+// but are stored in Go as a struct with named fields, requiring this custom
+// unmarshaling logic.
+func (e *edge) UnmarshalJSON(data []byte) error {
+	var fields []int
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	if len(fields) != 2 {
+		return fmt.Errorf("expected 2 fields, found %d", len(fields))
+	}
+
+	e.Origin = fields[0]
+	e.Destination = fields[1]
+
+	return nil
+}
+
+// MarshalJSON serializes an edge into its JSON representation, inverting UnmarshalJSON.
+func (e *edge) MarshalJSON() ([]byte, error) {
+	rawEdge := []int{e.Origin, e.Destination}
+	return json.Marshal(rawEdge)
+}
+
+var defaultUpstreamUpdateService = "https://api.openshift.com/api/upgrades_info/graph"
+
+// roundTrip converts a RoundTrip function into a RoundTripper.
+type roundTrip struct {
+	roundTripper RoundTrip
+}
+
+// RoundTrip executes a single HTTP transaction, returning a Response
+// for the provided Request.
+func (rt *roundTrip) RoundTrip(request *http.Request) (*http.Response, error) {
+	return rt.roundTripper(request)
+}
+
+// cincinnati calls an update-service to retrieve a list of releases,
+// and the update recommendation graph connecting them.
+func cincinnati(ctx context.Context, roundTripper RoundTrip, updateService *url.URL, userAgent string, channel string) ([]configv1.Release, *graph, *url.URL, error) {
+	if updateService == nil {
+		var err error
+		updateService, err = url.Parse(defaultUpstreamUpdateService)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	} else { // copy to avoid mutating function arguments
+		u := *updateService
+		updateService = &u
+	}
+
+	queryParams := updateService.Query()
+	queryParams.Set("arch", "multi")
+	queryParams.Set("channel", channel)
+	updateService.RawQuery = queryParams.Encode()
+	req, err := http.NewRequest("GET", updateService.String(), nil)
+	if err != nil {
+		return nil, nil, updateService, err
+	}
+	req.Header.Set("Accept", "application/vnd.redhat.cincinnati.v1+json")
+	if len(userAgent) > 0 {
+		req.Header.Set("User-Agent", userAgent)
+	}
+	client := &http.Client{}
+	if roundTripper != nil {
+		client.Transport = &roundTrip{roundTripper: roundTripper}
+	}
+	resp, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, nil, updateService, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, updateService, fmt.Errorf("%s returned unexpected HTTP status %s", updateService, resp.Status)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, updateService, err
+	}
+	var graph graph
+	err = json.Unmarshal(body, &graph)
+	if err != nil {
+		return nil, nil, updateService, err
+	}
+
+	releases, err := nodesToReleases(graph.Nodes)
+	return releases, &graph, updateService, err
+}
+
+// nodesToReleases converts a slice of update-service nodes to a slice
+// of Releases (mostly parsing channel metadata).
+func nodesToReleases(nodes []node) ([]configv1.Release, error) {
+	releases := make([]configv1.Release, 0, len(nodes))
+	for _, node := range nodes {
+		channels := strings.Split(node.Metadata.ChannelsString, ",")
+		if len(node.Metadata.ChannelsString) == 0 {
+			channels = nil
+		}
+		releases = append(releases, configv1.Release{
+			Version:  node.Version,
+			Image:    node.Payload,
+			Channels: channels,
+		})
+	}
+
+	return releases, nil
+}

--- a/backend/pkg/controllers/controlplaneversion/controlplaneversion.go
+++ b/backend/pkg/controllers/controlplaneversion/controlplaneversion.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"slices"
+
+	"github.com/blang/semver/v4"
+	configv1 "github.com/openshift/api/config/v1"
+	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func defaultInstall(ctx context.Context, roundTripper RoundTrip, updateService *url.URL, userAgent string, channel string, rankRelease rankRelease) (*semver.Version, error) {
+	releases, _, updateService, err := cincinnati(ctx, roundTripper, updateService, userAgent, channel)
+	if err != nil {
+		return nil, err
+	}
+	if len(releases) == 0 {
+		return nil, fmt.Errorf("no install targets found in %s.", updateService)
+	}
+	return rankedSelection(releases, rankRelease)
+}
+
+func defaultUpdate(ctx context.Context, hostedCluster *hypershiftv1beta1.HostedCluster, rankRelease rankRelease) (*semver.Version, error) {
+	if hostedCluster.Status.Version == nil {
+		return nil, errors.New("HostedCluster status.version is not set, so neither the current version nor available update advice are available.")
+	}
+
+	updates := slices.Clone(hostedCluster.Status.Version.AvailableUpdates)
+	conditionalUpdates := slices.Clone(hostedCluster.Status.Version.ConditionalUpdates)
+
+	// Process Upgradeable=False locally, until https://github.com/openshift/cluster-version-operator/tree/42ff52c75c65ca9351bc391f777709631bec3666/pkg/risk/upgradeable goes GA with the ClusterUpdateAcceptRisks feature-gate, https://github.com/openshift/api/blob/181bcde0d9c778458cf2faec55e5fde023fd3c20/features/features.go#L709-L715
+	upgradeable := meta.FindStatusCondition(hostedCluster.Status.Conditions, string(hypershiftv1beta1.ClusterVersionUpgradeable))
+	if upgradeable != nil && upgradeable.Status == metav1.ConditionFalse {
+		currentTargetVersion, err := semver.Parse(hostedCluster.Status.Version.Desired.Version)
+		if err != nil {
+			return nil, fmt.Errorf("HostedCluster status.version.desired.version is not SemVer: %w", err)
+		}
+		for i := len(updates) - 1; i >= 0; i-- {
+			nextVersion, err := semver.Parse(updates[i].Version)
+			if err == nil && (nextVersion.Major > currentTargetVersion.Major ||
+				(nextVersion.Major == currentTargetVersion.Major && nextVersion.Minor > currentTargetVersion.Minor)) {
+				updates = append(updates[:i], updates[i+1:]...)
+				found := false
+				for _, conditionalUpdate := range conditionalUpdates {
+					if conditionalUpdate.Release.Version == nextVersion.String() {
+						found = true
+					}
+				}
+				if !found {
+					conditionalUpdates = append(conditionalUpdates, configv1.ConditionalUpdate{Release: configv1.Release{Version: nextVersion.String()}})
+				}
+			}
+		}
+	}
+
+	if len(updates) == 0 {
+		if len(conditionalUpdates) == 0 {
+			return nil, errors.New("HostedCluster status.version.availableUpdates and conditionalUpdates are both empty, so no updates are currently recommended for this cluster.")
+		}
+		return nil, fmt.Errorf("HostedCluster status.version.availableUpdates is empty, so no updates are currently recommended for this cluster.  There are %d conditional updates, which are supported, but not recommended for this cluster without administrator approval.", len(conditionalUpdates))
+	}
+
+	return rankedSelection(updates, rankRelease)
+}

--- a/backend/pkg/controllers/controlplaneversion/install_test.go
+++ b/backend/pkg/controllers/controlplaneversion/install_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/blang/semver/v4"
+)
+
+func makeNode(version string, channels string) node {
+	return node{
+		Version:  version,
+		Payload:  fmt.Sprintf("quay.io/openshift-release-dev/ocp-release:%s-multi", version),
+		Metadata: metadata{ChannelsString: channels},
+	}
+}
+
+func jsonBody(v interface{}) io.ReadCloser {
+	b, _ := json.Marshal(v)
+	return io.NopCloser(strings.NewReader(string(b)))
+}
+
+func testRoundTripper(graphs map[string]graph) RoundTrip {
+	return func(request *http.Request) (*http.Response, error) {
+		values, err := url.ParseQuery(request.URL.RawQuery)
+		if err != nil {
+			return nil, err
+		}
+		channel := values.Get("channel")
+		graph, ok := graphs[channel]
+		if !ok {
+			return nil, fmt.Errorf("requested channel %q not in test fixture %v", channel, slices.Collect(maps.Keys(graphs)))
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       jsonBody(graph),
+		}, nil
+	}
+}
+
+func TestSelectControlPlaneVersionInstall(t *testing.T) {
+	tests := []struct {
+		name            string
+		graphs          map[string]graph
+		expectedVersion string
+		expectedError   string
+	}{
+		{
+			name: "returns highest version when channel membership ties",
+			graphs: map[string]graph{
+				"stable-4.20": {
+					Nodes: []node{
+						makeNode("4.20.1", ""),
+						makeNode("4.20.2", ""),
+						makeNode("4.20.3", ""),
+					},
+				},
+			},
+			expectedVersion: "4.20.3",
+		},
+		{
+			name: "filter rejects highest, returns an older release that improves channel connectivity",
+			graphs: map[string]graph{
+				"stable-4.20": {
+					Nodes: []node{
+						makeNode("4.20.1", "stable-4.20,stable-4.21"),
+						makeNode("4.20.2", "stable-4.20,stable-4.21"),
+						makeNode("4.20.3", "stable-4.20"), // newer than the most recent 4.21 in stable-4.21, so waiting on a newer 4.21.z.
+					},
+				},
+				"stable-4.21": {
+					Nodes: []node{
+						makeNode("4.20.1", "stable-4.20,stable-4.21"),
+						makeNode("4.20.2", "stable-4.20,stable-4.21"),
+					},
+				},
+			},
+			expectedVersion: "4.20.2", // this leaves the 4.20.3 fixes on the table, with installPreferFeatureConnectivityOverPatchFixes asserting the ARO policy that connectivity to 4.21 (in case the cluster wants to update to 4.21) outranks the importance of bug-fixes in stable-4.20.
+		},
+		{
+			name: "filter rejects highest, returns an older release that most improves channel connectivity",
+			graphs: map[string]graph{
+				"stable-4.20": {
+					Nodes: []node{
+						makeNode("4.20.1", "stable-4.20,stable-4.21,stable-4.22"),
+						makeNode("4.20.2", "stable-4.20,stable-4.21"), // newer than the most recent 4.21/4.22 pair, so waiting on a newer pair.
+						makeNode("4.20.3", "stable-4.20"),             // newer than the most recent 4.21 in stable-4.21, so waiting on a newer 4.21.z.
+					},
+				},
+				"stable-4.21": {
+					Nodes: []node{
+						makeNode("4.20.1", "stable-4.20,stable-4.21,stable-4.22"),
+						makeNode("4.20.2", "stable-4.20,stable-4.21"), // newer than the most recent 4.21/4.22 pair, so waiting on a newer pair.
+					},
+				},
+				"stable-4.22": {
+					Nodes: []node{
+						makeNode("4.20.1", "stable-4.20,stable-4.21,stable-4.22"),
+					},
+				},
+			},
+			expectedVersion: "4.20.1", // this leaves the 4.20.2 and 4.20.3 fixes on the table, with installPreferFeatureConnectivityOverPatchFixes asserting the ARO policy that connectivity to 4.22 (in case the cluster wants to update through 4.21 to 4.22) outranks the importance of bug-fixes in stable-4.20.
+		},
+		{
+			name: "filter rejects highest, returns an older release that improves channel connectivity, but only cares about the target stability level",
+			graphs: map[string]graph{
+				"stable-4.20": {
+					Nodes: []node{
+						makeNode("4.20.1", "stable-4.20,stable-4.21,candidate-4.20,candidate-4.21,candidate-4.22"),
+						makeNode("4.20.2", "stable-4.20,stable-4.21,candidate-4.20,candidate-4.21"),
+						makeNode("4.20.3", "stable-4.20,candidate-4.20,candidate-4.21"), // newer than the most recent 4.21 in stable-4.21, so waiting on a newer 4.21.z.
+					},
+				},
+				"stable-4.21": {
+					Nodes: []node{
+						makeNode("4.20.1", "stable-4.20,stable-4.21,candidate-4.20,candidate-4.21,candidate-4.22"),
+						makeNode("4.20.2", "stable-4.20,stable-4.21,candidate-4.20,candidate-4.21"),
+					},
+				},
+			},
+			expectedVersion: "4.20.2", // this leaves the 4.20.3 fixes on the table, with installPreferFeatureConnectivityOverPatchFixes asserting the ARO policy that connectivity to 4.21 (in case the cluster wants to update to 4.21) outranks the importance of bug-fixes in stable-4.20.
+		},
+		{
+			name: "filter rejects highest, returns an older release that improves channel connectivity, including walking future channel changes",
+			graphs: map[string]graph{
+				"stable-4.20": {
+					Nodes: []node{
+						makeNode("4.20.1", "stable-4.20,stable-4.21"),
+						makeNode("4.20.2", "stable-4.20,stable-4.21"),
+						makeNode("4.20.3", "stable-4.20"), // newer than the most recent 4.21 in stable-4.21, so waiting on a newer 4.21.z.
+					},
+				},
+				"stable-4.21": {
+					Nodes: []node{
+						makeNode("4.20.1", "stable-4.20,stable-4.21"),
+						makeNode("4.20.2", "stable-4.20,stable-4.21"),
+						makeNode("4.21.0", "stable-4.21,stable-4.22"),
+					},
+					Edges: []edge{{Origin: 0, Destination: 2}}, // connect 4.20.1 to 4.21.0.  4.20.2 is newer than 4.21.0, so that update could have regressions vs. backported fixes, and is not supported.
+				},
+				"stable-4.22": {
+					Nodes: []node{
+						makeNode("4.21.0", "stable-4.21,stable-4.22"),
+						makeNode("4.22.0", "stable-4.22"),
+					},
+					Edges: []edge{{Origin: 0, Destination: 1}}, // connect 4.21.0 to 4.22.0, which is a requirement before 4.22.0 is included in stable-4.22.
+				},
+			},
+			expectedVersion: "4.20.1", // this leaves the 4.20.3 and 4.20.2 fixes on the table, with installPreferFeatureConnectivityOverPatchFixes asserting the ARO policy that connectivity to 4.22 (in case the cluster wants to update through 4.21 to 4.22) outranks the importance of bug-fixes in stable-4.20.
+		},
+		{
+			name:          "empty graph",
+			graphs:        map[string]graph{"stable-4.20": {Nodes: []node{}}},
+			expectedError: "no install targets found in https://api.openshift.com/api/upgrades_info/graph?arch=multi&channel=stable-4.20.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			roundTripper := testRoundTripper(tt.graphs)
+			version, err := SelectControlPlaneVersion(context.Background(), "stable", semver.Version{Major: 4, Minor: 20}, roundTripper, nil, nil)
+			if len(tt.expectedError) == 0 && err != nil {
+				t.Error(err)
+			} else if len(tt.expectedError) > 0 && err == nil {
+				t.Errorf("expected error %q, but got %v", tt.expectedError, err)
+			} else if err != nil && err.Error() != tt.expectedError {
+				t.Errorf("expected error %q, but got %q", tt.expectedError, err)
+			}
+			if len(tt.expectedVersion) == 0 && version != nil {
+				t.Errorf("expected nil version, got %q", version)
+			} else if len(tt.expectedVersion) > 0 && version == nil {
+				t.Errorf("expected version %q, but got %v", tt.expectedVersion, version)
+			} else if version != nil && version.String() != tt.expectedVersion {
+				t.Errorf("expected version %q, but got %q", tt.expectedVersion, version)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/controlplaneversion/main.go
+++ b/backend/pkg/controllers/controlplaneversion/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/blang/semver/v4"
+	"k8s.io/klog/v2"
+)
+
+func main() {
+	klog.InitFlags(flag.CommandLine)
+	flag.Parse()
+	args := flag.Args()
+
+	if len(args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s CHANNEL_STABILITY X.Y [UPSTREAM_UPDATE_SERVICE]\n", os.Args[0])
+		os.Exit(1)
+	}
+	channelStability := args[0]
+	desiredXYVersion, err := semver.Parse(fmt.Sprintf("%s.0", args[1]))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "expected X.Y version, but failed to parse: %v\n", err)
+		os.Exit(1)
+	}
+	var upstreamUpdateService string // customizable for testing and disconnected/restricted-network environments
+	if len(args) >= 3 {
+		upstreamUpdateService = args[2]
+	} else {
+		upstreamUpdateService = defaultUpstreamUpdateService
+	}
+
+	updateService, err := url.Parse(upstreamUpdateService)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v", err)
+		os.Exit(1)
+	}
+
+	version, err := SelectControlPlaneVersion(context.Background(), channelStability, desiredXYVersion, nil, updateService, nil)
+	fmt.Printf("%v (%v)\n", version, err)
+}

--- a/backend/pkg/controllers/controlplaneversion/rank.go
+++ b/backend/pkg/controllers/controlplaneversion/rank.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/blang/semver/v4"
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/klog/v2"
+)
+
+// rankRelease allows hosting maintainers to rank a target release
+// based on their own criteria.  Releases that the function ranks are
+// preferred over releases where ranking errors.  If error state ties,
+// releases with a higher rank are preferred over releases with a
+// lower rank.  If both error state and rank tie, releases with a larger
+// Semantic Version are preferred over releases with a lower Semantic
+// Version.
+type rankRelease func(release configv1.Release) (float32, error)
+
+// rankedRelease holds a release and the hosting-maintainer's rank of that release.
+type rankedRelease struct {
+	rank    float32
+	error   error
+	release configv1.Release
+}
+
+// String represents the rankedRelease as a string.
+func (rr rankedRelease) String() string {
+	if rr.error != nil {
+		return fmt.Sprintf("%v (rank %g, error %v)", rr.release.Version, rr.rank, rr.error)
+	}
+	return fmt.Sprintf("%v (rank %g)", rr.release.Version, rr.rank)
+}
+
+// rankedSelection runs the rankRelease function on each of the
+// releases, and returns the release that the ranking function prefers,
+// even if that is not the largest semantic version in the release set.
+func rankedSelection(targets []configv1.Release, rankRelease rankRelease) (*semver.Version, error) {
+	initialTargets := len(targets)
+	var err error
+	for i := len(targets) - 1; i >= 0; i-- {
+		if _, err = semver.Parse(targets[i].Version); err != nil {
+			err = fmt.Errorf("failed to parse SemVer %q: %w", targets[i].Version, err)
+			targets = append(targets[:i], targets[i+1:]...)
+		}
+	}
+
+	if len(targets) == 0 {
+		if initialTargets > 0 {
+			return nil, fmt.Errorf("rankedSelection requires a non-empty target set, and while this call had %d targets, none of them had valid SemVer versions: %w", initialTargets, err)
+		}
+		return nil, errors.New("rankedSelection requires a non-empty target set.  Callers with zero targets should not call us.")
+	}
+
+	slices.SortFunc(targets, func(a, b configv1.Release) int {
+		vA := semver.MustParse(a.Version)
+		vB := semver.MustParse(b.Version)
+		return -vA.Compare(vB)
+	})
+
+	if rankRelease == nil {
+		v, err := semver.Parse(targets[0].Version)
+		return &v, err
+	}
+
+	ranks := make([]rankedRelease, 0, len(targets))
+	for _, target := range targets {
+		rank, err := rankRelease(target)
+		ranks = append(ranks, rankedRelease{
+			rank:    rank,
+			error:   err,
+			release: target,
+		})
+	}
+
+	slices.SortFunc(ranks, func(a, b rankedRelease) int {
+		if a.error == nil && b.error != nil {
+			return -1
+		}
+		if a.error != nil && b.error == nil {
+			return 1
+		}
+		if a.rank != b.rank {
+			return -cmp.Compare(a.rank, b.rank)
+		}
+		vA := semver.MustParse(a.release.Version)
+		vB := semver.MustParse(b.release.Version)
+		return -vA.Compare(vB)
+	})
+	if ranks[0].error != nil {
+		return nil, fmt.Errorf("failed to rank all %d releases, including %s", len(ranks), ranks[0])
+	}
+	if ranks[0].release.Version != targets[0].Version {
+		rankInversions := make([]rankedRelease, 0, len(targets))
+		for _, target := range targets {
+			if target.Version == ranks[0].release.Version {
+				break
+			}
+			for _, ranked := range ranks {
+				if ranked.release.Version == target.Version {
+					rankInversions = append(rankInversions, ranked)
+					break
+				}
+			}
+		}
+		klog.V(2).Infof("recommending %s after the caller had concerns with greater releases like %s (%v)", ranks[0], targets[0].Version, rankInversions)
+	}
+	v, err := semver.Parse(ranks[0].release.Version)
+	return &v, err
+}

--- a/backend/pkg/controllers/controlplaneversion/rank_test.go
+++ b/backend/pkg/controllers/controlplaneversion/rank_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestRankedSelection(t *testing.T) {
+	tests := []struct {
+		name            string
+		targets         []configv1.Release
+		rankRelease     rankRelease
+		expectedVersion string
+		expectedError   string
+	}{
+		{
+			name: "every target erroring is fatal",
+			targets: []configv1.Release{
+				{Version: "4.20.1"},
+				{Version: "4.20.2"},
+				{Version: "4.20.3"},
+			},
+			rankRelease:   func(_ configv1.Release) (float32, error) { return 0, errors.New("example error") },
+			expectedError: "failed to rank all 3 releases, including 4.20.3 (rank 0, error example error)",
+		},
+		{
+			name: "prefers non-error releases, even if they have low rank or lower SemVer",
+			targets: []configv1.Release{
+				{Version: "4.20.1"},
+				{Version: "4.20.2"},
+				{Version: "4.20.3"},
+			},
+			rankRelease: func(release configv1.Release) (float32, error) {
+				switch release.Version {
+				case "4.20.2":
+					return 1, errors.New("example error")
+				case "4.20.3":
+					return 0, errors.New("example error")
+				default:
+					return 0, nil
+				}
+			},
+			expectedVersion: "4.20.1",
+		},
+		{
+			name: "prefers high rank among non-error releases",
+			targets: []configv1.Release{
+				{Version: "4.20.1"},
+				{Version: "4.20.2"},
+				{Version: "4.20.3"},
+			},
+			rankRelease: func(release configv1.Release) (float32, error) {
+				switch release.Version {
+				case "4.20.2":
+					return 0, nil
+				case "4.20.3":
+					return 0, errors.New("example error")
+				default:
+					return 1, nil
+				}
+			},
+			expectedVersion: "4.20.1",
+		},
+		{
+			name: "returns highest version when rank ties",
+			targets: []configv1.Release{
+				{Version: "4.20.1"},
+				{Version: "4.20.2"},
+				{Version: "4.20.3"},
+			},
+			rankRelease:     func(_ configv1.Release) (float32, error) { return 0, nil },
+			expectedVersion: "4.20.3",
+		},
+		{
+			name: "versions strings that are not SemVer are never returned",
+			targets: []configv1.Release{
+				{Version: "0"},
+				{Version: "1"},
+			},
+			expectedError: `rankedSelection requires a non-empty target set, and while this call had 2 targets, none of them had valid SemVer versions: failed to parse SemVer "0": No Major.Minor.Patch elements found`,
+		},
+		{
+			name: "versions strings that are not SemVer are never prioritized",
+			targets: []configv1.Release{
+				{Version: "0"},
+				{Version: "4.20.1"},
+			},
+			rankRelease:     func(_ configv1.Release) (float32, error) { return 0, nil },
+			expectedVersion: "4.20.1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version, err := rankedSelection(tt.targets, tt.rankRelease)
+			if len(tt.expectedError) == 0 && err != nil {
+				t.Error(err)
+			} else if len(tt.expectedError) > 0 && err == nil {
+				t.Errorf("expected error %q, but got %v", tt.expectedError, err)
+			} else if err != nil && err.Error() != tt.expectedError {
+				t.Errorf("expected error %q, but got %q", tt.expectedError, err)
+			}
+			if len(tt.expectedVersion) == 0 && version != nil {
+				t.Errorf("expected nil version, got %q", version)
+			} else if len(tt.expectedVersion) > 0 && version == nil {
+				t.Errorf("expected version %q, but got %v", tt.expectedVersion, version)
+			} else if version != nil && version.String() != tt.expectedVersion {
+				t.Errorf("expected version %q, but got %q", tt.expectedVersion, version)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/controlplaneversion/update_test.go
+++ b/backend/pkg/controllers/controlplaneversion/update_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/blang/semver/v4"
+	configv1 "github.com/openshift/api/config/v1"
+	hypershiftv1beta1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSelectControlPlaneVersionUpdate(t *testing.T) {
+	tests := []struct {
+		name            string
+		cluster         *hypershiftv1beta1.HostedCluster
+		graphs          map[string]graph
+		expectedVersion string
+		expectedError   string
+	}{
+		{
+			name: "nil status.version returns error",
+			cluster: &hypershiftv1beta1.HostedCluster{
+				Spec: hypershiftv1beta1.HostedClusterSpec{
+					Channel: "stable-0.0",
+				},
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Version: nil,
+				},
+			},
+			expectedError: "HostedCluster status.version is not set, so neither the current version nor available update advice are available.",
+		},
+		{
+			name: "empty available updates returns error",
+			cluster: &hypershiftv1beta1.HostedCluster{
+				Spec: hypershiftv1beta1.HostedClusterSpec{
+					Channel: "stable-0.0",
+				},
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Version: &hypershiftv1beta1.ClusterVersionStatus{
+						Desired: configv1.Release{Version: "4.20.3"},
+					},
+				},
+			},
+			expectedError: "HostedCluster status.version.availableUpdates and conditionalUpdates are both empty, so no updates are currently recommended for this cluster.",
+		},
+		{
+			name: "empty available updates with conditional updates counts the conditional entries",
+			cluster: &hypershiftv1beta1.HostedCluster{
+				Spec: hypershiftv1beta1.HostedClusterSpec{
+					Channel: "stable-0.0",
+				},
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Version: &hypershiftv1beta1.ClusterVersionStatus{
+						Desired:            configv1.Release{Version: "4.20.3"},
+						ConditionalUpdates: []configv1.ConditionalUpdate{{Release: configv1.Release{}}},
+					},
+				},
+			},
+			expectedError: "HostedCluster status.version.availableUpdates is empty, so no updates are currently recommended for this cluster.  There are 1 conditional updates, which are supported, but not recommended for this cluster without administrator approval.",
+		},
+		{
+			name: "available updates with Upgradeable=False processing",
+			cluster: &hypershiftv1beta1.HostedCluster{
+				Spec: hypershiftv1beta1.HostedClusterSpec{
+					Channel: "stable-0.0",
+				},
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(hypershiftv1beta1.ClusterVersionUpgradeable),
+							Status: metav1.ConditionFalse,
+						},
+					},
+					Version: &hypershiftv1beta1.ClusterVersionStatus{
+						Desired:          configv1.Release{Version: "4.20.3"},
+						AvailableUpdates: []configv1.Release{{Version: "4.21.0"}},
+					},
+				},
+			},
+			expectedError: "HostedCluster status.version.availableUpdates is empty, so no updates are currently recommended for this cluster.  There are 1 conditional updates, which are supported, but not recommended for this cluster without administrator approval.",
+		},
+		{
+			name: "returns highest version when channel membership ties",
+			cluster: &hypershiftv1beta1.HostedCluster{
+				Spec: hypershiftv1beta1.HostedClusterSpec{
+					Channel: "stable-0.0",
+				},
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Version: &hypershiftv1beta1.ClusterVersionStatus{
+						AvailableUpdates: []configv1.Release{
+							{Version: "4.20.1", Channels: []string{"stable-4.20", "stable-4.21"}},
+							{Version: "4.20.2", Channels: []string{"stable-4.20", "stable-4.21"}},
+							{Version: "4.20.3", Channels: []string{"stable-4.20", "stable-4.21"}},
+							{Version: "4.21.1", Channels: []string{"stable-4.20", "stable-4.21"}},
+							{Version: "4.21.2", Channels: []string{"stable-4.20", "stable-4.21"}},
+						},
+					},
+				},
+			},
+			graphs: map[string]graph{
+				"stable-4.21": {
+					Nodes: []node{
+						makeNode("4.20.1", ""),
+						makeNode("4.20.2", ""),
+						makeNode("4.20.3", ""),
+						makeNode("4.21.1", ""),
+						makeNode("4.21.2", ""),
+					},
+				},
+			},
+			expectedVersion: "4.21.2",
+		},
+		{
+			name: "filter rejects highest, returns an older release that improves channel connectivity",
+			cluster: &hypershiftv1beta1.HostedCluster{
+				Spec: hypershiftv1beta1.HostedClusterSpec{
+					Channel: "stable-0.0",
+				},
+				Status: hypershiftv1beta1.HostedClusterStatus{
+					Version: &hypershiftv1beta1.ClusterVersionStatus{
+						AvailableUpdates: []configv1.Release{
+							{Version: "4.20.1", Channels: []string{"stable-4.20", "stable-4.22"}},
+							{Version: "4.20.2", Channels: []string{"stable-4.20", "stable-4.22"}},
+							{Version: "4.20.3", Channels: []string{"stable-4.20", "stable-4.22"}},
+							{Version: "4.21.1", Channels: []string{"stable-4.21", "stable-4.22", "stable-4.23"}},
+							{Version: "4.21.2", Channels: []string{"stable-4.21"}},
+						},
+					},
+				},
+			},
+			graphs: map[string]graph{
+				"stable-4.21": {
+					Nodes: []node{
+						makeNode("4.20.1", ""),
+						makeNode("4.20.2", ""),
+						makeNode("4.20.3", ""),
+						makeNode("4.21.1", ""),
+						makeNode("4.21.2", ""),
+					},
+				},
+				"stable-4.22": {
+					Nodes: []node{
+						makeNode("4.20.1", ""),
+						makeNode("4.20.2", ""),
+						makeNode("4.20.3", ""),
+						makeNode("4.21.1", ""),
+					},
+				},
+				"stable-4.23": {
+					Nodes: []node{
+						makeNode("4.21.1", ""),
+					},
+				},
+			},
+			expectedVersion: "4.21.1", // leaves 4.20.3 and 4.21.2 bug fixes on the table
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			roundTripper := testRoundTripper(tt.graphs)
+			version, err := SelectControlPlaneVersion(context.Background(), "stable", semver.Version{}, roundTripper, nil, tt.cluster)
+			if len(tt.expectedError) == 0 && err != nil {
+				t.Error(err)
+			} else if len(tt.expectedError) > 0 && err == nil {
+				t.Errorf("expected error %q, but got %v", tt.expectedError, err)
+			} else if err != nil && err.Error() != tt.expectedError {
+				t.Errorf("expected error %q, but got %q", tt.expectedError, err)
+			}
+			if len(tt.expectedVersion) == 0 && version != nil {
+				t.Errorf("expected nil version, got %q", version)
+			} else if len(tt.expectedVersion) > 0 && version == nil {
+				t.Errorf("expected version %q, but got %v", tt.expectedVersion, version)
+			} else if version != nil && version.String() != tt.expectedVersion {
+				t.Errorf("expected version %q, but got %q", tt.expectedVersion, version)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What

Stubs in a library that implements the requested ARO-policy logic for selecting OpenShift install versions (for new clusters) and update targets (for existing clusters).

### Why

[OCPBUGS-99304][6] asked me to do this, and I'm delivering on that ask.

### Testing

Unit tests included.  I'm happy to discuss coverage if you feel like I'm not sufficiently excercising some piece.

I have not added integration or end-to-end tests.  I'm leaving that responsibilty to the ARO engineer who picks up this library and integrates it into the rest of the repository.  Until then, the library is dead code with no user impact.

### Special notes for your reviewer

I'm an OpenShift core developer with a focus on cluster updates.  My personal preference for "which release should a customer in interested in `$CHANNEL` use?" is:

* Prefer the largest SemVer in that channel.  That gets the most of the target features and bugfixes you can get, given your current chosen channel.  [These][1] and similar docs help you choose the channel whose semenatics match your intentions.

* Sometimes there are regressions that would impact your cluster/workload.  In this case, it's a sticky balance between avoiding the regression (pushing you to pre-regression releases) and getting all the other bugfixes those more-recent releases provide (pushing you to post-regression releases).  Have a discussion with your security and workload teams about which way you want to go for that particular particular set of regressions vs. that particular set of recently-fixed bugs.

OpenShift has [a backport policy][2] that newer z-streams will recieve fixes before they are backported to older z-streams.  And we also do not release new patches in every supported z-stream every week. For example, looking at 4.16.63 in [graph-data][3]:

<details>
<summary>4.16.43 membership in fast and EUS channels; click to expand</summary>

```console
$ git log --first-parent --date=short --format='%ad %h %s' -G ' 4[.]16[.]63| 4[.]1[78][.]' internal-channels/fast.yaml channels/eus-4.* | grep -B1000 '4[.]16[.]63'
2026-08-04 18ebf6c36 Merge pull request #10217 from openshift-ota-bot/promote-4.18.49-to-eus-4.20
2026-07-29 687a6f1a3 Merge pull request #10160 from openshift-ota-bot/promote-4.18.49-to-eus-4.18
2026-07-29 2fb767f28 Merge pull request #10150 from openshift-ota-bot/promote-4.18.50-to-fast
2026-07-28 ed297c615 Merge pull request #10145 from openshift-ota-bot/promote-4.18.48-to-eus-4.20
2026-07-22 e2a840bf5 Merge pull request #10072 from openshift-ota-bot/promote-4.18.48-to-eus-4.18
2026-07-22 b8f5daf16 Merge pull request #10069 from openshift-ota-bot/promote-4.18.49-to-fast
2026-07-21 a939d88de Merge pull request #10063 from openshift-ota-bot/promote-4.18.47-to-eus-4.20
2026-07-20 cc5d181b4 Merge pull request #10036 from dis016/promote-4.16.63-to-eus-4.18
2026-07-16 c7f289850 Merge pull request #10004 from openshift-ota-bot/promote-4.17.55-to-eus-4.18
2026-07-15 a02cee33e Merge pull request #9990 from openshift-ota-bot/promote-4.18.47-to-eus-4.18
2026-07-15 d61139d51 Merge pull request #9985 from openshift-ota-bot/promote-4.18.48-to-fast
2026-07-14 5771d0847 Merge pull request #9981 from openshift-ota-bot/promote-4.18.46-to-eus-4.20
2026-07-09 b7c5f43a3 Merge pull request #9914 from openshift-ota-bot/promote-4.17.55-to-fast
2026-07-08 5f2474f82 Merge pull request #9892 from openshift-ota-bot/promote-4.18.46-to-eus-4.18
2026-07-08 5f9f7dd6f Merge pull request #9893 from openshift-ota-bot/promote-4.18.47-to-fast
2026-07-07 0da71d7ee Merge pull request #9889 from openshift-ota-bot/promote-4.18.45-to-eus-4.20
2026-07-01 98cfbf2ab Merge pull request #9823 from openshift-ota-bot/promote-4.18.45-to-eus-4.18
2026-07-01 0751145b5 Merge pull request #9814 from openshift-ota-bot/promote-4.18.46-to-fast
2026-06-24 b0afe128f Merge pull request #9755 from openshift-ota-bot/promote-4.18.44-to-eus-4.20
2026-06-24 e5aac24d4 Merge pull request #9747 from openshift-ota-bot/promote-4.18.45-to-fast
2026-06-24 ec0a68578 Merge pull request #9744 from openshift-ota-bot/promote-4.18.44-to-eus-4.18
2026-06-23 915e17dfa Merge pull request #9738 from openshift-ota-bot/promote-4.18.43-to-eus-4.20
2026-06-17 dce8d16aa Merge pull request #9676 from openshift-ota-bot/promote-4.18.44-to-fast
2026-06-10 8aa209b81 Merge pull request #9625 from openshift-ota-bot/promote-4.18.42-to-eus-4.20
2026-06-10 5c758e2a8 Merge pull request #9620 from openshift-ota-bot/promote-4.18.43-to-eus-4.18
2026-06-05 4c167147f Merge pull request #9596 from openshift-ota-bot/promote-4.16.63-to-eus-4.16
2026-06-03 c99103cda Merge pull request #9571 from openshift-ota-bot/promote-4.18.43-to-fast
2026-05-29 e83fb6c95 Merge pull request #9545 from openshift-ota-bot/promote-4.16.63-to-fast
```

</details>

That has 4.16.63 go GA on 2026-05-29, [carring some Important CVE and bug fixes into 4.16][4].  But until 4.17.55 and 4.18.47 arrived with a path from 4.16.63 to 4.17.newer to 4.18.newest on 2026-07-15 and the next few days, 4.16.63 did not have an `eus-4.18` path through 4.17 to 4.18.  Updating from 4.16.63 to the older 4.17.54 would risk regressing on bugfixes that landed in 4.17 and went back to 4.16.63 after 4.17.54 was cut.

For folks on 4.16.62 in `eus-*` channels on 2026-06-10, the world looked like:

<details>
<summary>4.16.62 EUS channel options on 2026-06-10; click to expand</summary>

```console
$ git grep 4.16.62 8aa209b81 channels/eus-*
8aa209b81:channels/eus-4.16.yaml:- 4.16.62
8aa209b81:channels/eus-4.18.yaml:- 4.16.62
$ git cat-file -p 8aa209b81:channels/eus-4.16.yaml | tail -n2
- 4.16.62
- 4.16.63
$ git cat-file -p 8aa209b81:channels/eus-4.18.yaml | grep ' 4[.]16[.]' | tail -n1
- 4.16.62
$ git cat-file -p 8aa209b81:channels/eus-4.18.yaml | grep ' 4[.]17[.]' | tail -n1
- 4.17.54
$ git cat-file -p 8aa209b81:channels/eus-4.18.yaml | tail -n1
- 4.18.43
```

</details>

I'd have recommended `eus-4.16` folks update to 4.16.63 to pick up those fixes.  And I'd have recommended `eus-4.18` folks update through 4.17.54 to 4.18.43 to pick up those new features (and bugfixes!).  I would not have recommended waiting on 4.16.62, unless they were aware of some regression with 4.16.63 (for `eus-4.16` folks) or 4.17.54 or 4.18.43 (for `eus-4.18` folks) that they'd decided was more painful than remaining exposed to the issues those updates would have fixed.

If, after updating to 4.16.63 in `eus-4.16`, the cluster owner decided they wanted to pick up 4.18 features, they'd have to wait until 2026-07-20 until that became an option.  That's over a month.  I'm fine with that, because [4.18 GAed back on 2025-02-25][5].  Not being interested in 4.18 features on 2026-06-10 (and using the `eus-4.16` channel says "I want 4.16 bug fixes, and am not interested in 4.18") and then not being able to wait until 2026-07-20 to get those 4.18 features seems unlikely to me.  I'd expect folks to be planning their update to future feature releases with a larger window for the transition than that.

However, that's just me.  In [OCPBUGS-99304][6], the ask includes:

> SelectControlPlaneVersion must return a z-stream that always has a path for 4.y+1 up to 4.y(latest) and then the latest 4.y(latest).latest.

That seems risky to me, because what if the cluster admin is not interested in 4.(y+1) but is interested in 4.y.z bug-fixes?  I'd expect the fraction of 4.y admins interested in low CVE/bug exposure to be high.  And I'd expect the fraction of 4.y admins interested in updating to 4.(y+1) or 4.y(latest) features to be low, or they'd already have updated to pick up those new features.  But I understand that I'm not an ARO maintainer, and that it's the responsibility of the ARO maintainers to make these decisions for their own fleet.  This commit delivers the specified logic, with the ARO policy isolated into the `aro.go` file's `preferFeatureConnectivityOverPatchFixes` function returning a `rankRelease` helper, and using that helper in the ARO-specific `SelectControlPlaneVersion`.  The associated test cases include mention `release that improves channel connectivity`. Comments on those test-cases point out that that's (intentionally, per ARO policy) leaving supported bug fixes on the table.

If ARO folks want to adjust the logic in `aro.go`, that's entirely up to them, and despite donating this commit, I have no stake in the semantics being delivered.  I put a few FIXMEs in there to help encourage an active handoff ;).

The `main` package name and little, demo `main.go` caller are just placeholders while folks discuss the implementation.  I expect ARO to remove the `main.go` file and update the package name after catching the donation.

[1]: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/updating_clusters/understanding-openshift-updates-1#fast-stable-channel-strategies_understanding-update-channels-releases
[2]: https://redhat.atlassian.net/browse/OTA-1352
[3]: https://github.com/openshift/cincinnati-graph-data
[4]: https://access.redhat.com/errata/RHSA-2026:20088
[5]: https://access.redhat.com/errata/RHSA-2024:6122
[6]: https://redhat.atlassian.net/browse/OCPBUGS-99304

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) (there are no graph/UI/metrics changes to screenshot, because the donation is a Go library, and I'm deferring integration with the rest of the code base to an ARO-engineer in follow-up work)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable) (not applicable, I'm going straight to asking for feedback, after this pull passes my local testing)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented (I hope they are, but I'll defer to reviewers as to which bits are tricky enough to be worth comments.  Drop a comment on any lines where you want to see comments, and I'll push something).
- [ ] Specific reviewers tagged (I'll wait for passing presubmits before pinging anyone)
- [ ] All comment threads resolved before merge (I can't check this when I open the pull, we need some time for folks to make those comments)
