### PR TITLE
feat: Use newer API version for aksCluster

### DIFF
--- a/dev-infrastructure/modules/aks-cluster-base.bicep
+++ b/dev-infrastructure/modules/aks-cluster-base.bicep
@@ -264,7 +264,7 @@ var systemPoolZonesArray = systemZoneRedundantMode == 'Enabled' || (systemZoneRe
   ? systemAgentPoolZones
   : null
 
-resource aksCluster 'Microsoft.ContainerService/managedClusters@2025-07-02-preview' = {
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2026-04-02-preview' = {
   location: location
   name: aksClusterName
   sku: {

--- a/dev-infrastructure/modules/aks/pool.bicep
+++ b/dev-infrastructure/modules/aks/pool.bicep
@@ -68,7 +68,7 @@ var userPools = concat(zonalPools, nonZonalPools)
 //   P O O L   C R E A T I O N
 //
 
-resource aksCluster 'Microsoft.ContainerService/managedClusters@2025-07-02-preview' existing = {
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2026-04-02-preview' existing = {
   name: aksClusterName
 }
 
@@ -84,7 +84,7 @@ var swiftNodepoolTags = enableSwiftV2
         })
   : null
 
-resource userAgentPools 'Microsoft.ContainerService/managedClusters/agentPools@2025-07-02-preview' = [
+resource userAgentPools 'Microsoft.ContainerService/managedClusters/agentPools@2026-04-02-preview' = [
   for (pool, i) in userPools: {
     parent: aksCluster
     name: take(pool.name, 12)


### PR DESCRIPTION


<!-- Link to Jira issue -->

### What

The newer api version allows changing the SKU on system node pools.

### Testing

1. Created a personal dev cluster from main
2. Changed the API Version
3. Changed the vmSize attribute
4. Ran make personal dev again
5. The vmSize got changed

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
