### PR TITLE
chore: automate CIHealth image updates

### DIFF
--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -130,7 +130,7 @@ clouds:
           image:
             registry: "quay.io"
             repository: "roivaz/cihealth"
-            tag: "c402cb7"
+            digest: sha256:d6be00b644b6b69bd412fc475629905ab5225e2de2ffbdfda66850f4bb9d53d0 # d07a0f1 (2026-08-05 13:40)
           disableRuntimeWorkloads: false
           app:
             replicas: 2

--- a/dev-infrastructure/dev-ci/cihealth/deploy/templates/_helpers.tpl
+++ b/dev-infrastructure/dev-ci/cihealth/deploy/templates/_helpers.tpl
@@ -35,10 +35,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "cihealth.image" -}}
+{{- $repository := .Values.image.repository -}}
 {{- if .Values.image.registry -}}
-{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository .Values.image.tag -}}
+{{- $repository = printf "%s/%s" .Values.image.registry .Values.image.repository -}}
+{{- end -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" $repository .Values.image.digest -}}
 {{- else -}}
-{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- printf "%s:%s" $repository .Values.image.tag -}}
 {{- end -}}
 {{- end -}}
 

--- a/dev-infrastructure/dev-ci/cihealth/deploy/values.yaml
+++ b/dev-infrastructure/dev-ci/cihealth/deploy/values.yaml
@@ -9,6 +9,7 @@ image:
   registry: "quay.io"
   repository: "roivaz/cihealth"
   tag: "8e6b0cd"
+  digest: ""
   pullPolicy: Always
   pullSecrets: []
 disableRuntimeWorkloads: false

--- a/dev-infrastructure/dev-ci/cihealth/values.yaml.tmpl
+++ b/dev-infrastructure/dev-ci/cihealth/values.yaml.tmpl
@@ -11,7 +11,7 @@ secretProvider:
 image:
   registry: "{{ .opstool.cihealth.image.registry }}"
   repository: "{{ .opstool.cihealth.image.repository }}"
-  tag: "{{ .opstool.cihealth.image.tag }}"
+  digest: "{{ .opstool.cihealth.image.digest }}"
 
 disableRuntimeWorkloads: {{ .opstool.cihealth.disableRuntimeWorkloads }}
 

--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -165,6 +165,17 @@ images:
     targets:
     - jsonPath: clouds.dev.defaults.opstool.tenantQuota.image.digest
       filePath: ../../config/config-dev-ci.yaml
+  # CIHealth image
+  cihealth:
+    group: aro-ci-images
+    source:
+      image: quay.io/roivaz/cihealth
+      tagPattern: "^[a-f0-9]{7}$"
+      versionLabel: vcs-ref
+      multiArch: true
+    targets:
+    - jsonPath: clouds.dev.defaults.opstool.cihealth.image.digest
+      filePath: ../../config/config-dev-ci.yaml
   # Prometheus images
   prometheus-operator:
     group: prom-stack


### PR DESCRIPTION
Follow-up to #6388.

### What

- Register the CIHealth Quay image with the image updater using immutable seven-character commit tags.
- Replace the DEV-CI image tag with the latest published digest for `d07a0f1`.
- Render CIHealth deployments as `repository@sha256:...` while retaining tag fallback for local chart defaults.

### Why

CIHealth image bumps are currently manual and use tags in the deployed configuration. Digest pinning makes deployments deterministic, while the existing image-updater periodic can keep CIHealth current through automated PRs.

### Image update

| Name | Old Digest | New Digest | Tag | Date | Status |
| --- | --- | --- | --- | --- | --- |
| cihealth | e6ce1b0bdf29… | d6be00b644b6… | d07a0f1 | 2026-08-05 13:40 | updated |

### Testing

- `make -C config materialize`
- `AZURE_TOKEN_CREDENTIALS=dev go test ./tooling/image-updater/...`
- `go run . update --config config.yaml --tags --components cihealth --dry-run --output-format markdown`
- Rendered the CIHealth Helm chart with digest and tag values and verified both app and controllers image references.