### PR TITLE
feat(observability): add etcd fsync performance Grafana dashboard (AR…

### DIFF
--- a/observability/grafana-dashboards/sre/cluster-health/README.md
+++ b/observability/grafana-dashboards/sre/cluster-health/README.md
@@ -9,6 +9,7 @@ Grafana dashboards for ARO-HCP SRE oncall and fleet health monitoring.
 | `resource-state.json` | Fleet-wide cluster provisioning state, clusters per region, nodepool health |
 | `operations-overview.json` | Fleet-wide in-flight operations, stuck/failed ops, duration distribution |
 | `per-cluster-drill-in.json` | Single-cluster oncall triage: KAS, etcd, provisioning state, nodepools |
+| `etcd-fsync-performance.json` | etcd disk latency deep-dive: heatmaps, tail latencies, throughput, regional comparison |
 
 ## Datasource Model
 

--- a/observability/grafana-dashboards/sre/cluster-health/README.md
+++ b/observability/grafana-dashboards/sre/cluster-health/README.md
@@ -9,7 +9,7 @@ Grafana dashboards for ARO-HCP SRE oncall and fleet health monitoring.
 | `resource-state.json` | Fleet-wide cluster provisioning state, clusters per region, nodepool health |
 | `operations-overview.json` | Fleet-wide in-flight operations, stuck/failed ops, duration distribution |
 | `per-cluster-drill-in.json` | Single-cluster oncall triage: KAS, etcd, provisioning state, nodepools |
-| `etcd-fsync-performance.json` | etcd disk latency deep-dive: heatmaps, tail latencies, throughput, regional comparison |
+| `etcd-fsync-performance.json` | etcd disk-level deep-dive: fsync latency heatmaps, tail latencies (P99→P99.99), throughput, DB size/quota/fragmentation, read/write operation rates, per-pod breakdown, fleet-wide comparison |
 
 ## Datasource Model
 

--- a/observability/grafana-dashboards/sre/cluster-health/etcd-fsync-performance.json
+++ b/observability/grafana-dashboards/sre/cluster-health/etcd-fsync-performance.json
@@ -1,0 +1,1082 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "etcd Availability (Fleet)",
+      "tooltip": "Fleet-wide etcd availability, leader stability, SLO violators",
+      "type": "link",
+      "url": "/d/etcd-availability/etcd-availability"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Per-Cluster Drill-in",
+      "tooltip": "Single-cluster oncall triage: KAS, etcd, provisioning, nodepools",
+      "type": "link",
+      "url": "/d/sre-cluster-health-per-cluster-drill-in/per-cluster-oncall-drill-in"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Fleet: Resource State",
+      "tooltip": "Fleet-wide cluster provisioning state overview",
+      "type": "link",
+      "url": "/d/sre-cluster-health-resource-state/resource-state-fleet-wide"
+    }
+  ],
+  "panels": [
+    {
+      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "code": { "language": "plaintext", "showLineNumbers": false, "showMiniMap": false },
+        "content": "### etcd Fsync Performance Dashboard\n\nDisk-level etcd latency analysis beyond P99 — covering latency distribution, tail latencies, throughput, and regional comparison.\n\n**Complements** `etcd-availability.json` (fleet SLO violators) and `per-cluster-drill-in.json` (single-cluster P99). This dashboard adds:\n- Full latency distribution heatmaps (WAL fsync + backend commit)\n- Tail latency percentiles (P99, P99.9, P99.99)\n- Fsync operation rate (ops/sec)\n- Regional latency comparison\n- Latency vs throughput correlation\n\n**SLO targets:** WAL fsync P99 < 10ms, backend commit P99 < 25ms.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.6.9",
+      "title": "Dashboard Info",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "Current WAL fsync P99 for the selected HCP namespace",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.008 },
+              { "color": "red", "value": 0.01 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 4, "x": 8, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "instant": true,
+          "legendFormat": "WAL fsync P99",
+          "refId": "A"
+        }
+      ],
+      "title": "WAL Fsync P99",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "Current WAL fsync P99.9 for the selected HCP namespace — catches intermittent disk stalls invisible at P99",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.015 },
+              { "color": "red", "value": 0.025 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 4, "x": 12, "y": 0 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.999, sum by (le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "instant": true,
+          "legendFormat": "WAL fsync P99.9",
+          "refId": "A"
+        }
+      ],
+      "title": "WAL Fsync P99.9",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "Current backend commit P99 for the selected HCP namespace",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.020 },
+              { "color": "red", "value": 0.025 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 4, "x": 16, "y": 0 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(etcd_disk_backend_commit_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "instant": true,
+          "legendFormat": "Backend Commit P99",
+          "refId": "A"
+        }
+      ],
+      "title": "Backend Commit P99",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "Current fsync operation rate (ops/sec) for the selected HCP namespace",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 4, "x": 20, "y": 0 },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "sum(rate(etcd_disk_wal_fsync_duration_seconds_count{namespace=~\"$namespace\"}[5m]))",
+          "instant": true,
+          "legendFormat": "WAL fsync ops/sec",
+          "refId": "A"
+        }
+      ],
+      "title": "WAL Fsync Rate",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 10,
+      "title": "WAL Fsync Latency Distribution",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "Heatmap of WAL fsync latency distribution over time. Shows the full shape of the latency distribution — not just P99. Dense bands at high latencies indicate sustained disk pressure, while sparse outliers indicate intermittent stalls.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "scaleDistribution": { "type": "log", "log": 2 }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 6 },
+      "id": 11,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": { "color": "rgba(255,0,255,0.7)" },
+        "filterValues": { "le": 1e-9 },
+        "legend": { "show": true },
+        "rowsFrame": { "layout": "auto" },
+        "tooltip": { "mode": "single", "showColorScale": false, "yHistogram": true },
+        "yAxis": {
+          "axisPlacement": "left",
+          "decimals": 0,
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "WAL Fsync Latency Heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "Heatmap of backend commit latency distribution over time. Backend commits are larger than WAL fsyncs and have a higher SLO threshold (25ms vs 10ms).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "scaleDistribution": { "type": "log", "log": 2 }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 6 },
+      "id": 12,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-purple",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Purples",
+          "steps": 64
+        },
+        "exemplars": { "color": "rgba(255,0,255,0.7)" },
+        "filterValues": { "le": 1e-9 },
+        "legend": { "show": true },
+        "rowsFrame": { "layout": "auto" },
+        "tooltip": { "mode": "single", "showColorScale": false, "yHistogram": true },
+        "yAxis": {
+          "axisPlacement": "left",
+          "decimals": 0,
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(etcd_disk_backend_commit_duration_seconds_bucket{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Backend Commit Latency Heatmap",
+      "type": "heatmap"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 16 },
+      "id": 20,
+      "title": "Tail Latency Analysis",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "WAL fsync tail latency percentiles over time (P50, P90, P99, P99.9, P99.99). Divergence between P99 and P99.9/P99.99 indicates intermittent disk stalls that P99-only monitoring misses.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": {
+              "mode": "dashed",
+              "line": true
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "transparent", "value": null },
+              { "color": "red", "value": 0.01 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "P50" },
+            "properties": [{ "id": "custom.lineWidth", "value": 1 }, { "id": "custom.fillOpacity", "value": 0 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "P99.99" },
+            "properties": [{ "id": "custom.lineStyle", "value": { "fill": "dash", "dash": [10, 10] } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 17 },
+      "id": 21,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "P50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "P90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "P99",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.999, sum by (le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "P99.9",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9999, sum by (le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "P99.99",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "WAL Fsync Tail Latencies (P50 → P99.99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "Backend commit tail latency percentiles over time (P50, P90, P99, P99.9, P99.99). SLO threshold at 25ms.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": {
+              "mode": "dashed",
+              "line": true
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "transparent", "value": null },
+              { "color": "red", "value": 0.025 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "P50" },
+            "properties": [{ "id": "custom.lineWidth", "value": 1 }, { "id": "custom.fillOpacity", "value": 0 }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "P99.99" },
+            "properties": [{ "id": "custom.lineStyle", "value": { "fill": "dash", "dash": [10, 10] } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 17 },
+      "id": 22,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(etcd_disk_backend_commit_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "P50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9, sum by (le) (rate(etcd_disk_backend_commit_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "P90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(etcd_disk_backend_commit_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "P99",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.999, sum by (le) (rate(etcd_disk_backend_commit_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "P99.9",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9999, sum by (le) (rate(etcd_disk_backend_commit_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "P99.99",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Backend Commit Tail Latencies (P50 → P99.99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 },
+      "id": 30,
+      "title": "Fsync Throughput & Correlation",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "WAL fsync and backend commit operation rates over time. High throughput combined with high latency indicates sustained disk pressure rather than intermittent stalls.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "ops/sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 28 },
+      "id": 31,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "sum(rate(etcd_disk_wal_fsync_duration_seconds_count{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "WAL fsync ops/sec",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "sum(rate(etcd_disk_backend_commit_duration_seconds_count{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "Backend commit ops/sec",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Fsync Operation Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "WAL fsync P99 latency overlaid with fsync operation rate. When latency rises with constant throughput, the disk is degrading. When both rise together, the workload is increasing.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "WAL fsync ops/sec" },
+            "properties": [
+              { "id": "custom.axisPlacement", "value": "right" },
+              { "id": "unit", "value": "ops" },
+              { "id": "custom.drawStyle", "value": "bars" },
+              { "id": "custom.fillOpacity", "value": 30 },
+              { "id": "custom.lineWidth", "value": 0 },
+              { "id": "color", "value": { "fixedColor": "light-blue", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 28 },
+      "id": 32,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])))",
+          "legendFormat": "WAL fsync P99",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "sum(rate(etcd_disk_wal_fsync_duration_seconds_count{namespace=~\"$namespace\"}[5m]))",
+          "legendFormat": "WAL fsync ops/sec",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Latency vs Throughput Correlation",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 38 },
+      "id": 40,
+      "title": "Regional Comparison (Fleet-Wide)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "WAL fsync P99 latency per region. Each line represents the worst per-cluster P99 in that region. Quickly identify which regions have disk-related latency issues.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": {
+              "mode": "dashed",
+              "line": true
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "transparent", "value": null },
+              { "color": "red", "value": 0.01 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 39 },
+      "id": 41,
+      "options": {
+        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true, "sortBy": "Max", "sortDesc": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_fleet" },
+          "editorMode": "code",
+          "expr": "max by (cluster) (histogram_quantile(0.99, sum by (cluster, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster!=\"\"}[5m]))))",
+          "legendFormat": "{{cluster}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "WAL Fsync P99 by Region",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Backend commit P99 latency per region. Identifies regions with slow disk commit performance.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": {
+              "mode": "dashed",
+              "line": true
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "transparent", "value": null },
+              { "color": "red", "value": 0.025 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 39 },
+      "id": 42,
+      "options": {
+        "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true, "sortBy": "Max", "sortDesc": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_fleet" },
+          "editorMode": "code",
+          "expr": "max by (cluster) (histogram_quantile(0.99, sum by (cluster, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster!=\"\"}[5m]))))",
+          "legendFormat": "{{cluster}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Backend Commit P99 by Region",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 49 },
+      "id": 50,
+      "title": "Per-Pod Breakdown",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "WAL fsync P99 per etcd pod in the selected HCP namespace. Asymmetry between pods may indicate a node-local disk issue rather than a fleet-wide problem.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": {
+              "mode": "dashed",
+              "line": true
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "transparent", "value": null },
+              { "color": "red", "value": 0.01 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 50 },
+      "id": 51,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le, pod) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{namespace=~\"$namespace\"}[$__rate_interval])))",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "WAL Fsync P99 per etcd Pod",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_hcps"
+      },
+      "description": "Fsync operation rate per etcd pod. Uneven distribution may indicate leader imbalance or asymmetric write load.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "ops/sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 50 },
+      "id": 52,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "sum by (pod) (rate(etcd_disk_wal_fsync_duration_seconds_count{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Fsync Rate per etcd Pod",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "5m",
+  "schemaVersion": 41,
+  "tags": ["etcd", "fsync", "disk", "sre"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "HCPs Datasource",
+        "multi": false,
+        "name": "ds_hcps",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "^Managed_Prometheus_hcps-(?![a-z]{2,3}$).+$",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allowCustomValue": false,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Fleet HCPs Datasource",
+        "multi": true,
+        "name": "ds_fleet",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "^Managed_Prometheus_hcps-(?![a-z]{2,3}$).+$",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$ds_hcps"
+        },
+        "definition": "label_values(etcd_disk_wal_fsync_duration_seconds_count, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "HCP Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(etcd_disk_wal_fsync_duration_seconds_count, namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "etcd Fsync Performance",
+  "uid": "sre-cluster-health-etcd-fsync-performance",
+  "version": 1
+}

--- a/observability/grafana-dashboards/sre/cluster-health/etcd-fsync-performance.json
+++ b/observability/grafana-dashboards/sre/cluster-health/etcd-fsync-performance.json
@@ -63,7 +63,7 @@
       "id": 1,
       "options": {
         "code": { "language": "plaintext", "showLineNumbers": false, "showMiniMap": false },
-        "content": "### etcd Fsync Performance Dashboard\n\nDisk-level etcd latency analysis beyond P99 — covering latency distribution, tail latencies, throughput, and regional comparison.\n\n**Complements** `etcd-availability.json` (fleet SLO violators) and `per-cluster-drill-in.json` (single-cluster P99). This dashboard adds:\n- Full latency distribution heatmaps (WAL fsync + backend commit)\n- Tail latency percentiles (P99, P99.9, P99.99)\n- Fsync operation rate (ops/sec)\n- Regional latency comparison\n- Latency vs throughput correlation\n\n**SLO targets:** WAL fsync P99 < 10ms, backend commit P99 < 25ms.",
+        "content": "### etcd Fsync Performance Dashboard\n\nDisk-level etcd analysis beyond P99 — covering latency distribution, tail latencies, throughput, DB size/fragmentation, read/write operation rates, and fleet-wide comparison.\n\n**Complements** `etcd-availability.json` (fleet SLO violators) and `per-cluster-drill-in.json` (single-cluster P99). This dashboard adds:\n- Full latency distribution heatmaps (WAL fsync + backend commit)\n- Tail latency percentiles (P99, P99.9, P99.99)\n- Fsync operation rate (ops/sec) and latency vs throughput correlation\n- DB size, in-use size, fragmentation %, quota usage\n- Read/write/delete operation rates and slow request tracking\n- Per-pod breakdown for noisy-neighbor detection\n- Fleet-wide per-cluster comparison\n\n**SLO targets:** WAL fsync P99 < 10ms, backend commit P99 < 25ms.",
         "mode": "markdown"
       },
       "pluginVersion": "11.6.9",
@@ -747,7 +747,7 @@
       "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 38 },
       "id": 40,
-      "title": "Regional Comparison (Fleet-Wide)",
+      "title": "Fleet-Wide Per-Cluster Comparison",
       "type": "row"
     },
     {
@@ -755,7 +755,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "WAL fsync P99 latency per region. Each line represents the worst per-cluster P99 in that region. Quickly identify which regions have disk-related latency issues.",
+      "description": "WAL fsync P99 latency per cluster across the fleet. Each line represents one cluster's P99. Quickly identify which clusters have disk-related latency issues.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -811,7 +811,7 @@
           "refId": "A"
         }
       ],
-      "title": "WAL Fsync P99 by Region",
+      "title": "WAL Fsync P99 per Cluster (Fleet)",
       "type": "timeseries"
     },
     {
@@ -819,7 +819,7 @@
         "type": "datasource",
         "uid": "-- Mixed --"
       },
-      "description": "Backend commit P99 latency per region. Identifies regions with slow disk commit performance.",
+      "description": "Backend commit P99 latency per cluster across the fleet. Identifies clusters with slow disk commit performance.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -875,7 +875,7 @@
           "refId": "A"
         }
       ],
-      "title": "Backend Commit P99 by Region",
+      "title": "Backend Commit P99 per Cluster (Fleet)",
       "type": "timeseries"
     },
     {

--- a/observability/grafana-dashboards/sre/cluster-health/etcd-fsync-performance.json
+++ b/observability/grafana-dashboards/sre/cluster-health/etcd-fsync-performance.json
@@ -1003,6 +1003,532 @@
       ],
       "title": "Fsync Rate per etcd Pod",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 60 },
+      "id": 60,
+      "title": "DB Size & Health — Scenarios 2 (Helm bloat), 4 (Job garbage), 5 (High-cardinality CRs), 9 (No defrag)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+      "description": "Current etcd DB total allocated size. Approaches 8 GB hard quota.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 2 },
+              { "color": "red", "value": 6 }
+            ]
+          },
+          "unit": "decgbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 5, "x": 0, "y": 61 },
+      "id": 61,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "max(etcd_mvcc_db_total_size_in_bytes{namespace=~\"$namespace\"}) / 1073741824",
+          "instant": true,
+          "legendFormat": "DB Total Size",
+          "refId": "A"
+        }
+      ],
+      "title": "DB Total Size",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+      "description": "Actual data in DB (excludes fragmented space). Compare with total size to detect fragmentation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1.5 },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "unit": "decgbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 5, "x": 5, "y": 61 },
+      "id": 62,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "max(etcd_mvcc_db_total_size_in_use_in_bytes{namespace=~\"$namespace\"}) / 1073741824",
+          "instant": true,
+          "legendFormat": "DB In-Use Size",
+          "refId": "A"
+        }
+      ],
+      "title": "DB In-Use Size",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+      "description": "Percentage of DB allocated to fragmented (wasted) space. High fragmentation means defrag is needed. >40% is critical.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 20 },
+              { "color": "red", "value": 40 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 5, "x": 10, "y": 61 },
+      "id": 63,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "(1 - max(etcd_mvcc_db_total_size_in_use_in_bytes{namespace=~\"$namespace\"}) / max(etcd_mvcc_db_total_size_in_bytes{namespace=~\"$namespace\"})) * 100",
+          "instant": true,
+          "legendFormat": "DB Fragmentation %",
+          "refId": "A"
+        }
+      ],
+      "title": "DB Fragmentation",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+      "description": "DB size as % of the 8 GB quota. At 100% the cluster goes read-only (NOSPACE alarm). SRE alert fires at 80%.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 75 },
+              { "color": "red", "value": 90 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 5, "x": 15, "y": 61 },
+      "id": 64,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "max(etcd_mvcc_db_total_size_in_bytes{namespace=~\"$namespace\"}) / max(etcd_server_quota_backend_bytes{namespace=~\"$namespace\"}) * 100",
+          "instant": true,
+          "legendFormat": "DB % of Quota",
+          "refId": "A"
+        }
+      ],
+      "title": "DB % of Quota",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+      "description": "Current key-value put operation rate. High put rate combined with high WAL fsync latency indicates write saturation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 4, "x": 20, "y": 61 },
+      "id": 65,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "sum(rate(etcd_mvcc_put_total{namespace=~\"$namespace\"}[5m]))",
+          "instant": true,
+          "legendFormat": "Put Rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Put Rate (ops/sec)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 66 },
+      "id": 70,
+      "title": "DB Size Growth Over Time",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+      "description": "DB growth over time. When total size approaches quota (8 GB default), etcd will trigger NOSPACE and go read-only. Gap between total and in-use indicates fragmented space needing defrag.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "dashed", "line": true }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "transparent", "value": null },
+              { "color": "red", "value": 6.4 }
+            ]
+          },
+          "unit": "decgbytes"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "8 GB Quota" },
+            "properties": [
+              { "id": "custom.lineStyle", "value": { "fill": "dash", "dash": [10, 10] } },
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } },
+              { "id": "custom.fillOpacity", "value": 0 }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 10, "w": 14, "x": 0, "y": 67 },
+      "id": 71,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "max(etcd_mvcc_db_total_size_in_bytes{namespace=~\"$namespace\"}) / 1073741824",
+          "legendFormat": "DB Total Size",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "max(etcd_mvcc_db_total_size_in_use_in_bytes{namespace=~\"$namespace\"}) / 1073741824",
+          "legendFormat": "DB In-Use Size",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "max(etcd_server_quota_backend_bytes{namespace=~\"$namespace\"}) / 1073741824",
+          "legendFormat": "8 GB Quota",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "DB Total Size, In-Use Size & Quota",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+      "description": "Rising fragmentation after compaction without defrag. Run `etcdctl defrag` when this exceeds 30%.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "dashed", "line": true }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "transparent", "value": null },
+              { "color": "red", "value": 0.4 }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 10, "x": 14, "y": 67 },
+      "id": 72,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "1 - max(etcd_mvcc_db_total_size_in_use_in_bytes{namespace=~\"$namespace\"}) / max(etcd_mvcc_db_total_size_in_bytes{namespace=~\"$namespace\"})",
+          "legendFormat": "Fragmentation Ratio",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "DB Fragmentation Ratio Over Time",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 77 },
+      "id": 80,
+      "title": "Read & Write Operation Rate — Scenario 8 (Abusive LIST clients)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+      "description": "Range read rate vs put rate. Abusive LIST clients show massive range read spike with low put rate — this is pure read pressure, not write pressure. High range reads also cause backend commit latency spikes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 78 },
+      "id": 81,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "sum(rate(etcd_mvcc_range_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "Range Reads (ops/sec)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "sum(rate(etcd_mvcc_put_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "Puts (ops/sec)",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "sum(rate(etcd_mvcc_delete_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "Deletes (ops/sec)",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Key Operation Rate (Reads vs Writes)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+      "description": "Requests exceeding 300ms usually indicate disk pressure or network issues. Leader changes (election count rate) indicate instability.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Leader Changes/sec" },
+            "properties": [
+              { "id": "custom.axisPlacement", "value": "right" },
+              { "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 78 },
+      "id": 82,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "sum(rate(etcd_server_slow_apply_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "Slow Applies (>300ms)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$ds_hcps" },
+          "editorMode": "code",
+          "expr": "sum(rate(etcd_server_leader_changes_seen_total{namespace=~\"$namespace\"}[$__rate_interval]))",
+          "legendFormat": "Leader Changes/sec",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Slow Requests (>300ms) & Leader Changes",
+      "type": "timeseries"
     }
   ],
   "preload": false,
@@ -1077,6 +1603,6 @@
   "timepicker": {},
   "timezone": "browser",
   "title": "etcd Fsync Performance",
-  "uid": "sre-cluster-health-etcd-fsync-performance",
-  "version": 1
+  "uid": "sre-cluster-health-etcd-fsync",
+  "version": 2
 }


