### PR TITLE
feat: migrate ACR + image sync steps to ARMStack (global)

### DIFF
--- a/dev-infrastructure/global-pipeline-stg.yaml
+++ b/dev-infrastructure/global-pipeline-stg.yaml
@@ -350,10 +350,17 @@ resourceGroups:
       step: infra
   # create global ARO HCP ACRs for OCP and SVC images
   - name: acrs
-    action: ARM
+    action: ARMStack
     template: templates/global-acr.bicep
     parameters: configurations/global-acr-stg.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
+    bypassStackOutOfSyncError: false
+    automatedRetry:
+      errorContainsAny:
+      - "DeploymentStackInNonTerminalState"
+      maximumRetryCount: 3
+      durationBetweenRetries: 2m
     dependsOn:
     - resourceGroup: singleton
       step: infra
@@ -405,10 +412,17 @@ resourceGroups:
       durationBetweenRetries: 1m
   # deploys the image mirror for the ACRs
   - name: imagemirror
-    action: ARM
+    action: ARMStack
     template: templates/global-image-sync.bicep
     parameters: configurations/global-image-sync-stg.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
+    bypassStackOutOfSyncError: false
+    automatedRetry:
+      errorContainsAny:
+      - "DeploymentStackInNonTerminalState"
+      maximumRetryCount: 3
+      durationBetweenRetries: 2m
     dependsOn:
     - resourceGroup: singleton
       step: mirror-oc-mirror-image

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -290,10 +290,17 @@ resourceGroups:
       step: infra
   # create global ARO HCP ACRs for OCP and SVC images
   - name: acrs
-    action: ARM
+    action: ARMStack
     template: templates/global-acr.bicep
     parameters: configurations/global-acr.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
+    bypassStackOutOfSyncError: false
+    automatedRetry:
+      errorContainsAny:
+      - "DeploymentStackInNonTerminalState"
+      maximumRetryCount: 3
+      durationBetweenRetries: 2m
     dependsOn:
     - resourceGroup: singleton
       step: infra
@@ -343,10 +350,17 @@ resourceGroups:
       durationBetweenRetries: 1m
   # deploys the image mirror for the ACRs
   - name: imagemirror
-    action: ARM
+    action: ARMStack
     template: templates/global-image-sync.bicep
     parameters: configurations/global-image-sync.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+    actionOnUnmanage: delete
+    bypassStackOutOfSyncError: false
+    automatedRetry:
+      errorContainsAny:
+      - "DeploymentStackInNonTerminalState"
+      maximumRetryCount: 3
+      durationBetweenRetries: 2m
     dependsOn:
     - resourceGroup: singleton
       step: mirror-oc-mirror-image


### PR DESCRIPTION
[AROSLSRE-1638](https://redhat.atlassian.net/browse/AROSLSRE-1638)

### What

Migrate the `acrs` and `imagemirror` steps in `global-pipeline.yaml` and
`global-pipeline-stg.yaml` from `action: ARM` to `action: ARMStack`.

### Why

ARM Deployments in incremental mode have no apply/prune semantics — removing a
resource from a bicep template leaves it orphaned in Azure. Deployment Stacks
track every resource they manage and auto-delete anything no longer in the
template (`actionOnUnmanage: delete`), eliminating orphaned resources.

This is part of the broader ARMStack migration epic ([AROSLSRE-510](https://redhat.atlassian.net/browse/AROSLSRE-510)).

### Testing

- Pipeline validation passes (`make validate-config-pipelines`)
- No bicep template changes — only the pipeline step type changes
- First deploy is safe by design: the stack adopts existing resources that the
  template deploys (no deletion occurs on initial stack creation)
- Settings follow the proven `monitoring-pipeline.yaml` precedent
- After merge, the `global-pipeline-postsubmit` Prow job will deploy this to
  shared dev global infra automatically

### Special notes for your reviewer

- `actionOnUnmanage: delete` is used (not `detachAll`) to match the monitoring
  precedent and enable actual resource cleanup
- `denySettings` is not added because it's hardcoded to `none` in templatize
  and would conflict with auto-cleanup (blocks all deletions in the stack)
- `automatedRetry` on `DeploymentStackInNonTerminalState` handles concurrent
  regional rollouts against the same singleton RG (prod runs from
  eastus2euap + uksouth)
- The `-stg` variant (`global-pipeline-stg.yaml`) has the same changes applied

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) — N/A
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide) — will verify after push
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented — N/A (YAML config only)
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge