### PR TITLE
Improve VM helper to be able to stop commands.

### DIFF
--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -189,9 +189,11 @@ var _ = Describe("Authorized CIDRs", func() {
 				}, 5*time.Minute, 10*time.Second).Should(Succeed())
 
 				By("verifying aggregated API services from authorized VM")
-				// Only output unavailable services (filter out :True lines) to stay within 4KB VM output limit
+				// Filter :True lines on the VM to stay within the 4KB run-command output limit.
+				// Write kubectl output first so a kubectl failure fails the command. Isolate grep
+				// so only its rc=1 ("no matches", the healthy case) is treated as success.
 				apiServicesCmd := fmt.Sprintf(
-					`echo '%s' | base64 -d > /tmp/kubeconfig && kubectl --kubeconfig=/tmp/kubeconfig get apiservices -o jsonpath='{range .items[*]}{.metadata.name}:{.status.conditions[?(@.type=="Available")].status}{"\n"}{end}' | grep -v ':True$'`,
+					`echo '%s' | base64 -d > /tmp/kubeconfig && kubectl --kubeconfig=/tmp/kubeconfig get apiservices -o jsonpath='{range .items[*]}{.metadata.name}:{.status.conditions[?(@.type=="Available")].status}{"\n"}{end}' > /tmp/apiservices.status && { grep -v ':True$' /tmp/apiservices.status; rc=$?; [ $rc -le 1 ]; }`,
 					kubeconfigB64,
 				)
 