### PR DESCRIPTION
Jira: [ARO-26901](https://redhat.atlassian.net/browse/ARO-26901)

<!-- Link to Jira issue -->

## What

Extends the **etcd Fsync Performance** Grafana dashboard with 12 new panels (3 sections) covering etcd DB size, fragmentation, and read/write operation rate analysis. Total panels increased from 20 to 32, dashboard version bumped from 1 to 2.

**New sections added:**

1. **DB Size & Health** — 5 stat cards with color-coded thresholds:
   - DB Total Size, DB In-Use Size, Fragmentation %, DB % of Quota, Put Rate (ops/sec)
   - Enables instant triage of scenarios: Helm chart bloat, job garbage accumulation, high-cardinality CRDs, missing defrag

2. **DB Size Growth Over Time** — 2 timeseries panels:
   - DB Total Size / In-Use Size / Quota (with dashed red quota line and 80% threshold)
   - DB Fragmentation Ratio Over Time (with 0.4 critical threshold)

3. **Read & Write Operation Rate** — 2 timeseries panels:
   - Key Operation Rate: range reads vs puts vs deletes (detects abusive LIST clients)
   - Slow Requests (>300ms) & Leader Changes (leader changes on secondary Y-axis in red)

## Why

The original dashboard (v1) focused exclusively on disk I/O latency (WAL fsync, backend commit). Customer escalations revealed 10 recurring etcd failure scenarios that the v1 dashboard could not detect:

| Gap | Customer Scenarios Not Covered |
|---|---|
| No DB size visibility | Helm chart bloat, Job garbage accumulation, High-cardinality CRDs |
| No fragmentation tracking | Missing defrag, Compaction lag |
| No read/write rate analysis | Abusive LIST clients |
| No leader election visibility | Network partition / split-brain |

These new panels close all gaps, enabling SREs to triage all 10 known etcd failure patterns from a single dashboard without needing to shell into etcd pods or run manual `etcdctl` commands.

## Testing

Live verification performed against a personal dev environment (`DEPLOY_ENV=pers`) with a real HCP cluster (`etcdtest`) running 3 etcd pods.

**Setup:**
1. Deployed full ARO HCP personal dev stack (`make personal-dev-env`) — service cluster, management cluster, Grafana, Azure Monitor Workspace
2. Created HCP cluster `etcdtest` via frontend API — 3 etcd pods running in namespace `ocm-arohcppers-2sm350gmuu45dll79nj8ibnqgk7u1et2-etcdtest`
3. Synced dashboard to Azure Managed Grafana via `grafanactl sync dashboards`

## Special notes for your reviewer
**Dashboard URL:**
https://arohcp-dev-c9g7a4fjanb0c4gc.wus3.grafana.azure.com/d/sre-cluster-health-etcd-fsync/etcd-fsync-performance

> Datasource: `Managed_Prometheus_hcps-usw3vsco` | Namespace: `ocm-arohcppers-*-etcdtest`

**Verified:**
- [x] All 32 panels render with live Prometheus data (no "No data" panels)
- [x] Stat cards show correct values with proper color thresholds (green/yellow/red)
- [x] Heatmaps, timeseries, and per-pod breakdowns display real etcd metrics
- [x] DB size, fragmentation, and operation rate panels populate correctly
- [x] Dashboard JSON passes `grafanactl verify dashboards` validation

**Screenshots:** Uploaded to [ARO-26901](https://redhat.atlassian.net/browse/ARO-26901)

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
