### PR TITLE
make sure that v20260901 consistently uses v20260901 code

### DIFF
--- a/internal/azureapi/v20260901preview/external_auth_methods.go
+++ b/internal/azureapi/v20260901preview/external_auth_methods.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
-	"github.com/Azure/ARO-HCP/internal/azureapi/v20260630preview/generated"
+	"github.com/Azure/ARO-HCP/internal/azureapi/v20260901preview/generated"
 )
 
 type ExternalAuth struct {

--- a/internal/azureapi/v20260901preview/hcpopenshiftclusters_methods.go
+++ b/internal/azureapi/v20260901preview/hcpopenshiftclusters_methods.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
-	"github.com/Azure/ARO-HCP/internal/azureapi/v20260630preview/generated"
+	"github.com/Azure/ARO-HCP/internal/azureapi/v20260901preview/generated"
 )
 
 type HcpOpenShiftCluster struct {

--- a/internal/azureapi/v20260901preview/hcpopenshiftversions_methods.go
+++ b/internal/azureapi/v20260901preview/hcpopenshiftversions_methods.go
@@ -16,7 +16,7 @@ package v20260901preview
 
 import (
 	"github.com/Azure/ARO-HCP/internal/api"
-	"github.com/Azure/ARO-HCP/internal/azureapi/v20260630preview/generated"
+	"github.com/Azure/ARO-HCP/internal/azureapi/v20260901preview/generated"
 )
 
 type HcpOpenShiftVersion struct {

--- a/internal/azureapi/v20260901preview/nodepools_methods.go
+++ b/internal/azureapi/v20260901preview/nodepools_methods.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
-	"github.com/Azure/ARO-HCP/internal/azureapi/v20260630preview/generated"
+	"github.com/Azure/ARO-HCP/internal/azureapi/v20260901preview/generated"
 )
 
 type NodePool struct {

--- a/internal/azureapi/v20260901preview/nodepools_methods_test.go
+++ b/internal/azureapi/v20260901preview/nodepools_methods_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api"
 	"github.com/Azure/ARO-HCP/internal/api/arm"
-	"github.com/Azure/ARO-HCP/internal/azureapi/v20260630preview/generated"
+	"github.com/Azure/ARO-HCP/internal/azureapi/v20260901preview/generated"
 )
 
 func TestSizeGiBRoundTrip(t *testing.T) {

--- a/internal/azureapi/v20260901preview/patch_validation_test.go
+++ b/internal/azureapi/v20260901preview/patch_validation_test.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/utils/ptr"
 
-	"github.com/Azure/ARO-HCP/internal/azureapi/v20260630preview/generated"
+	"github.com/Azure/ARO-HCP/internal/azureapi/v20260901preview/generated"
 )
 
 // TestClusterConvertToInternal_RejectsNullOnRequiredFields verifies that


### PR DESCRIPTION
prelim work for https://github.com/Azure/ARO-HCP/pull/6157

### What

make sure that v20260901 consistently uses v20260901 code

### Why

To prevent unexpected behaviour

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
