### PR TITLE
fix(mgmt-agent): increase kube-state-metrics memory limit to 256Mi (AROSLSRE-1739)

### DIFF
--- a/mgmt-agent/pkg/controller/ksmhcp/resources.go
+++ b/mgmt-agent/pkg/controller/ksmhcp/resources.go
@@ -125,7 +125,7 @@ func buildDeployment(namespace, ksmImage, kubeconfigSecretName, kubeconfigKey st
 								corev1.ResourceMemory: resource.MustParse("64Mi"),
 							}).
 							WithLimits(corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("128Mi"),
+								corev1.ResourceMemory: resource.MustParse("256Mi"),
 							})).
 						WithVolumeMounts(
 							coreac.VolumeMount().

--- a/mgmt-agent/pkg/controller/ksmhcp/testdata/zz_fixture_TestBuildDeployment.yaml
+++ b/mgmt-agent/pkg/controller/ksmhcp/testdata/zz_fixture_TestBuildDeployment.yaml
@@ -51,7 +51,7 @@ spec:
           timeoutSeconds: 5
         resources:
           limits:
-            memory: 128Mi
+            memory: 256Mi
           requests:
             cpu: 10m
             memory: 64Mi


### PR DESCRIPTION
<!-- Link to Jira issue -->

[AROSLSRE-1739](https://redhat.atlassian.net/browse/AROSLSRE-1739)

### What

Raise the `kube-state-metrics` HCP memory limit from `128Mi` to `256Mi`.

### Why

The previous increase is deployed to all production regions, but Canada Central is still recording OOMKills at the `128Mi` limit. This applies the planned escalation and keeps the existing `64Mi` request.

### Testing

- Unit tests: `go test ./pkg/controller/ksmhcp`
- Integration tests: not needed for this resource-only change
- E2E tests: existing rollout validation

### Special notes for your reviewer

After rollout, I will confirm the `256Mi` limit is live in Canada Central and that OOMKills stop.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
