### PR TITLE
fix(config): pin uksouth stg kusto rg to match the recreated -2 cluster

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -73,6 +73,18 @@ clouds:
               # US-geography cluster (hcp-{env}-{geoShort} convention), separate from
               # the uksouth hcp-stg-uk-* cluster.
               kustoName: "hcp-{{ .ctx.environment }}-us-1"
+          # uksouth: the kustoName default below (in stg.defaults.kusto) points at
+          # the "-2" cluster it had to be recreated as (b7b54161a), but that commit
+          # only overrode kustoName, not rg. The base config.yaml template still
+          # resolves rg to the un-suffixed "hcp-kusto-stg-uk", so the region-pipeline
+          # "kusto" step (which scopes its ARM deployment to `{{ .kusto.rg }}`) looks
+          # up Microsoft.Kusto/clusters/hcp-stg-uk-2 in the wrong resource group and
+          # fails with ResourceNotFound (AROSLSRE-1744). Pin rg here, scoped to just
+          # uksouth, so westus3 (which inherits the un-suffixed rg templating
+          # correctly for its own "us-1" cluster) is unaffected.
+          uksouth:
+            kusto:
+              rg: "hcp-kusto-stg-uk-2"
         defaults:
           # Carry the environment in the subscription display names for stage, so the
           # stg subscriptions are distinguishable from the identically-named prod ones.


### PR DESCRIPTION
## Why

The `Microsoft.Azure.ARO.HCP.Global.StgGlobalBuildout` rollout (StgGlobal V2) failed its `kusto-lookup` step in the 2026-08-05 16:46 UTC run (rollout `8564eb48-9f6e-4c97-b6c9-1ad93028c53f`, ARO-HCP `3e8d3486383a`, sdp `7f463c07e`, build 175300149) with:

```
ResourceNotFound: The Resource 'Microsoft.Kusto/clusters/hcp-stg-uk-2' under resource group 'hcp-kusto-stg-uk' was not found.
```

This was the first time the rollout got this far (previously blocked by the [AROSLSRE-1653](https://redhat.atlassian.net/browse/AROSLSRE-1653) geneva-identities/mise-identity race, now fixed), so the bug was likely dormant for a while.

Root cause: `dev-infrastructure/region-pipeline.yaml`'s `kusto` stage scopes its ARM deployment to `{{ .kusto.rg }}` and looks up `{{ .kusto.kustoName }}` inside it. When the uksouth stg Kusto cluster had to be recreated as `hcp-stg-uk-2` (commit `b7b54161a`), only `kustoName` was overridden in `config.msft.clouds-overlay.yaml` - the `rg` override was missed, so it kept resolving via the base `config.yaml` template to the un-suffixed `hcp-kusto-stg-uk`, which doesn't hold the `-2` cluster.

## What

Adds a `rg: "hcp-kusto-stg-uk-2"` override, scoped to `clouds.public.environments.stg.regions.uksouth.kusto` (not the stg-wide `defaults`), so only uksouth is affected. westus3 already resolves its own `hcp-kusto-stg-us` rg correctly via the base template (it only overrides `kustoName`), and stays untouched.

## Testing

Verified with `templatize configuration render` for both regions, before and after:

| region | field | before | after |
|---|---|---|---|
| uksouth | `kusto.rg` | `hcp-kusto-stg-uk` (wrong) | `hcp-kusto-stg-uk-2` |
| westus3 | `kusto.rg` | `hcp-kusto-stg-us` | `hcp-kusto-stg-us` (unchanged) |

Ran `cd config && make materialize` - passes; `config/rendered/` is unaffected since only the `dev` cloud renders in this repo, `public`/stg rendering happens downstream in `sdp-pipelines`.

Jira: [AROSLSRE-1744](https://redhat.atlassian.net/browse/AROSLSRE-1744)
