### PR TITLE
fix(swift-vnet): recreate ACI after DNS or MSI exhaustion

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -356,6 +356,8 @@ resourceGroups:
       errorContainsAny:
       - "ContainerGroupDeploymentNotReady"
       - "Timed out"
+      - "dns readiness (login.microsoftonline.com): giving up"
+      - "az login (globalMSI): giving up"
       maximumRetryCount: 3
       durationBetweenRetries: 1m
   - name: cluster


### PR DESCRIPTION
## What

Add the two observed terminal `swift-vnet` container errors to the pipeline step's `automatedRetry.errorContainsAny` list:

- `dns readiness (login.microsoftonline.com): giving up`
- `az login (globalMSI): giving up`

A matching retry reruns `swift-vnet.sh`. The script deletes the failed container group and launches a new ACI instance with the same `globalMSI` identity.

## Why

CIHealth recorded **23 DEV provision failures** between 2026-07-14 and 2026-08-04:

- **22** ACI instances reached `Running` but failed every DNS lookup for `login.microsoftonline.com` through the full 480-second inner retry budget.
- **1** instance passed DNS but failed to contact the managed-identity endpoint through the same budget (`BadStatusLine('HTTP/1.1 000 status code 0')`).

The existing pipeline retry only matches `ContainerGroupDeploymentNotReady` and `Timed out`, so neither observed inner-container exhaustion error triggers a retry. Increasing the inner timeout again would keep waiting on an instance that has shown no recovery. Recreating the ACI gives Azure another placement/provisioning attempt.

`maximumRetryCount: 3` is unchanged (three total step executions). With a failed attempt taking approximately nine minutes and one-minute delays, this remains within the shared 30-minute step timeout, though the third attempt has limited headroom.

## Testing

- `make yamlfmt`
- `make validate-config-pipelines`
- `git diff --check`