### PR TITLE
fix: USE_LATEST_IMAGES=1 queries nonexistent image repos

### DIFF
--- a/admin/Makefile
+++ b/admin/Makefile
@@ -103,7 +103,7 @@ record-override: $(YQ) $(ORAS)
 record-latest-override: $(YQ)
 	@../hack/record-latest-image-override.sh \
 		"$(ARO_HCP_IMAGE_ACR)" "$(ARO_HCP_IMAGE_REGISTRY)" \
-		"$(ADMIN_API_GENERATED_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
+		"$(ADMIN_API_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
 		"adminApi" "$(OVERRIDE_CONFIG_FILE)" "$(YQ)"
 .PHONY: record-latest-override
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -85,7 +85,7 @@ record-override: $(YQ) $(ORAS)
 record-latest-override: $(YQ)
 	@../hack/record-latest-image-override.sh \
 		"$(ARO_HCP_IMAGE_ACR)" "$(ARO_HCP_IMAGE_REGISTRY)" \
-		"$(BACKEND_GENERATED_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
+		"$(BACKEND_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
 		"backend" "$(OVERRIDE_CONFIG_FILE)" "$(YQ)"
 .PHONY: record-latest-override
 

--- a/fleet/Makefile
+++ b/fleet/Makefile
@@ -68,6 +68,6 @@ record-override: $(YQ) $(ORAS)
 record-latest-override: $(YQ)
 	@../hack/record-latest-image-override.sh \
 		"$(ARO_HCP_IMAGE_ACR)" "$(ARO_HCP_IMAGE_REGISTRY)" \
-		"$(FLEET_GENERATED_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
+		"$(FLEET_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
 		"fleet" "$(OVERRIDE_CONFIG_FILE)" "$(YQ)"
 .PHONY: record-latest-override

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -85,7 +85,7 @@ record-override: $(YQ) $(ORAS)
 record-latest-override: $(YQ)
 	@../hack/record-latest-image-override.sh \
 		"$(ARO_HCP_IMAGE_ACR)" "$(ARO_HCP_IMAGE_REGISTRY)" \
-		"$(FRONTEND_GENERATED_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
+		"$(FRONTEND_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
 		"frontend" "$(OVERRIDE_CONFIG_FILE)" "$(YQ)"
 .PHONY: record-latest-override
 

--- a/kube-applier/Makefile
+++ b/kube-applier/Makefile
@@ -75,7 +75,7 @@ record-override: $(YQ) $(ORAS)
 record-latest-override: $(YQ)
 	@../hack/record-latest-image-override.sh \
 		"$(ARO_HCP_IMAGE_ACR)" "$(ARO_HCP_IMAGE_REGISTRY)" \
-		"$(KUBE_APPLIER_GENERATED_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
+		"$(KUBE_APPLIER_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
 		"kubeApplier" "$(OVERRIDE_CONFIG_FILE)" "$(YQ)"
 .PHONY: record-latest-override
 

--- a/mgmt-agent/Makefile
+++ b/mgmt-agent/Makefile
@@ -76,7 +76,7 @@ record-override: $(YQ) $(ORAS)
 record-latest-override: $(YQ)
 	@../hack/record-latest-image-override.sh \
 		"$(ARO_HCP_IMAGE_ACR)" "$(ARO_HCP_IMAGE_REGISTRY)" \
-		"$(MGMT_AGENT_GENERATED_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
+		"$(MGMT_AGENT_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
 		"mgmtAgent" "$(OVERRIDE_CONFIG_FILE)" "$(YQ)"
 .PHONY: record-latest-override
 

--- a/sessiongate/Makefile
+++ b/sessiongate/Makefile
@@ -88,7 +88,7 @@ record-override: $(YQ) $(ORAS)
 record-latest-override: $(YQ)
 	@../hack/record-latest-image-override.sh \
 		"$(ARO_HCP_IMAGE_ACR)" "$(ARO_HCP_IMAGE_REGISTRY)" \
-		"$(SESSION_GATE_GENERATED_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
+		"$(SESSION_GATE_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
 		"sessiongate" "$(OVERRIDE_CONFIG_FILE)" "$(YQ)"
 .PHONY: record-latest-override
 

--- a/tooling/aro-hcp-exporter/Makefile
+++ b/tooling/aro-hcp-exporter/Makefile
@@ -79,6 +79,6 @@ record-override: $(YQ) $(ORAS)
 record-latest-override: $(YQ)
 	@../../hack/record-latest-image-override.sh \
 		"$(ARO_HCP_IMAGE_ACR)" "$(ARO_HCP_IMAGE_REGISTRY)" \
-		"$(ARO_HCP_EXPORTER_GENERATED_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
+		"$(ARO_HCP_EXPORTER_IMAGE_REPOSITORY)" "$(DEPLOY_ENV)" \
 		"customExporter" "$(OVERRIDE_CONFIG_FILE)" "$(YQ)"
 .PHONY: record-latest-override


### PR DESCRIPTION
### What

record-latest-override used *_GENERATED_IMAGE_REPOSITORY which generate-repo.sh prefixes with "test-$USER-" for pers environments. ACR queries then hit nonexistent repos. Use baseline *_IMAGE_REPOSITORY instead to query the real repos where postsubmit images are pushed.

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