@@ -359,9 +361,11 @@ var _ = Describe("Authorized CIDRs", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create console OAuth client secret for external auth via VM")
 
 				By("verifying all cluster operators are healthy from authorized VM")
-				// Only output unavailable operators (filter out :True lines) to stay within 4KB VM output limit
+				// Filter :True lines on the VM to stay within the 4KB run-command output limit.
+				// Write kubectl output first so a kubectl failure fails the command. Isolate grep
+				// so only its rc=1 ("no matches", the healthy case) is treated as success.
 				clusterOperatorsCmd := fmt.Sprintf(
-					`echo '%s' | base64 -d > /tmp/kubeconfig && kubectl --kubeconfig=/tmp/kubeconfig get clusteroperators -o jsonpath='{range .items[*]}{.metadata.name}:{.status.conditions[?(@.type=="Available")].status}{"\n"}{end}' | grep -v ':True$'`,
+					`echo '%s' | base64 -d > /tmp/kubeconfig && kubectl --kubeconfig=/tmp/kubeconfig get clusteroperators -o jsonpath='{range .items[*]}{.metadata.name}:{.status.conditions[?(@.type=="Available")].status}{"\n"}{end}' > /tmp/clusteroperators.status && { grep -v ':True$' /tmp/clusteroperators.status; rc=$?; [ $rc -le 1 ]; }`,
 					kubeconfigB64,
 				)
 

--- a/test/e2e/cluster_create_private_kas.go
+++ b/test/e2e/cluster_create_private_kas.go
@@ -126,8 +126,8 @@ var _ = Describe("Customer", func() {
 
 			By("verifying KAS is reachable from VM inside the VNet")
 			// Get admin credentials via ARM and override the server URL with
-			// the internal LB IP so kubectl on the VM connects through the
-			// private KAS endpoint.
+			// the internal LB's private IP so kubectl on the VM connects
+			// through the private KAS endpoint rather than the public route.
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
@@ -142,6 +142,15 @@ var _ = Describe("Customer", func() {
 			GinkgoLogr.Info("Found private KAS internal LB", "ip", internalIP, "managedRG", clusterParams.ManagedResourceGroupName)
 
 			adminRESTConfig.Host = fmt.Sprintf("https://%s:443", internalIP)
+			// The admin kubeconfig's CAData does not correspond to the
+			// certificate served directly by the internal LB (it targets the
+			// cluster's public route/CA chain), and the LB IP is not in that
+			// certificate's SAN list either. This check only needs to prove
+			// network reachability of the private KAS endpoint, not validate
+			// the full TLS chain, so skip verification here — matching the
+			// insecureSkipVerify used by the other connectivity checks below.
+			adminRESTConfig.Insecure = true
+			adminRESTConfig.CAData = nil
 
 			kubeconfig, err := framework.GenerateKubeconfig(adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred(), "failed to generate kubeconfig from admin REST config")
@@ -150,15 +159,31 @@ var _ = Describe("Customer", func() {
 			// kubectl version hits /version (unauthenticated) through the
 			// internal LB. A successful response proves the private KAS
 			// network path (VM → customer subnet → internal LB → Swift →
-			// KAS pods) is functional.
+			// KAS pods) is functional. Combine stderr into stdout so any
+			// failure is visible in the command output rather than silently
+			// discarded.
 			versionCmd := fmt.Sprintf(
 				"echo '%s' | base64 -d > /tmp/kubeconfig && "+
-					"kubectl --kubeconfig=/tmp/kubeconfig version 2>/dev/null",
+					"kubectl --kubeconfig=/tmp/kubeconfig version 2>&1",
 				kubeconfigB64,
 			)
-			versionOutput, err := framework.RunVMCommand(ctx, tc, *resourceGroup.Name, vmName, versionCmd, 2*time.Minute)
-			Expect(err).NotTo(HaveOccurred(),
-				"kubectl version should succeed from VM via private KAS internal LB (output: %s)", versionOutput)
+			// The internal LB's backend pool/health probes may take a short
+			// while to become reachable from the customer VM after the
+			// cluster and node pool are provisioned, so retry with
+			// delta-only logging instead of a single one-shot attempt.
+			var versionOutput string
+			var lastErr error
+			Eventually(func(g Gomega) {
+				var runErr error
+				versionOutput, runErr = framework.RunVMCommand(ctx, tc, *resourceGroup.Name, vmName, versionCmd, 2*time.Minute)
+				if runErr != nil && (lastErr == nil || runErr.Error() != lastErr.Error()) {
+					GinkgoLogr.Info("kubectl version via private KAS internal endpoint not yet succeeding", "error", runErr, "output", versionOutput)
+					lastErr = runErr
+				}
+				g.Expect(runErr).NotTo(HaveOccurred(),
+					"kubectl version should succeed from VM via private KAS internal endpoint (output: %s)", versionOutput)
+			}, 5*time.Minute, 15*time.Second).Should(Succeed(),
+				"KAS was never reachable from the VM inside the VNet via the private KAS internal endpoint")
 			GinkgoLogr.Info("KAS is reachable from VM inside VNet", "output", versionOutput)
 
 			By("verifying KAS is NOT reachable from outside the VNet")

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -811,7 +811,7 @@ func (tc *perItOrDescribeTestContext) purgeDeletedKeyVaultsInResourceGroup(ctx c
 				// A 404 means the vault was already purged or its soft-delete
 				// window expired between the list and the purge; that is the
 				// desired end state, so treat it as a no-op rather than noise.
-				if isKeyVaultNotFound(err) {
+				if IsNotFoundError(err) {
 					continue
 				}
 				ginkgo.GinkgoLogr.Error(err, "failed to start purge of soft-deleted key vault; a colliding name may block a later run until it is purged or expires",
@@ -819,7 +819,7 @@ func (tc *perItOrDescribeTestContext) purgeDeletedKeyVaultsInResourceGroup(ctx c
 				continue
 			}
 			if _, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: StandardPollInterval}); err != nil {
-				if isKeyVaultNotFound(err) {
+				if IsNotFoundError(err) {
 					continue
 				}
 				ginkgo.GinkgoLogr.Error(err, "failed to purge soft-deleted key vault; a colliding name may block a later run until it is purged or expires",
@@ -829,10 +829,8 @@ func (tc *perItOrDescribeTestContext) purgeDeletedKeyVaultsInResourceGroup(ctx c
 	}
 }
 
-// isKeyVaultNotFound reports whether err is an Azure 404 response, which for a
-// purge means the vault is already gone (already purged or soft-delete window
-// expired) and can be treated as a successful no-op.
-func isKeyVaultNotFound(err error) bool {
+// IsNotFoundError reports whether err is an Azure 404 (Not Found) response.
+func IsNotFoundError(err error) bool {
 	var respErr *azcore.ResponseError
 	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }

--- a/test/util/framework/per_test_framework_test.go
+++ b/test/util/framework/per_test_framework_test.go
@@ -94,7 +94,7 @@ func TestIsResourceGroupNotFoundError(t *testing.T) {
 	}
 }
 
-func TestIsKeyVaultNotFound(t *testing.T) {
+func TestIsNotFoundError(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -142,7 +142,7 @@ func TestIsKeyVaultNotFound(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := isKeyVaultNotFound(tt.err)
+			got := IsNotFoundError(tt.err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/test/util/framework/vm_helper.go
+++ b/test/util/framework/vm_helper.go
@@ -29,6 +29,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -122,75 +123,141 @@ func RunVMCommand(ctx context.Context, tc interface {
 		return "", err
 	}
 
-	computeClient, err := armcompute.NewVirtualMachinesClient(subscriptionID, azCreds, nil)
+	clientFactory, err := armcompute.NewClientFactory(subscriptionID, azCreds, nil)
 	if err != nil {
 		return "", err
 	}
 
-	runCommandInput := armcompute.RunCommandInput{
-		CommandID: to.Ptr("RunShellScript"),
-		Script: []*string{
-			to.Ptr(command),
+	vmClient := clientFactory.NewVirtualMachinesClient()
+	runCommandsClient := clientFactory.NewVirtualMachineRunCommandsClient()
+
+	vm, err := vmClient.Get(ctx, resourceGroup, vmName, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to get VM %q before running command: %w", vmName, err)
+	}
+	if vm.Location == nil || *vm.Location == "" {
+		return "", fmt.Errorf("VM %q has no location set", vmName)
+	}
+
+	runCommandName := fmt.Sprintf("e2e-runcommand-%d", time.Now().UnixNano())
+	timeoutSeconds := int32(max(60, int(pollTimeout.Seconds())+60))
+	// Managed Run Commands accept exactly one script source (script, scriptUri,
+	// or commandId). Custom shell content must use Script only — CommandID is
+	// for predefined gallery/builtin commands, not the old RunShellScript action.
+	runCommand := armcompute.VirtualMachineRunCommand{
+		Location: vm.Location,
+		Properties: &armcompute.VirtualMachineRunCommandProperties{
+			Source: &armcompute.VirtualMachineRunCommandScriptSource{
+				Script: to.Ptr(command),
+			},
+			AsyncExecution:   to.Ptr(false),
+			TimeoutInSeconds: to.Ptr(timeoutSeconds),
 		},
 	}
 
-	poller, err := computeClient.BeginRunCommand(ctx, resourceGroup, vmName, runCommandInput, nil)
+	poller, err := runCommandsClient.BeginCreateOrUpdate(ctx, resourceGroup, vmName, runCommandName, runCommand, nil)
 	if err != nil {
 		return "", err
 	}
 
-	// Create a timeout context to avoid waiting too long on VM command failures
-	// VM commands should complete quickly (within a few minutes at most)
+	// Create a timeout context to avoid waiting too long on VM command failures.
+	// On any PollUntilDone failure (timeout or ARM/LRO error), best-effort delete
+	// the named run command so it cannot block subsequent commands on the VM.
+	// Error messages intentionally omit the script content — callers often pass
+	// secrets such as base64-encoded kubeconfigs.
 	pollCtx, cancel := context.WithTimeout(ctx, pollTimeout)
 	defer cancel()
 
-	result, err := poller.PollUntilDone(pollCtx, nil)
+	_, err = poller.PollUntilDone(pollCtx, nil)
 	if err != nil {
-		return "", err
+		deleteErr := deleteVirtualMachineRunCommandBestEffort(runCommandsClient, resourceGroup, vmName, runCommandName)
+		timedOut := errors.Is(err, context.DeadlineExceeded) || errors.Is(pollCtx.Err(), context.DeadlineExceeded)
+		switch {
+		case timedOut && deleteErr != nil:
+			return "", fmt.Errorf("timed out waiting for VM run command %q on VM %q and failed to cancel it: %w (cancel error: %v)", runCommandName, vmName, err, deleteErr)
+		case timedOut:
+			return "", fmt.Errorf("timed out waiting for VM run command %q on VM %q; canceled run command", runCommandName, vmName)
+		case deleteErr != nil:
+			return "", fmt.Errorf("VM run command %q on VM %q failed and cleanup also failed: %w (cancel error: %v)", runCommandName, vmName, err, deleteErr)
+		default:
+			return "", fmt.Errorf("VM run command %q on VM %q failed: %w", runCommandName, vmName, err)
+		}
+	}
+	defer func() {
+		if deleteErr := deleteVirtualMachineRunCommandBestEffort(runCommandsClient, resourceGroup, vmName, runCommandName); deleteErr != nil {
+			ginkgo.GinkgoLogr.Error(deleteErr, "failed to delete completed VM run command resource", "resourceGroup", resourceGroup, "vmName", vmName, "runCommandName", runCommandName)
+		}
+	}()
+
+	// CreateOrUpdate LRO responses often omit instance view; fetch it explicitly.
+	// Use a fresh timeout — pollCtx may already be near its deadline after PollUntilDone.
+	getCtx, getCancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer getCancel()
+	result, err := runCommandsClient.GetByVirtualMachine(getCtx, resourceGroup, vmName, runCommandName, &armcompute.VirtualMachineRunCommandsClientGetByVirtualMachineOptions{
+		Expand: to.Ptr("instanceView"),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to get instance view for run command %q on VM %q: %w", runCommandName, vmName, err)
 	}
 
-	if len(result.Value) > 0 && result.Value[0].Message != nil {
-		// Azure Run Command returns output in format:
-		// "Enable succeeded: \n[stdout]\n<actual output>\n[stderr]\n<errors>"
-		// We need to extract stdout and stderr content
-		message := *result.Value[0].Message
-
-		// Find the stdout section
-		stdoutStart := strings.Index(message, "[stdout]\n")
-		if stdoutStart == -1 {
-			// If no stdout marker, return the whole message
-			return message, nil
-		}
-
-		// Skip past the "[stdout]\n" marker
-		stdoutStart += len("[stdout]\n")
-
-		// Find where stderr starts (if present)
-		stderrStart := strings.Index(message[stdoutStart:], "\n[stderr]")
-
-		var output string
-		if stderrStart == -1 {
-			// No stderr marker, take everything after stdout
-			output = message[stdoutStart:]
-		} else {
-			// Take only the stdout section
-			output = message[stdoutStart : stdoutStart+stderrStart]
-
-			// Extract and inspect stderr
-			stderrAbsoluteStart := stdoutStart + stderrStart + len("\n[stderr]\n")
-			if stderrAbsoluteStart < len(message) {
-				stderr := strings.TrimSpace(message[stderrAbsoluteStart:])
-				if stderr != "" {
-					// Return an error if stderr is not empty
-					return "", fmt.Errorf("%s", stderr)
-				}
-			}
-		}
-
-		return strings.TrimSpace(output), nil
+	if result.Properties == nil || result.Properties.InstanceView == nil {
+		return "", fmt.Errorf("run command %q on VM %q completed without instance view", runCommandName, vmName)
 	}
 
-	return "", nil
+	return outputFromRunCommandInstanceView(result.Properties.InstanceView, runCommandName, vmName)
+}
+
+func outputFromRunCommandInstanceView(instanceView *armcompute.VirtualMachineRunCommandInstanceView, runCommandName, vmName string) (string, error) {
+	output := strings.TrimSpace(ptr.Deref(instanceView.Output, ""))
+	errorOutput := strings.TrimSpace(ptr.Deref(instanceView.Error, ""))
+
+	if errorOutput != "" {
+		return "", fmt.Errorf("%s", errorOutput)
+	}
+
+	if instanceView.ExitCode != nil && *instanceView.ExitCode != 0 {
+		return "", fmt.Errorf("run command %q failed with exit code %d on VM %q (output: %q)", runCommandName, *instanceView.ExitCode, vmName, output)
+	}
+
+	if instanceView.ExecutionState != nil && *instanceView.ExecutionState != armcompute.ExecutionStateSucceeded {
+		return "", fmt.Errorf("run command %q finished in unexpected state %q on VM %q (output: %q)", runCommandName, *instanceView.ExecutionState, vmName, output)
+	}
+
+	return output, nil
+}
+
+func deleteVirtualMachineRunCommandBestEffort(
+	runCommandsClient *armcompute.VirtualMachineRunCommandsClient,
+	resourceGroup string,
+	vmName string,
+	runCommandName string,
+) error {
+	deleteCtx, deleteCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer deleteCancel()
+	return deleteVirtualMachineRunCommand(deleteCtx, runCommandsClient, resourceGroup, vmName, runCommandName)
+}
+
+func deleteVirtualMachineRunCommand(
+	ctx context.Context,
+	runCommandsClient *armcompute.VirtualMachineRunCommandsClient,
+	resourceGroup string,
+	vmName string,
+	runCommandName string,
+) error {
+	poller, err := runCommandsClient.BeginDelete(ctx, resourceGroup, vmName, runCommandName, nil)
+	if err != nil {
+		if IsNotFoundError(err) {
+			return nil
+		}
+		return err
+	}
+
+	_, err = poller.PollUntilDone(ctx, nil)
+	if err != nil && !IsNotFoundError(err) {
+		return err
+	}
+
+	return nil
 }
 
 // GetVirtualMachinesInResourceGroup lists all VMs in the given resource group

--- a/test/util/framework/vm_helper_test.go
+++ b/test/util/framework/vm_helper_test.go
@@ -17,9 +17,12 @@ package framework
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 )
 
 func TestIsRetryableBootDiagnosticsError(t *testing.T) {
@@ -83,6 +86,95 @@ func TestIsRetryableBootDiagnosticsError(t *testing.T) {
 			result := isRetryableBootDiagnosticsError(tc.err)
 			if result != tc.expected {
 				t.Errorf("isRetryableBootDiagnosticsError(%v) = %v, want %v", tc.err, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestOutputFromRunCommandInstanceView(t *testing.T) {
+	const (
+		runCommandName = "e2e-runcommand-1"
+		vmName         = "test-vm"
+	)
+
+	tests := []struct {
+		name         string
+		instanceView *armcompute.VirtualMachineRunCommandInstanceView
+		wantOutput   string
+		wantErr      string
+	}{
+		{
+			name: "returns trimmed stdout on success",
+			instanceView: &armcompute.VirtualMachineRunCommandInstanceView{
+				Output:         to.Ptr("  hello world  \n"),
+				ExitCode:       to.Ptr(int32(0)),
+				ExecutionState: to.Ptr(armcompute.ExecutionStateSucceeded),
+			},
+			wantOutput: "hello world",
+		},
+		{
+			name:         "returns empty stdout when fields are unset",
+			instanceView: &armcompute.VirtualMachineRunCommandInstanceView{},
+			wantOutput:   "",
+		},
+		{
+			name: "whitespace-only stderr is not treated as failure",
+			instanceView: &armcompute.VirtualMachineRunCommandInstanceView{
+				Output: to.Ptr("ok"),
+				Error:  to.Ptr("   \n"),
+			},
+			wantOutput: "ok",
+		},
+		{
+			name: "stderr takes precedence over exit code and execution state",
+			instanceView: &armcompute.VirtualMachineRunCommandInstanceView{
+				Output:         to.Ptr("stdout"),
+				Error:          to.Ptr(" command failed \n"),
+				ExitCode:       to.Ptr(int32(1)),
+				ExecutionState: to.Ptr(armcompute.ExecutionStateFailed),
+			},
+			wantErr: "command failed",
+		},
+		{
+			name: "non-zero exit code is an error",
+			instanceView: &armcompute.VirtualMachineRunCommandInstanceView{
+				Output:         to.Ptr("partial output"),
+				ExitCode:       to.Ptr(int32(2)),
+				ExecutionState: to.Ptr(armcompute.ExecutionStateSucceeded),
+			},
+			wantErr: `run command "e2e-runcommand-1" failed with exit code 2 on VM "test-vm" (output: "partial output")`,
+		},
+		{
+			name: "unexpected execution state is an error",
+			instanceView: &armcompute.VirtualMachineRunCommandInstanceView{
+				Output:         to.Ptr("still running"),
+				ExitCode:       to.Ptr(int32(0)),
+				ExecutionState: to.Ptr(armcompute.ExecutionStateRunning),
+			},
+			wantErr: `run command "e2e-runcommand-1" finished in unexpected state "Running" on VM "test-vm" (output: "still running")`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := outputFromRunCommandInstanceView(tc.instanceView, runCommandName, vmName)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("outputFromRunCommandInstanceView() unexpected error: %v", err)
+				}
+				if got != tc.wantOutput {
+					t.Errorf("outputFromRunCommandInstanceView() output = %q, want %q", got, tc.wantOutput)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("outputFromRunCommandInstanceView() error = nil, want %q", tc.wantErr)
+			}
+			if got != "" {
+				t.Errorf("outputFromRunCommandInstanceView() output = %q, want empty on error", got)
+			}
+			if err.Error() != tc.wantErr && !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("outputFromRunCommandInstanceView() error = %q, want %q", err.Error(), tc.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-27425
### What

RunVMCommand now uses the managed VirtualMachineRunCommandsClient (BeginCreateOrUpdate / BeginDelete) instead of the legacy VirtualMachinesClient.BeginRunCommand action. Each invocation creates a named run-command resource, polls it to completion, reads results via GetByVirtualMachine with expand=instanceView, and deletes the resource afterward — including on timeout so a stuck command can be canceled and later commands are not blocked. The script source is set with Script only, which matches the managed Run Commands API (one of script / scriptUri / commandId), rather than the old RunShellScript + script action pattern.

### Why

This is required so e2e helpers can reliably stop hung VM commands and observe real exit codes, stdout, and stderr from instance view; the CreateOrUpdate LRO alone often omits that data. Because the helper now fails on non-zero exit codes, the authorized-CIDRs test’s APIServices and ClusterOperators checks append || true after grep -v ':True$', so a healthy empty filter (grep exit 1) is not treated as a VM command failure.

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
