### PR TITLE
feature: adding subscription key for quotaizer msi

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -3173,6 +3173,10 @@
         "managedIdentityName": {
           "type": "string"
         },
+        "managedIdentitySubscriptionKey": {
+          "type": "string",
+          "description": "The ev2 subscription key for the MSI that will be used by quotaizer"
+        },
         "image": {
           "$ref": "#/definitions/containerImage"
         },

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -463,6 +463,8 @@ defaults:
       id: "aro-{{ .ctx.environment }}-{{ .ctx.region }}"
       displayName: "HCP - {{ .ctx.environment }} {{ .ctx.region }}"
     managedIdentityName: aro-quotaizer
+    # This should be removed and replaced with global.subscription.key in quotaizer deployment pipeline once old stg infra is decommissioned (AROSLSRE-1202)
+    managedIdentitySubscriptionKey: "hcp-global"
     image:
       registry: "empty-sentinel"
       repository: "empty-sentinel"

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -904,6 +904,7 @@ quotaizer:
     artifactName: empty-sentinel
     buildId: 0
   managedIdentityName: aro-quotaizer
+  managedIdentitySubscriptionKey: hcp-global
   quotaGroup:
     displayName: HCP - ci00 centralus
     id: aro-ci00-centralus

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -904,6 +904,7 @@ quotaizer:
     artifactName: empty-sentinel
     buildId: 0
   managedIdentityName: aro-quotaizer
+  managedIdentitySubscriptionKey: hcp-global
   quotaGroup:
     displayName: HCP - ci01 centralus
     id: aro-ci01-centralus

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -902,6 +902,7 @@ quotaizer:
     artifactName: empty-sentinel
     buildId: 0
   managedIdentityName: aro-quotaizer
+  managedIdentitySubscriptionKey: hcp-global
   quotaGroup:
     displayName: HCP - cspr westus3
     id: aro-cspr-westus3

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -902,6 +902,7 @@ quotaizer:
     artifactName: empty-sentinel
     buildId: 0
   managedIdentityName: aro-quotaizer
+  managedIdentitySubscriptionKey: hcp-global
   quotaGroup:
     displayName: HCP - dev westus3
     id: aro-dev-westus3

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -902,6 +902,7 @@ quotaizer:
     artifactName: empty-sentinel
     buildId: 0
   managedIdentityName: aro-quotaizer
+  managedIdentitySubscriptionKey: hcp-global
   quotaGroup:
     displayName: HCP - perf westus3
     id: aro-perf-westus3

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -904,6 +904,7 @@ quotaizer:
     artifactName: empty-sentinel
     buildId: 0
   managedIdentityName: aro-quotaizer
+  managedIdentitySubscriptionKey: hcp-global
   quotaGroup:
     displayName: HCP - pers westus3
     id: aro-pers-westus3


### PR DESCRIPTION
[ARO-28898](https://redhat.atlassian.net/browse/ARO-28898)

### What

Adding a subscription key for the quotaizer msi

### Why

This MSI is shared across environments, but it should be separate for stg and production. Because the global subscription key in stg is still pointing to the global production subscription, adding a field here that I can overwrite in stg. Without this, the deployment pipeline is quite messy.

### Testing
N/A just adding a field to config.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge

If E2E tests are included:

- [x] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [x] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
