### PR TITLE
feat: split cluster service ARM helper identity

### DIFF
--- a/cluster-service/testdata/helmtest_cs-distinct-arm-helper.yaml
+++ b/cluster-service/testdata/helmtest_cs-distinct-arm-helper.yaml
@@ -1,0 +1,9 @@
+values: ../values.yaml
+name: cs-distinct-arm-helper
+namespace: clusters-service
+testData:
+  armHelperClientId: shared-client-id
+  armHelperCertName: shared-cert-name
+  armHelperFPAPrincipalId: mock-fpa-principal-id
+  clustersServiceArmHelperClientId: clusters-service-client-id
+  clustersServiceArmHelperCertName: clusters-service-cert-name

--- a/cluster-service/testdata/helmtest_cs-shared-arm-helper-fallback.yaml
+++ b/cluster-service/testdata/helmtest_cs-shared-arm-helper-fallback.yaml
@@ -1,0 +1,9 @@
+values: ../values.yaml
+name: cs-shared-arm-helper-fallback
+namespace: clusters-service
+testData:
+  armHelperClientId: shared-client-id
+  armHelperCertName: shared-cert-name
+  armHelperFPAPrincipalId: mock-fpa-principal-id
+  clustersServiceArmHelperClientId: ""
+  clustersServiceArmHelperCertName: ""

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_distinct_arm_helper.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_distinct_arm_helper.yaml
@@ -1,0 +1,8436 @@
+---
+# Source: clusters-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: 'clusters-service'
+  namespace: 'clusters-service'
+  labels:
+    app: clusters-service
+  annotations:
+    azure.workload.identity/client-id: '__azureCsMiClientId__'
+---
+# Source: clusters-service/templates/clusters-service.secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: clusters-service
+  namespace: 'clusters-service'
+stringData:
+  client.id: 'foo'
+  client.secret: 'bar'
+---
+# Source: clusters-service/templates/database.secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: 'ocm-cs-db'
+  namespace: 'clusters-service'
+stringData:
+  db.host: '__databaseHost__'
+  db.name: '__databaseName__'
+  db.password: '__databasePassword__'
+  db.user: '__databaseUser__'
+  db.port: "5432"
+---
+# Source: clusters-service/templates/provisioning-shards.secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: provision-shards
+  namespace: 'clusters-service'
+  annotations:
+    helm.sh/resource-policy: keep
+stringData:
+  config: |
+    provision_shards: []
+---
+# Source: clusters-service/templates/aro-hcp-ocp-versions-config.configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aro-hcp-ocp-versions-config
+  namespace: 'clusters-service'
+data:
+  aro-hcp-ocp-versions-config.yaml: |
+    defaultVersion:
+      channelGroupName: stable
+      version: 4.20.8
+    channelGroups:
+      - url: https://api.openshift.com/api/upgrades_info/graph
+        channelGroupName: stable
+        minVersion: 4.19.0
+        maxVersion: ""
+      - url: https://api.openshift.com/api/upgrades_info/graph
+        channelGroupName: fast
+        minVersion: 4.19.0
+        maxVersion: ""
+      - url: https://api.openshift.com/api/upgrades_info/graph
+        channelGroupName: candidate
+        minVersion: 4.19.7
+        maxVersion: ""
+      - url: https://multi.ocp.releases.ci.openshift.org/graph
+        channelGroupName: nightly
+        minVersion: 4.19.0-0.nightly-20200101
+        maxVersion: ""
+---
+# Source: clusters-service/templates/authentication.configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentication
+  namespace: 'clusters-service'
+data:
+  jwks.json: ""
+  acl.yml: ""
+---
+# Source: clusters-service/templates/azure-operators-managed-identities-config.configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: azure-operators-managed-identities-config
+  namespace: 'clusters-service'
+data:
+  azure-operators-managed-identities-config.yaml: |
+    controlPlaneOperatorsIdentities:
+      cluster-api-azure:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e'
+            name: 'Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider'
+        optional: false
+      control-plane:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/fc0c873f-45e9-4d0d-a7d1-585aab30c6ed'
+            name: 'Azure Red Hat OpenShift Hosted Control Planes Control Plane Operator'
+        optional: false
+      cloud-controller-manager:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/a1f96423-95ce-4224-ab27-4e3dc72facd4'
+            name: 'Azure Red Hat OpenShift Cloud Controller Manager'
+        optional: false
+      ingress:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/0336e1d3-7a87-462b-b6db-342b63f7802c'
+            name: 'Azure Red Hat OpenShift Cluster Ingress Operator'
+        optional: false
+      disk-csi-driver:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/5b7237c5-45e1-49d6-bc18-a1f62f400748'
+            name: 'Azure Red Hat OpenShift Disk Storage Operator'
+        optional: false
+      file-csi-driver:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e'
+            name: 'Azure Red Hat OpenShift File Storage Operator'
+        optional: false
+      image-registry:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/8b32b316-c2f5-4ddf-b05b-83dacd2d08b5'
+            name: 'Azure Red Hat OpenShift Image Registry Operator'
+        optional: false
+      cloud-network-config:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/be7a6435-15ae-4171-8f30-4a343eff9e8f'
+            name: 'Azure Red Hat OpenShift Network Operator'
+        optional: false
+      kms:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/12338af0-0e69-4776-bea7-57ae8d297424'
+            name: 'Key Vault Crypto User'
+        optional: true
+    dataPlaneOperatorsIdentities:
+      disk-csi-driver:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/5b7237c5-45e1-49d6-bc18-a1f62f400748'
+            name: 'Azure Red Hat OpenShift Disk Storage Operator'
+        k8sServiceAccounts:
+          - name: 'azure-disk-csi-driver-operator'
+            namespace: 'openshift-cluster-csi-drivers'
+          - name: 'azure-disk-csi-driver-controller-sa'
+            namespace: 'openshift-cluster-csi-drivers'
+        optional: false
+      image-registry:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/8b32b316-c2f5-4ddf-b05b-83dacd2d08b5'
+            name: 'Azure Red Hat OpenShift Image Registry Operator'
+        k8sServiceAccounts:
+          - name: 'cluster-image-registry-operator'
+            namespace: 'openshift-image-registry'
+          - name: 'registry'
+            namespace: 'openshift-image-registry'
+        optional: false
+      file-csi-driver:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e'
+            name: 'Azure Red Hat OpenShift File Storage Operator'
+        k8sServiceAccounts:
+          - name: 'azure-file-csi-driver-operator'
+            namespace: 'openshift-cluster-csi-drivers'
+          - name: 'azure-file-csi-driver-controller-sa'
+            namespace: 'openshift-cluster-csi-drivers'
+          - name: 'azure-file-csi-driver-node-sa'
+            namespace: 'openshift-cluster-csi-drivers'
+        optional: false
+    serviceManagedIdentity:
+      roleDefinitions:
+        - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/c0ff367d-66d8-445e-917c-583feb0ef0d4'
+          name: 'Azure Red Hat OpenShift Hosted Control Planes Service Managed Identity'
+---
+# Source: clusters-service/templates/azure-runtime-config.configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: azure-runtime-config
+  namespace: 'clusters-service'
+data:
+  config.json: |
+    {
+      "cloud_environment": "AzurePublicCloud",
+      "managed_identities_data_plane_audience_resource": "https://dummy.org",
+      "tenant_id": "__tenantId__",
+      "ocp_images_acr": {
+        "resource_id": "__ocpAcrResourceId__",
+        "url": "__ocpAcrResourceUrl__",
+        "scope_map_name": "_repositories_pull"
+      },
+      "data_plane_identities_oidc_configuration": {
+        "storage_account_blob_container_name": "$web",
+        "storage_account_blob_service_url": "__oidcIssuerBlobServiceUrl__",
+        "oidc_issuer_base_url": "__oidcIssuerBaseUrl__"
+      },
+      "tls_certificates_config": {
+        "issuer": "Self",
+        "enabled": true
+      }
+    }
+---
+# Source: clusters-service/templates/cloud-resource-constraints-config.configmap.yaml
+apiVersion: v1
+data:
+  cloud-region-constraints.yaml: |
+    cloud_regions:
+      - id: 'westus3'
+        enabled: true
+        govcloud: false
+        ccs_only: false
+  instance-type-constraints.yaml: |
+    instance_types:
+    # hand-crafted list to the ones mentioned in
+    # https://issues.redhat.com/browse/ARO-21660
+    # those are the instance types that are also enabled in ARO Classic.
+    # We also include the ones mentioned in https://issues.redhat.com/browse/ARO-22443
+    - id: Standard_D8s_v3
+      ccs_only: true
+      enabled: true
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC4as_T4_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC8as_T4_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC16as_T4_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC64as_T4_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_E4s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E8s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E16s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E20s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E32s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E48s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E64s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E80is_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E80ids_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D4s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D8s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D16s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D32s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D64s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D4s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_D16s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_D32s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_E4s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_E8s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_E16s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_E32s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_F4s_v2
+    - ccs_only: true
+      enabled: true
+      id: Standard_F8s_v2
+    - ccs_only: true
+      enabled: true
+      id: Standard_F16s_v2
+    - ccs_only: true
+      enabled: true
+      id: Standard_F32s_v2
+    - ccs_only: true
+      enabled: true
+      id: Standard_F72s_v2
+    - ccs_only: true
+      enabled: true
+      id: Standard_D4s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D8s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D16s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D32s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D64s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D96s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E96ds_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E104ids_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E4s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E8s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E16s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E20s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E32s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E48s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E64s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E96s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E104is_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D4as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D8as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D16as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D32as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D64as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D96as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E4as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E8as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E16as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E20as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E32as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E48as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E64as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E96as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D4as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D8as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D16as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D32as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D64as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D96as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E8as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E16as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E20as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E32as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E48as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E64as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E96as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC24ads_A100_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC48ads_A100_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC96ads_A100_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_L8s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_L16s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_L32s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_L48s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_L64s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC6s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC12s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC24rs_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC24s_v3
+    - id: Standard_D2pls_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D4pls_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D8pls_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D16pls_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D32pls_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D48pls_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D64pls_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D96pls_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D2plds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D4plds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D8plds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D16plds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D32plds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D48plds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D64plds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D96plds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D2ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D4ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D8ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D16ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D32ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D48ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D64ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D96ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D2pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D4pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D8pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D16pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D32pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D48pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D64pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D96pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E2ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E4ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E8ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E16ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E32ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E48ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E64ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E96ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E2pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E4pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E8pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E16pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E32pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E48pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E64pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E96pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D2s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D4s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D8s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D16s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D32s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D48s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D64s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D96s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D128s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D192s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_L2s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_L4s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_L8s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_L16s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_L32s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_L48s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_L64s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_L80s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_L96s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_E2s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E4s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E8s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E16s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E20s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E32s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E48s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E64s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E96s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E128s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E192is_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_NC40ads_H100_v5
+      ccs_only: true
+      enabled: true
+    - id: Standard_NC80adis_H100_v5
+      ccs_only: true
+      enabled: true
+    - id: Standard_ND96isr_H200_v5
+      ccs_only: true
+      enabled: true
+kind: ConfigMap
+metadata:
+  name: cloud-resource-constraints-config
+  namespace: 'clusters-service'
+---
+# Source: clusters-service/templates/cloud-resources-config.configmap.yaml
+apiVersion: v1
+data:
+  cloud-regions.yaml: |
+    cloud_regions:
+      - id: 'westus3'
+        cloud_provider_id: azure
+        display_name: Azure East US
+        supports_multi_az: true
+  instance-types.yaml: |
+    instance_types:
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_nc4as_t4_v3
+      id: Standard_NC4as_T4_v3
+      memory: 30064771072
+      name: Standard_NC4as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_nc8as_t4_v3
+      id: Standard_NC8as_T4_v3
+      memory: 60129542144
+      name: Standard_NC8as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_nc16as_t4_v3
+      id: Standard_NC16as_T4_v3
+      memory: 118111600640
+      name: Standard_NC16as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_nc64as_t4_v3
+      id: Standard_NC64as_T4_v3
+      memory: 472446402560
+      name: Standard_NC64as_T4_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2_v4
+      id: Standard_E2_v4
+      memory: 17179869184
+      name: Standard_E2_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4_v4
+      id: Standard_E4_v4
+      memory: 34359738368
+      name: Standard_E4_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8_v4
+      id: Standard_E8_v4
+      memory: 68719476736
+      name: Standard_E8_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16_v4
+      id: Standard_E16_v4
+      memory: 137438953472
+      name: Standard_E16_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20_v4
+      id: Standard_E20_v4
+      memory: 171798691840
+      name: Standard_E20_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32_v4
+      id: Standard_E32_v4
+      memory: 274877906944
+      name: Standard_E32_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48_v4
+      id: Standard_E48_v4
+      memory: 412316860416
+      name: Standard_E48_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64_v4
+      id: Standard_E64_v4
+      memory: 541165879296
+      name: Standard_E64_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2d_v4
+      id: Standard_E2d_v4
+      memory: 17179869184
+      name: Standard_E2d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4d_v4
+      id: Standard_E4d_v4
+      memory: 34359738368
+      name: Standard_E4d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8d_v4
+      id: Standard_E8d_v4
+      memory: 68719476736
+      name: Standard_E8d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16d_v4
+      id: Standard_E16d_v4
+      memory: 137438953472
+      name: Standard_E16d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20d_v4
+      id: Standard_E20d_v4
+      memory: 171798691840
+      name: Standard_E20d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32d_v4
+      id: Standard_E32d_v4
+      memory: 274877906944
+      name: Standard_E32d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48d_v4
+      id: Standard_E48d_v4
+      memory: 412316860416
+      name: Standard_E48d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64d_v4
+      id: Standard_E64d_v4
+      memory: 541165879296
+      name: Standard_E64d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2s_v4
+      id: Standard_E2s_v4
+      memory: 17179869184
+      name: Standard_E2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2s_v4
+      id: Standard_E4-2s_v4
+      memory: 34359738368
+      name: Standard_E4-2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4s_v4
+      id: Standard_E4s_v4
+      memory: 34359738368
+      name: Standard_E4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2s_v4
+      id: Standard_E8-2s_v4
+      memory: 68719476736
+      name: Standard_E8-2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4s_v4
+      id: Standard_E8-4s_v4
+      memory: 68719476736
+      name: Standard_E8-4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8s_v4
+      id: Standard_E8s_v4
+      memory: 68719476736
+      name: Standard_E8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4s_v4
+      id: Standard_E16-4s_v4
+      memory: 137438953472
+      name: Standard_E16-4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8s_v4
+      id: Standard_E16-8s_v4
+      memory: 137438953472
+      name: Standard_E16-8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16s_v4
+      id: Standard_E16s_v4
+      memory: 137438953472
+      name: Standard_E16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20s_v4
+      id: Standard_E20s_v4
+      memory: 171798691840
+      name: Standard_E20s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8s_v4
+      id: Standard_E32-8s_v4
+      memory: 274877906944
+      name: Standard_E32-8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16s_v4
+      id: Standard_E32-16s_v4
+      memory: 274877906944
+      name: Standard_E32-16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32s_v4
+      id: Standard_E32s_v4
+      memory: 274877906944
+      name: Standard_E32s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48s_v4
+      id: Standard_E48s_v4
+      memory: 412316860416
+      name: Standard_E48s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16s_v4
+      id: Standard_E64-16s_v4
+      memory: 541165879296
+      name: Standard_E64-16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32s_v4
+      id: Standard_E64-32s_v4
+      memory: 541165879296
+      name: Standard_E64-32s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64s_v4
+      id: Standard_E64s_v4
+      memory: 541165879296
+      name: Standard_E64s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_e80is_v4
+      id: Standard_E80is_v4
+      memory: 541165879296
+      name: Standard_E80is_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2ds_v4
+      id: Standard_E2ds_v4
+      memory: 17179869184
+      name: Standard_E2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2ds_v4
+      id: Standard_E4-2ds_v4
+      memory: 34359738368
+      name: Standard_E4-2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4ds_v4
+      id: Standard_E4ds_v4
+      memory: 34359738368
+      name: Standard_E4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2ds_v4
+      id: Standard_E8-2ds_v4
+      memory: 68719476736
+      name: Standard_E8-2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4ds_v4
+      id: Standard_E8-4ds_v4
+      memory: 68719476736
+      name: Standard_E8-4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8ds_v4
+      id: Standard_E8ds_v4
+      memory: 68719476736
+      name: Standard_E8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4ds_v4
+      id: Standard_E16-4ds_v4
+      memory: 137438953472
+      name: Standard_E16-4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8ds_v4
+      id: Standard_E16-8ds_v4
+      memory: 137438953472
+      name: Standard_E16-8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16ds_v4
+      id: Standard_E16ds_v4
+      memory: 137438953472
+      name: Standard_E16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20ds_v4
+      id: Standard_E20ds_v4
+      memory: 171798691840
+      name: Standard_E20ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8ds_v4
+      id: Standard_E32-8ds_v4
+      memory: 274877906944
+      name: Standard_E32-8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16ds_v4
+      id: Standard_E32-16ds_v4
+      memory: 274877906944
+      name: Standard_E32-16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32ds_v4
+      id: Standard_E32ds_v4
+      memory: 274877906944
+      name: Standard_E32ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48ds_v4
+      id: Standard_E48ds_v4
+      memory: 412316860416
+      name: Standard_E48ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16ds_v4
+      id: Standard_E64-16ds_v4
+      memory: 541165879296
+      name: Standard_E64-16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32ds_v4
+      id: Standard_E64-32ds_v4
+      memory: 541165879296
+      name: Standard_E64-32ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64ds_v4
+      id: Standard_E64ds_v4
+      memory: 541165879296
+      name: Standard_E64ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_e80ids_v4
+      id: Standard_E80ids_v4
+      memory: 541165879296
+      name: Standard_E80ids_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2d_v4
+      id: Standard_D2d_v4
+      memory: 8589934592
+      name: Standard_D2d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4d_v4
+      id: Standard_D4d_v4
+      memory: 17179869184
+      name: Standard_D4d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8d_v4
+      id: Standard_D8d_v4
+      memory: 34359738368
+      name: Standard_D8d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16d_v4
+      id: Standard_D16d_v4
+      memory: 68719476736
+      name: Standard_D16d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32d_v4
+      id: Standard_D32d_v4
+      memory: 137438953472
+      name: Standard_D32d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48d_v4
+      id: Standard_D48d_v4
+      memory: 206158430208
+      name: Standard_D48d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64d_v4
+      id: Standard_D64d_v4
+      memory: 274877906944
+      name: Standard_D64d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2_v4
+      id: Standard_D2_v4
+      memory: 8589934592
+      name: Standard_D2_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4_v4
+      id: Standard_D4_v4
+      memory: 17179869184
+      name: Standard_D4_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8_v4
+      id: Standard_D8_v4
+      memory: 34359738368
+      name: Standard_D8_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16_v4
+      id: Standard_D16_v4
+      memory: 68719476736
+      name: Standard_D16_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32_v4
+      id: Standard_D32_v4
+      memory: 137438953472
+      name: Standard_D32_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48_v4
+      id: Standard_D48_v4
+      memory: 206158430208
+      name: Standard_D48_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64_v4
+      id: Standard_D64_v4
+      memory: 274877906944
+      name: Standard_D64_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ds_v4
+      id: Standard_D2ds_v4
+      memory: 8589934592
+      name: Standard_D2ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ds_v4
+      id: Standard_D4ds_v4
+      memory: 17179869184
+      name: Standard_D4ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ds_v4
+      id: Standard_D8ds_v4
+      memory: 34359738368
+      name: Standard_D8ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ds_v4
+      id: Standard_D16ds_v4
+      memory: 68719476736
+      name: Standard_D16ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ds_v4
+      id: Standard_D32ds_v4
+      memory: 137438953472
+      name: Standard_D32ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ds_v4
+      id: Standard_D48ds_v4
+      memory: 206158430208
+      name: Standard_D48ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ds_v4
+      id: Standard_D64ds_v4
+      memory: 274877906944
+      name: Standard_D64ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2s_v4
+      id: Standard_D2s_v4
+      memory: 8589934592
+      name: Standard_D2s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4s_v4
+      id: Standard_D4s_v4
+      memory: 17179869184
+      name: Standard_D4s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8s_v4
+      id: Standard_D8s_v4
+      memory: 34359738368
+      name: Standard_D8s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16s_v4
+      id: Standard_D16s_v4
+      memory: 68719476736
+      name: Standard_D16s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32s_v4
+      id: Standard_D32s_v4
+      memory: 137438953472
+      name: Standard_D32s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48s_v4
+      id: Standard_D48s_v4
+      memory: 206158430208
+      name: Standard_D48s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64s_v4
+      id: Standard_D64s_v4
+      memory: 274877906944
+      name: Standard_D64s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_d1_v2
+      id: Standard_D1_v2
+      memory: 3758096384
+      name: Standard_D1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2_v2
+      id: Standard_D2_v2
+      memory: 7516192768
+      name: Standard_D2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d3_v2
+      id: Standard_D3_v2
+      memory: 15032385536
+      name: Standard_D3_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d4_v2
+      id: Standard_D4_v2
+      memory: 30064771072
+      name: Standard_D4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d5_v2
+      id: Standard_D5_v2
+      memory: 60129542144
+      name: Standard_D5_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d11_v2
+      id: Standard_D11_v2
+      memory: 15032385536
+      name: Standard_D11_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d12_v2
+      id: Standard_D12_v2
+      memory: 30064771072
+      name: Standard_D12_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d13_v2
+      id: Standard_D13_v2
+      memory: 60129542144
+      name: Standard_D13_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d14_v2
+      id: Standard_D14_v2
+      memory: 120259084288
+      name: Standard_D14_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_d15_v2
+      id: Standard_D15_v2
+      memory: 150323855360
+      name: Standard_D15_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_f1
+      id: Standard_F1
+      memory: 2147483648
+      name: Standard_F1
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2
+      id: Standard_F2
+      memory: 4294967296
+      name: Standard_F2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4
+      id: Standard_F4
+      memory: 8589934592
+      name: Standard_F4
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8
+      id: Standard_F8
+      memory: 17179869184
+      name: Standard_F8
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16
+      id: Standard_F16
+      memory: 34359738368
+      name: Standard_F16
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_ds1_v2
+      id: Standard_DS1_v2
+      memory: 3758096384
+      name: Standard_DS1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_ds2_v2
+      id: Standard_DS2_v2
+      memory: 7516192768
+      name: Standard_DS2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_ds3_v2
+      id: Standard_DS3_v2
+      memory: 15032385536
+      name: Standard_DS3_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_ds4_v2
+      id: Standard_DS4_v2
+      memory: 30064771072
+      name: Standard_DS4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_ds5_v2
+      id: Standard_DS5_v2
+      memory: 60129542144
+      name: Standard_DS5_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_ds11-1_v2
+      id: Standard_DS11-1_v2
+      memory: 15032385536
+      name: Standard_DS11-1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_ds11_v2
+      id: Standard_DS11_v2
+      memory: 15032385536
+      name: Standard_DS11_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_ds12-1_v2
+      id: Standard_DS12-1_v2
+      memory: 30064771072
+      name: Standard_DS12-1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_ds12-2_v2
+      id: Standard_DS12-2_v2
+      memory: 30064771072
+      name: Standard_DS12-2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_ds12_v2
+      id: Standard_DS12_v2
+      memory: 30064771072
+      name: Standard_DS12_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_ds13-2_v2
+      id: Standard_DS13-2_v2
+      memory: 60129542144
+      name: Standard_DS13-2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_ds13-4_v2
+      id: Standard_DS13-4_v2
+      memory: 60129542144
+      name: Standard_DS13-4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_ds13_v2
+      id: Standard_DS13_v2
+      memory: 60129542144
+      name: Standard_DS13_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_ds14-4_v2
+      id: Standard_DS14-4_v2
+      memory: 120259084288
+      name: Standard_DS14-4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_ds14-8_v2
+      id: Standard_DS14-8_v2
+      memory: 120259084288
+      name: Standard_DS14-8_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_ds14_v2
+      id: Standard_DS14_v2
+      memory: 120259084288
+      name: Standard_DS14_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_ds15_v2
+      id: Standard_DS15_v2
+      memory: 150323855360
+      name: Standard_DS15_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_f1s
+      id: Standard_F1s
+      memory: 2147483648
+      name: Standard_F1s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2s
+      id: Standard_F2s
+      memory: 4294967296
+      name: Standard_F2s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4s
+      id: Standard_F4s
+      memory: 8589934592
+      name: Standard_F4s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8s
+      id: Standard_F8s
+      memory: 17179869184
+      name: Standard_F8s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16s
+      id: Standard_F16s
+      memory: 34359738368
+      name: Standard_F16s
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2_v3
+      id: Standard_D2_v3
+      memory: 8589934592
+      name: Standard_D2_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4_v3
+      id: Standard_D4_v3
+      memory: 17179869184
+      name: Standard_D4_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8_v3
+      id: Standard_D8_v3
+      memory: 34359738368
+      name: Standard_D8_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16_v3
+      id: Standard_D16_v3
+      memory: 68719476736
+      name: Standard_D16_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32_v3
+      id: Standard_D32_v3
+      memory: 137438953472
+      name: Standard_D32_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48_v3
+      id: Standard_D48_v3
+      memory: 206158430208
+      name: Standard_D48_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64_v3
+      id: Standard_D64_v3
+      memory: 274877906944
+      name: Standard_D64_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2s_v3
+      id: Standard_D2s_v3
+      memory: 8589934592
+      name: Standard_D2s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4s_v3
+      id: Standard_D4s_v3
+      memory: 17179869184
+      name: Standard_D4s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8s_v3
+      id: Standard_D8s_v3
+      memory: 34359738368
+      name: Standard_D8s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16s_v3
+      id: Standard_D16s_v3
+      memory: 68719476736
+      name: Standard_D16s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32s_v3
+      id: Standard_D32s_v3
+      memory: 137438953472
+      name: Standard_D32s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48s_v3
+      id: Standard_D48s_v3
+      memory: 206158430208
+      name: Standard_D48s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64s_v3
+      id: Standard_D64s_v3
+      memory: 274877906944
+      name: Standard_D64s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2_v3
+      id: Standard_E2_v3
+      memory: 17179869184
+      name: Standard_E2_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4_v3
+      id: Standard_E4_v3
+      memory: 34359738368
+      name: Standard_E4_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8_v3
+      id: Standard_E8_v3
+      memory: 68719476736
+      name: Standard_E8_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16_v3
+      id: Standard_E16_v3
+      memory: 137438953472
+      name: Standard_E16_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20_v3
+      id: Standard_E20_v3
+      memory: 171798691840
+      name: Standard_E20_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32_v3
+      id: Standard_E32_v3
+      memory: 274877906944
+      name: Standard_E32_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48_v3
+      id: Standard_E48_v3
+      memory: 412316860416
+      name: Standard_E48_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64_v3
+      id: Standard_E64_v3
+      memory: 463856467968
+      name: Standard_E64_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2s_v3
+      id: Standard_E2s_v3
+      memory: 17179869184
+      name: Standard_E2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2s_v3
+      id: Standard_E4-2s_v3
+      memory: 34359738368
+      name: Standard_E4-2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4s_v3
+      id: Standard_E4s_v3
+      memory: 34359738368
+      name: Standard_E4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2s_v3
+      id: Standard_E8-2s_v3
+      memory: 68719476736
+      name: Standard_E8-2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4s_v3
+      id: Standard_E8-4s_v3
+      memory: 68719476736
+      name: Standard_E8-4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8s_v3
+      id: Standard_E8s_v3
+      memory: 68719476736
+      name: Standard_E8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4s_v3
+      id: Standard_E16-4s_v3
+      memory: 137438953472
+      name: Standard_E16-4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8s_v3
+      id: Standard_E16-8s_v3
+      memory: 137438953472
+      name: Standard_E16-8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16s_v3
+      id: Standard_E16s_v3
+      memory: 137438953472
+      name: Standard_E16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20s_v3
+      id: Standard_E20s_v3
+      memory: 171798691840
+      name: Standard_E20s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8s_v3
+      id: Standard_E32-8s_v3
+      memory: 274877906944
+      name: Standard_E32-8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16s_v3
+      id: Standard_E32-16s_v3
+      memory: 274877906944
+      name: Standard_E32-16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32s_v3
+      id: Standard_E32s_v3
+      memory: 274877906944
+      name: Standard_E32s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48s_v3
+      id: Standard_E48s_v3
+      memory: 412316860416
+      name: Standard_E48s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16s_v3
+      id: Standard_E64-16s_v3
+      memory: 463856467968
+      name: Standard_E64-16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32s_v3
+      id: Standard_E64-32s_v3
+      memory: 463856467968
+      name: Standard_E64-32s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64s_v3
+      id: Standard_E64s_v3
+      memory: 463856467968
+      name: Standard_E64s_v3
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2s_v2
+      id: Standard_F2s_v2
+      memory: 4294967296
+      name: Standard_F2s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4s_v2
+      id: Standard_F4s_v2
+      memory: 8589934592
+      name: Standard_F4s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8s_v2
+      id: Standard_F8s_v2
+      memory: 17179869184
+      name: Standard_F8s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16s_v2
+      id: Standard_F16s_v2
+      memory: 34359738368
+      name: Standard_F16s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32s_v2
+      id: Standard_F32s_v2
+      memory: 68719476736
+      name: Standard_F32s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48s_v2
+      id: Standard_F48s_v2
+      memory: 103079215104
+      name: Standard_F48s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64s_v2
+      id: Standard_F64s_v2
+      memory: 137438953472
+      name: Standard_F64s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 72
+      generic_name: standard_f72s_v2
+      id: Standard_F72s_v2
+      memory: 154618822656
+      name: Standard_F72s_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2as_v5
+      id: Standard_D2as_v5
+      memory: 8589934592
+      name: Standard_D2as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4as_v5
+      id: Standard_D4as_v5
+      memory: 17179869184
+      name: Standard_D4as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8as_v5
+      id: Standard_D8as_v5
+      memory: 34359738368
+      name: Standard_D8as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16as_v5
+      id: Standard_D16as_v5
+      memory: 68719476736
+      name: Standard_D16as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32as_v5
+      id: Standard_D32as_v5
+      memory: 137438953472
+      name: Standard_D32as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48as_v5
+      id: Standard_D48as_v5
+      memory: 206158430208
+      name: Standard_D48as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64as_v5
+      id: Standard_D64as_v5
+      memory: 274877906944
+      name: Standard_D64as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96as_v5
+      id: Standard_D96as_v5
+      memory: 412316860416
+      name: Standard_D96as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2as_v5
+      id: Standard_E2as_v5
+      memory: 17179869184
+      name: Standard_E2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2as_v5
+      id: Standard_E4-2as_v5
+      memory: 34359738368
+      name: Standard_E4-2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4as_v5
+      id: Standard_E4as_v5
+      memory: 34359738368
+      name: Standard_E4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2as_v5
+      id: Standard_E8-2as_v5
+      memory: 68719476736
+      name: Standard_E8-2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4as_v5
+      id: Standard_E8-4as_v5
+      memory: 68719476736
+      name: Standard_E8-4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8as_v5
+      id: Standard_E8as_v5
+      memory: 68719476736
+      name: Standard_E8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4as_v5
+      id: Standard_E16-4as_v5
+      memory: 137438953472
+      name: Standard_E16-4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8as_v5
+      id: Standard_E16-8as_v5
+      memory: 137438953472
+      name: Standard_E16-8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16as_v5
+      id: Standard_E16as_v5
+      memory: 137438953472
+      name: Standard_E16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20as_v5
+      id: Standard_E20as_v5
+      memory: 171798691840
+      name: Standard_E20as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8as_v5
+      id: Standard_E32-8as_v5
+      memory: 274877906944
+      name: Standard_E32-8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16as_v5
+      id: Standard_E32-16as_v5
+      memory: 274877906944
+      name: Standard_E32-16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32as_v5
+      id: Standard_E32as_v5
+      memory: 274877906944
+      name: Standard_E32as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48as_v5
+      id: Standard_E48as_v5
+      memory: 412316860416
+      name: Standard_E48as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16as_v5
+      id: Standard_E64-16as_v5
+      memory: 549755813888
+      name: Standard_E64-16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32as_v5
+      id: Standard_E64-32as_v5
+      memory: 549755813888
+      name: Standard_E64-32as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64as_v5
+      id: Standard_E64as_v5
+      memory: 549755813888
+      name: Standard_E64as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24as_v5
+      id: Standard_E96-24as_v5
+      memory: 721554505728
+      name: Standard_E96-24as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48as_v5
+      id: Standard_E96-48as_v5
+      memory: 721554505728
+      name: Standard_E96-48as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96as_v5
+      id: Standard_E96as_v5
+      memory: 721554505728
+      name: Standard_E96as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ads_v5
+      id: Standard_D2ads_v5
+      memory: 8589934592
+      name: Standard_D2ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ads_v5
+      id: Standard_D4ads_v5
+      memory: 17179869184
+      name: Standard_D4ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ads_v5
+      id: Standard_D8ads_v5
+      memory: 34359738368
+      name: Standard_D8ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ads_v5
+      id: Standard_D16ads_v5
+      memory: 68719476736
+      name: Standard_D16ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ads_v5
+      id: Standard_D32ads_v5
+      memory: 137438953472
+      name: Standard_D32ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ads_v5
+      id: Standard_D48ads_v5
+      memory: 206158430208
+      name: Standard_D48ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ads_v5
+      id: Standard_D64ads_v5
+      memory: 274877906944
+      name: Standard_D64ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96ads_v5
+      id: Standard_D96ads_v5
+      memory: 412316860416
+      name: Standard_D96ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2ads_v5
+      id: Standard_E2ads_v5
+      memory: 17179869184
+      name: Standard_E2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2ads_v5
+      id: Standard_E4-2ads_v5
+      memory: 34359738368
+      name: Standard_E4-2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4ads_v5
+      id: Standard_E4ads_v5
+      memory: 34359738368
+      name: Standard_E4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2ads_v5
+      id: Standard_E8-2ads_v5
+      memory: 68719476736
+      name: Standard_E8-2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4ads_v5
+      id: Standard_E8-4ads_v5
+      memory: 68719476736
+      name: Standard_E8-4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8ads_v5
+      id: Standard_E8ads_v5
+      memory: 68719476736
+      name: Standard_E8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4ads_v5
+      id: Standard_E16-4ads_v5
+      memory: 137438953472
+      name: Standard_E16-4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8ads_v5
+      id: Standard_E16-8ads_v5
+      memory: 137438953472
+      name: Standard_E16-8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16ads_v5
+      id: Standard_E16ads_v5
+      memory: 137438953472
+      name: Standard_E16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20ads_v5
+      id: Standard_E20ads_v5
+      memory: 171798691840
+      name: Standard_E20ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8ads_v5
+      id: Standard_E32-8ads_v5
+      memory: 274877906944
+      name: Standard_E32-8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16ads_v5
+      id: Standard_E32-16ads_v5
+      memory: 274877906944
+      name: Standard_E32-16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32ads_v5
+      id: Standard_E32ads_v5
+      memory: 274877906944
+      name: Standard_E32ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48ads_v5
+      id: Standard_E48ads_v5
+      memory: 412316860416
+      name: Standard_E48ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16ads_v5
+      id: Standard_E64-16ads_v5
+      memory: 549755813888
+      name: Standard_E64-16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32ads_v5
+      id: Standard_E64-32ads_v5
+      memory: 549755813888
+      name: Standard_E64-32ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64ads_v5
+      id: Standard_E64ads_v5
+      memory: 549755813888
+      name: Standard_E64ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24ads_v5
+      id: Standard_E96-24ads_v5
+      memory: 721554505728
+      name: Standard_E96-24ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48ads_v5
+      id: Standard_E96-48ads_v5
+      memory: 721554505728
+      name: Standard_E96-48ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96ads_v5
+      id: Standard_E96ads_v5
+      memory: 721554505728
+      name: Standard_E96ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2as_v6
+      id: Standard_D2as_v6
+      memory: 8589934592
+      name: Standard_D2as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4as_v6
+      id: Standard_D4as_v6
+      memory: 17179869184
+      name: Standard_D4as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8as_v6
+      id: Standard_D8as_v6
+      memory: 34359738368
+      name: Standard_D8as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16as_v6
+      id: Standard_D16as_v6
+      memory: 68719476736
+      name: Standard_D16as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32as_v6
+      id: Standard_D32as_v6
+      memory: 137438953472
+      name: Standard_D32as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48as_v6
+      id: Standard_D48as_v6
+      memory: 206158430208
+      name: Standard_D48as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64as_v6
+      id: Standard_D64as_v6
+      memory: 274877906944
+      name: Standard_D64as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96as_v6
+      id: Standard_D96as_v6
+      memory: 412316860416
+      name: Standard_D96as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2as_v6
+      id: Standard_E2as_v6
+      memory: 17179869184
+      name: Standard_E2as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4as_v6
+      id: Standard_E4as_v6
+      memory: 34359738368
+      name: Standard_E4as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8as_v6
+      id: Standard_E8as_v6
+      memory: 68719476736
+      name: Standard_E8as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16as_v6
+      id: Standard_E16as_v6
+      memory: 137438953472
+      name: Standard_E16as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20as_v6
+      id: Standard_E20as_v6
+      memory: 171798691840
+      name: Standard_E20as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32as_v6
+      id: Standard_E32as_v6
+      memory: 274877906944
+      name: Standard_E32as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48as_v6
+      id: Standard_E48as_v6
+      memory: 412316860416
+      name: Standard_E48as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64as_v6
+      id: Standard_E64as_v6
+      memory: 549755813888
+      name: Standard_E64as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96as_v6
+      id: Standard_E96as_v6
+      memory: 721554505728
+      name: Standard_E96as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ads_v6
+      id: Standard_D2ads_v6
+      memory: 8589934592
+      name: Standard_D2ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ads_v6
+      id: Standard_D4ads_v6
+      memory: 17179869184
+      name: Standard_D4ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ads_v6
+      id: Standard_D8ads_v6
+      memory: 34359738368
+      name: Standard_D8ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ads_v6
+      id: Standard_D16ads_v6
+      memory: 68719476736
+      name: Standard_D16ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ads_v6
+      id: Standard_D32ads_v6
+      memory: 137438953472
+      name: Standard_D32ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ads_v6
+      id: Standard_D48ads_v6
+      memory: 206158430208
+      name: Standard_D48ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ads_v6
+      id: Standard_D64ads_v6
+      memory: 274877906944
+      name: Standard_D64ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96ads_v6
+      id: Standard_D96ads_v6
+      memory: 412316860416
+      name: Standard_D96ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2als_v6
+      id: Standard_D2als_v6
+      memory: 4294967296
+      name: Standard_D2als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4als_v6
+      id: Standard_D4als_v6
+      memory: 8589934592
+      name: Standard_D4als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8als_v6
+      id: Standard_D8als_v6
+      memory: 17179869184
+      name: Standard_D8als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16als_v6
+      id: Standard_D16als_v6
+      memory: 34359738368
+      name: Standard_D16als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32als_v6
+      id: Standard_D32als_v6
+      memory: 68719476736
+      name: Standard_D32als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48als_v6
+      id: Standard_D48als_v6
+      memory: 103079215104
+      name: Standard_D48als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64als_v6
+      id: Standard_D64als_v6
+      memory: 137438953472
+      name: Standard_D64als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96als_v6
+      id: Standard_D96als_v6
+      memory: 206158430208
+      name: Standard_D96als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2alds_v6
+      id: Standard_D2alds_v6
+      memory: 4294967296
+      name: Standard_D2alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4alds_v6
+      id: Standard_D4alds_v6
+      memory: 8589934592
+      name: Standard_D4alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8alds_v6
+      id: Standard_D8alds_v6
+      memory: 17179869184
+      name: Standard_D8alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16alds_v6
+      id: Standard_D16alds_v6
+      memory: 34359738368
+      name: Standard_D16alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32alds_v6
+      id: Standard_D32alds_v6
+      memory: 68719476736
+      name: Standard_D32alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48alds_v6
+      id: Standard_D48alds_v6
+      memory: 103079215104
+      name: Standard_D48alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64alds_v6
+      id: Standard_D64alds_v6
+      memory: 137438953472
+      name: Standard_D64alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96alds_v6
+      id: Standard_D96alds_v6
+      memory: 206158430208
+      name: Standard_D96alds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2ads_v6
+      id: Standard_E2ads_v6
+      memory: 17179869184
+      name: Standard_E2ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4ads_v6
+      id: Standard_E4ads_v6
+      memory: 34359738368
+      name: Standard_E4ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8ads_v6
+      id: Standard_E8ads_v6
+      memory: 68719476736
+      name: Standard_E8ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16ads_v6
+      id: Standard_E16ads_v6
+      memory: 137438953472
+      name: Standard_E16ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20ads_v6
+      id: Standard_E20ads_v6
+      memory: 171798691840
+      name: Standard_E20ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32ads_v6
+      id: Standard_E32ads_v6
+      memory: 274877906944
+      name: Standard_E32ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48ads_v6
+      id: Standard_E48ads_v6
+      memory: 412316860416
+      name: Standard_E48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64ads_v6
+      id: Standard_E64ads_v6
+      memory: 549755813888
+      name: Standard_E64ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24ads_v6
+      id: Standard_E96-24ads_v6
+      memory: 721554505728
+      name: Standard_E96-24ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48ads_v6
+      id: Standard_E96-48ads_v6
+      memory: 721554505728
+      name: Standard_E96-48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96ads_v6
+      id: Standard_E96ads_v6
+      memory: 721554505728
+      name: Standard_E96ads_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2as_v6
+      id: Standard_F2as_v6
+      memory: 8589934592
+      name: Standard_F2as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4as_v6
+      id: Standard_F4as_v6
+      memory: 17179869184
+      name: Standard_F4as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8as_v6
+      id: Standard_F8as_v6
+      memory: 34359738368
+      name: Standard_F8as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16as_v6
+      id: Standard_F16as_v6
+      memory: 68719476736
+      name: Standard_F16as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32as_v6
+      id: Standard_F32as_v6
+      memory: 137438953472
+      name: Standard_F32as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48as_v6
+      id: Standard_F48as_v6
+      memory: 206158430208
+      name: Standard_F48as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64as_v6
+      id: Standard_F64as_v6
+      memory: 274877906944
+      name: Standard_F64as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2als_v6
+      id: Standard_F2als_v6
+      memory: 4294967296
+      name: Standard_F2als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4als_v6
+      id: Standard_F4als_v6
+      memory: 8589934592
+      name: Standard_F4als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8als_v6
+      id: Standard_F8als_v6
+      memory: 17179869184
+      name: Standard_F8als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16als_v6
+      id: Standard_F16als_v6
+      memory: 34359738368
+      name: Standard_F16als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32als_v6
+      id: Standard_F32als_v6
+      memory: 68719476736
+      name: Standard_F32als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48als_v6
+      id: Standard_F48als_v6
+      memory: 103079215104
+      name: Standard_F48als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64als_v6
+      id: Standard_F64als_v6
+      memory: 137438953472
+      name: Standard_F64als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2ams_v6
+      id: Standard_F2ams_v6
+      memory: 17179869184
+      name: Standard_F2ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4ams_v6
+      id: Standard_F4ams_v6
+      memory: 34359738368
+      name: Standard_F4ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8ams_v6
+      id: Standard_F8ams_v6
+      memory: 68719476736
+      name: Standard_F8ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16ams_v6
+      id: Standard_F16ams_v6
+      memory: 137438953472
+      name: Standard_F16ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32ams_v6
+      id: Standard_F32ams_v6
+      memory: 274877906944
+      name: Standard_F32ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48ams_v6
+      id: Standard_F48ams_v6
+      memory: 412316860416
+      name: Standard_F48ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64ams_v6
+      id: Standard_F64ams_v6
+      memory: 549755813888
+      name: Standard_F64ams_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ds_v5
+      id: Standard_D2ds_v5
+      memory: 8589934592
+      name: Standard_D2ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ds_v5
+      id: Standard_D4ds_v5
+      memory: 17179869184
+      name: Standard_D4ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ds_v5
+      id: Standard_D8ds_v5
+      memory: 34359738368
+      name: Standard_D8ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ds_v5
+      id: Standard_D16ds_v5
+      memory: 68719476736
+      name: Standard_D16ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ds_v5
+      id: Standard_D32ds_v5
+      memory: 137438953472
+      name: Standard_D32ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ds_v5
+      id: Standard_D48ds_v5
+      memory: 206158430208
+      name: Standard_D48ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ds_v5
+      id: Standard_D64ds_v5
+      memory: 274877906944
+      name: Standard_D64ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96ds_v5
+      id: Standard_D96ds_v5
+      memory: 412316860416
+      name: Standard_D96ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2d_v5
+      id: Standard_D2d_v5
+      memory: 8589934592
+      name: Standard_D2d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4d_v5
+      id: Standard_D4d_v5
+      memory: 17179869184
+      name: Standard_D4d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8d_v5
+      id: Standard_D8d_v5
+      memory: 34359738368
+      name: Standard_D8d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16d_v5
+      id: Standard_D16d_v5
+      memory: 68719476736
+      name: Standard_D16d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32d_v5
+      id: Standard_D32d_v5
+      memory: 137438953472
+      name: Standard_D32d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48d_v5
+      id: Standard_D48d_v5
+      memory: 206158430208
+      name: Standard_D48d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64d_v5
+      id: Standard_D64d_v5
+      memory: 274877906944
+      name: Standard_D64d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96d_v5
+      id: Standard_D96d_v5
+      memory: 412316860416
+      name: Standard_D96d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2s_v5
+      id: Standard_D2s_v5
+      memory: 8589934592
+      name: Standard_D2s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4s_v5
+      id: Standard_D4s_v5
+      memory: 17179869184
+      name: Standard_D4s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8s_v5
+      id: Standard_D8s_v5
+      memory: 34359738368
+      name: Standard_D8s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16s_v5
+      id: Standard_D16s_v5
+      memory: 68719476736
+      name: Standard_D16s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32s_v5
+      id: Standard_D32s_v5
+      memory: 137438953472
+      name: Standard_D32s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48s_v5
+      id: Standard_D48s_v5
+      memory: 206158430208
+      name: Standard_D48s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64s_v5
+      id: Standard_D64s_v5
+      memory: 274877906944
+      name: Standard_D64s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96s_v5
+      id: Standard_D96s_v5
+      memory: 412316860416
+      name: Standard_D96s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2_v5
+      id: Standard_D2_v5
+      memory: 8589934592
+      name: Standard_D2_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4_v5
+      id: Standard_D4_v5
+      memory: 17179869184
+      name: Standard_D4_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8_v5
+      id: Standard_D8_v5
+      memory: 34359738368
+      name: Standard_D8_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16_v5
+      id: Standard_D16_v5
+      memory: 68719476736
+      name: Standard_D16_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32_v5
+      id: Standard_D32_v5
+      memory: 137438953472
+      name: Standard_D32_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48_v5
+      id: Standard_D48_v5
+      memory: 206158430208
+      name: Standard_D48_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64_v5
+      id: Standard_D64_v5
+      memory: 274877906944
+      name: Standard_D64_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96_v5
+      id: Standard_D96_v5
+      memory: 412316860416
+      name: Standard_D96_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2ds_v5
+      id: Standard_E2ds_v5
+      memory: 17179869184
+      name: Standard_E2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2ds_v5
+      id: Standard_E4-2ds_v5
+      memory: 34359738368
+      name: Standard_E4-2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4ds_v5
+      id: Standard_E4ds_v5
+      memory: 34359738368
+      name: Standard_E4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2ds_v5
+      id: Standard_E8-2ds_v5
+      memory: 68719476736
+      name: Standard_E8-2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4ds_v5
+      id: Standard_E8-4ds_v5
+      memory: 68719476736
+      name: Standard_E8-4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8ds_v5
+      id: Standard_E8ds_v5
+      memory: 68719476736
+      name: Standard_E8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4ds_v5
+      id: Standard_E16-4ds_v5
+      memory: 137438953472
+      name: Standard_E16-4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8ds_v5
+      id: Standard_E16-8ds_v5
+      memory: 137438953472
+      name: Standard_E16-8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16ds_v5
+      id: Standard_E16ds_v5
+      memory: 137438953472
+      name: Standard_E16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20ds_v5
+      id: Standard_E20ds_v5
+      memory: 171798691840
+      name: Standard_E20ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8ds_v5
+      id: Standard_E32-8ds_v5
+      memory: 274877906944
+      name: Standard_E32-8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16ds_v5
+      id: Standard_E32-16ds_v5
+      memory: 274877906944
+      name: Standard_E32-16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32ds_v5
+      id: Standard_E32ds_v5
+      memory: 274877906944
+      name: Standard_E32ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48ds_v5
+      id: Standard_E48ds_v5
+      memory: 412316860416
+      name: Standard_E48ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16ds_v5
+      id: Standard_E64-16ds_v5
+      memory: 549755813888
+      name: Standard_E64-16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32ds_v5
+      id: Standard_E64-32ds_v5
+      memory: 549755813888
+      name: Standard_E64-32ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64ds_v5
+      id: Standard_E64ds_v5
+      memory: 549755813888
+      name: Standard_E64ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24ds_v5
+      id: Standard_E96-24ds_v5
+      memory: 721554505728
+      name: Standard_E96-24ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48ds_v5
+      id: Standard_E96-48ds_v5
+      memory: 721554505728
+      name: Standard_E96-48ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96ds_v5
+      id: Standard_E96ds_v5
+      memory: 721554505728
+      name: Standard_E96ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      generic_name: standard_e104ids_v5
+      id: Standard_E104ids_v5
+      memory: 721554505728
+      name: Standard_E104ids_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2d_v5
+      id: Standard_E2d_v5
+      memory: 17179869184
+      name: Standard_E2d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4d_v5
+      id: Standard_E4d_v5
+      memory: 34359738368
+      name: Standard_E4d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8d_v5
+      id: Standard_E8d_v5
+      memory: 68719476736
+      name: Standard_E8d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16d_v5
+      id: Standard_E16d_v5
+      memory: 137438953472
+      name: Standard_E16d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20d_v5
+      id: Standard_E20d_v5
+      memory: 171798691840
+      name: Standard_E20d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32d_v5
+      id: Standard_E32d_v5
+      memory: 274877906944
+      name: Standard_E32d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48d_v5
+      id: Standard_E48d_v5
+      memory: 412316860416
+      name: Standard_E48d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64d_v5
+      id: Standard_E64d_v5
+      memory: 549755813888
+      name: Standard_E64d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96d_v5
+      id: Standard_E96d_v5
+      memory: 721554505728
+      name: Standard_E96d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      generic_name: standard_e104id_v5
+      id: Standard_E104id_v5
+      memory: 721554505728
+      name: Standard_E104id_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2s_v5
+      id: Standard_E2s_v5
+      memory: 17179869184
+      name: Standard_E2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2s_v5
+      id: Standard_E4-2s_v5
+      memory: 34359738368
+      name: Standard_E4-2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4s_v5
+      id: Standard_E4s_v5
+      memory: 34359738368
+      name: Standard_E4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2s_v5
+      id: Standard_E8-2s_v5
+      memory: 68719476736
+      name: Standard_E8-2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4s_v5
+      id: Standard_E8-4s_v5
+      memory: 68719476736
+      name: Standard_E8-4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8s_v5
+      id: Standard_E8s_v5
+      memory: 68719476736
+      name: Standard_E8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4s_v5
+      id: Standard_E16-4s_v5
+      memory: 137438953472
+      name: Standard_E16-4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8s_v5
+      id: Standard_E16-8s_v5
+      memory: 137438953472
+      name: Standard_E16-8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16s_v5
+      id: Standard_E16s_v5
+      memory: 137438953472
+      name: Standard_E16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20s_v5
+      id: Standard_E20s_v5
+      memory: 171798691840
+      name: Standard_E20s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8s_v5
+      id: Standard_E32-8s_v5
+      memory: 274877906944
+      name: Standard_E32-8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16s_v5
+      id: Standard_E32-16s_v5
+      memory: 274877906944
+      name: Standard_E32-16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32s_v5
+      id: Standard_E32s_v5
+      memory: 274877906944
+      name: Standard_E32s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48s_v5
+      id: Standard_E48s_v5
+      memory: 412316860416
+      name: Standard_E48s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16s_v5
+      id: Standard_E64-16s_v5
+      memory: 549755813888
+      name: Standard_E64-16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32s_v5
+      id: Standard_E64-32s_v5
+      memory: 549755813888
+      name: Standard_E64-32s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64s_v5
+      id: Standard_E64s_v5
+      memory: 549755813888
+      name: Standard_E64s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24s_v5
+      id: Standard_E96-24s_v5
+      memory: 721554505728
+      name: Standard_E96-24s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48s_v5
+      id: Standard_E96-48s_v5
+      memory: 721554505728
+      name: Standard_E96-48s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96s_v5
+      id: Standard_E96s_v5
+      memory: 721554505728
+      name: Standard_E96s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      generic_name: standard_e104is_v5
+      id: Standard_E104is_v5
+      memory: 721554505728
+      name: Standard_E104is_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2_v5
+      id: Standard_E2_v5
+      memory: 17179869184
+      name: Standard_E2_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4_v5
+      id: Standard_E4_v5
+      memory: 34359738368
+      name: Standard_E4_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8_v5
+      id: Standard_E8_v5
+      memory: 68719476736
+      name: Standard_E8_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16_v5
+      id: Standard_E16_v5
+      memory: 137438953472
+      name: Standard_E16_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20_v5
+      id: Standard_E20_v5
+      memory: 171798691840
+      name: Standard_E20_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32_v5
+      id: Standard_E32_v5
+      memory: 274877906944
+      name: Standard_E32_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48_v5
+      id: Standard_E48_v5
+      memory: 412316860416
+      name: Standard_E48_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64_v5
+      id: Standard_E64_v5
+      memory: 549755813888
+      name: Standard_E64_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96_v5
+      id: Standard_E96_v5
+      memory: 721554505728
+      name: Standard_E96_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      generic_name: standard_e104i_v5
+      id: Standard_E104i_v5
+      memory: 721554505728
+      name: Standard_E104i_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2bs_v5
+      id: Standard_E2bs_v5
+      memory: 17179869184
+      name: Standard_E2bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4bs_v5
+      id: Standard_E4bs_v5
+      memory: 34359738368
+      name: Standard_E4bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8bs_v5
+      id: Standard_E8bs_v5
+      memory: 68719476736
+      name: Standard_E8bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16bs_v5
+      id: Standard_E16bs_v5
+      memory: 137438953472
+      name: Standard_E16bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32bs_v5
+      id: Standard_E32bs_v5
+      memory: 274877906944
+      name: Standard_E32bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48bs_v5
+      id: Standard_E48bs_v5
+      memory: 412316860416
+      name: Standard_E48bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64bs_v5
+      id: Standard_E64bs_v5
+      memory: 549755813888
+      name: Standard_E64bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96bs_v5
+      id: Standard_E96bs_v5
+      memory: 721554505728
+      name: Standard_E96bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      generic_name: standard_e112ibs_v5
+      id: Standard_E112ibs_v5
+      memory: 721554505728
+      name: Standard_E112ibs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2bds_v5
+      id: Standard_E2bds_v5
+      memory: 17179869184
+      name: Standard_E2bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4bds_v5
+      id: Standard_E4bds_v5
+      memory: 34359738368
+      name: Standard_E4bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8bds_v5
+      id: Standard_E8bds_v5
+      memory: 68719476736
+      name: Standard_E8bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16bds_v5
+      id: Standard_E16bds_v5
+      memory: 137438953472
+      name: Standard_E16bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32bds_v5
+      id: Standard_E32bds_v5
+      memory: 274877906944
+      name: Standard_E32bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48bds_v5
+      id: Standard_E48bds_v5
+      memory: 412316860416
+      name: Standard_E48bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64bds_v5
+      id: Standard_E64bds_v5
+      memory: 549755813888
+      name: Standard_E64bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96bds_v5
+      id: Standard_E96bds_v5
+      memory: 721554505728
+      name: Standard_E96bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      generic_name: standard_e112ibds_v5
+      id: Standard_E112ibds_v5
+      memory: 721554505728
+      name: Standard_E112ibds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ls_v5
+      id: Standard_D2ls_v5
+      memory: 4294967296
+      name: Standard_D2ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ls_v5
+      id: Standard_D4ls_v5
+      memory: 8589934592
+      name: Standard_D4ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ls_v5
+      id: Standard_D8ls_v5
+      memory: 17179869184
+      name: Standard_D8ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ls_v5
+      id: Standard_D16ls_v5
+      memory: 34359738368
+      name: Standard_D16ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ls_v5
+      id: Standard_D32ls_v5
+      memory: 68719476736
+      name: Standard_D32ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ls_v5
+      id: Standard_D48ls_v5
+      memory: 103079215104
+      name: Standard_D48ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ls_v5
+      id: Standard_D64ls_v5
+      memory: 137438953472
+      name: Standard_D64ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96ls_v5
+      id: Standard_D96ls_v5
+      memory: 206158430208
+      name: Standard_D96ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2lds_v5
+      id: Standard_D2lds_v5
+      memory: 4294967296
+      name: Standard_D2lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4lds_v5
+      id: Standard_D4lds_v5
+      memory: 8589934592
+      name: Standard_D4lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8lds_v5
+      id: Standard_D8lds_v5
+      memory: 17179869184
+      name: Standard_D8lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16lds_v5
+      id: Standard_D16lds_v5
+      memory: 34359738368
+      name: Standard_D16lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32lds_v5
+      id: Standard_D32lds_v5
+      memory: 68719476736
+      name: Standard_D32lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48lds_v5
+      id: Standard_D48lds_v5
+      memory: 103079215104
+      name: Standard_D48lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64lds_v5
+      id: Standard_D64lds_v5
+      memory: 137438953472
+      name: Standard_D64lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96lds_v5
+      id: Standard_D96lds_v5
+      memory: 206158430208
+      name: Standard_D96lds_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_nc8ads_a10_v4
+      id: Standard_NC8ads_A10_v4
+      memory: 107374182400
+      name: Standard_NC8ads_A10_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_nc16ads_a10_v4
+      id: Standard_NC16ads_A10_v4
+      memory: 214748364800
+      name: Standard_NC16ads_A10_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_nc32ads_a10_v4
+      id: Standard_NC32ads_A10_v4
+      memory: 429496729600
+      name: Standard_NC32ads_A10_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 40
+      generic_name: standard_nc40ads_h100_v5
+      id: Standard_NC40ads_H100_v5
+      memory: 343597383680
+      name: Standard_NC40ads_H100_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_nc80adis_h100_v5
+      id: Standard_NC80adis_H100_v5
+      memory: 687194767360
+      name: Standard_NC80adis_H100_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ls_v6
+      id: Standard_D2ls_v6
+      memory: 4294967296
+      name: Standard_D2ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ls_v6
+      id: Standard_D4ls_v6
+      memory: 8589934592
+      name: Standard_D4ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ls_v6
+      id: Standard_D8ls_v6
+      memory: 17179869184
+      name: Standard_D8ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ls_v6
+      id: Standard_D16ls_v6
+      memory: 34359738368
+      name: Standard_D16ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ls_v6
+      id: Standard_D32ls_v6
+      memory: 68719476736
+      name: Standard_D32ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ls_v6
+      id: Standard_D48ls_v6
+      memory: 103079215104
+      name: Standard_D48ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ls_v6
+      id: Standard_D64ls_v6
+      memory: 137438953472
+      name: Standard_D64ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96ls_v6
+      id: Standard_D96ls_v6
+      memory: 206158430208
+      name: Standard_D96ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_d128ls_v6
+      id: Standard_D128ls_v6
+      memory: 274877906944
+      name: Standard_D128ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2lds_v6
+      id: Standard_D2lds_v6
+      memory: 4294967296
+      name: Standard_D2lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4lds_v6
+      id: Standard_D4lds_v6
+      memory: 8589934592
+      name: Standard_D4lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8lds_v6
+      id: Standard_D8lds_v6
+      memory: 17179869184
+      name: Standard_D8lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16lds_v6
+      id: Standard_D16lds_v6
+      memory: 34359738368
+      name: Standard_D16lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32lds_v6
+      id: Standard_D32lds_v6
+      memory: 68719476736
+      name: Standard_D32lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48lds_v6
+      id: Standard_D48lds_v6
+      memory: 103079215104
+      name: Standard_D48lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64lds_v6
+      id: Standard_D64lds_v6
+      memory: 137438953472
+      name: Standard_D64lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96lds_v6
+      id: Standard_D96lds_v6
+      memory: 206158430208
+      name: Standard_D96lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_d128lds_v6
+      id: Standard_D128lds_v6
+      memory: 274877906944
+      name: Standard_D128lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2s_v6
+      id: Standard_D2s_v6
+      memory: 8589934592
+      name: Standard_D2s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4s_v6
+      id: Standard_D4s_v6
+      memory: 17179869184
+      name: Standard_D4s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8s_v6
+      id: Standard_D8s_v6
+      memory: 34359738368
+      name: Standard_D8s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16s_v6
+      id: Standard_D16s_v6
+      memory: 68719476736
+      name: Standard_D16s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32s_v6
+      id: Standard_D32s_v6
+      memory: 137438953472
+      name: Standard_D32s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48s_v6
+      id: Standard_D48s_v6
+      memory: 206158430208
+      name: Standard_D48s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64s_v6
+      id: Standard_D64s_v6
+      memory: 274877906944
+      name: Standard_D64s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96s_v6
+      id: Standard_D96s_v6
+      memory: 412316860416
+      name: Standard_D96s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_d128s_v6
+      id: Standard_D128s_v6
+      memory: 549755813888
+      name: Standard_D128s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 192
+      generic_name: standard_d192s_v6
+      id: Standard_D192s_v6
+      memory: 824633720832
+      name: Standard_D192s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ds_v6
+      id: Standard_D2ds_v6
+      memory: 8589934592
+      name: Standard_D2ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ds_v6
+      id: Standard_D4ds_v6
+      memory: 17179869184
+      name: Standard_D4ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ds_v6
+      id: Standard_D8ds_v6
+      memory: 34359738368
+      name: Standard_D8ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ds_v6
+      id: Standard_D16ds_v6
+      memory: 68719476736
+      name: Standard_D16ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ds_v6
+      id: Standard_D32ds_v6
+      memory: 137438953472
+      name: Standard_D32ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ds_v6
+      id: Standard_D48ds_v6
+      memory: 206158430208
+      name: Standard_D48ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ds_v6
+      id: Standard_D64ds_v6
+      memory: 274877906944
+      name: Standard_D64ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96ds_v6
+      id: Standard_D96ds_v6
+      memory: 412316860416
+      name: Standard_D96ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_d128ds_v6
+      id: Standard_D128ds_v6
+      memory: 549755813888
+      name: Standard_D128ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 192
+      generic_name: standard_d192ds_v6
+      id: Standard_D192ds_v6
+      memory: 824633720832
+      name: Standard_D192ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2s_v6
+      id: Standard_E2s_v6
+      memory: 17179869184
+      name: Standard_E2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2s_v6
+      id: Standard_E4-2s_v6
+      memory: 34359738368
+      name: Standard_E4-2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4s_v6
+      id: Standard_E4s_v6
+      memory: 34359738368
+      name: Standard_E4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2s_v6
+      id: Standard_E8-2s_v6
+      memory: 68719476736
+      name: Standard_E8-2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4s_v6
+      id: Standard_E8-4s_v6
+      memory: 68719476736
+      name: Standard_E8-4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8s_v6
+      id: Standard_E8s_v6
+      memory: 68719476736
+      name: Standard_E8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4s_v6
+      id: Standard_E16-4s_v6
+      memory: 137438953472
+      name: Standard_E16-4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8s_v6
+      id: Standard_E16-8s_v6
+      memory: 137438953472
+      name: Standard_E16-8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16s_v6
+      id: Standard_E16s_v6
+      memory: 137438953472
+      name: Standard_E16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20s_v6
+      id: Standard_E20s_v6
+      memory: 171798691840
+      name: Standard_E20s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8s_v6
+      id: Standard_E32-8s_v6
+      memory: 274877906944
+      name: Standard_E32-8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16s_v6
+      id: Standard_E32-16s_v6
+      memory: 274877906944
+      name: Standard_E32-16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32s_v6
+      id: Standard_E32s_v6
+      memory: 274877906944
+      name: Standard_E32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48s_v6
+      id: Standard_E48s_v6
+      memory: 412316860416
+      name: Standard_E48s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16s_v6
+      id: Standard_E64-16s_v6
+      memory: 549755813888
+      name: Standard_E64-16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32s_v6
+      id: Standard_E64-32s_v6
+      memory: 549755813888
+      name: Standard_E64-32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64s_v6
+      id: Standard_E64s_v6
+      memory: 549755813888
+      name: Standard_E64s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24s_v6
+      id: Standard_E96-24s_v6
+      memory: 824633720832
+      name: Standard_E96-24s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48s_v6
+      id: Standard_E96-48s_v6
+      memory: 824633720832
+      name: Standard_E96-48s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96s_v6
+      id: Standard_E96s_v6
+      memory: 824633720832
+      name: Standard_E96s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2ds_v6
+      id: Standard_E2ds_v6
+      memory: 17179869184
+      name: Standard_E2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2ds_v6
+      id: Standard_E4-2ds_v6
+      memory: 34359738368
+      name: Standard_E4-2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4ds_v6
+      id: Standard_E4ds_v6
+      memory: 34359738368
+      name: Standard_E4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2ds_v6
+      id: Standard_E8-2ds_v6
+      memory: 68719476736
+      name: Standard_E8-2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4ds_v6
+      id: Standard_E8-4ds_v6
+      memory: 68719476736
+      name: Standard_E8-4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8ds_v6
+      id: Standard_E8ds_v6
+      memory: 68719476736
+      name: Standard_E8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4ds_v6
+      id: Standard_E16-4ds_v6
+      memory: 137438953472
+      name: Standard_E16-4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8ds_v6
+      id: Standard_E16-8ds_v6
+      memory: 137438953472
+      name: Standard_E16-8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16ds_v6
+      id: Standard_E16ds_v6
+      memory: 137438953472
+      name: Standard_E16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20ds_v6
+      id: Standard_E20ds_v6
+      memory: 171798691840
+      name: Standard_E20ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8ds_v6
+      id: Standard_E32-8ds_v6
+      memory: 274877906944
+      name: Standard_E32-8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16ds_v6
+      id: Standard_E32-16ds_v6
+      memory: 274877906944
+      name: Standard_E32-16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32ds_v6
+      id: Standard_E32ds_v6
+      memory: 274877906944
+      name: Standard_E32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48ds_v6
+      id: Standard_E48ds_v6
+      memory: 412316860416
+      name: Standard_E48ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16ds_v6
+      id: Standard_E64-16ds_v6
+      memory: 549755813888
+      name: Standard_E64-16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32ds_v6
+      id: Standard_E64-32ds_v6
+      memory: 549755813888
+      name: Standard_E64-32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64ds_v6
+      id: Standard_E64ds_v6
+      memory: 549755813888
+      name: Standard_E64ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24ds_v6
+      id: Standard_E96-24ds_v6
+      memory: 824633720832
+      name: Standard_E96-24ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48ds_v6
+      id: Standard_E96-48ds_v6
+      memory: 824633720832
+      name: Standard_E96-48ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96ds_v6
+      id: Standard_E96ds_v6
+      memory: 824633720832
+      name: Standard_E96ds_v6
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_l8as_v3
+      id: Standard_L8as_v3
+      memory: 68719476736
+      name: Standard_L8as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_l16as_v3
+      id: Standard_L16as_v3
+      memory: 137438953472
+      name: Standard_L16as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_l32as_v3
+      id: Standard_L32as_v3
+      memory: 274877906944
+      name: Standard_L32as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_l48as_v3
+      id: Standard_L48as_v3
+      memory: 412316860416
+      name: Standard_L48as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_l64as_v3
+      id: Standard_L64as_v3
+      memory: 549755813888
+      name: Standard_L64as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_l80as_v3
+      id: Standard_L80as_v3
+      memory: 687194767360
+      name: Standard_L80as_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2a_v4
+      id: Standard_D2a_v4
+      memory: 8589934592
+      name: Standard_D2a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4a_v4
+      id: Standard_D4a_v4
+      memory: 17179869184
+      name: Standard_D4a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8a_v4
+      id: Standard_D8a_v4
+      memory: 34359738368
+      name: Standard_D8a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16a_v4
+      id: Standard_D16a_v4
+      memory: 68719476736
+      name: Standard_D16a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32a_v4
+      id: Standard_D32a_v4
+      memory: 137438953472
+      name: Standard_D32a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48a_v4
+      id: Standard_D48a_v4
+      memory: 206158430208
+      name: Standard_D48a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64a_v4
+      id: Standard_D64a_v4
+      memory: 274877906944
+      name: Standard_D64a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96a_v4
+      id: Standard_D96a_v4
+      memory: 412316860416
+      name: Standard_D96a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2as_v4
+      id: Standard_D2as_v4
+      memory: 8589934592
+      name: Standard_D2as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4as_v4
+      id: Standard_D4as_v4
+      memory: 17179869184
+      name: Standard_D4as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8as_v4
+      id: Standard_D8as_v4
+      memory: 34359738368
+      name: Standard_D8as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16as_v4
+      id: Standard_D16as_v4
+      memory: 68719476736
+      name: Standard_D16as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32as_v4
+      id: Standard_D32as_v4
+      memory: 137438953472
+      name: Standard_D32as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48as_v4
+      id: Standard_D48as_v4
+      memory: 206158430208
+      name: Standard_D48as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64as_v4
+      id: Standard_D64as_v4
+      memory: 274877906944
+      name: Standard_D64as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96as_v4
+      id: Standard_D96as_v4
+      memory: 412316860416
+      name: Standard_D96as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2a_v4
+      id: Standard_E2a_v4
+      memory: 17179869184
+      name: Standard_E2a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4a_v4
+      id: Standard_E4a_v4
+      memory: 34359738368
+      name: Standard_E4a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8a_v4
+      id: Standard_E8a_v4
+      memory: 68719476736
+      name: Standard_E8a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16a_v4
+      id: Standard_E16a_v4
+      memory: 137438953472
+      name: Standard_E16a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20a_v4
+      id: Standard_E20a_v4
+      memory: 171798691840
+      name: Standard_E20a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32a_v4
+      id: Standard_E32a_v4
+      memory: 274877906944
+      name: Standard_E32a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48a_v4
+      id: Standard_E48a_v4
+      memory: 412316860416
+      name: Standard_E48a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64a_v4
+      id: Standard_E64a_v4
+      memory: 549755813888
+      name: Standard_E64a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96a_v4
+      id: Standard_E96a_v4
+      memory: 721554505728
+      name: Standard_E96a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2as_v4
+      id: Standard_E2as_v4
+      memory: 17179869184
+      name: Standard_E2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2as_v4
+      id: Standard_E4-2as_v4
+      memory: 34359738368
+      name: Standard_E4-2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4as_v4
+      id: Standard_E4as_v4
+      memory: 34359738368
+      name: Standard_E4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2as_v4
+      id: Standard_E8-2as_v4
+      memory: 68719476736
+      name: Standard_E8-2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4as_v4
+      id: Standard_E8-4as_v4
+      memory: 68719476736
+      name: Standard_E8-4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8as_v4
+      id: Standard_E8as_v4
+      memory: 68719476736
+      name: Standard_E8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4as_v4
+      id: Standard_E16-4as_v4
+      memory: 137438953472
+      name: Standard_E16-4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8as_v4
+      id: Standard_E16-8as_v4
+      memory: 137438953472
+      name: Standard_E16-8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16as_v4
+      id: Standard_E16as_v4
+      memory: 137438953472
+      name: Standard_E16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20as_v4
+      id: Standard_E20as_v4
+      memory: 171798691840
+      name: Standard_E20as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8as_v4
+      id: Standard_E32-8as_v4
+      memory: 274877906944
+      name: Standard_E32-8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16as_v4
+      id: Standard_E32-16as_v4
+      memory: 274877906944
+      name: Standard_E32-16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32as_v4
+      id: Standard_E32as_v4
+      memory: 274877906944
+      name: Standard_E32as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48as_v4
+      id: Standard_E48as_v4
+      memory: 412316860416
+      name: Standard_E48as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16as_v4
+      id: Standard_E64-16as_v4
+      memory: 549755813888
+      name: Standard_E64-16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32as_v4
+      id: Standard_E64-32as_v4
+      memory: 549755813888
+      name: Standard_E64-32as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64as_v4
+      id: Standard_E64as_v4
+      memory: 549755813888
+      name: Standard_E64as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24as_v4
+      id: Standard_E96-24as_v4
+      memory: 721554505728
+      name: Standard_E96-24as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48as_v4
+      id: Standard_E96-48as_v4
+      memory: 721554505728
+      name: Standard_E96-48as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96as_v4
+      id: Standard_E96as_v4
+      memory: 721554505728
+      name: Standard_E96as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_l8s_v3
+      id: Standard_L8s_v3
+      memory: 68719476736
+      name: Standard_L8s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_l16s_v3
+      id: Standard_L16s_v3
+      memory: 137438953472
+      name: Standard_L16s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_l32s_v3
+      id: Standard_L32s_v3
+      memory: 274877906944
+      name: Standard_L32s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_l48s_v3
+      id: Standard_L48s_v3
+      memory: 412316860416
+      name: Standard_L48s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_l64s_v3
+      id: Standard_L64s_v3
+      memory: 549755813888
+      name: Standard_L64s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_l80s_v3
+      id: Standard_L80s_v3
+      memory: 687194767360
+      name: Standard_L80s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_l2aos_v4
+      id: Standard_L2aos_v4
+      memory: 17179869184
+      name: Standard_L2aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_l4aos_v4
+      id: Standard_L4aos_v4
+      memory: 34359738368
+      name: Standard_L4aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_l8aos_v4
+      id: Standard_L8aos_v4
+      memory: 68719476736
+      name: Standard_L8aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      generic_name: standard_l12aos_v4
+      id: Standard_L12aos_v4
+      memory: 103079215104
+      name: Standard_L12aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_l16aos_v4
+      id: Standard_L16aos_v4
+      memory: 137438953472
+      name: Standard_L16aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_l24aos_v4
+      id: Standard_L24aos_v4
+      memory: 206158430208
+      name: Standard_L24aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_l32aos_v4
+      id: Standard_L32aos_v4
+      memory: 274877906944
+      name: Standard_L32aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_l2as_v4
+      id: Standard_L2as_v4
+      memory: 17179869184
+      name: Standard_L2as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_l4as_v4
+      id: Standard_L4as_v4
+      memory: 34359738368
+      name: Standard_L4as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_l8as_v4
+      id: Standard_L8as_v4
+      memory: 68719476736
+      name: Standard_L8as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_l16as_v4
+      id: Standard_L16as_v4
+      memory: 137438953472
+      name: Standard_L16as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_l32as_v4
+      id: Standard_L32as_v4
+      memory: 274877906944
+      name: Standard_L32as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_l48as_v4
+      id: Standard_L48as_v4
+      memory: 412316860416
+      name: Standard_L48as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_l64as_v4
+      id: Standard_L64as_v4
+      memory: 549755813888
+      name: Standard_L64as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_l80as_v4
+      id: Standard_L80as_v4
+      memory: 687194767360
+      name: Standard_L80as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_l96as_v4
+      id: Standard_L96as_v4
+      memory: 824633720832
+      name: Standard_L96as_v4
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2plds_v5
+      id: Standard_D2plds_v5
+      memory: 4294967296
+      name: Standard_D2plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4plds_v5
+      id: Standard_D4plds_v5
+      memory: 8589934592
+      name: Standard_D4plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8plds_v5
+      id: Standard_D8plds_v5
+      memory: 17179869184
+      name: Standard_D8plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16plds_v5
+      id: Standard_D16plds_v5
+      memory: 34359738368
+      name: Standard_D16plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32plds_v5
+      id: Standard_D32plds_v5
+      memory: 68719476736
+      name: Standard_D32plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48plds_v5
+      id: Standard_D48plds_v5
+      memory: 103079215104
+      name: Standard_D48plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64plds_v5
+      id: Standard_D64plds_v5
+      memory: 137438953472
+      name: Standard_D64plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2pls_v5
+      id: Standard_D2pls_v5
+      memory: 4294967296
+      name: Standard_D2pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4pls_v5
+      id: Standard_D4pls_v5
+      memory: 8589934592
+      name: Standard_D4pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8pls_v5
+      id: Standard_D8pls_v5
+      memory: 17179869184
+      name: Standard_D8pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16pls_v5
+      id: Standard_D16pls_v5
+      memory: 34359738368
+      name: Standard_D16pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32pls_v5
+      id: Standard_D32pls_v5
+      memory: 68719476736
+      name: Standard_D32pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48pls_v5
+      id: Standard_D48pls_v5
+      memory: 103079215104
+      name: Standard_D48pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64pls_v5
+      id: Standard_D64pls_v5
+      memory: 137438953472
+      name: Standard_D64pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2pds_v5
+      id: Standard_D2pds_v5
+      memory: 8589934592
+      name: Standard_D2pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4pds_v5
+      id: Standard_D4pds_v5
+      memory: 17179869184
+      name: Standard_D4pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8pds_v5
+      id: Standard_D8pds_v5
+      memory: 34359738368
+      name: Standard_D8pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16pds_v5
+      id: Standard_D16pds_v5
+      memory: 68719476736
+      name: Standard_D16pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32pds_v5
+      id: Standard_D32pds_v5
+      memory: 137438953472
+      name: Standard_D32pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48pds_v5
+      id: Standard_D48pds_v5
+      memory: 206158430208
+      name: Standard_D48pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64pds_v5
+      id: Standard_D64pds_v5
+      memory: 223338299392
+      name: Standard_D64pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ps_v5
+      id: Standard_D2ps_v5
+      memory: 8589934592
+      name: Standard_D2ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ps_v5
+      id: Standard_D4ps_v5
+      memory: 17179869184
+      name: Standard_D4ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ps_v5
+      id: Standard_D8ps_v5
+      memory: 34359738368
+      name: Standard_D8ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ps_v5
+      id: Standard_D16ps_v5
+      memory: 68719476736
+      name: Standard_D16ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ps_v5
+      id: Standard_D32ps_v5
+      memory: 137438953472
+      name: Standard_D32ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ps_v5
+      id: Standard_D48ps_v5
+      memory: 206158430208
+      name: Standard_D48ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ps_v5
+      id: Standard_D64ps_v5
+      memory: 223338299392
+      name: Standard_D64ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2pds_v5
+      id: Standard_E2pds_v5
+      memory: 17179869184
+      name: Standard_E2pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4pds_v5
+      id: Standard_E4pds_v5
+      memory: 34359738368
+      name: Standard_E4pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8pds_v5
+      id: Standard_E8pds_v5
+      memory: 68719476736
+      name: Standard_E8pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16pds_v5
+      id: Standard_E16pds_v5
+      memory: 137438953472
+      name: Standard_E16pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20pds_v5
+      id: Standard_E20pds_v5
+      memory: 171798691840
+      name: Standard_E20pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32pds_v5
+      id: Standard_E32pds_v5
+      memory: 223338299392
+      name: Standard_E32pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2ps_v5
+      id: Standard_E2ps_v5
+      memory: 17179869184
+      name: Standard_E2ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4ps_v5
+      id: Standard_E4ps_v5
+      memory: 34359738368
+      name: Standard_E4ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8ps_v5
+      id: Standard_E8ps_v5
+      memory: 68719476736
+      name: Standard_E8ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16ps_v5
+      id: Standard_E16ps_v5
+      memory: 137438953472
+      name: Standard_E16ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20ps_v5
+      id: Standard_E20ps_v5
+      memory: 171798691840
+      name: Standard_E20ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32ps_v5
+      id: Standard_E32ps_v5
+      memory: 223338299392
+      name: Standard_E32ps_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128-32s_v6
+      id: Standard_E128-32s_v6
+      memory: 1099511627776
+      name: Standard_E128-32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128-64s_v6
+      id: Standard_E128-64s_v6
+      memory: 1099511627776
+      name: Standard_E128-64s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128s_v6
+      id: Standard_E128s_v6
+      memory: 1099511627776
+      name: Standard_E128s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 192
+      generic_name: standard_e192is_v6
+      id: Standard_E192is_v6
+      memory: 1967095021568
+      name: Standard_E192is_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128-32ds_v6
+      id: Standard_E128-32ds_v6
+      memory: 1099511627776
+      name: Standard_E128-32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128-64ds_v6
+      id: Standard_E128-64ds_v6
+      memory: 1099511627776
+      name: Standard_E128-64ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128ds_v6
+      id: Standard_E128ds_v6
+      memory: 1099511627776
+      name: Standard_E128ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 192
+      generic_name: standard_e192ids_v6
+      id: Standard_E192ids_v6
+      memory: 1967095021568
+      name: Standard_E192ids_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_fx2ms_v2
+      id: Standard_FX2ms_v2
+      memory: 45097156608
+      name: Standard_FX2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_fx4-2ms_v2
+      id: Standard_FX4-2ms_v2
+      memory: 90194313216
+      name: Standard_FX4-2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_fx4ms_v2
+      id: Standard_FX4ms_v2
+      memory: 90194313216
+      name: Standard_FX4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_fx8-2ms_v2
+      id: Standard_FX8-2ms_v2
+      memory: 180388626432
+      name: Standard_FX8-2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_fx8-4ms_v2
+      id: Standard_FX8-4ms_v2
+      memory: 180388626432
+      name: Standard_FX8-4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_fx8ms_v2
+      id: Standard_FX8ms_v2
+      memory: 180388626432
+      name: Standard_FX8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      generic_name: standard_fx12-6ms_v2
+      id: Standard_FX12-6ms_v2
+      memory: 270582939648
+      name: Standard_FX12-6ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      generic_name: standard_fx12ms_v2
+      id: Standard_FX12ms_v2
+      memory: 270582939648
+      name: Standard_FX12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_fx16-4ms_v2
+      id: Standard_FX16-4ms_v2
+      memory: 360777252864
+      name: Standard_FX16-4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_fx16-8ms_v2
+      id: Standard_FX16-8ms_v2
+      memory: 360777252864
+      name: Standard_FX16-8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_fx16ms_v2
+      id: Standard_FX16ms_v2
+      memory: 360777252864
+      name: Standard_FX16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_fx24-6ms_v2
+      id: Standard_FX24-6ms_v2
+      memory: 541165879296
+      name: Standard_FX24-6ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_fx24-12ms_v2
+      id: Standard_FX24-12ms_v2
+      memory: 541165879296
+      name: Standard_FX24-12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_fx24ms_v2
+      id: Standard_FX24ms_v2
+      memory: 541165879296
+      name: Standard_FX24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_fx32-8ms_v2
+      id: Standard_FX32-8ms_v2
+      memory: 721554505728
+      name: Standard_FX32-8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_fx32-16ms_v2
+      id: Standard_FX32-16ms_v2
+      memory: 721554505728
+      name: Standard_FX32-16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_fx32ms_v2
+      id: Standard_FX32ms_v2
+      memory: 721554505728
+      name: Standard_FX32ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_fx48-12ms_v2
+      id: Standard_FX48-12ms_v2
+      memory: 1082331758592
+      name: Standard_FX48-12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_fx48-24ms_v2
+      id: Standard_FX48-24ms_v2
+      memory: 1082331758592
+      name: Standard_FX48-24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_fx48ms_v2
+      id: Standard_FX48ms_v2
+      memory: 1082331758592
+      name: Standard_FX48ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_fx64-16ms_v2
+      id: Standard_FX64-16ms_v2
+      memory: 1443109011456
+      name: Standard_FX64-16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_fx64-32ms_v2
+      id: Standard_FX64-32ms_v2
+      memory: 1443109011456
+      name: Standard_FX64-32ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_fx64ms_v2
+      id: Standard_FX64ms_v2
+      memory: 1443109011456
+      name: Standard_FX64ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_fx96-24ms_v2
+      id: Standard_FX96-24ms_v2
+      memory: 1967095021568
+      name: Standard_FX96-24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_fx96-48ms_v2
+      id: Standard_FX96-48ms_v2
+      memory: 1967095021568
+      name: Standard_FX96-48ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_fx96ms_v2
+      id: Standard_FX96ms_v2
+      memory: 1967095021568
+      name: Standard_FX96ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_fx2mds_v2
+      id: Standard_FX2mds_v2
+      memory: 45097156608
+      name: Standard_FX2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_fx4-2mds_v2
+      id: Standard_FX4-2mds_v2
+      memory: 90194313216
+      name: Standard_FX4-2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_fx4mds_v2
+      id: Standard_FX4mds_v2
+      memory: 90194313216
+      name: Standard_FX4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_fx8-2mds_v2
+      id: Standard_FX8-2mds_v2
+      memory: 180388626432
+      name: Standard_FX8-2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_fx8-4mds_v2
+      id: Standard_FX8-4mds_v2
+      memory: 180388626432
+      name: Standard_FX8-4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_fx8mds_v2
+      id: Standard_FX8mds_v2
+      memory: 180388626432
+      name: Standard_FX8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      generic_name: standard_fx12-6mds_v2
+      id: Standard_FX12-6mds_v2
+      memory: 270582939648
+      name: Standard_FX12-6mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      generic_name: standard_fx12mds_v2
+      id: Standard_FX12mds_v2
+      memory: 270582939648
+      name: Standard_FX12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_fx16-4mds_v2
+      id: Standard_FX16-4mds_v2
+      memory: 360777252864
+      name: Standard_FX16-4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_fx16-8mds_v2
+      id: Standard_FX16-8mds_v2
+      memory: 360777252864
+      name: Standard_FX16-8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_fx16mds_v2
+      id: Standard_FX16mds_v2
+      memory: 360777252864
+      name: Standard_FX16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_fx24-6mds_v2
+      id: Standard_FX24-6mds_v2
+      memory: 541165879296
+      name: Standard_FX24-6mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_fx24-12mds_v2
+      id: Standard_FX24-12mds_v2
+      memory: 541165879296
+      name: Standard_FX24-12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_fx24mds_v2
+      id: Standard_FX24mds_v2
+      memory: 541165879296
+      name: Standard_FX24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_fx32-8mds_v2
+      id: Standard_FX32-8mds_v2
+      memory: 721554505728
+      name: Standard_FX32-8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_fx32-16mds_v2
+      id: Standard_FX32-16mds_v2
+      memory: 721554505728
+      name: Standard_FX32-16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_fx32mds_v2
+      id: Standard_FX32mds_v2
+      memory: 721554505728
+      name: Standard_FX32mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_fx48-12mds_v2
+      id: Standard_FX48-12mds_v2
+      memory: 1082331758592
+      name: Standard_FX48-12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_fx48-24mds_v2
+      id: Standard_FX48-24mds_v2
+      memory: 1082331758592
+      name: Standard_FX48-24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_fx48mds_v2
+      id: Standard_FX48mds_v2
+      memory: 1082331758592
+      name: Standard_FX48mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_fx64-16mds_v2
+      id: Standard_FX64-16mds_v2
+      memory: 1443109011456
+      name: Standard_FX64-16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_fx64-32mds_v2
+      id: Standard_FX64-32mds_v2
+      memory: 1443109011456
+      name: Standard_FX64-32mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_fx64mds_v2
+      id: Standard_FX64mds_v2
+      memory: 1443109011456
+      name: Standard_FX64mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_fx96-24mds_v2
+      id: Standard_FX96-24mds_v2
+      memory: 1967095021568
+      name: Standard_FX96-24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_fx96-48mds_v2
+      id: Standard_FX96-48mds_v2
+      memory: 1967095021568
+      name: Standard_FX96-48mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_fx96mds_v2
+      id: Standard_FX96mds_v2
+      memory: 1967095021568
+      name: Standard_FX96mds_v2
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_l2s_v4
+      id: Standard_L2s_v4
+      memory: 17179869184
+      name: Standard_L2s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_l4s_v4
+      id: Standard_L4s_v4
+      memory: 34359738368
+      name: Standard_L4s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_l8s_v4
+      id: Standard_L8s_v4
+      memory: 68719476736
+      name: Standard_L8s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_l16s_v4
+      id: Standard_L16s_v4
+      memory: 137438953472
+      name: Standard_L16s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_l32s_v4
+      id: Standard_L32s_v4
+      memory: 274877906944
+      name: Standard_L32s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_l48s_v4
+      id: Standard_L48s_v4
+      memory: 412316860416
+      name: Standard_L48s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_l64s_v4
+      id: Standard_L64s_v4
+      memory: 549755813888
+      name: Standard_L64s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_l80s_v4
+      id: Standard_L80s_v4
+      memory: 687194767360
+      name: Standard_L80s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_l96s_v4
+      id: Standard_L96s_v4
+      memory: 824633720832
+      name: Standard_L96s_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 6
+      generic_name: standard_nv6ads_a10_v5
+      id: Standard_NV6ads_A10_v5
+      memory: 59055800320
+      name: Standard_NV6ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 12
+      generic_name: standard_nv12ads_a10_v5
+      id: Standard_NV12ads_A10_v5
+      memory: 118111600640
+      name: Standard_NV12ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 18
+      generic_name: standard_nv18ads_a10_v5
+      id: Standard_NV18ads_A10_v5
+      memory: 236223201280
+      name: Standard_NV18ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 36
+      generic_name: standard_nv36adms_a10_v5
+      id: Standard_NV36adms_A10_v5
+      memory: 944892805120
+      name: Standard_NV36adms_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 36
+      generic_name: standard_nv36ads_a10_v5
+      id: Standard_NV36ads_A10_v5
+      memory: 472446402560
+      name: Standard_NV36ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 72
+      generic_name: standard_nv72ads_a10_v5
+      id: Standard_NV72ads_A10_v5
+      memory: 944892805120
+      name: Standard_NV72ads_A10_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      generic_name: standard_e112ias_v5
+      id: Standard_E112ias_v5
+      memory: 721554505728
+      name: Standard_E112ias_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      generic_name: standard_e112iads_v5
+      id: Standard_E112iads_v5
+      memory: 721554505728
+      name: Standard_E112iads_v5
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_fx4mds
+      id: Standard_FX4mds
+      memory: 90194313216
+      name: Standard_FX4mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      generic_name: standard_fx12mds
+      id: Standard_FX12mds
+      memory: 270582939648
+      name: Standard_FX12mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_fx24mds
+      id: Standard_FX24mds
+      memory: 541165879296
+      name: Standard_FX24mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 36
+      generic_name: standard_fx36mds
+      id: Standard_FX36mds
+      memory: 811748818944
+      name: Standard_FX36mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_fx48mds
+      id: Standard_FX48mds
+      memory: 1082331758592
+      name: Standard_FX48mds
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2pls_v6
+      id: Standard_D2pls_v6
+      memory: 4294967296
+      name: Standard_D2pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4pls_v6
+      id: Standard_D4pls_v6
+      memory: 8589934592
+      name: Standard_D4pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8pls_v6
+      id: Standard_D8pls_v6
+      memory: 17179869184
+      name: Standard_D8pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16pls_v6
+      id: Standard_D16pls_v6
+      memory: 34359738368
+      name: Standard_D16pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32pls_v6
+      id: Standard_D32pls_v6
+      memory: 68719476736
+      name: Standard_D32pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48pls_v6
+      id: Standard_D48pls_v6
+      memory: 103079215104
+      name: Standard_D48pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64pls_v6
+      id: Standard_D64pls_v6
+      memory: 137438953472
+      name: Standard_D64pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96pls_v6
+      id: Standard_D96pls_v6
+      memory: 206158430208
+      name: Standard_D96pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2pds_v6
+      id: Standard_D2pds_v6
+      memory: 8589934592
+      name: Standard_D2pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4pds_v6
+      id: Standard_D4pds_v6
+      memory: 17179869184
+      name: Standard_D4pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8pds_v6
+      id: Standard_D8pds_v6
+      memory: 34359738368
+      name: Standard_D8pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16pds_v6
+      id: Standard_D16pds_v6
+      memory: 68719476736
+      name: Standard_D16pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32pds_v6
+      id: Standard_D32pds_v6
+      memory: 137438953472
+      name: Standard_D32pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48pds_v6
+      id: Standard_D48pds_v6
+      memory: 206158430208
+      name: Standard_D48pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64pds_v6
+      id: Standard_D64pds_v6
+      memory: 274877906944
+      name: Standard_D64pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96pds_v6
+      id: Standard_D96pds_v6
+      memory: 412316860416
+      name: Standard_D96pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2plds_v6
+      id: Standard_D2plds_v6
+      memory: 4294967296
+      name: Standard_D2plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4plds_v6
+      id: Standard_D4plds_v6
+      memory: 8589934592
+      name: Standard_D4plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8plds_v6
+      id: Standard_D8plds_v6
+      memory: 17179869184
+      name: Standard_D8plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16plds_v6
+      id: Standard_D16plds_v6
+      memory: 34359738368
+      name: Standard_D16plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32plds_v6
+      id: Standard_D32plds_v6
+      memory: 68719476736
+      name: Standard_D32plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48plds_v6
+      id: Standard_D48plds_v6
+      memory: 103079215104
+      name: Standard_D48plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64plds_v6
+      id: Standard_D64plds_v6
+      memory: 137438953472
+      name: Standard_D64plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96plds_v6
+      id: Standard_D96plds_v6
+      memory: 206158430208
+      name: Standard_D96plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ps_v6
+      id: Standard_D2ps_v6
+      memory: 8589934592
+      name: Standard_D2ps_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ps_v6
+      id: Standard_D4ps_v6
+      memory: 17179869184
+      name: Standard_D4ps_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ps_v6
+      id: Standard_D8ps_v6
+      memory: 34359738368
+      name: Standard_D8ps_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ps_v6
+      id: Standard_D16ps_v6
+      memory: 68719476736
+      name: Standard_D16ps_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ps_v6
+      id: Standard_D32ps_v6
+      memory: 137438953472
+      name: Standard_D32ps_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ps_v6
+      id: Standard_D48ps_v6
+      memory: 206158430208
+      name: Standard_D48ps_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ps_v6
+      id: Standard_D64ps_v6
+      memory: 274877906944
+      name: Standard_D64ps_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96ps_v6
+      id: Standard_D96ps_v6
+      memory: 412316860416
+      name: Standard_D96ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2ps_v6
+      id: Standard_E2ps_v6
+      memory: 17179869184
+      name: Standard_E2ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4ps_v6
+      id: Standard_E4ps_v6
+      memory: 34359738368
+      name: Standard_E4ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8ps_v6
+      id: Standard_E8ps_v6
+      memory: 68719476736
+      name: Standard_E8ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16ps_v6
+      id: Standard_E16ps_v6
+      memory: 137438953472
+      name: Standard_E16ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32ps_v6
+      id: Standard_E32ps_v6
+      memory: 274877906944
+      name: Standard_E32ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48ps_v6
+      id: Standard_E48ps_v6
+      memory: 412316860416
+      name: Standard_E48ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64ps_v6
+      id: Standard_E64ps_v6
+      memory: 549755813888
+      name: Standard_E64ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96ps_v6
+      id: Standard_E96ps_v6
+      memory: 721554505728
+      name: Standard_E96ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2pds_v6
+      id: Standard_E2pds_v6
+      memory: 17179869184
+      name: Standard_E2pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4pds_v6
+      id: Standard_E4pds_v6
+      memory: 34359738368
+      name: Standard_E4pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8pds_v6
+      id: Standard_E8pds_v6
+      memory: 68719476736
+      name: Standard_E8pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16pds_v6
+      id: Standard_E16pds_v6
+      memory: 137438953472
+      name: Standard_E16pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32pds_v6
+      id: Standard_E32pds_v6
+      memory: 274877906944
+      name: Standard_E32pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48pds_v6
+      id: Standard_E48pds_v6
+      memory: 412316860416
+      name: Standard_E48pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64pds_v6
+      id: Standard_E64pds_v6
+      memory: 549755813888
+      name: Standard_E64pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96pds_v6
+      id: Standard_E96pds_v6
+      memory: 721554505728
+      name: Standard_E96pds_v6
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_nc24ads_a100_v4
+      id: Standard_NC24ads_A100_v4
+      memory: 236223201280
+      name: Standard_NC24ads_A100_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_nc48ads_a100_v4
+      id: Standard_NC48ads_A100_v4
+      memory: 472446402560
+      name: Standard_NC48ads_A100_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_nc96ads_a100_v4
+      id: Standard_NC96ads_A100_v4
+      memory: 944892805120
+      name: Standard_NC96ads_A100_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_dc2as_v6
+      id: Standard_DC2as_v6
+      memory: 8589934592
+      name: Standard_DC2as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_dc4as_v6
+      id: Standard_DC4as_v6
+      memory: 17179869184
+      name: Standard_DC4as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_dc8as_v6
+      id: Standard_DC8as_v6
+      memory: 34359738368
+      name: Standard_DC8as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_dc16as_v6
+      id: Standard_DC16as_v6
+      memory: 68719476736
+      name: Standard_DC16as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_dc32as_v6
+      id: Standard_DC32as_v6
+      memory: 137438953472
+      name: Standard_DC32as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_dc48as_v6
+      id: Standard_DC48as_v6
+      memory: 206158430208
+      name: Standard_DC48as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_dc64as_v6
+      id: Standard_DC64as_v6
+      memory: 274877906944
+      name: Standard_DC64as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_dc96as_v6
+      id: Standard_DC96as_v6
+      memory: 412316860416
+      name: Standard_DC96as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_dc2ads_v6
+      id: Standard_DC2ads_v6
+      memory: 8589934592
+      name: Standard_DC2ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_dc4ads_v6
+      id: Standard_DC4ads_v6
+      memory: 17179869184
+      name: Standard_DC4ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_dc8ads_v6
+      id: Standard_DC8ads_v6
+      memory: 34359738368
+      name: Standard_DC8ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_dc16ads_v6
+      id: Standard_DC16ads_v6
+      memory: 68719476736
+      name: Standard_DC16ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_dc32ads_v6
+      id: Standard_DC32ads_v6
+      memory: 137438953472
+      name: Standard_DC32ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_dc48ads_v6
+      id: Standard_DC48ads_v6
+      memory: 206158430208
+      name: Standard_DC48ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_dc64ads_v6
+      id: Standard_DC64ads_v6
+      memory: 274877906944
+      name: Standard_DC64ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_dc96ads_v6
+      id: Standard_DC96ads_v6
+      memory: 412316860416
+      name: Standard_DC96ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_ec2as_v6
+      id: Standard_EC2as_v6
+      memory: 17179869184
+      name: Standard_EC2as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_ec4as_v6
+      id: Standard_EC4as_v6
+      memory: 34359738368
+      name: Standard_EC4as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_ec8as_v6
+      id: Standard_EC8as_v6
+      memory: 68719476736
+      name: Standard_EC8as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_ec16as_v6
+      id: Standard_EC16as_v6
+      memory: 137438953472
+      name: Standard_EC16as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_ec32as_v6
+      id: Standard_EC32as_v6
+      memory: 274877906944
+      name: Standard_EC32as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_ec48as_v6
+      id: Standard_EC48as_v6
+      memory: 412316860416
+      name: Standard_EC48as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_ec64as_v6
+      id: Standard_EC64as_v6
+      memory: 549755813888
+      name: Standard_EC64as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_ec96as_v6
+      id: Standard_EC96as_v6
+      memory: 721554505728
+      name: Standard_EC96as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_ec2ads_v6
+      id: Standard_EC2ads_v6
+      memory: 17179869184
+      name: Standard_EC2ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_ec4ads_v6
+      id: Standard_EC4ads_v6
+      memory: 34359738368
+      name: Standard_EC4ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_ec8ads_v6
+      id: Standard_EC8ads_v6
+      memory: 68719476736
+      name: Standard_EC8ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_ec16ads_v6
+      id: Standard_EC16ads_v6
+      memory: 137438953472
+      name: Standard_EC16ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_ec32ads_v6
+      id: Standard_EC32ads_v6
+      memory: 274877906944
+      name: Standard_EC32ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_ec48ads_v6
+      id: Standard_EC48ads_v6
+      memory: 412316860416
+      name: Standard_EC48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_ec64ads_v6
+      id: Standard_EC64ads_v6
+      memory: 549755813888
+      name: Standard_EC64ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_ec96ads_v6
+      id: Standard_EC96ads_v6
+      memory: 721554505728
+      name: Standard_EC96ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2als_v7
+      id: Standard_D2als_v7
+      memory: 4294967296
+      name: Standard_D2als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4als_v7
+      id: Standard_D4als_v7
+      memory: 8589934592
+      name: Standard_D4als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8als_v7
+      id: Standard_D8als_v7
+      memory: 17179869184
+      name: Standard_D8als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16als_v7
+      id: Standard_D16als_v7
+      memory: 34359738368
+      name: Standard_D16als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32als_v7
+      id: Standard_D32als_v7
+      memory: 68719476736
+      name: Standard_D32als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48als_v7
+      id: Standard_D48als_v7
+      memory: 103079215104
+      name: Standard_D48als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64als_v7
+      id: Standard_D64als_v7
+      memory: 137438953472
+      name: Standard_D64als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96als_v7
+      id: Standard_D96als_v7
+      memory: 206158430208
+      name: Standard_D96als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_d128als_v7
+      id: Standard_D128als_v7
+      memory: 274877906944
+      name: Standard_D128als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 160
+      generic_name: standard_d160als_v7
+      id: Standard_D160als_v7
+      memory: 343597383680
+      name: Standard_D160als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2alds_v7
+      id: Standard_D2alds_v7
+      memory: 4294967296
+      name: Standard_D2alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4alds_v7
+      id: Standard_D4alds_v7
+      memory: 8589934592
+      name: Standard_D4alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8alds_v7
+      id: Standard_D8alds_v7
+      memory: 17179869184
+      name: Standard_D8alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16alds_v7
+      id: Standard_D16alds_v7
+      memory: 34359738368
+      name: Standard_D16alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32alds_v7
+      id: Standard_D32alds_v7
+      memory: 68719476736
+      name: Standard_D32alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48alds_v7
+      id: Standard_D48alds_v7
+      memory: 103079215104
+      name: Standard_D48alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64alds_v7
+      id: Standard_D64alds_v7
+      memory: 137438953472
+      name: Standard_D64alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96alds_v7
+      id: Standard_D96alds_v7
+      memory: 206158430208
+      name: Standard_D96alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_d128alds_v7
+      id: Standard_D128alds_v7
+      memory: 274877906944
+      name: Standard_D128alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 160
+      generic_name: standard_d160alds_v7
+      id: Standard_D160alds_v7
+      memory: 343597383680
+      name: Standard_D160alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2as_v7
+      id: Standard_D2as_v7
+      memory: 8589934592
+      name: Standard_D2as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4as_v7
+      id: Standard_D4as_v7
+      memory: 17179869184
+      name: Standard_D4as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8as_v7
+      id: Standard_D8as_v7
+      memory: 34359738368
+      name: Standard_D8as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16as_v7
+      id: Standard_D16as_v7
+      memory: 68719476736
+      name: Standard_D16as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32as_v7
+      id: Standard_D32as_v7
+      memory: 137438953472
+      name: Standard_D32as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48as_v7
+      id: Standard_D48as_v7
+      memory: 206158430208
+      name: Standard_D48as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64as_v7
+      id: Standard_D64as_v7
+      memory: 274877906944
+      name: Standard_D64as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96as_v7
+      id: Standard_D96as_v7
+      memory: 412316860416
+      name: Standard_D96as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_d128as_v7
+      id: Standard_D128as_v7
+      memory: 549755813888
+      name: Standard_D128as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 160
+      generic_name: standard_d160as_v7
+      id: Standard_D160as_v7
+      memory: 687194767360
+      name: Standard_D160as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ads_v7
+      id: Standard_D2ads_v7
+      memory: 8589934592
+      name: Standard_D2ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ads_v7
+      id: Standard_D4ads_v7
+      memory: 17179869184
+      name: Standard_D4ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ads_v7
+      id: Standard_D8ads_v7
+      memory: 34359738368
+      name: Standard_D8ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ads_v7
+      id: Standard_D16ads_v7
+      memory: 68719476736
+      name: Standard_D16ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ads_v7
+      id: Standard_D32ads_v7
+      memory: 137438953472
+      name: Standard_D32ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ads_v7
+      id: Standard_D48ads_v7
+      memory: 206158430208
+      name: Standard_D48ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ads_v7
+      id: Standard_D64ads_v7
+      memory: 274877906944
+      name: Standard_D64ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96ads_v7
+      id: Standard_D96ads_v7
+      memory: 412316860416
+      name: Standard_D96ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_d128ads_v7
+      id: Standard_D128ads_v7
+      memory: 549755813888
+      name: Standard_D128ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 160
+      generic_name: standard_d160ads_v7
+      id: Standard_D160ads_v7
+      memory: 687194767360
+      name: Standard_D160ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2as_v7
+      id: Standard_E2as_v7
+      memory: 17179869184
+      name: Standard_E2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2as_v7
+      id: Standard_E4-2as_v7
+      memory: 34359738368
+      name: Standard_E4-2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4as_v7
+      id: Standard_E4as_v7
+      memory: 34359738368
+      name: Standard_E4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2as_v7
+      id: Standard_E8-2as_v7
+      memory: 68719476736
+      name: Standard_E8-2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4as_v7
+      id: Standard_E8-4as_v7
+      memory: 68719476736
+      name: Standard_E8-4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8as_v7
+      id: Standard_E8as_v7
+      memory: 68719476736
+      name: Standard_E8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4as_v7
+      id: Standard_E16-4as_v7
+      memory: 137438953472
+      name: Standard_E16-4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8as_v7
+      id: Standard_E16-8as_v7
+      memory: 137438953472
+      name: Standard_E16-8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16as_v7
+      id: Standard_E16as_v7
+      memory: 137438953472
+      name: Standard_E16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8as_v7
+      id: Standard_E32-8as_v7
+      memory: 274877906944
+      name: Standard_E32-8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16as_v7
+      id: Standard_E32-16as_v7
+      memory: 274877906944
+      name: Standard_E32-16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32as_v7
+      id: Standard_E32as_v7
+      memory: 274877906944
+      name: Standard_E32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48as_v7
+      id: Standard_E48as_v7
+      memory: 412316860416
+      name: Standard_E48as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16as_v7
+      id: Standard_E64-16as_v7
+      memory: 549755813888
+      name: Standard_E64-16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32as_v7
+      id: Standard_E64-32as_v7
+      memory: 549755813888
+      name: Standard_E64-32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64as_v7
+      id: Standard_E64as_v7
+      memory: 549755813888
+      name: Standard_E64as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24as_v7
+      id: Standard_E96-24as_v7
+      memory: 824633720832
+      name: Standard_E96-24as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48as_v7
+      id: Standard_E96-48as_v7
+      memory: 824633720832
+      name: Standard_E96-48as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96as_v7
+      id: Standard_E96as_v7
+      memory: 824633720832
+      name: Standard_E96as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128-32as_v7
+      id: Standard_E128-32as_v7
+      memory: 1099511627776
+      name: Standard_E128-32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128-64as_v7
+      id: Standard_E128-64as_v7
+      memory: 1099511627776
+      name: Standard_E128-64as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128as_v7
+      id: Standard_E128as_v7
+      memory: 1099511627776
+      name: Standard_E128as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2ads_v7
+      id: Standard_E2ads_v7
+      memory: 17179869184
+      name: Standard_E2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2ads_v7
+      id: Standard_E4-2ads_v7
+      memory: 34359738368
+      name: Standard_E4-2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4ads_v7
+      id: Standard_E4ads_v7
+      memory: 34359738368
+      name: Standard_E4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2ads_v7
+      id: Standard_E8-2ads_v7
+      memory: 68719476736
+      name: Standard_E8-2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4ads_v7
+      id: Standard_E8-4ads_v7
+      memory: 68719476736
+      name: Standard_E8-4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8ads_v7
+      id: Standard_E8ads_v7
+      memory: 68719476736
+      name: Standard_E8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4ads_v7
+      id: Standard_E16-4ads_v7
+      memory: 137438953472
+      name: Standard_E16-4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8ads_v7
+      id: Standard_E16-8ads_v7
+      memory: 137438953472
+      name: Standard_E16-8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16ads_v7
+      id: Standard_E16ads_v7
+      memory: 137438953472
+      name: Standard_E16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8ads_v7
+      id: Standard_E32-8ads_v7
+      memory: 274877906944
+      name: Standard_E32-8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16ads_v7
+      id: Standard_E32-16ads_v7
+      memory: 274877906944
+      name: Standard_E32-16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32ads_v7
+      id: Standard_E32ads_v7
+      memory: 274877906944
+      name: Standard_E32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48ads_v7
+      id: Standard_E48ads_v7
+      memory: 412316860416
+      name: Standard_E48ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16ads_v7
+      id: Standard_E64-16ads_v7
+      memory: 549755813888
+      name: Standard_E64-16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32ads_v7
+      id: Standard_E64-32ads_v7
+      memory: 549755813888
+      name: Standard_E64-32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64ads_v7
+      id: Standard_E64ads_v7
+      memory: 549755813888
+      name: Standard_E64ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24ads_v7
+      id: Standard_E96-24ads_v7
+      memory: 824633720832
+      name: Standard_E96-24ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48ads_v7
+      id: Standard_E96-48ads_v7
+      memory: 824633720832
+      name: Standard_E96-48ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96ads_v7
+      id: Standard_E96ads_v7
+      memory: 824633720832
+      name: Standard_E96ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128-32ads_v7
+      id: Standard_E128-32ads_v7
+      memory: 1099511627776
+      name: Standard_E128-32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128-64ads_v7
+      id: Standard_E128-64ads_v7
+      memory: 1099511627776
+      name: Standard_E128-64ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128ads_v7
+      id: Standard_E128ads_v7
+      memory: 1099511627776
+      name: Standard_E128ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_f1als_v7
+      id: Standard_F1als_v7
+      memory: 2147483648
+      name: Standard_F1als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2als_v7
+      id: Standard_F2als_v7
+      memory: 4294967296
+      name: Standard_F2als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4als_v7
+      id: Standard_F4als_v7
+      memory: 8589934592
+      name: Standard_F4als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8als_v7
+      id: Standard_F8als_v7
+      memory: 17179869184
+      name: Standard_F8als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16als_v7
+      id: Standard_F16als_v7
+      memory: 34359738368
+      name: Standard_F16als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32als_v7
+      id: Standard_F32als_v7
+      memory: 68719476736
+      name: Standard_F32als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48als_v7
+      id: Standard_F48als_v7
+      memory: 103079215104
+      name: Standard_F48als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64als_v7
+      id: Standard_F64als_v7
+      memory: 137438953472
+      name: Standard_F64als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_f80als_v7
+      id: Standard_F80als_v7
+      memory: 171798691840
+      name: Standard_F80als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_f1alds_v7
+      id: Standard_F1alds_v7
+      memory: 2147483648
+      name: Standard_F1alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2alds_v7
+      id: Standard_F2alds_v7
+      memory: 4294967296
+      name: Standard_F2alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4alds_v7
+      id: Standard_F4alds_v7
+      memory: 8589934592
+      name: Standard_F4alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8alds_v7
+      id: Standard_F8alds_v7
+      memory: 17179869184
+      name: Standard_F8alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16alds_v7
+      id: Standard_F16alds_v7
+      memory: 34359738368
+      name: Standard_F16alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32alds_v7
+      id: Standard_F32alds_v7
+      memory: 68719476736
+      name: Standard_F32alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48alds_v7
+      id: Standard_F48alds_v7
+      memory: 103079215104
+      name: Standard_F48alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64alds_v7
+      id: Standard_F64alds_v7
+      memory: 137438953472
+      name: Standard_F64alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_f80alds_v7
+      id: Standard_F80alds_v7
+      memory: 171798691840
+      name: Standard_F80alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_f1as_v7
+      id: Standard_F1as_v7
+      memory: 4294967296
+      name: Standard_F1as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2as_v7
+      id: Standard_F2as_v7
+      memory: 8589934592
+      name: Standard_F2as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4as_v7
+      id: Standard_F4as_v7
+      memory: 17179869184
+      name: Standard_F4as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8as_v7
+      id: Standard_F8as_v7
+      memory: 34359738368
+      name: Standard_F8as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16as_v7
+      id: Standard_F16as_v7
+      memory: 68719476736
+      name: Standard_F16as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32as_v7
+      id: Standard_F32as_v7
+      memory: 137438953472
+      name: Standard_F32as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48as_v7
+      id: Standard_F48as_v7
+      memory: 206158430208
+      name: Standard_F48as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64as_v7
+      id: Standard_F64as_v7
+      memory: 274877906944
+      name: Standard_F64as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_f80as_v7
+      id: Standard_F80as_v7
+      memory: 343597383680
+      name: Standard_F80as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_f1ads_v7
+      id: Standard_F1ads_v7
+      memory: 4294967296
+      name: Standard_F1ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2ads_v7
+      id: Standard_F2ads_v7
+      memory: 8589934592
+      name: Standard_F2ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4ads_v7
+      id: Standard_F4ads_v7
+      memory: 17179869184
+      name: Standard_F4ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8ads_v7
+      id: Standard_F8ads_v7
+      memory: 34359738368
+      name: Standard_F8ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16ads_v7
+      id: Standard_F16ads_v7
+      memory: 68719476736
+      name: Standard_F16ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32ads_v7
+      id: Standard_F32ads_v7
+      memory: 137438953472
+      name: Standard_F32ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48ads_v7
+      id: Standard_F48ads_v7
+      memory: 206158430208
+      name: Standard_F48ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64ads_v7
+      id: Standard_F64ads_v7
+      memory: 274877906944
+      name: Standard_F64ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_f80ads_v7
+      id: Standard_F80ads_v7
+      memory: 343597383680
+      name: Standard_F80ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_f1ams_v7
+      id: Standard_F1ams_v7
+      memory: 8589934592
+      name: Standard_F1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2-1ams_v7
+      id: Standard_F2-1ams_v7
+      memory: 17179869184
+      name: Standard_F2-1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2ams_v7
+      id: Standard_F2ams_v7
+      memory: 17179869184
+      name: Standard_F2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4-1ams_v7
+      id: Standard_F4-1ams_v7
+      memory: 34359738368
+      name: Standard_F4-1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4-2ams_v7
+      id: Standard_F4-2ams_v7
+      memory: 34359738368
+      name: Standard_F4-2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4ams_v7
+      id: Standard_F4ams_v7
+      memory: 34359738368
+      name: Standard_F4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8-2ams_v7
+      id: Standard_F8-2ams_v7
+      memory: 68719476736
+      name: Standard_F8-2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8-4ams_v7
+      id: Standard_F8-4ams_v7
+      memory: 68719476736
+      name: Standard_F8-4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8ams_v7
+      id: Standard_F8ams_v7
+      memory: 68719476736
+      name: Standard_F8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16-4ams_v7
+      id: Standard_F16-4ams_v7
+      memory: 137438953472
+      name: Standard_F16-4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16-8ams_v7
+      id: Standard_F16-8ams_v7
+      memory: 137438953472
+      name: Standard_F16-8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16ams_v7
+      id: Standard_F16ams_v7
+      memory: 137438953472
+      name: Standard_F16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32-8ams_v7
+      id: Standard_F32-8ams_v7
+      memory: 274877906944
+      name: Standard_F32-8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32-16ams_v7
+      id: Standard_F32-16ams_v7
+      memory: 274877906944
+      name: Standard_F32-16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32ams_v7
+      id: Standard_F32ams_v7
+      memory: 274877906944
+      name: Standard_F32ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48ams_v7
+      id: Standard_F48ams_v7
+      memory: 412316860416
+      name: Standard_F48ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_f64-16ams_v7
+      id: Standard_F64-16ams_v7
+      memory: 549755813888
+      name: Standard_F64-16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64-32ams_v7
+      id: Standard_F64-32ams_v7
+      memory: 549755813888
+      name: Standard_F64-32ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64ams_v7
+      id: Standard_F64ams_v7
+      memory: 549755813888
+      name: Standard_F64ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_f80ams_v7
+      id: Standard_F80ams_v7
+      memory: 687194767360
+      name: Standard_F80ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_f1amds_v7
+      id: Standard_F1amds_v7
+      memory: 8589934592
+      name: Standard_F1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2-1amds_v7
+      id: Standard_F2-1amds_v7
+      memory: 17179869184
+      name: Standard_F2-1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2amds_v7
+      id: Standard_F2amds_v7
+      memory: 17179869184
+      name: Standard_F2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4-1amds_v7
+      id: Standard_F4-1amds_v7
+      memory: 34359738368
+      name: Standard_F4-1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4-2amds_v7
+      id: Standard_F4-2amds_v7
+      memory: 34359738368
+      name: Standard_F4-2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4amds_v7
+      id: Standard_F4amds_v7
+      memory: 34359738368
+      name: Standard_F4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8-2amds_v7
+      id: Standard_F8-2amds_v7
+      memory: 68719476736
+      name: Standard_F8-2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8-4amds_v7
+      id: Standard_F8-4amds_v7
+      memory: 68719476736
+      name: Standard_F8-4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8amds_v7
+      id: Standard_F8amds_v7
+      memory: 68719476736
+      name: Standard_F8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16-4amds_v7
+      id: Standard_F16-4amds_v7
+      memory: 137438953472
+      name: Standard_F16-4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16-8amds_v7
+      id: Standard_F16-8amds_v7
+      memory: 137438953472
+      name: Standard_F16-8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16amds_v7
+      id: Standard_F16amds_v7
+      memory: 137438953472
+      name: Standard_F16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32-8amds_v7
+      id: Standard_F32-8amds_v7
+      memory: 274877906944
+      name: Standard_F32-8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32-16amds_v7
+      id: Standard_F32-16amds_v7
+      memory: 274877906944
+      name: Standard_F32-16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32amds_v7
+      id: Standard_F32amds_v7
+      memory: 274877906944
+      name: Standard_F32amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48amds_v7
+      id: Standard_F48amds_v7
+      memory: 412316860416
+      name: Standard_F48amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64-16amds_v7
+      id: Standard_F64-16amds_v7
+      memory: 549755813888
+      name: Standard_F64-16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64-32amds_v7
+      id: Standard_F64-32amds_v7
+      memory: 549755813888
+      name: Standard_F64-32amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64amds_v7
+      id: Standard_F64amds_v7
+      memory: 549755813888
+      name: Standard_F64amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_f80amds_v7
+      id: Standard_F80amds_v7
+      memory: 687194767360
+      name: Standard_F80amds_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96ias_v4
+      id: Standard_E96ias_v4
+      memory: 721554505728
+      name: Standard_E96ias_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_nd96isr_h200_v5
+      id: Standard_ND96isr_H200_v5
+      memory: 1986422374400
+      name: Standard_ND96isr_H200_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_nv4as_v4
+      id: Standard_NV4as_v4
+      memory: 15032385536
+      name: Standard_NV4as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_nv8as_v4
+      id: Standard_NV8as_v4
+      memory: 30064771072
+      name: Standard_NV8as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_nv16as_v4
+      id: Standard_NV16as_v4
+      memory: 60129542144
+      name: Standard_NV16as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_nv32as_v4
+      id: Standard_NV32as_v4
+      memory: 120259084288
+      name: Standard_NV32as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 160
+      generic_name: standard_e160as_v7
+      id: Standard_E160as_v7
+      memory: 1374389534720
+      name: Standard_E160as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 160
+      generic_name: standard_e160ads_v7
+      id: Standard_E160ads_v7
+      memory: 1374389534720
+      name: Standard_E160ads_v7
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 6
+      generic_name: standard_nc6s_v3
+      id: Standard_NC6s_v3
+      memory: 120259084288
+      name: Standard_NC6s_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 12
+      generic_name: standard_nc12s_v3
+      id: Standard_NC12s_v3
+      memory: 240518168576
+      name: Standard_NC12s_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_nc24rs_v3
+      id: Standard_NC24rs_v3
+      memory: 481036337152
+      name: Standard_NC24rs_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_nc24s_v3
+      id: Standard_NC24s_v3
+      memory: 481036337152
+      name: Standard_NC24s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_dc2es_v6
+      id: Standard_DC2es_v6
+      memory: 8589934592
+      name: Standard_DC2es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_dc4es_v6
+      id: Standard_DC4es_v6
+      memory: 17179869184
+      name: Standard_DC4es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_dc8es_v6
+      id: Standard_DC8es_v6
+      memory: 34359738368
+      name: Standard_DC8es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_dc16es_v6
+      id: Standard_DC16es_v6
+      memory: 68719476736
+      name: Standard_DC16es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_dc32es_v6
+      id: Standard_DC32es_v6
+      memory: 137438953472
+      name: Standard_DC32es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_dc48es_v6
+      id: Standard_DC48es_v6
+      memory: 206158430208
+      name: Standard_DC48es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_dc64es_v6
+      id: Standard_DC64es_v6
+      memory: 274877906944
+      name: Standard_DC64es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_dc96es_v6
+      id: Standard_DC96es_v6
+      memory: 412316860416
+      name: Standard_DC96es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_dc128es_v6
+      id: Standard_DC128es_v6
+      memory: 549755813888
+      name: Standard_DC128es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_dc2eds_v6
+      id: Standard_DC2eds_v6
+      memory: 8589934592
+      name: Standard_DC2eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_dc4eds_v6
+      id: Standard_DC4eds_v6
+      memory: 17179869184
+      name: Standard_DC4eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_dc8eds_v6
+      id: Standard_DC8eds_v6
+      memory: 34359738368
+      name: Standard_DC8eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_dc16eds_v6
+      id: Standard_DC16eds_v6
+      memory: 68719476736
+      name: Standard_DC16eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_dc32eds_v6
+      id: Standard_DC32eds_v6
+      memory: 137438953472
+      name: Standard_DC32eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_dc48eds_v6
+      id: Standard_DC48eds_v6
+      memory: 206158430208
+      name: Standard_DC48eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_dc64eds_v6
+      id: Standard_DC64eds_v6
+      memory: 274877906944
+      name: Standard_DC64eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_dc96eds_v6
+      id: Standard_DC96eds_v6
+      memory: 412316860416
+      name: Standard_DC96eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_dc128eds_v6
+      id: Standard_DC128eds_v6
+      memory: 549755813888
+      name: Standard_DC128eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_ec2es_v6
+      id: Standard_EC2es_v6
+      memory: 17179869184
+      name: Standard_EC2es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_ec4es_v6
+      id: Standard_EC4es_v6
+      memory: 34359738368
+      name: Standard_EC4es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_ec8es_v6
+      id: Standard_EC8es_v6
+      memory: 68719476736
+      name: Standard_EC8es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_ec16es_v6
+      id: Standard_EC16es_v6
+      memory: 137438953472
+      name: Standard_EC16es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_ec32es_v6
+      id: Standard_EC32es_v6
+      memory: 274877906944
+      name: Standard_EC32es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_ec48es_v6
+      id: Standard_EC48es_v6
+      memory: 412316860416
+      name: Standard_EC48es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_ec64es_v6
+      id: Standard_EC64es_v6
+      memory: 549755813888
+      name: Standard_EC64es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_ec2eds_v6
+      id: Standard_EC2eds_v6
+      memory: 17179869184
+      name: Standard_EC2eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_ec4eds_v6
+      id: Standard_EC4eds_v6
+      memory: 34359738368
+      name: Standard_EC4eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_ec8eds_v6
+      id: Standard_EC8eds_v6
+      memory: 68719476736
+      name: Standard_EC8eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_ec16eds_v6
+      id: Standard_EC16eds_v6
+      memory: 137438953472
+      name: Standard_EC16eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_ec32eds_v6
+      id: Standard_EC32eds_v6
+      memory: 274877906944
+      name: Standard_EC32eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_ec48eds_v6
+      id: Standard_EC48eds_v6
+      memory: 412316860416
+      name: Standard_EC48eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_ec64eds_v6
+      id: Standard_EC64eds_v6
+      memory: 549755813888
+      name: Standard_EC64eds_v6
+kind: ConfigMap
+metadata:
+  name: cloud-resources-config
+  namespace: 'clusters-service'
+---
+# Source: clusters-service/templates/cluster-proxy-service-config.configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-proxy-service-config
+  namespace: 'clusters-service'
+data:
+  config.yaml: |
+    # Hosts that should be added to noProxy for all clusters
+    noProxy: []
+    # Hosts that should be added to noProxy for AWS clusters
+    noProxy_aws: []
+    # Hosts that should be added to noProxy for GCP clusters
+    noProxy_gcp: []
+    # Readiness endpoints that verify proxy connectivity
+    readinessEndpoints:
+      - "https://api.openshift.com"
+---
+# Source: clusters-service/templates/region-constraints-config.configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: region-constraints-config
+  namespace: 'clusters-service'
+data:
+  config.yaml: |
+    cloud_providers:
+    - name: azure
+      regions:
+        - name: 'westus3'
+          version_constraints:
+            min_version: 4.11.0
+---
+# Source: clusters-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clusters-service
+  namespace: 'clusters-service'
+  labels:
+    app: clusters-service
+    port: api
+spec:
+  selector:
+    app: clusters-service
+  ports:
+  - port: 8000
+    targetPort: 8000
+    protocol: TCP
+---
+# Source: clusters-service/templates/service.yaml
+# Services for diagnostic ports (not part of main service because we
+# don't want exposing them externally through same route).
+apiVersion: v1
+kind: Service
+metadata:
+  name: clusters-service-metrics
+  namespace: 'clusters-service'
+  labels:
+    # {app, port} labels together identify this service for monitoring
+    app: clusters-service
+    port: metrics
+spec:
+  selector:
+    app: clusters-service
+  ports:
+  - port: 8080
+    targetPort: 8080
+    name: metrics
+    protocol: TCP
+---
+# Source: clusters-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clusters-service-healthcheck
+  namespace: 'clusters-service'
+  labels:
+    app: clusters-service
+    port: healthcheck
+spec:
+  selector:
+    app: clusters-service
+  ports:
+  - port: 8083
+    targetPort: 8083
+    name: healthcheck
+    protocol: TCP
+---
+# Source: clusters-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clusters-service
+  namespace: 'clusters-service'
+  labels:
+    app: clusters-service
+spec:
+  selector:
+    matchLabels:
+      app: clusters-service
+  replicas: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: clusters-service
+        azure.workload.identity/use: "true"
+      annotations:
+        checksum/db: '7d748725a08edbe974bbd237e5dd517833a82eaa0f0b211fc2881961bf4515a8'
+        checksum/operatorcfg: '110eacb1e465d620a2c26da89d5b6246433bb53a2dd3f9853e2daaa035e53df5'
+        checksum/ocpversionscfg: '9e5cff6bf43f7b8d712e0b54656c6b1ec66693e7fe17ba6801070134b28b2900'
+        checksum/cskv: '089346897c49e4b24754b3c6c3be350f8b0e6bf2c2c64c442b1744db4faee2fb'
+        checksum/provisionshard: 'd2d4582f46da482e7a0c56f8a4372d95839bf6ced1d48a964d7030dc7e1b5b4b'
+        checksum/cs: '7f91f7a8dc3a8b51073043defb13df2c3864a9c93f5a5588a2431f012bc2ae28'
+        checksum/runtime: 'a59b6e4224066ebe7cb35d89a9e9c179f9e90942d3b4173c91c0609299a983ef'
+        checksum/cloudres: '6db050cd35a77e565d80d2ba2c028450a8758e3ab0a4e524ede12cf207c3a73a'
+        checksum/sa: '0187a6f1019114e284fb5565a82e4e954460ac079f952f07b9602117c0d81e3f'
+    spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: 'topology.kubernetes.io/zone'
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: clusters-service
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: clusters-service
+      serviceAccount: 'clusters-service'
+      serviceAccountName: 'clusters-service'
+      volumes:
+      - name: service
+        secret:
+          secretName: clusters-service
+      - name: shards
+        secret:
+          secretName: provision-shards
+      - name: rds
+        secret:
+          secretName: ocm-cs-db
+      - name: oidc
+        secret:
+          secretName: rh-oidc-s3-secret
+      - name: authentication
+        configMap:
+          name: authentication
+      - name: region-constraints
+        configMap:
+          name: region-constraints-config
+      - name: instance-types
+        configMap:
+          name: cloud-resources-config
+      - name: instance-type-constraints
+        configMap:
+          name: cloud-resource-constraints-config
+      - name: cloud-regions
+        configMap:
+          name: cloud-resources-config
+      - name: cloud-region-constraints
+        configMap:
+          name: cloud-resource-constraints-config
+      - name: proxy
+        configMap:
+          name: cluster-proxy-service-config
+      - name: azure-runtime-config
+        configMap:
+          name: azure-runtime-config
+      - name: azure-operators-managed-identities-config
+        configMap:
+          name: azure-operators-managed-identities-config
+      - name: aro-hcp-ocp-versions-config
+        configMap:
+          name: aro-hcp-ocp-versions-config
+      - name: mixin-pull-secret
+        secret:
+          secretName: hive-ci-global-pull-secret
+          optional: true
+      - name: keyvault
+        csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: cs-keyvault
+      initContainers:
+      - name: clusters-service-init
+        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        imagePullPolicy: IfNotPresent
+        env:
+        # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
+        # Azure Workload Identity (azure.workload.identity/use); that effectively restricts other credential chains from being tried.
+        - name: AZURE_TOKEN_CREDENTIALS
+          value: "WorkloadIdentityCredential"
+        volumeMounts:
+        - name: rds
+          mountPath: /secrets/rds
+        - name: service
+          mountPath: /secrets/service
+        - name: azure-runtime-config
+          mountPath: /configs/azure-runtime-config
+        - name: keyvault
+          mountPath: "/secrets/keyvault"
+          readOnly: true
+        command:
+        - /usr/local/bin/clusters-service
+        - init
+        - --db-host=@/secrets/rds/db.host
+        - --db-port=@/secrets/rds/db.port
+        - --db-name=@/secrets/rds/db.name
+        - --db-user=@/secrets/rds/db.user
+        - --db-password=@/secrets/rds/db.password
+        - --db-disable-tls=__databaseDisableTls__
+        - --db-auth-method=__databaseAuthMethod__
+        - --force-migration=
+        - --batch-processes-dry-run=true
+        - --batch-processes=
+        - --azure-runtime-config-path=/configs/azure-runtime-config/config.json
+        - --azure-first-party-application-client-id=b3cb2fab-15cb-4583-ad06-f91da9bfe2d1
+        - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
+      containers:
+      - name: clusters-service-server
+        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: DENYASSIGNMENTS
+          value: disabled
+        # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
+        # Azure Workload Identity (azure.workload.identity/use); that effectively restricts other credential chains from being tried.
+        - name: AZURE_TOKEN_CREDENTIALS
+          value: "WorkloadIdentityCredential"
+        volumeMounts:
+        - name: service
+          mountPath: /secrets/service
+        - name: shards
+          mountPath: /secrets/shards
+        - name: rds
+          mountPath: /secrets/rds
+        - name: authentication
+          mountPath: /configs/authentication
+        - name: region-constraints
+          mountPath: /configs/region-constraints
+        - name: proxy
+          mountPath: /configs/proxy
+        - name: mixin-pull-secret
+          mountPath: /secrets/mixin-pull-secret
+        - name: instance-types
+          mountPath: /configs/cloud-resources/instance-types.yaml
+          subPath: instance-types.yaml
+        - name: instance-type-constraints
+          mountPath: /configs/cloud-resource-constraints/instance-type-constraints.yaml
+          subPath: instance-type-constraints.yaml
+        - name: cloud-regions
+          mountPath: /configs/cloud-resources/cloud-regions.yaml
+          subPath: cloud-regions.yaml
+        - name: cloud-region-constraints
+          mountPath: /configs/cloud-resource-constraints/cloud-region-constraints.yaml
+          subPath: cloud-region-constraints.yaml
+        - name: keyvault
+          mountPath: "/secrets/keyvault"
+          readOnly: true
+        - name: azure-runtime-config
+          mountPath: /configs/azure-runtime-config
+        - name: azure-operators-managed-identities-config
+          mountPath: /configs/azure-operators-managed-identities-config.yaml
+          subPath: azure-operators-managed-identities-config.yaml
+        - name: aro-hcp-ocp-versions-config
+          mountPath: /configs/aro-hcp-ocp-versions-config.yaml
+          subPath: aro-hcp-ocp-versions-config.yaml
+        command:
+        - /usr/local/bin/clusters-service
+        - serve
+        - --log-level=4
+        - --namespace=clusters-service
+        - --runtime-mode=aro-hcp
+        - --default-expiration=0
+        - --maximum-expiration=0
+        - --provision-shard-cluster-limit=100
+        - --db-host=@/secrets/rds/db.host
+        - --db-port=@/secrets/rds/db.port
+        - --db-name=@/secrets/rds/db.name
+        - --db-user=@/secrets/rds/db.user
+        - --db-password=@/secrets/rds/db.password
+        - --db-disable-tls=__databaseDisableTls__
+        - --db-auth-method=__databaseAuthMethod__
+        - --gateway-url=http://127.0.0.1:9090
+        - --client-id=@/secrets/service/client.id
+        - --client-secret=@/secrets/service/client.secret
+        - --client-scopes=openid
+        - --user-defined-dns-base-domain=i1.devshift.org
+        - --jwks-url=http://localhost
+        - --jwks-file=/configs/authentication/jwks.json
+        - --acl-file=/configs/authentication/acl.yml
+        - --token-url=http://localhost
+        - --insecure=false
+        - --api-listener-network=tcp
+        - --api-listener-address=:8000
+        - --metrics-listener-network=tcp
+        - --metrics-listener-address=:8080
+        - --healthcheck-listener-network=tcp
+        - --healthcheck-listener-address=:8083
+        - --environment=arohcpdev
+        - --backplane-url=
+        - --provision-shards-config=/secrets/shards/config
+        - --proxy-config-file=/configs/proxy/config.yaml
+        - --aws-sts-policy-directory=/configs/policies
+        - --mixin-pull-secret-path=/secrets/mixin-pull-secret
+        - --region-constraints-config=/configs/region-constraints/config.yaml
+        - --instance-type-config=/configs/cloud-resources/instance-types.yaml
+        - --instance-type-constraints-config=/configs/cloud-resource-constraints/instance-type-constraints.yaml
+        - --cloud-region-config=/configs/cloud-resources/cloud-regions.yaml
+        - --cloud-region-constraints-config=/configs/cloud-resource-constraints/cloud-region-constraints.yaml
+        - --azure-first-party-application-client-id=b3cb2fab-15cb-4583-ad06-f91da9bfe2d1
+        - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
+        - --azure-runtime-config-path=/configs/azure-runtime-config/config.json
+        - --azure-operators-managed-identities-config-path=/configs/azure-operators-managed-identities-config.yaml
+        - --aro-hcp-ocp-versions-config-path=/configs/aro-hcp-ocp-versions-config.yaml
+        - --azure-mi-mock-service-principal-certificate-bundle-path=/secrets/keyvault/mockMiServicePrincipalCertificateBundle
+        - --azure-mi-mock-service-principal-client-id=e8723db7-9b9e-46a4-9f7d-64d75c3534f0
+        - --azure-mi-mock-service-principal-principal-id=d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+        - --azure-arm-helper-identity-certificate-bundle-path=/secrets/keyvault/armHelperIndentityCertificateBundle
+        - --azure-arm-helper-identity-client-id=clusters-service-client-id
+        - --azure-arm-helper-mock-fpa-principal-id=mock-fpa-principal-id
+        # Baggage items are populated by the RP frontend and defined in internal/tracing/attributes.go.
+        - --log-fields-from-baggage=aro.correlation_id=correlation_id,aro.client.request_id=client_request_id
+        
+        
+        livenessProbe:
+          httpGet:
+            path: /api/clusters_mgmt/v1
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 8083
+            scheme: HTTP
+            httpHeaders:
+            - name: User-Agent
+              value: Probe
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 10
+        resources:
+          requests:
+            memory: '150Mi'
+            cpu: '50m'
+---
+# Source: clusters-service/templates/postgres-breakglass.deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres-breakglass
+  namespace: 'clusters-service'
+  labels:
+    app: postgres-breakglass
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: postgres-breakglass
+  template:
+    metadata:
+      labels:
+        app: postgres-breakglass
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccount: 'clusters-service'
+      serviceAccountName: 'clusters-service'
+      initContainers:
+      - name: init
+        image: 'mcr.microsoft.com/azure-cli:azurelinux3.0'
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+          echo "PostgreSQL breakglass init container started at $(date)"
+
+          # Check required environment variables
+          if [ -z "${AZURE_FEDERATED_TOKEN_FILE:-}" ]; then
+            echo "Error: AZURE_FEDERATED_TOKEN_FILE environment variable is not set, check workload identity settings"
+            exit 1
+          fi
+          if [ -z "${AZURE_CLIENT_ID:-}" ]; then
+            echo "Error: AZURE_CLIENT_ID environment variable is not set, check workload identity settings"
+            exit 1
+          fi
+          if [ -z "${AZURE_TENANT_ID:-}" ]; then
+            echo "Error: AZURE_TENANT_ID environment variable is not set, check workload identity settings"
+            exit 1
+          fi
+
+          echo "Logging into Azure using workload identity..."
+          FEDERATED_TOKEN="$(cat $AZURE_FEDERATED_TOKEN_FILE)"
+          az login --federated-token "$FEDERATED_TOKEN" --service-principal -u $AZURE_CLIENT_ID -t $AZURE_TENANT_ID
+
+          echo "Getting PostgreSQL access token..."
+          ACCESS_TOKEN=$(az account get-access-token --resource-type oss-rdbms -o json | jq .accessToken -r)
+
+          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
+            echo "Failed to get access token"
+            exit 1
+          fi
+
+          echo "Writing access token and connect script to shared volume..."
+          {
+            echo "#!/bin/sh"
+            echo "export PGPASSWORD=$ACCESS_TOKEN"
+            echo "exec psql"
+          } > /breakglass/connect.sh
+          chmod +x /breakglass/connect.sh
+
+          echo "Access token and script written successfully"
+          echo "Init container completed at $(date)"
+        volumeMounts:
+        - name: breakglass
+          mountPath: /breakglass
+      containers:
+      - name: postgres
+        image: mcr.microsoft.com/azurelinux/base/postgres:16
+        command:
+        - /bin/bash
+        - -c
+        - |
+          # Create welcome message for both bash and sh users
+          {
+            echo '# PostgreSQL Breakglass Access'
+            echo 'echo ""'
+            echo 'echo "PostgreSQL Breakglass Access Ready"'
+            echo 'echo "To connect to PostgreSQL, run: connect"'
+            echo 'echo ""'
+            echo ''
+            echo '# Connection alias'
+            echo 'alias connect="/breakglass/connect.sh"'
+          } > ~/.bashrc
+
+          # Copy to .profile for /bin/sh users
+          cp ~/.bashrc ~/.profile
+
+          echo "PostgreSQL breakglass container ready at $(date)"
+          sleep infinity
+        env:
+        - name: PGUSER
+          value: "__databaseUser__"
+        - name: PGDATABASE
+          value: "__databaseName__"
+        - name: PGHOST
+          value: "__databaseHost__"
+        - name: PGPORT
+          value: "5432"
+        volumeMounts:
+        - name: breakglass
+          mountPath: /breakglass
+      volumes:
+      - name: breakglass
+        emptyDir: {}
+---
+# Source: clusters-service/templates/acrpullbinding.yaml
+apiVersion: acrpull.microsoft.com/v1beta2
+kind: AcrPullBinding
+metadata:
+  name: pull-binding
+  namespace: 'clusters-service'
+spec:
+  acr:
+    environment: PublicCloud
+    server: 'arohcpsvcdev.azurecr.io'
+    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+  auth:
+    workloadIdentity:
+      serviceAccountRef: 'clusters-service'
+      clientID: '__imagePullerMsiClientId__'
+      tenantID: '__tenantId__'
+  serviceAccountName: 'clusters-service'
+---
+# Source: clusters-service/templates/istio.yml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-metrics
+  namespace: 'clusters-service'
+spec:
+  action: "ALLOW"
+  rules:
+  - to:
+    - operation:
+        paths: ["/metrics"]
+        methods: ["GET"]
+        ports: ["8080"]
+  selector:
+    matchLabels:
+      app: "clusters-service"
+---
+# Source: clusters-service/templates/istio.yml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-nothing
+  namespace: 'clusters-service'
+spec: {}
+---
+# Source: clusters-service/templates/istio.yml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-frontend
+  namespace: 'clusters-service'
+spec:
+  action: "ALLOW"
+  rules:
+  - from:
+    - source:
+        principals:
+        - "cluster.local/ns/aro-hcp/sa/frontend"
+        - "cluster.local/ns/aro-hcp/sa/backend"
+    to:
+    - operation:
+        ports:
+        - "8000"
+  selector:
+    matchLabels:
+      app: "clusters-service"
+---
+# Source: clusters-service/templates/istio.yml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-admin-api
+  namespace: 'clusters-service'
+spec:
+  action: "ALLOW"
+  rules:
+  - from:
+    - source:
+        principals:
+        - "cluster.local/ns/aro-hcp-admin-api/sa/admin-api"
+    to:
+    - operation:
+        ports:
+        - "8000"
+  selector:
+    matchLabels:
+      app: "clusters-service"
+---
+# Source: clusters-service/templates/istio.yml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-fleet-controller
+  namespace: 'clusters-service'
+spec:
+  action: "ALLOW"
+  rules:
+  - from:
+    - source:
+        principals:
+        - "cluster.local/ns/fleet/sa/fleet"
+    to:
+    - operation:
+        ports:
+        - "8000"
+  selector:
+    matchLabels:
+      app: "clusters-service"
+---
+# Source: clusters-service/templates/istio.yml
+# TODO: Remove when migration to Azure Postgres completes
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-intra-namespace
+  namespace: 'clusters-service'
+spec:
+  action: "ALLOW"
+  rules:
+  - from:
+    - source:
+        principals: ["cluster.local/ns/clusters-service/sa/clusters-service"]
+    to:
+    - operation:
+        ports:
+        - "5432"
+  selector:
+    matchLabels:
+      name: "ocm-cs-db"
+---
+# Source: clusters-service/templates/istio.yml
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: 'clusters-service'
+spec:
+  selector:
+    matchLabels:
+      app: clusters-service
+  portLevelMtls:
+    8080:
+      mode: PERMISSIVE
+---
+# Source: clusters-service/templates/cs-keyvault.secret.yaml
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: cs-keyvault
+  namespace: 'clusters-service'
+spec:
+  parameters:
+    clientID: '__azureCsMiClientId__'
+    cloudName: 'AzurePublicCloud'
+    keyvaultName: 'aro-hcp-dev-svc-kv'
+    objects: |-
+      array:
+        - |
+          objectName: 'firstPartyCert2'
+          objectType: secret
+          objectAlias: firstPartyApplicationCertificateBundle
+        - |
+          objectName: 'msiMockCert2'
+          objectType: secret
+          objectAlias: mockMiServicePrincipalCertificateBundle
+        - |
+          objectName: 'clusters-service-cert-name'
+          objectType: secret
+          objectAlias: armHelperIndentityCertificateBundle
+    tenantId: '__tenantId__'
+    usePodIdentity: "false"
+  provider: azure
+---
+# Source: clusters-service/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clusters-service
+  namespace: 'clusters-service'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'clusters-service'
+  selector:
+    matchLabels:
+      app: clusters-service
+      port: metrics
+

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_shared_arm_helper_fallback.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_shared_arm_helper_fallback.yaml
@@ -1,0 +1,8436 @@
+---
+# Source: clusters-service/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: 'clusters-service'
+  namespace: 'clusters-service'
+  labels:
+    app: clusters-service
+  annotations:
+    azure.workload.identity/client-id: '__azureCsMiClientId__'
+---
+# Source: clusters-service/templates/clusters-service.secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: clusters-service
+  namespace: 'clusters-service'
+stringData:
+  client.id: 'foo'
+  client.secret: 'bar'
+---
+# Source: clusters-service/templates/database.secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: 'ocm-cs-db'
+  namespace: 'clusters-service'
+stringData:
+  db.host: '__databaseHost__'
+  db.name: '__databaseName__'
+  db.password: '__databasePassword__'
+  db.user: '__databaseUser__'
+  db.port: "5432"
+---
+# Source: clusters-service/templates/provisioning-shards.secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: provision-shards
+  namespace: 'clusters-service'
+  annotations:
+    helm.sh/resource-policy: keep
+stringData:
+  config: |
+    provision_shards: []
+---
+# Source: clusters-service/templates/aro-hcp-ocp-versions-config.configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aro-hcp-ocp-versions-config
+  namespace: 'clusters-service'
+data:
+  aro-hcp-ocp-versions-config.yaml: |
+    defaultVersion:
+      channelGroupName: stable
+      version: 4.20.8
+    channelGroups:
+      - url: https://api.openshift.com/api/upgrades_info/graph
+        channelGroupName: stable
+        minVersion: 4.19.0
+        maxVersion: ""
+      - url: https://api.openshift.com/api/upgrades_info/graph
+        channelGroupName: fast
+        minVersion: 4.19.0
+        maxVersion: ""
+      - url: https://api.openshift.com/api/upgrades_info/graph
+        channelGroupName: candidate
+        minVersion: 4.19.7
+        maxVersion: ""
+      - url: https://multi.ocp.releases.ci.openshift.org/graph
+        channelGroupName: nightly
+        minVersion: 4.19.0-0.nightly-20200101
+        maxVersion: ""
+---
+# Source: clusters-service/templates/authentication.configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentication
+  namespace: 'clusters-service'
+data:
+  jwks.json: ""
+  acl.yml: ""
+---
+# Source: clusters-service/templates/azure-operators-managed-identities-config.configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: azure-operators-managed-identities-config
+  namespace: 'clusters-service'
+data:
+  azure-operators-managed-identities-config.yaml: |
+    controlPlaneOperatorsIdentities:
+      cluster-api-azure:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/88366f10-ed47-4cc0-9fab-c8a06148393e'
+            name: 'Azure Red Hat OpenShift Hosted Control Planes Cluster API Provider'
+        optional: false
+      control-plane:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/fc0c873f-45e9-4d0d-a7d1-585aab30c6ed'
+            name: 'Azure Red Hat OpenShift Hosted Control Planes Control Plane Operator'
+        optional: false
+      cloud-controller-manager:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/a1f96423-95ce-4224-ab27-4e3dc72facd4'
+            name: 'Azure Red Hat OpenShift Cloud Controller Manager'
+        optional: false
+      ingress:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/0336e1d3-7a87-462b-b6db-342b63f7802c'
+            name: 'Azure Red Hat OpenShift Cluster Ingress Operator'
+        optional: false
+      disk-csi-driver:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/5b7237c5-45e1-49d6-bc18-a1f62f400748'
+            name: 'Azure Red Hat OpenShift Disk Storage Operator'
+        optional: false
+      file-csi-driver:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e'
+            name: 'Azure Red Hat OpenShift File Storage Operator'
+        optional: false
+      image-registry:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/8b32b316-c2f5-4ddf-b05b-83dacd2d08b5'
+            name: 'Azure Red Hat OpenShift Image Registry Operator'
+        optional: false
+      cloud-network-config:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/be7a6435-15ae-4171-8f30-4a343eff9e8f'
+            name: 'Azure Red Hat OpenShift Network Operator'
+        optional: false
+      kms:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/12338af0-0e69-4776-bea7-57ae8d297424'
+            name: 'Key Vault Crypto User'
+        optional: true
+    dataPlaneOperatorsIdentities:
+      disk-csi-driver:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/5b7237c5-45e1-49d6-bc18-a1f62f400748'
+            name: 'Azure Red Hat OpenShift Disk Storage Operator'
+        k8sServiceAccounts:
+          - name: 'azure-disk-csi-driver-operator'
+            namespace: 'openshift-cluster-csi-drivers'
+          - name: 'azure-disk-csi-driver-controller-sa'
+            namespace: 'openshift-cluster-csi-drivers'
+        optional: false
+      image-registry:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/8b32b316-c2f5-4ddf-b05b-83dacd2d08b5'
+            name: 'Azure Red Hat OpenShift Image Registry Operator'
+        k8sServiceAccounts:
+          - name: 'cluster-image-registry-operator'
+            namespace: 'openshift-image-registry'
+          - name: 'registry'
+            namespace: 'openshift-image-registry'
+        optional: false
+      file-csi-driver:
+        minOpenShiftVersion: 4.19
+        roleDefinitions:
+          - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/0d7aedc0-15fd-4a67-a412-efad370c947e'
+            name: 'Azure Red Hat OpenShift File Storage Operator'
+        k8sServiceAccounts:
+          - name: 'azure-file-csi-driver-operator'
+            namespace: 'openshift-cluster-csi-drivers'
+          - name: 'azure-file-csi-driver-controller-sa'
+            namespace: 'openshift-cluster-csi-drivers'
+          - name: 'azure-file-csi-driver-node-sa'
+            namespace: 'openshift-cluster-csi-drivers'
+        optional: false
+    serviceManagedIdentity:
+      roleDefinitions:
+        - resourceId: '/providers/Microsoft.Authorization/roleDefinitions/c0ff367d-66d8-445e-917c-583feb0ef0d4'
+          name: 'Azure Red Hat OpenShift Hosted Control Planes Service Managed Identity'
+---
+# Source: clusters-service/templates/azure-runtime-config.configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: azure-runtime-config
+  namespace: 'clusters-service'
+data:
+  config.json: |
+    {
+      "cloud_environment": "AzurePublicCloud",
+      "managed_identities_data_plane_audience_resource": "https://dummy.org",
+      "tenant_id": "__tenantId__",
+      "ocp_images_acr": {
+        "resource_id": "__ocpAcrResourceId__",
+        "url": "__ocpAcrResourceUrl__",
+        "scope_map_name": "_repositories_pull"
+      },
+      "data_plane_identities_oidc_configuration": {
+        "storage_account_blob_container_name": "$web",
+        "storage_account_blob_service_url": "__oidcIssuerBlobServiceUrl__",
+        "oidc_issuer_base_url": "__oidcIssuerBaseUrl__"
+      },
+      "tls_certificates_config": {
+        "issuer": "Self",
+        "enabled": true
+      }
+    }
+---
+# Source: clusters-service/templates/cloud-resource-constraints-config.configmap.yaml
+apiVersion: v1
+data:
+  cloud-region-constraints.yaml: |
+    cloud_regions:
+      - id: 'westus3'
+        enabled: true
+        govcloud: false
+        ccs_only: false
+  instance-type-constraints.yaml: |
+    instance_types:
+    # hand-crafted list to the ones mentioned in
+    # https://issues.redhat.com/browse/ARO-21660
+    # those are the instance types that are also enabled in ARO Classic.
+    # We also include the ones mentioned in https://issues.redhat.com/browse/ARO-22443
+    - id: Standard_D8s_v3
+      ccs_only: true
+      enabled: true
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC4as_T4_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC8as_T4_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC16as_T4_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC64as_T4_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_E4s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E8s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E16s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E20s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E32s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E48s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E64s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E80is_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E80ids_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D4s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D8s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D16s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D32s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D64s_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D4s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_D16s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_D32s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_E4s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_E8s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_E16s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_E32s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_F4s_v2
+    - ccs_only: true
+      enabled: true
+      id: Standard_F8s_v2
+    - ccs_only: true
+      enabled: true
+      id: Standard_F16s_v2
+    - ccs_only: true
+      enabled: true
+      id: Standard_F32s_v2
+    - ccs_only: true
+      enabled: true
+      id: Standard_F72s_v2
+    - ccs_only: true
+      enabled: true
+      id: Standard_D4s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D8s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D16s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D32s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D64s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D96s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E96ds_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E104ids_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E4s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E8s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E16s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E20s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E32s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E48s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E64s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E96s_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E104is_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D4as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D8as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D16as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D32as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D64as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D96as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E4as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E8as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E16as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E20as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E32as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E48as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E64as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_E96as_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_D4as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D8as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D16as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D32as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D64as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_D96as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E8as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E16as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E20as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E32as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E48as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E64as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_E96as_v5
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC24ads_A100_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC48ads_A100_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC96ads_A100_v4
+    - ccs_only: true
+      enabled: true
+      id: Standard_L8s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_L16s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_L32s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_L48s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_L64s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC6s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC12s_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC24rs_v3
+    - ccs_only: true
+      enabled: true
+      id: Standard_NC24s_v3
+    - id: Standard_D2pls_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D4pls_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D8pls_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D16pls_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D32pls_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D48pls_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D64pls_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D96pls_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D2plds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D4plds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D8plds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D16plds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D32plds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D48plds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D64plds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D96plds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D2ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D4ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D8ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D16ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D32ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D48ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D64ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D96ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D2pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D4pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D8pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D16pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D32pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D48pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D64pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D96pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E2ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E4ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E8ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E16ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E32ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E48ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E64ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E96ps_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E2pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E4pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E8pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E16pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E32pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E48pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E64pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E96pds_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D2s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D4s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D8s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D16s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D32s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D48s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D64s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D96s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D128s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_D192s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_L2s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_L4s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_L8s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_L16s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_L32s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_L48s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_L64s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_L80s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_L96s_v4
+      ccs_only: true
+      enabled: true
+    - id: Standard_E2s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E4s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E8s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E16s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E20s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E32s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E48s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E64s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E96s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E128s_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_E192is_v6
+      ccs_only: true
+      enabled: true
+    - id: Standard_NC40ads_H100_v5
+      ccs_only: true
+      enabled: true
+    - id: Standard_NC80adis_H100_v5
+      ccs_only: true
+      enabled: true
+    - id: Standard_ND96isr_H200_v5
+      ccs_only: true
+      enabled: true
+kind: ConfigMap
+metadata:
+  name: cloud-resource-constraints-config
+  namespace: 'clusters-service'
+---
+# Source: clusters-service/templates/cloud-resources-config.configmap.yaml
+apiVersion: v1
+data:
+  cloud-regions.yaml: |
+    cloud_regions:
+      - id: 'westus3'
+        cloud_provider_id: azure
+        display_name: Azure East US
+        supports_multi_az: true
+  instance-types.yaml: |
+    instance_types:
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_nc4as_t4_v3
+      id: Standard_NC4as_T4_v3
+      memory: 30064771072
+      name: Standard_NC4as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_nc8as_t4_v3
+      id: Standard_NC8as_T4_v3
+      memory: 60129542144
+      name: Standard_NC8as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_nc16as_t4_v3
+      id: Standard_NC16as_T4_v3
+      memory: 118111600640
+      name: Standard_NC16as_T4_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_nc64as_t4_v3
+      id: Standard_NC64as_T4_v3
+      memory: 472446402560
+      name: Standard_NC64as_T4_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2_v4
+      id: Standard_E2_v4
+      memory: 17179869184
+      name: Standard_E2_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4_v4
+      id: Standard_E4_v4
+      memory: 34359738368
+      name: Standard_E4_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8_v4
+      id: Standard_E8_v4
+      memory: 68719476736
+      name: Standard_E8_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16_v4
+      id: Standard_E16_v4
+      memory: 137438953472
+      name: Standard_E16_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20_v4
+      id: Standard_E20_v4
+      memory: 171798691840
+      name: Standard_E20_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32_v4
+      id: Standard_E32_v4
+      memory: 274877906944
+      name: Standard_E32_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48_v4
+      id: Standard_E48_v4
+      memory: 412316860416
+      name: Standard_E48_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64_v4
+      id: Standard_E64_v4
+      memory: 541165879296
+      name: Standard_E64_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2d_v4
+      id: Standard_E2d_v4
+      memory: 17179869184
+      name: Standard_E2d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4d_v4
+      id: Standard_E4d_v4
+      memory: 34359738368
+      name: Standard_E4d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8d_v4
+      id: Standard_E8d_v4
+      memory: 68719476736
+      name: Standard_E8d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16d_v4
+      id: Standard_E16d_v4
+      memory: 137438953472
+      name: Standard_E16d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20d_v4
+      id: Standard_E20d_v4
+      memory: 171798691840
+      name: Standard_E20d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32d_v4
+      id: Standard_E32d_v4
+      memory: 274877906944
+      name: Standard_E32d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48d_v4
+      id: Standard_E48d_v4
+      memory: 412316860416
+      name: Standard_E48d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64d_v4
+      id: Standard_E64d_v4
+      memory: 541165879296
+      name: Standard_E64d_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2s_v4
+      id: Standard_E2s_v4
+      memory: 17179869184
+      name: Standard_E2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2s_v4
+      id: Standard_E4-2s_v4
+      memory: 34359738368
+      name: Standard_E4-2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4s_v4
+      id: Standard_E4s_v4
+      memory: 34359738368
+      name: Standard_E4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2s_v4
+      id: Standard_E8-2s_v4
+      memory: 68719476736
+      name: Standard_E8-2s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4s_v4
+      id: Standard_E8-4s_v4
+      memory: 68719476736
+      name: Standard_E8-4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8s_v4
+      id: Standard_E8s_v4
+      memory: 68719476736
+      name: Standard_E8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4s_v4
+      id: Standard_E16-4s_v4
+      memory: 137438953472
+      name: Standard_E16-4s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8s_v4
+      id: Standard_E16-8s_v4
+      memory: 137438953472
+      name: Standard_E16-8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16s_v4
+      id: Standard_E16s_v4
+      memory: 137438953472
+      name: Standard_E16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20s_v4
+      id: Standard_E20s_v4
+      memory: 171798691840
+      name: Standard_E20s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8s_v4
+      id: Standard_E32-8s_v4
+      memory: 274877906944
+      name: Standard_E32-8s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16s_v4
+      id: Standard_E32-16s_v4
+      memory: 274877906944
+      name: Standard_E32-16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32s_v4
+      id: Standard_E32s_v4
+      memory: 274877906944
+      name: Standard_E32s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48s_v4
+      id: Standard_E48s_v4
+      memory: 412316860416
+      name: Standard_E48s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16s_v4
+      id: Standard_E64-16s_v4
+      memory: 541165879296
+      name: Standard_E64-16s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32s_v4
+      id: Standard_E64-32s_v4
+      memory: 541165879296
+      name: Standard_E64-32s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64s_v4
+      id: Standard_E64s_v4
+      memory: 541165879296
+      name: Standard_E64s_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_e80is_v4
+      id: Standard_E80is_v4
+      memory: 541165879296
+      name: Standard_E80is_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2ds_v4
+      id: Standard_E2ds_v4
+      memory: 17179869184
+      name: Standard_E2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2ds_v4
+      id: Standard_E4-2ds_v4
+      memory: 34359738368
+      name: Standard_E4-2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4ds_v4
+      id: Standard_E4ds_v4
+      memory: 34359738368
+      name: Standard_E4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2ds_v4
+      id: Standard_E8-2ds_v4
+      memory: 68719476736
+      name: Standard_E8-2ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4ds_v4
+      id: Standard_E8-4ds_v4
+      memory: 68719476736
+      name: Standard_E8-4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8ds_v4
+      id: Standard_E8ds_v4
+      memory: 68719476736
+      name: Standard_E8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4ds_v4
+      id: Standard_E16-4ds_v4
+      memory: 137438953472
+      name: Standard_E16-4ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8ds_v4
+      id: Standard_E16-8ds_v4
+      memory: 137438953472
+      name: Standard_E16-8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16ds_v4
+      id: Standard_E16ds_v4
+      memory: 137438953472
+      name: Standard_E16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20ds_v4
+      id: Standard_E20ds_v4
+      memory: 171798691840
+      name: Standard_E20ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8ds_v4
+      id: Standard_E32-8ds_v4
+      memory: 274877906944
+      name: Standard_E32-8ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16ds_v4
+      id: Standard_E32-16ds_v4
+      memory: 274877906944
+      name: Standard_E32-16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32ds_v4
+      id: Standard_E32ds_v4
+      memory: 274877906944
+      name: Standard_E32ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48ds_v4
+      id: Standard_E48ds_v4
+      memory: 412316860416
+      name: Standard_E48ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16ds_v4
+      id: Standard_E64-16ds_v4
+      memory: 541165879296
+      name: Standard_E64-16ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32ds_v4
+      id: Standard_E64-32ds_v4
+      memory: 541165879296
+      name: Standard_E64-32ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64ds_v4
+      id: Standard_E64ds_v4
+      memory: 541165879296
+      name: Standard_E64ds_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_e80ids_v4
+      id: Standard_E80ids_v4
+      memory: 541165879296
+      name: Standard_E80ids_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2d_v4
+      id: Standard_D2d_v4
+      memory: 8589934592
+      name: Standard_D2d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4d_v4
+      id: Standard_D4d_v4
+      memory: 17179869184
+      name: Standard_D4d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8d_v4
+      id: Standard_D8d_v4
+      memory: 34359738368
+      name: Standard_D8d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16d_v4
+      id: Standard_D16d_v4
+      memory: 68719476736
+      name: Standard_D16d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32d_v4
+      id: Standard_D32d_v4
+      memory: 137438953472
+      name: Standard_D32d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48d_v4
+      id: Standard_D48d_v4
+      memory: 206158430208
+      name: Standard_D48d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64d_v4
+      id: Standard_D64d_v4
+      memory: 274877906944
+      name: Standard_D64d_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2_v4
+      id: Standard_D2_v4
+      memory: 8589934592
+      name: Standard_D2_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4_v4
+      id: Standard_D4_v4
+      memory: 17179869184
+      name: Standard_D4_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8_v4
+      id: Standard_D8_v4
+      memory: 34359738368
+      name: Standard_D8_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16_v4
+      id: Standard_D16_v4
+      memory: 68719476736
+      name: Standard_D16_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32_v4
+      id: Standard_D32_v4
+      memory: 137438953472
+      name: Standard_D32_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48_v4
+      id: Standard_D48_v4
+      memory: 206158430208
+      name: Standard_D48_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64_v4
+      id: Standard_D64_v4
+      memory: 274877906944
+      name: Standard_D64_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ds_v4
+      id: Standard_D2ds_v4
+      memory: 8589934592
+      name: Standard_D2ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ds_v4
+      id: Standard_D4ds_v4
+      memory: 17179869184
+      name: Standard_D4ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ds_v4
+      id: Standard_D8ds_v4
+      memory: 34359738368
+      name: Standard_D8ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ds_v4
+      id: Standard_D16ds_v4
+      memory: 68719476736
+      name: Standard_D16ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ds_v4
+      id: Standard_D32ds_v4
+      memory: 137438953472
+      name: Standard_D32ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ds_v4
+      id: Standard_D48ds_v4
+      memory: 206158430208
+      name: Standard_D48ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ds_v4
+      id: Standard_D64ds_v4
+      memory: 274877906944
+      name: Standard_D64ds_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2s_v4
+      id: Standard_D2s_v4
+      memory: 8589934592
+      name: Standard_D2s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4s_v4
+      id: Standard_D4s_v4
+      memory: 17179869184
+      name: Standard_D4s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8s_v4
+      id: Standard_D8s_v4
+      memory: 34359738368
+      name: Standard_D8s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16s_v4
+      id: Standard_D16s_v4
+      memory: 68719476736
+      name: Standard_D16s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32s_v4
+      id: Standard_D32s_v4
+      memory: 137438953472
+      name: Standard_D32s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48s_v4
+      id: Standard_D48s_v4
+      memory: 206158430208
+      name: Standard_D48s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64s_v4
+      id: Standard_D64s_v4
+      memory: 274877906944
+      name: Standard_D64s_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_d1_v2
+      id: Standard_D1_v2
+      memory: 3758096384
+      name: Standard_D1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2_v2
+      id: Standard_D2_v2
+      memory: 7516192768
+      name: Standard_D2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d3_v2
+      id: Standard_D3_v2
+      memory: 15032385536
+      name: Standard_D3_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d4_v2
+      id: Standard_D4_v2
+      memory: 30064771072
+      name: Standard_D4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d5_v2
+      id: Standard_D5_v2
+      memory: 60129542144
+      name: Standard_D5_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d11_v2
+      id: Standard_D11_v2
+      memory: 15032385536
+      name: Standard_D11_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d12_v2
+      id: Standard_D12_v2
+      memory: 30064771072
+      name: Standard_D12_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d13_v2
+      id: Standard_D13_v2
+      memory: 60129542144
+      name: Standard_D13_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d14_v2
+      id: Standard_D14_v2
+      memory: 120259084288
+      name: Standard_D14_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_d15_v2
+      id: Standard_D15_v2
+      memory: 150323855360
+      name: Standard_D15_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_f1
+      id: Standard_F1
+      memory: 2147483648
+      name: Standard_F1
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2
+      id: Standard_F2
+      memory: 4294967296
+      name: Standard_F2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4
+      id: Standard_F4
+      memory: 8589934592
+      name: Standard_F4
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8
+      id: Standard_F8
+      memory: 17179869184
+      name: Standard_F8
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16
+      id: Standard_F16
+      memory: 34359738368
+      name: Standard_F16
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_ds1_v2
+      id: Standard_DS1_v2
+      memory: 3758096384
+      name: Standard_DS1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_ds2_v2
+      id: Standard_DS2_v2
+      memory: 7516192768
+      name: Standard_DS2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_ds3_v2
+      id: Standard_DS3_v2
+      memory: 15032385536
+      name: Standard_DS3_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_ds4_v2
+      id: Standard_DS4_v2
+      memory: 30064771072
+      name: Standard_DS4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_ds5_v2
+      id: Standard_DS5_v2
+      memory: 60129542144
+      name: Standard_DS5_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_ds11-1_v2
+      id: Standard_DS11-1_v2
+      memory: 15032385536
+      name: Standard_DS11-1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_ds11_v2
+      id: Standard_DS11_v2
+      memory: 15032385536
+      name: Standard_DS11_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_ds12-1_v2
+      id: Standard_DS12-1_v2
+      memory: 30064771072
+      name: Standard_DS12-1_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_ds12-2_v2
+      id: Standard_DS12-2_v2
+      memory: 30064771072
+      name: Standard_DS12-2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_ds12_v2
+      id: Standard_DS12_v2
+      memory: 30064771072
+      name: Standard_DS12_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_ds13-2_v2
+      id: Standard_DS13-2_v2
+      memory: 60129542144
+      name: Standard_DS13-2_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_ds13-4_v2
+      id: Standard_DS13-4_v2
+      memory: 60129542144
+      name: Standard_DS13-4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_ds13_v2
+      id: Standard_DS13_v2
+      memory: 60129542144
+      name: Standard_DS13_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_ds14-4_v2
+      id: Standard_DS14-4_v2
+      memory: 120259084288
+      name: Standard_DS14-4_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_ds14-8_v2
+      id: Standard_DS14-8_v2
+      memory: 120259084288
+      name: Standard_DS14-8_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_ds14_v2
+      id: Standard_DS14_v2
+      memory: 120259084288
+      name: Standard_DS14_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_ds15_v2
+      id: Standard_DS15_v2
+      memory: 150323855360
+      name: Standard_DS15_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_f1s
+      id: Standard_F1s
+      memory: 2147483648
+      name: Standard_F1s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2s
+      id: Standard_F2s
+      memory: 4294967296
+      name: Standard_F2s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4s
+      id: Standard_F4s
+      memory: 8589934592
+      name: Standard_F4s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8s
+      id: Standard_F8s
+      memory: 17179869184
+      name: Standard_F8s
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16s
+      id: Standard_F16s
+      memory: 34359738368
+      name: Standard_F16s
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2_v3
+      id: Standard_D2_v3
+      memory: 8589934592
+      name: Standard_D2_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4_v3
+      id: Standard_D4_v3
+      memory: 17179869184
+      name: Standard_D4_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8_v3
+      id: Standard_D8_v3
+      memory: 34359738368
+      name: Standard_D8_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16_v3
+      id: Standard_D16_v3
+      memory: 68719476736
+      name: Standard_D16_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32_v3
+      id: Standard_D32_v3
+      memory: 137438953472
+      name: Standard_D32_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48_v3
+      id: Standard_D48_v3
+      memory: 206158430208
+      name: Standard_D48_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64_v3
+      id: Standard_D64_v3
+      memory: 274877906944
+      name: Standard_D64_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2s_v3
+      id: Standard_D2s_v3
+      memory: 8589934592
+      name: Standard_D2s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4s_v3
+      id: Standard_D4s_v3
+      memory: 17179869184
+      name: Standard_D4s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8s_v3
+      id: Standard_D8s_v3
+      memory: 34359738368
+      name: Standard_D8s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16s_v3
+      id: Standard_D16s_v3
+      memory: 68719476736
+      name: Standard_D16s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32s_v3
+      id: Standard_D32s_v3
+      memory: 137438953472
+      name: Standard_D32s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48s_v3
+      id: Standard_D48s_v3
+      memory: 206158430208
+      name: Standard_D48s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64s_v3
+      id: Standard_D64s_v3
+      memory: 274877906944
+      name: Standard_D64s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2_v3
+      id: Standard_E2_v3
+      memory: 17179869184
+      name: Standard_E2_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4_v3
+      id: Standard_E4_v3
+      memory: 34359738368
+      name: Standard_E4_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8_v3
+      id: Standard_E8_v3
+      memory: 68719476736
+      name: Standard_E8_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16_v3
+      id: Standard_E16_v3
+      memory: 137438953472
+      name: Standard_E16_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20_v3
+      id: Standard_E20_v3
+      memory: 171798691840
+      name: Standard_E20_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32_v3
+      id: Standard_E32_v3
+      memory: 274877906944
+      name: Standard_E32_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48_v3
+      id: Standard_E48_v3
+      memory: 412316860416
+      name: Standard_E48_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64_v3
+      id: Standard_E64_v3
+      memory: 463856467968
+      name: Standard_E64_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2s_v3
+      id: Standard_E2s_v3
+      memory: 17179869184
+      name: Standard_E2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2s_v3
+      id: Standard_E4-2s_v3
+      memory: 34359738368
+      name: Standard_E4-2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4s_v3
+      id: Standard_E4s_v3
+      memory: 34359738368
+      name: Standard_E4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2s_v3
+      id: Standard_E8-2s_v3
+      memory: 68719476736
+      name: Standard_E8-2s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4s_v3
+      id: Standard_E8-4s_v3
+      memory: 68719476736
+      name: Standard_E8-4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8s_v3
+      id: Standard_E8s_v3
+      memory: 68719476736
+      name: Standard_E8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4s_v3
+      id: Standard_E16-4s_v3
+      memory: 137438953472
+      name: Standard_E16-4s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8s_v3
+      id: Standard_E16-8s_v3
+      memory: 137438953472
+      name: Standard_E16-8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16s_v3
+      id: Standard_E16s_v3
+      memory: 137438953472
+      name: Standard_E16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20s_v3
+      id: Standard_E20s_v3
+      memory: 171798691840
+      name: Standard_E20s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8s_v3
+      id: Standard_E32-8s_v3
+      memory: 274877906944
+      name: Standard_E32-8s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16s_v3
+      id: Standard_E32-16s_v3
+      memory: 274877906944
+      name: Standard_E32-16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32s_v3
+      id: Standard_E32s_v3
+      memory: 274877906944
+      name: Standard_E32s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48s_v3
+      id: Standard_E48s_v3
+      memory: 412316860416
+      name: Standard_E48s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16s_v3
+      id: Standard_E64-16s_v3
+      memory: 463856467968
+      name: Standard_E64-16s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32s_v3
+      id: Standard_E64-32s_v3
+      memory: 463856467968
+      name: Standard_E64-32s_v3
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64s_v3
+      id: Standard_E64s_v3
+      memory: 463856467968
+      name: Standard_E64s_v3
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2s_v2
+      id: Standard_F2s_v2
+      memory: 4294967296
+      name: Standard_F2s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4s_v2
+      id: Standard_F4s_v2
+      memory: 8589934592
+      name: Standard_F4s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8s_v2
+      id: Standard_F8s_v2
+      memory: 17179869184
+      name: Standard_F8s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16s_v2
+      id: Standard_F16s_v2
+      memory: 34359738368
+      name: Standard_F16s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32s_v2
+      id: Standard_F32s_v2
+      memory: 68719476736
+      name: Standard_F32s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48s_v2
+      id: Standard_F48s_v2
+      memory: 103079215104
+      name: Standard_F48s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64s_v2
+      id: Standard_F64s_v2
+      memory: 137438953472
+      name: Standard_F64s_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 72
+      generic_name: standard_f72s_v2
+      id: Standard_F72s_v2
+      memory: 154618822656
+      name: Standard_F72s_v2
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2as_v5
+      id: Standard_D2as_v5
+      memory: 8589934592
+      name: Standard_D2as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4as_v5
+      id: Standard_D4as_v5
+      memory: 17179869184
+      name: Standard_D4as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8as_v5
+      id: Standard_D8as_v5
+      memory: 34359738368
+      name: Standard_D8as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16as_v5
+      id: Standard_D16as_v5
+      memory: 68719476736
+      name: Standard_D16as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32as_v5
+      id: Standard_D32as_v5
+      memory: 137438953472
+      name: Standard_D32as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48as_v5
+      id: Standard_D48as_v5
+      memory: 206158430208
+      name: Standard_D48as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64as_v5
+      id: Standard_D64as_v5
+      memory: 274877906944
+      name: Standard_D64as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96as_v5
+      id: Standard_D96as_v5
+      memory: 412316860416
+      name: Standard_D96as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2as_v5
+      id: Standard_E2as_v5
+      memory: 17179869184
+      name: Standard_E2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2as_v5
+      id: Standard_E4-2as_v5
+      memory: 34359738368
+      name: Standard_E4-2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4as_v5
+      id: Standard_E4as_v5
+      memory: 34359738368
+      name: Standard_E4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2as_v5
+      id: Standard_E8-2as_v5
+      memory: 68719476736
+      name: Standard_E8-2as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4as_v5
+      id: Standard_E8-4as_v5
+      memory: 68719476736
+      name: Standard_E8-4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8as_v5
+      id: Standard_E8as_v5
+      memory: 68719476736
+      name: Standard_E8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4as_v5
+      id: Standard_E16-4as_v5
+      memory: 137438953472
+      name: Standard_E16-4as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8as_v5
+      id: Standard_E16-8as_v5
+      memory: 137438953472
+      name: Standard_E16-8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16as_v5
+      id: Standard_E16as_v5
+      memory: 137438953472
+      name: Standard_E16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20as_v5
+      id: Standard_E20as_v5
+      memory: 171798691840
+      name: Standard_E20as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8as_v5
+      id: Standard_E32-8as_v5
+      memory: 274877906944
+      name: Standard_E32-8as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16as_v5
+      id: Standard_E32-16as_v5
+      memory: 274877906944
+      name: Standard_E32-16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32as_v5
+      id: Standard_E32as_v5
+      memory: 274877906944
+      name: Standard_E32as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48as_v5
+      id: Standard_E48as_v5
+      memory: 412316860416
+      name: Standard_E48as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16as_v5
+      id: Standard_E64-16as_v5
+      memory: 549755813888
+      name: Standard_E64-16as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32as_v5
+      id: Standard_E64-32as_v5
+      memory: 549755813888
+      name: Standard_E64-32as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64as_v5
+      id: Standard_E64as_v5
+      memory: 549755813888
+      name: Standard_E64as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24as_v5
+      id: Standard_E96-24as_v5
+      memory: 721554505728
+      name: Standard_E96-24as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48as_v5
+      id: Standard_E96-48as_v5
+      memory: 721554505728
+      name: Standard_E96-48as_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96as_v5
+      id: Standard_E96as_v5
+      memory: 721554505728
+      name: Standard_E96as_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ads_v5
+      id: Standard_D2ads_v5
+      memory: 8589934592
+      name: Standard_D2ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ads_v5
+      id: Standard_D4ads_v5
+      memory: 17179869184
+      name: Standard_D4ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ads_v5
+      id: Standard_D8ads_v5
+      memory: 34359738368
+      name: Standard_D8ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ads_v5
+      id: Standard_D16ads_v5
+      memory: 68719476736
+      name: Standard_D16ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ads_v5
+      id: Standard_D32ads_v5
+      memory: 137438953472
+      name: Standard_D32ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ads_v5
+      id: Standard_D48ads_v5
+      memory: 206158430208
+      name: Standard_D48ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ads_v5
+      id: Standard_D64ads_v5
+      memory: 274877906944
+      name: Standard_D64ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96ads_v5
+      id: Standard_D96ads_v5
+      memory: 412316860416
+      name: Standard_D96ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2ads_v5
+      id: Standard_E2ads_v5
+      memory: 17179869184
+      name: Standard_E2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2ads_v5
+      id: Standard_E4-2ads_v5
+      memory: 34359738368
+      name: Standard_E4-2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4ads_v5
+      id: Standard_E4ads_v5
+      memory: 34359738368
+      name: Standard_E4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2ads_v5
+      id: Standard_E8-2ads_v5
+      memory: 68719476736
+      name: Standard_E8-2ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4ads_v5
+      id: Standard_E8-4ads_v5
+      memory: 68719476736
+      name: Standard_E8-4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8ads_v5
+      id: Standard_E8ads_v5
+      memory: 68719476736
+      name: Standard_E8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4ads_v5
+      id: Standard_E16-4ads_v5
+      memory: 137438953472
+      name: Standard_E16-4ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8ads_v5
+      id: Standard_E16-8ads_v5
+      memory: 137438953472
+      name: Standard_E16-8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16ads_v5
+      id: Standard_E16ads_v5
+      memory: 137438953472
+      name: Standard_E16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20ads_v5
+      id: Standard_E20ads_v5
+      memory: 171798691840
+      name: Standard_E20ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8ads_v5
+      id: Standard_E32-8ads_v5
+      memory: 274877906944
+      name: Standard_E32-8ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16ads_v5
+      id: Standard_E32-16ads_v5
+      memory: 274877906944
+      name: Standard_E32-16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32ads_v5
+      id: Standard_E32ads_v5
+      memory: 274877906944
+      name: Standard_E32ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48ads_v5
+      id: Standard_E48ads_v5
+      memory: 412316860416
+      name: Standard_E48ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16ads_v5
+      id: Standard_E64-16ads_v5
+      memory: 549755813888
+      name: Standard_E64-16ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32ads_v5
+      id: Standard_E64-32ads_v5
+      memory: 549755813888
+      name: Standard_E64-32ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64ads_v5
+      id: Standard_E64ads_v5
+      memory: 549755813888
+      name: Standard_E64ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24ads_v5
+      id: Standard_E96-24ads_v5
+      memory: 721554505728
+      name: Standard_E96-24ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48ads_v5
+      id: Standard_E96-48ads_v5
+      memory: 721554505728
+      name: Standard_E96-48ads_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96ads_v5
+      id: Standard_E96ads_v5
+      memory: 721554505728
+      name: Standard_E96ads_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2as_v6
+      id: Standard_D2as_v6
+      memory: 8589934592
+      name: Standard_D2as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4as_v6
+      id: Standard_D4as_v6
+      memory: 17179869184
+      name: Standard_D4as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8as_v6
+      id: Standard_D8as_v6
+      memory: 34359738368
+      name: Standard_D8as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16as_v6
+      id: Standard_D16as_v6
+      memory: 68719476736
+      name: Standard_D16as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32as_v6
+      id: Standard_D32as_v6
+      memory: 137438953472
+      name: Standard_D32as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48as_v6
+      id: Standard_D48as_v6
+      memory: 206158430208
+      name: Standard_D48as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64as_v6
+      id: Standard_D64as_v6
+      memory: 274877906944
+      name: Standard_D64as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96as_v6
+      id: Standard_D96as_v6
+      memory: 412316860416
+      name: Standard_D96as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2as_v6
+      id: Standard_E2as_v6
+      memory: 17179869184
+      name: Standard_E2as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4as_v6
+      id: Standard_E4as_v6
+      memory: 34359738368
+      name: Standard_E4as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8as_v6
+      id: Standard_E8as_v6
+      memory: 68719476736
+      name: Standard_E8as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16as_v6
+      id: Standard_E16as_v6
+      memory: 137438953472
+      name: Standard_E16as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20as_v6
+      id: Standard_E20as_v6
+      memory: 171798691840
+      name: Standard_E20as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32as_v6
+      id: Standard_E32as_v6
+      memory: 274877906944
+      name: Standard_E32as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48as_v6
+      id: Standard_E48as_v6
+      memory: 412316860416
+      name: Standard_E48as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64as_v6
+      id: Standard_E64as_v6
+      memory: 549755813888
+      name: Standard_E64as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96as_v6
+      id: Standard_E96as_v6
+      memory: 721554505728
+      name: Standard_E96as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ads_v6
+      id: Standard_D2ads_v6
+      memory: 8589934592
+      name: Standard_D2ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ads_v6
+      id: Standard_D4ads_v6
+      memory: 17179869184
+      name: Standard_D4ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ads_v6
+      id: Standard_D8ads_v6
+      memory: 34359738368
+      name: Standard_D8ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ads_v6
+      id: Standard_D16ads_v6
+      memory: 68719476736
+      name: Standard_D16ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ads_v6
+      id: Standard_D32ads_v6
+      memory: 137438953472
+      name: Standard_D32ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ads_v6
+      id: Standard_D48ads_v6
+      memory: 206158430208
+      name: Standard_D48ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ads_v6
+      id: Standard_D64ads_v6
+      memory: 274877906944
+      name: Standard_D64ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96ads_v6
+      id: Standard_D96ads_v6
+      memory: 412316860416
+      name: Standard_D96ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2als_v6
+      id: Standard_D2als_v6
+      memory: 4294967296
+      name: Standard_D2als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4als_v6
+      id: Standard_D4als_v6
+      memory: 8589934592
+      name: Standard_D4als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8als_v6
+      id: Standard_D8als_v6
+      memory: 17179869184
+      name: Standard_D8als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16als_v6
+      id: Standard_D16als_v6
+      memory: 34359738368
+      name: Standard_D16als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32als_v6
+      id: Standard_D32als_v6
+      memory: 68719476736
+      name: Standard_D32als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48als_v6
+      id: Standard_D48als_v6
+      memory: 103079215104
+      name: Standard_D48als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64als_v6
+      id: Standard_D64als_v6
+      memory: 137438953472
+      name: Standard_D64als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96als_v6
+      id: Standard_D96als_v6
+      memory: 206158430208
+      name: Standard_D96als_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2alds_v6
+      id: Standard_D2alds_v6
+      memory: 4294967296
+      name: Standard_D2alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4alds_v6
+      id: Standard_D4alds_v6
+      memory: 8589934592
+      name: Standard_D4alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8alds_v6
+      id: Standard_D8alds_v6
+      memory: 17179869184
+      name: Standard_D8alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16alds_v6
+      id: Standard_D16alds_v6
+      memory: 34359738368
+      name: Standard_D16alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32alds_v6
+      id: Standard_D32alds_v6
+      memory: 68719476736
+      name: Standard_D32alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48alds_v6
+      id: Standard_D48alds_v6
+      memory: 103079215104
+      name: Standard_D48alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64alds_v6
+      id: Standard_D64alds_v6
+      memory: 137438953472
+      name: Standard_D64alds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96alds_v6
+      id: Standard_D96alds_v6
+      memory: 206158430208
+      name: Standard_D96alds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2ads_v6
+      id: Standard_E2ads_v6
+      memory: 17179869184
+      name: Standard_E2ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4ads_v6
+      id: Standard_E4ads_v6
+      memory: 34359738368
+      name: Standard_E4ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8ads_v6
+      id: Standard_E8ads_v6
+      memory: 68719476736
+      name: Standard_E8ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16ads_v6
+      id: Standard_E16ads_v6
+      memory: 137438953472
+      name: Standard_E16ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20ads_v6
+      id: Standard_E20ads_v6
+      memory: 171798691840
+      name: Standard_E20ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32ads_v6
+      id: Standard_E32ads_v6
+      memory: 274877906944
+      name: Standard_E32ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48ads_v6
+      id: Standard_E48ads_v6
+      memory: 412316860416
+      name: Standard_E48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64ads_v6
+      id: Standard_E64ads_v6
+      memory: 549755813888
+      name: Standard_E64ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24ads_v6
+      id: Standard_E96-24ads_v6
+      memory: 721554505728
+      name: Standard_E96-24ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48ads_v6
+      id: Standard_E96-48ads_v6
+      memory: 721554505728
+      name: Standard_E96-48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96ads_v6
+      id: Standard_E96ads_v6
+      memory: 721554505728
+      name: Standard_E96ads_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2as_v6
+      id: Standard_F2as_v6
+      memory: 8589934592
+      name: Standard_F2as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4as_v6
+      id: Standard_F4as_v6
+      memory: 17179869184
+      name: Standard_F4as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8as_v6
+      id: Standard_F8as_v6
+      memory: 34359738368
+      name: Standard_F8as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16as_v6
+      id: Standard_F16as_v6
+      memory: 68719476736
+      name: Standard_F16as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32as_v6
+      id: Standard_F32as_v6
+      memory: 137438953472
+      name: Standard_F32as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48as_v6
+      id: Standard_F48as_v6
+      memory: 206158430208
+      name: Standard_F48as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64as_v6
+      id: Standard_F64as_v6
+      memory: 274877906944
+      name: Standard_F64as_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2als_v6
+      id: Standard_F2als_v6
+      memory: 4294967296
+      name: Standard_F2als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4als_v6
+      id: Standard_F4als_v6
+      memory: 8589934592
+      name: Standard_F4als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8als_v6
+      id: Standard_F8als_v6
+      memory: 17179869184
+      name: Standard_F8als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16als_v6
+      id: Standard_F16als_v6
+      memory: 34359738368
+      name: Standard_F16als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32als_v6
+      id: Standard_F32als_v6
+      memory: 68719476736
+      name: Standard_F32als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48als_v6
+      id: Standard_F48als_v6
+      memory: 103079215104
+      name: Standard_F48als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64als_v6
+      id: Standard_F64als_v6
+      memory: 137438953472
+      name: Standard_F64als_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2ams_v6
+      id: Standard_F2ams_v6
+      memory: 17179869184
+      name: Standard_F2ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4ams_v6
+      id: Standard_F4ams_v6
+      memory: 34359738368
+      name: Standard_F4ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8ams_v6
+      id: Standard_F8ams_v6
+      memory: 68719476736
+      name: Standard_F8ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16ams_v6
+      id: Standard_F16ams_v6
+      memory: 137438953472
+      name: Standard_F16ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32ams_v6
+      id: Standard_F32ams_v6
+      memory: 274877906944
+      name: Standard_F32ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48ams_v6
+      id: Standard_F48ams_v6
+      memory: 412316860416
+      name: Standard_F48ams_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64ams_v6
+      id: Standard_F64ams_v6
+      memory: 549755813888
+      name: Standard_F64ams_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ds_v5
+      id: Standard_D2ds_v5
+      memory: 8589934592
+      name: Standard_D2ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ds_v5
+      id: Standard_D4ds_v5
+      memory: 17179869184
+      name: Standard_D4ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ds_v5
+      id: Standard_D8ds_v5
+      memory: 34359738368
+      name: Standard_D8ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ds_v5
+      id: Standard_D16ds_v5
+      memory: 68719476736
+      name: Standard_D16ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ds_v5
+      id: Standard_D32ds_v5
+      memory: 137438953472
+      name: Standard_D32ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ds_v5
+      id: Standard_D48ds_v5
+      memory: 206158430208
+      name: Standard_D48ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ds_v5
+      id: Standard_D64ds_v5
+      memory: 274877906944
+      name: Standard_D64ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96ds_v5
+      id: Standard_D96ds_v5
+      memory: 412316860416
+      name: Standard_D96ds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2d_v5
+      id: Standard_D2d_v5
+      memory: 8589934592
+      name: Standard_D2d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4d_v5
+      id: Standard_D4d_v5
+      memory: 17179869184
+      name: Standard_D4d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8d_v5
+      id: Standard_D8d_v5
+      memory: 34359738368
+      name: Standard_D8d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16d_v5
+      id: Standard_D16d_v5
+      memory: 68719476736
+      name: Standard_D16d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32d_v5
+      id: Standard_D32d_v5
+      memory: 137438953472
+      name: Standard_D32d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48d_v5
+      id: Standard_D48d_v5
+      memory: 206158430208
+      name: Standard_D48d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64d_v5
+      id: Standard_D64d_v5
+      memory: 274877906944
+      name: Standard_D64d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96d_v5
+      id: Standard_D96d_v5
+      memory: 412316860416
+      name: Standard_D96d_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2s_v5
+      id: Standard_D2s_v5
+      memory: 8589934592
+      name: Standard_D2s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4s_v5
+      id: Standard_D4s_v5
+      memory: 17179869184
+      name: Standard_D4s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8s_v5
+      id: Standard_D8s_v5
+      memory: 34359738368
+      name: Standard_D8s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16s_v5
+      id: Standard_D16s_v5
+      memory: 68719476736
+      name: Standard_D16s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32s_v5
+      id: Standard_D32s_v5
+      memory: 137438953472
+      name: Standard_D32s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48s_v5
+      id: Standard_D48s_v5
+      memory: 206158430208
+      name: Standard_D48s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64s_v5
+      id: Standard_D64s_v5
+      memory: 274877906944
+      name: Standard_D64s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96s_v5
+      id: Standard_D96s_v5
+      memory: 412316860416
+      name: Standard_D96s_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2_v5
+      id: Standard_D2_v5
+      memory: 8589934592
+      name: Standard_D2_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4_v5
+      id: Standard_D4_v5
+      memory: 17179869184
+      name: Standard_D4_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8_v5
+      id: Standard_D8_v5
+      memory: 34359738368
+      name: Standard_D8_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16_v5
+      id: Standard_D16_v5
+      memory: 68719476736
+      name: Standard_D16_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32_v5
+      id: Standard_D32_v5
+      memory: 137438953472
+      name: Standard_D32_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48_v5
+      id: Standard_D48_v5
+      memory: 206158430208
+      name: Standard_D48_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64_v5
+      id: Standard_D64_v5
+      memory: 274877906944
+      name: Standard_D64_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96_v5
+      id: Standard_D96_v5
+      memory: 412316860416
+      name: Standard_D96_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2ds_v5
+      id: Standard_E2ds_v5
+      memory: 17179869184
+      name: Standard_E2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2ds_v5
+      id: Standard_E4-2ds_v5
+      memory: 34359738368
+      name: Standard_E4-2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4ds_v5
+      id: Standard_E4ds_v5
+      memory: 34359738368
+      name: Standard_E4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2ds_v5
+      id: Standard_E8-2ds_v5
+      memory: 68719476736
+      name: Standard_E8-2ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4ds_v5
+      id: Standard_E8-4ds_v5
+      memory: 68719476736
+      name: Standard_E8-4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8ds_v5
+      id: Standard_E8ds_v5
+      memory: 68719476736
+      name: Standard_E8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4ds_v5
+      id: Standard_E16-4ds_v5
+      memory: 137438953472
+      name: Standard_E16-4ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8ds_v5
+      id: Standard_E16-8ds_v5
+      memory: 137438953472
+      name: Standard_E16-8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16ds_v5
+      id: Standard_E16ds_v5
+      memory: 137438953472
+      name: Standard_E16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20ds_v5
+      id: Standard_E20ds_v5
+      memory: 171798691840
+      name: Standard_E20ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8ds_v5
+      id: Standard_E32-8ds_v5
+      memory: 274877906944
+      name: Standard_E32-8ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16ds_v5
+      id: Standard_E32-16ds_v5
+      memory: 274877906944
+      name: Standard_E32-16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32ds_v5
+      id: Standard_E32ds_v5
+      memory: 274877906944
+      name: Standard_E32ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48ds_v5
+      id: Standard_E48ds_v5
+      memory: 412316860416
+      name: Standard_E48ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16ds_v5
+      id: Standard_E64-16ds_v5
+      memory: 549755813888
+      name: Standard_E64-16ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32ds_v5
+      id: Standard_E64-32ds_v5
+      memory: 549755813888
+      name: Standard_E64-32ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64ds_v5
+      id: Standard_E64ds_v5
+      memory: 549755813888
+      name: Standard_E64ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24ds_v5
+      id: Standard_E96-24ds_v5
+      memory: 721554505728
+      name: Standard_E96-24ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48ds_v5
+      id: Standard_E96-48ds_v5
+      memory: 721554505728
+      name: Standard_E96-48ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96ds_v5
+      id: Standard_E96ds_v5
+      memory: 721554505728
+      name: Standard_E96ds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      generic_name: standard_e104ids_v5
+      id: Standard_E104ids_v5
+      memory: 721554505728
+      name: Standard_E104ids_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2d_v5
+      id: Standard_E2d_v5
+      memory: 17179869184
+      name: Standard_E2d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4d_v5
+      id: Standard_E4d_v5
+      memory: 34359738368
+      name: Standard_E4d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8d_v5
+      id: Standard_E8d_v5
+      memory: 68719476736
+      name: Standard_E8d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16d_v5
+      id: Standard_E16d_v5
+      memory: 137438953472
+      name: Standard_E16d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20d_v5
+      id: Standard_E20d_v5
+      memory: 171798691840
+      name: Standard_E20d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32d_v5
+      id: Standard_E32d_v5
+      memory: 274877906944
+      name: Standard_E32d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48d_v5
+      id: Standard_E48d_v5
+      memory: 412316860416
+      name: Standard_E48d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64d_v5
+      id: Standard_E64d_v5
+      memory: 549755813888
+      name: Standard_E64d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96d_v5
+      id: Standard_E96d_v5
+      memory: 721554505728
+      name: Standard_E96d_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      generic_name: standard_e104id_v5
+      id: Standard_E104id_v5
+      memory: 721554505728
+      name: Standard_E104id_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2s_v5
+      id: Standard_E2s_v5
+      memory: 17179869184
+      name: Standard_E2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2s_v5
+      id: Standard_E4-2s_v5
+      memory: 34359738368
+      name: Standard_E4-2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4s_v5
+      id: Standard_E4s_v5
+      memory: 34359738368
+      name: Standard_E4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2s_v5
+      id: Standard_E8-2s_v5
+      memory: 68719476736
+      name: Standard_E8-2s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4s_v5
+      id: Standard_E8-4s_v5
+      memory: 68719476736
+      name: Standard_E8-4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8s_v5
+      id: Standard_E8s_v5
+      memory: 68719476736
+      name: Standard_E8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4s_v5
+      id: Standard_E16-4s_v5
+      memory: 137438953472
+      name: Standard_E16-4s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8s_v5
+      id: Standard_E16-8s_v5
+      memory: 137438953472
+      name: Standard_E16-8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16s_v5
+      id: Standard_E16s_v5
+      memory: 137438953472
+      name: Standard_E16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20s_v5
+      id: Standard_E20s_v5
+      memory: 171798691840
+      name: Standard_E20s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8s_v5
+      id: Standard_E32-8s_v5
+      memory: 274877906944
+      name: Standard_E32-8s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16s_v5
+      id: Standard_E32-16s_v5
+      memory: 274877906944
+      name: Standard_E32-16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32s_v5
+      id: Standard_E32s_v5
+      memory: 274877906944
+      name: Standard_E32s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48s_v5
+      id: Standard_E48s_v5
+      memory: 412316860416
+      name: Standard_E48s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16s_v5
+      id: Standard_E64-16s_v5
+      memory: 549755813888
+      name: Standard_E64-16s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32s_v5
+      id: Standard_E64-32s_v5
+      memory: 549755813888
+      name: Standard_E64-32s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64s_v5
+      id: Standard_E64s_v5
+      memory: 549755813888
+      name: Standard_E64s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24s_v5
+      id: Standard_E96-24s_v5
+      memory: 721554505728
+      name: Standard_E96-24s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48s_v5
+      id: Standard_E96-48s_v5
+      memory: 721554505728
+      name: Standard_E96-48s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96s_v5
+      id: Standard_E96s_v5
+      memory: 721554505728
+      name: Standard_E96s_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      generic_name: standard_e104is_v5
+      id: Standard_E104is_v5
+      memory: 721554505728
+      name: Standard_E104is_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2_v5
+      id: Standard_E2_v5
+      memory: 17179869184
+      name: Standard_E2_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4_v5
+      id: Standard_E4_v5
+      memory: 34359738368
+      name: Standard_E4_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8_v5
+      id: Standard_E8_v5
+      memory: 68719476736
+      name: Standard_E8_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16_v5
+      id: Standard_E16_v5
+      memory: 137438953472
+      name: Standard_E16_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20_v5
+      id: Standard_E20_v5
+      memory: 171798691840
+      name: Standard_E20_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32_v5
+      id: Standard_E32_v5
+      memory: 274877906944
+      name: Standard_E32_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48_v5
+      id: Standard_E48_v5
+      memory: 412316860416
+      name: Standard_E48_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64_v5
+      id: Standard_E64_v5
+      memory: 549755813888
+      name: Standard_E64_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96_v5
+      id: Standard_E96_v5
+      memory: 721554505728
+      name: Standard_E96_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 104
+      generic_name: standard_e104i_v5
+      id: Standard_E104i_v5
+      memory: 721554505728
+      name: Standard_E104i_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2bs_v5
+      id: Standard_E2bs_v5
+      memory: 17179869184
+      name: Standard_E2bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4bs_v5
+      id: Standard_E4bs_v5
+      memory: 34359738368
+      name: Standard_E4bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8bs_v5
+      id: Standard_E8bs_v5
+      memory: 68719476736
+      name: Standard_E8bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16bs_v5
+      id: Standard_E16bs_v5
+      memory: 137438953472
+      name: Standard_E16bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32bs_v5
+      id: Standard_E32bs_v5
+      memory: 274877906944
+      name: Standard_E32bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48bs_v5
+      id: Standard_E48bs_v5
+      memory: 412316860416
+      name: Standard_E48bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64bs_v5
+      id: Standard_E64bs_v5
+      memory: 549755813888
+      name: Standard_E64bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96bs_v5
+      id: Standard_E96bs_v5
+      memory: 721554505728
+      name: Standard_E96bs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      generic_name: standard_e112ibs_v5
+      id: Standard_E112ibs_v5
+      memory: 721554505728
+      name: Standard_E112ibs_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2bds_v5
+      id: Standard_E2bds_v5
+      memory: 17179869184
+      name: Standard_E2bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4bds_v5
+      id: Standard_E4bds_v5
+      memory: 34359738368
+      name: Standard_E4bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8bds_v5
+      id: Standard_E8bds_v5
+      memory: 68719476736
+      name: Standard_E8bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16bds_v5
+      id: Standard_E16bds_v5
+      memory: 137438953472
+      name: Standard_E16bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32bds_v5
+      id: Standard_E32bds_v5
+      memory: 274877906944
+      name: Standard_E32bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48bds_v5
+      id: Standard_E48bds_v5
+      memory: 412316860416
+      name: Standard_E48bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64bds_v5
+      id: Standard_E64bds_v5
+      memory: 549755813888
+      name: Standard_E64bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96bds_v5
+      id: Standard_E96bds_v5
+      memory: 721554505728
+      name: Standard_E96bds_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      generic_name: standard_e112ibds_v5
+      id: Standard_E112ibds_v5
+      memory: 721554505728
+      name: Standard_E112ibds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ls_v5
+      id: Standard_D2ls_v5
+      memory: 4294967296
+      name: Standard_D2ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ls_v5
+      id: Standard_D4ls_v5
+      memory: 8589934592
+      name: Standard_D4ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ls_v5
+      id: Standard_D8ls_v5
+      memory: 17179869184
+      name: Standard_D8ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ls_v5
+      id: Standard_D16ls_v5
+      memory: 34359738368
+      name: Standard_D16ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ls_v5
+      id: Standard_D32ls_v5
+      memory: 68719476736
+      name: Standard_D32ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ls_v5
+      id: Standard_D48ls_v5
+      memory: 103079215104
+      name: Standard_D48ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ls_v5
+      id: Standard_D64ls_v5
+      memory: 137438953472
+      name: Standard_D64ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96ls_v5
+      id: Standard_D96ls_v5
+      memory: 206158430208
+      name: Standard_D96ls_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2lds_v5
+      id: Standard_D2lds_v5
+      memory: 4294967296
+      name: Standard_D2lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4lds_v5
+      id: Standard_D4lds_v5
+      memory: 8589934592
+      name: Standard_D4lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8lds_v5
+      id: Standard_D8lds_v5
+      memory: 17179869184
+      name: Standard_D8lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16lds_v5
+      id: Standard_D16lds_v5
+      memory: 34359738368
+      name: Standard_D16lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32lds_v5
+      id: Standard_D32lds_v5
+      memory: 68719476736
+      name: Standard_D32lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48lds_v5
+      id: Standard_D48lds_v5
+      memory: 103079215104
+      name: Standard_D48lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64lds_v5
+      id: Standard_D64lds_v5
+      memory: 137438953472
+      name: Standard_D64lds_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96lds_v5
+      id: Standard_D96lds_v5
+      memory: 206158430208
+      name: Standard_D96lds_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_nc8ads_a10_v4
+      id: Standard_NC8ads_A10_v4
+      memory: 107374182400
+      name: Standard_NC8ads_A10_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_nc16ads_a10_v4
+      id: Standard_NC16ads_A10_v4
+      memory: 214748364800
+      name: Standard_NC16ads_A10_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_nc32ads_a10_v4
+      id: Standard_NC32ads_A10_v4
+      memory: 429496729600
+      name: Standard_NC32ads_A10_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 40
+      generic_name: standard_nc40ads_h100_v5
+      id: Standard_NC40ads_H100_v5
+      memory: 343597383680
+      name: Standard_NC40ads_H100_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_nc80adis_h100_v5
+      id: Standard_NC80adis_H100_v5
+      memory: 687194767360
+      name: Standard_NC80adis_H100_v5
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ls_v6
+      id: Standard_D2ls_v6
+      memory: 4294967296
+      name: Standard_D2ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ls_v6
+      id: Standard_D4ls_v6
+      memory: 8589934592
+      name: Standard_D4ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ls_v6
+      id: Standard_D8ls_v6
+      memory: 17179869184
+      name: Standard_D8ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ls_v6
+      id: Standard_D16ls_v6
+      memory: 34359738368
+      name: Standard_D16ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ls_v6
+      id: Standard_D32ls_v6
+      memory: 68719476736
+      name: Standard_D32ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ls_v6
+      id: Standard_D48ls_v6
+      memory: 103079215104
+      name: Standard_D48ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ls_v6
+      id: Standard_D64ls_v6
+      memory: 137438953472
+      name: Standard_D64ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96ls_v6
+      id: Standard_D96ls_v6
+      memory: 206158430208
+      name: Standard_D96ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_d128ls_v6
+      id: Standard_D128ls_v6
+      memory: 274877906944
+      name: Standard_D128ls_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2lds_v6
+      id: Standard_D2lds_v6
+      memory: 4294967296
+      name: Standard_D2lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4lds_v6
+      id: Standard_D4lds_v6
+      memory: 8589934592
+      name: Standard_D4lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8lds_v6
+      id: Standard_D8lds_v6
+      memory: 17179869184
+      name: Standard_D8lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16lds_v6
+      id: Standard_D16lds_v6
+      memory: 34359738368
+      name: Standard_D16lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32lds_v6
+      id: Standard_D32lds_v6
+      memory: 68719476736
+      name: Standard_D32lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48lds_v6
+      id: Standard_D48lds_v6
+      memory: 103079215104
+      name: Standard_D48lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64lds_v6
+      id: Standard_D64lds_v6
+      memory: 137438953472
+      name: Standard_D64lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96lds_v6
+      id: Standard_D96lds_v6
+      memory: 206158430208
+      name: Standard_D96lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_d128lds_v6
+      id: Standard_D128lds_v6
+      memory: 274877906944
+      name: Standard_D128lds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2s_v6
+      id: Standard_D2s_v6
+      memory: 8589934592
+      name: Standard_D2s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4s_v6
+      id: Standard_D4s_v6
+      memory: 17179869184
+      name: Standard_D4s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8s_v6
+      id: Standard_D8s_v6
+      memory: 34359738368
+      name: Standard_D8s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16s_v6
+      id: Standard_D16s_v6
+      memory: 68719476736
+      name: Standard_D16s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32s_v6
+      id: Standard_D32s_v6
+      memory: 137438953472
+      name: Standard_D32s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48s_v6
+      id: Standard_D48s_v6
+      memory: 206158430208
+      name: Standard_D48s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64s_v6
+      id: Standard_D64s_v6
+      memory: 274877906944
+      name: Standard_D64s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96s_v6
+      id: Standard_D96s_v6
+      memory: 412316860416
+      name: Standard_D96s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_d128s_v6
+      id: Standard_D128s_v6
+      memory: 549755813888
+      name: Standard_D128s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 192
+      generic_name: standard_d192s_v6
+      id: Standard_D192s_v6
+      memory: 824633720832
+      name: Standard_D192s_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ds_v6
+      id: Standard_D2ds_v6
+      memory: 8589934592
+      name: Standard_D2ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ds_v6
+      id: Standard_D4ds_v6
+      memory: 17179869184
+      name: Standard_D4ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ds_v6
+      id: Standard_D8ds_v6
+      memory: 34359738368
+      name: Standard_D8ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ds_v6
+      id: Standard_D16ds_v6
+      memory: 68719476736
+      name: Standard_D16ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ds_v6
+      id: Standard_D32ds_v6
+      memory: 137438953472
+      name: Standard_D32ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ds_v6
+      id: Standard_D48ds_v6
+      memory: 206158430208
+      name: Standard_D48ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ds_v6
+      id: Standard_D64ds_v6
+      memory: 274877906944
+      name: Standard_D64ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96ds_v6
+      id: Standard_D96ds_v6
+      memory: 412316860416
+      name: Standard_D96ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_d128ds_v6
+      id: Standard_D128ds_v6
+      memory: 549755813888
+      name: Standard_D128ds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 192
+      generic_name: standard_d192ds_v6
+      id: Standard_D192ds_v6
+      memory: 824633720832
+      name: Standard_D192ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2s_v6
+      id: Standard_E2s_v6
+      memory: 17179869184
+      name: Standard_E2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2s_v6
+      id: Standard_E4-2s_v6
+      memory: 34359738368
+      name: Standard_E4-2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4s_v6
+      id: Standard_E4s_v6
+      memory: 34359738368
+      name: Standard_E4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2s_v6
+      id: Standard_E8-2s_v6
+      memory: 68719476736
+      name: Standard_E8-2s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4s_v6
+      id: Standard_E8-4s_v6
+      memory: 68719476736
+      name: Standard_E8-4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8s_v6
+      id: Standard_E8s_v6
+      memory: 68719476736
+      name: Standard_E8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4s_v6
+      id: Standard_E16-4s_v6
+      memory: 137438953472
+      name: Standard_E16-4s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8s_v6
+      id: Standard_E16-8s_v6
+      memory: 137438953472
+      name: Standard_E16-8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16s_v6
+      id: Standard_E16s_v6
+      memory: 137438953472
+      name: Standard_E16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20s_v6
+      id: Standard_E20s_v6
+      memory: 171798691840
+      name: Standard_E20s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8s_v6
+      id: Standard_E32-8s_v6
+      memory: 274877906944
+      name: Standard_E32-8s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16s_v6
+      id: Standard_E32-16s_v6
+      memory: 274877906944
+      name: Standard_E32-16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32s_v6
+      id: Standard_E32s_v6
+      memory: 274877906944
+      name: Standard_E32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48s_v6
+      id: Standard_E48s_v6
+      memory: 412316860416
+      name: Standard_E48s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16s_v6
+      id: Standard_E64-16s_v6
+      memory: 549755813888
+      name: Standard_E64-16s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32s_v6
+      id: Standard_E64-32s_v6
+      memory: 549755813888
+      name: Standard_E64-32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64s_v6
+      id: Standard_E64s_v6
+      memory: 549755813888
+      name: Standard_E64s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24s_v6
+      id: Standard_E96-24s_v6
+      memory: 824633720832
+      name: Standard_E96-24s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48s_v6
+      id: Standard_E96-48s_v6
+      memory: 824633720832
+      name: Standard_E96-48s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96s_v6
+      id: Standard_E96s_v6
+      memory: 824633720832
+      name: Standard_E96s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2ds_v6
+      id: Standard_E2ds_v6
+      memory: 17179869184
+      name: Standard_E2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2ds_v6
+      id: Standard_E4-2ds_v6
+      memory: 34359738368
+      name: Standard_E4-2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4ds_v6
+      id: Standard_E4ds_v6
+      memory: 34359738368
+      name: Standard_E4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2ds_v6
+      id: Standard_E8-2ds_v6
+      memory: 68719476736
+      name: Standard_E8-2ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4ds_v6
+      id: Standard_E8-4ds_v6
+      memory: 68719476736
+      name: Standard_E8-4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8ds_v6
+      id: Standard_E8ds_v6
+      memory: 68719476736
+      name: Standard_E8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4ds_v6
+      id: Standard_E16-4ds_v6
+      memory: 137438953472
+      name: Standard_E16-4ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8ds_v6
+      id: Standard_E16-8ds_v6
+      memory: 137438953472
+      name: Standard_E16-8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16ds_v6
+      id: Standard_E16ds_v6
+      memory: 137438953472
+      name: Standard_E16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20ds_v6
+      id: Standard_E20ds_v6
+      memory: 171798691840
+      name: Standard_E20ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8ds_v6
+      id: Standard_E32-8ds_v6
+      memory: 274877906944
+      name: Standard_E32-8ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16ds_v6
+      id: Standard_E32-16ds_v6
+      memory: 274877906944
+      name: Standard_E32-16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32ds_v6
+      id: Standard_E32ds_v6
+      memory: 274877906944
+      name: Standard_E32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48ds_v6
+      id: Standard_E48ds_v6
+      memory: 412316860416
+      name: Standard_E48ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16ds_v6
+      id: Standard_E64-16ds_v6
+      memory: 549755813888
+      name: Standard_E64-16ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32ds_v6
+      id: Standard_E64-32ds_v6
+      memory: 549755813888
+      name: Standard_E64-32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64ds_v6
+      id: Standard_E64ds_v6
+      memory: 549755813888
+      name: Standard_E64ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24ds_v6
+      id: Standard_E96-24ds_v6
+      memory: 824633720832
+      name: Standard_E96-24ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48ds_v6
+      id: Standard_E96-48ds_v6
+      memory: 824633720832
+      name: Standard_E96-48ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96ds_v6
+      id: Standard_E96ds_v6
+      memory: 824633720832
+      name: Standard_E96ds_v6
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_l8as_v3
+      id: Standard_L8as_v3
+      memory: 68719476736
+      name: Standard_L8as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_l16as_v3
+      id: Standard_L16as_v3
+      memory: 137438953472
+      name: Standard_L16as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_l32as_v3
+      id: Standard_L32as_v3
+      memory: 274877906944
+      name: Standard_L32as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_l48as_v3
+      id: Standard_L48as_v3
+      memory: 412316860416
+      name: Standard_L48as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_l64as_v3
+      id: Standard_L64as_v3
+      memory: 549755813888
+      name: Standard_L64as_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_l80as_v3
+      id: Standard_L80as_v3
+      memory: 687194767360
+      name: Standard_L80as_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2a_v4
+      id: Standard_D2a_v4
+      memory: 8589934592
+      name: Standard_D2a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4a_v4
+      id: Standard_D4a_v4
+      memory: 17179869184
+      name: Standard_D4a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8a_v4
+      id: Standard_D8a_v4
+      memory: 34359738368
+      name: Standard_D8a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16a_v4
+      id: Standard_D16a_v4
+      memory: 68719476736
+      name: Standard_D16a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32a_v4
+      id: Standard_D32a_v4
+      memory: 137438953472
+      name: Standard_D32a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48a_v4
+      id: Standard_D48a_v4
+      memory: 206158430208
+      name: Standard_D48a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64a_v4
+      id: Standard_D64a_v4
+      memory: 274877906944
+      name: Standard_D64a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96a_v4
+      id: Standard_D96a_v4
+      memory: 412316860416
+      name: Standard_D96a_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2as_v4
+      id: Standard_D2as_v4
+      memory: 8589934592
+      name: Standard_D2as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4as_v4
+      id: Standard_D4as_v4
+      memory: 17179869184
+      name: Standard_D4as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8as_v4
+      id: Standard_D8as_v4
+      memory: 34359738368
+      name: Standard_D8as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16as_v4
+      id: Standard_D16as_v4
+      memory: 68719476736
+      name: Standard_D16as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32as_v4
+      id: Standard_D32as_v4
+      memory: 137438953472
+      name: Standard_D32as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48as_v4
+      id: Standard_D48as_v4
+      memory: 206158430208
+      name: Standard_D48as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64as_v4
+      id: Standard_D64as_v4
+      memory: 274877906944
+      name: Standard_D64as_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96as_v4
+      id: Standard_D96as_v4
+      memory: 412316860416
+      name: Standard_D96as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2a_v4
+      id: Standard_E2a_v4
+      memory: 17179869184
+      name: Standard_E2a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4a_v4
+      id: Standard_E4a_v4
+      memory: 34359738368
+      name: Standard_E4a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8a_v4
+      id: Standard_E8a_v4
+      memory: 68719476736
+      name: Standard_E8a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16a_v4
+      id: Standard_E16a_v4
+      memory: 137438953472
+      name: Standard_E16a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20a_v4
+      id: Standard_E20a_v4
+      memory: 171798691840
+      name: Standard_E20a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32a_v4
+      id: Standard_E32a_v4
+      memory: 274877906944
+      name: Standard_E32a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48a_v4
+      id: Standard_E48a_v4
+      memory: 412316860416
+      name: Standard_E48a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64a_v4
+      id: Standard_E64a_v4
+      memory: 549755813888
+      name: Standard_E64a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96a_v4
+      id: Standard_E96a_v4
+      memory: 721554505728
+      name: Standard_E96a_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2as_v4
+      id: Standard_E2as_v4
+      memory: 17179869184
+      name: Standard_E2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2as_v4
+      id: Standard_E4-2as_v4
+      memory: 34359738368
+      name: Standard_E4-2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4as_v4
+      id: Standard_E4as_v4
+      memory: 34359738368
+      name: Standard_E4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2as_v4
+      id: Standard_E8-2as_v4
+      memory: 68719476736
+      name: Standard_E8-2as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4as_v4
+      id: Standard_E8-4as_v4
+      memory: 68719476736
+      name: Standard_E8-4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8as_v4
+      id: Standard_E8as_v4
+      memory: 68719476736
+      name: Standard_E8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4as_v4
+      id: Standard_E16-4as_v4
+      memory: 137438953472
+      name: Standard_E16-4as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8as_v4
+      id: Standard_E16-8as_v4
+      memory: 137438953472
+      name: Standard_E16-8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16as_v4
+      id: Standard_E16as_v4
+      memory: 137438953472
+      name: Standard_E16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20as_v4
+      id: Standard_E20as_v4
+      memory: 171798691840
+      name: Standard_E20as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8as_v4
+      id: Standard_E32-8as_v4
+      memory: 274877906944
+      name: Standard_E32-8as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16as_v4
+      id: Standard_E32-16as_v4
+      memory: 274877906944
+      name: Standard_E32-16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32as_v4
+      id: Standard_E32as_v4
+      memory: 274877906944
+      name: Standard_E32as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48as_v4
+      id: Standard_E48as_v4
+      memory: 412316860416
+      name: Standard_E48as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16as_v4
+      id: Standard_E64-16as_v4
+      memory: 549755813888
+      name: Standard_E64-16as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32as_v4
+      id: Standard_E64-32as_v4
+      memory: 549755813888
+      name: Standard_E64-32as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64as_v4
+      id: Standard_E64as_v4
+      memory: 549755813888
+      name: Standard_E64as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24as_v4
+      id: Standard_E96-24as_v4
+      memory: 721554505728
+      name: Standard_E96-24as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48as_v4
+      id: Standard_E96-48as_v4
+      memory: 721554505728
+      name: Standard_E96-48as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96as_v4
+      id: Standard_E96as_v4
+      memory: 721554505728
+      name: Standard_E96as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_l8s_v3
+      id: Standard_L8s_v3
+      memory: 68719476736
+      name: Standard_L8s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_l16s_v3
+      id: Standard_L16s_v3
+      memory: 137438953472
+      name: Standard_L16s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_l32s_v3
+      id: Standard_L32s_v3
+      memory: 274877906944
+      name: Standard_L32s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_l48s_v3
+      id: Standard_L48s_v3
+      memory: 412316860416
+      name: Standard_L48s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_l64s_v3
+      id: Standard_L64s_v3
+      memory: 549755813888
+      name: Standard_L64s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_l80s_v3
+      id: Standard_L80s_v3
+      memory: 687194767360
+      name: Standard_L80s_v3
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_l2aos_v4
+      id: Standard_L2aos_v4
+      memory: 17179869184
+      name: Standard_L2aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_l4aos_v4
+      id: Standard_L4aos_v4
+      memory: 34359738368
+      name: Standard_L4aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_l8aos_v4
+      id: Standard_L8aos_v4
+      memory: 68719476736
+      name: Standard_L8aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      generic_name: standard_l12aos_v4
+      id: Standard_L12aos_v4
+      memory: 103079215104
+      name: Standard_L12aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_l16aos_v4
+      id: Standard_L16aos_v4
+      memory: 137438953472
+      name: Standard_L16aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_l24aos_v4
+      id: Standard_L24aos_v4
+      memory: 206158430208
+      name: Standard_L24aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_l32aos_v4
+      id: Standard_L32aos_v4
+      memory: 274877906944
+      name: Standard_L32aos_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_l2as_v4
+      id: Standard_L2as_v4
+      memory: 17179869184
+      name: Standard_L2as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_l4as_v4
+      id: Standard_L4as_v4
+      memory: 34359738368
+      name: Standard_L4as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_l8as_v4
+      id: Standard_L8as_v4
+      memory: 68719476736
+      name: Standard_L8as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_l16as_v4
+      id: Standard_L16as_v4
+      memory: 137438953472
+      name: Standard_L16as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_l32as_v4
+      id: Standard_L32as_v4
+      memory: 274877906944
+      name: Standard_L32as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_l48as_v4
+      id: Standard_L48as_v4
+      memory: 412316860416
+      name: Standard_L48as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_l64as_v4
+      id: Standard_L64as_v4
+      memory: 549755813888
+      name: Standard_L64as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_l80as_v4
+      id: Standard_L80as_v4
+      memory: 687194767360
+      name: Standard_L80as_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_l96as_v4
+      id: Standard_L96as_v4
+      memory: 824633720832
+      name: Standard_L96as_v4
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2plds_v5
+      id: Standard_D2plds_v5
+      memory: 4294967296
+      name: Standard_D2plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4plds_v5
+      id: Standard_D4plds_v5
+      memory: 8589934592
+      name: Standard_D4plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8plds_v5
+      id: Standard_D8plds_v5
+      memory: 17179869184
+      name: Standard_D8plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16plds_v5
+      id: Standard_D16plds_v5
+      memory: 34359738368
+      name: Standard_D16plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32plds_v5
+      id: Standard_D32plds_v5
+      memory: 68719476736
+      name: Standard_D32plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48plds_v5
+      id: Standard_D48plds_v5
+      memory: 103079215104
+      name: Standard_D48plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64plds_v5
+      id: Standard_D64plds_v5
+      memory: 137438953472
+      name: Standard_D64plds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2pls_v5
+      id: Standard_D2pls_v5
+      memory: 4294967296
+      name: Standard_D2pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4pls_v5
+      id: Standard_D4pls_v5
+      memory: 8589934592
+      name: Standard_D4pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8pls_v5
+      id: Standard_D8pls_v5
+      memory: 17179869184
+      name: Standard_D8pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16pls_v5
+      id: Standard_D16pls_v5
+      memory: 34359738368
+      name: Standard_D16pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32pls_v5
+      id: Standard_D32pls_v5
+      memory: 68719476736
+      name: Standard_D32pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48pls_v5
+      id: Standard_D48pls_v5
+      memory: 103079215104
+      name: Standard_D48pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64pls_v5
+      id: Standard_D64pls_v5
+      memory: 137438953472
+      name: Standard_D64pls_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2pds_v5
+      id: Standard_D2pds_v5
+      memory: 8589934592
+      name: Standard_D2pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4pds_v5
+      id: Standard_D4pds_v5
+      memory: 17179869184
+      name: Standard_D4pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8pds_v5
+      id: Standard_D8pds_v5
+      memory: 34359738368
+      name: Standard_D8pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16pds_v5
+      id: Standard_D16pds_v5
+      memory: 68719476736
+      name: Standard_D16pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32pds_v5
+      id: Standard_D32pds_v5
+      memory: 137438953472
+      name: Standard_D32pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48pds_v5
+      id: Standard_D48pds_v5
+      memory: 206158430208
+      name: Standard_D48pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64pds_v5
+      id: Standard_D64pds_v5
+      memory: 223338299392
+      name: Standard_D64pds_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ps_v5
+      id: Standard_D2ps_v5
+      memory: 8589934592
+      name: Standard_D2ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ps_v5
+      id: Standard_D4ps_v5
+      memory: 17179869184
+      name: Standard_D4ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ps_v5
+      id: Standard_D8ps_v5
+      memory: 34359738368
+      name: Standard_D8ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ps_v5
+      id: Standard_D16ps_v5
+      memory: 68719476736
+      name: Standard_D16ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ps_v5
+      id: Standard_D32ps_v5
+      memory: 137438953472
+      name: Standard_D32ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ps_v5
+      id: Standard_D48ps_v5
+      memory: 206158430208
+      name: Standard_D48ps_v5
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ps_v5
+      id: Standard_D64ps_v5
+      memory: 223338299392
+      name: Standard_D64ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2pds_v5
+      id: Standard_E2pds_v5
+      memory: 17179869184
+      name: Standard_E2pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4pds_v5
+      id: Standard_E4pds_v5
+      memory: 34359738368
+      name: Standard_E4pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8pds_v5
+      id: Standard_E8pds_v5
+      memory: 68719476736
+      name: Standard_E8pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16pds_v5
+      id: Standard_E16pds_v5
+      memory: 137438953472
+      name: Standard_E16pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20pds_v5
+      id: Standard_E20pds_v5
+      memory: 171798691840
+      name: Standard_E20pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32pds_v5
+      id: Standard_E32pds_v5
+      memory: 223338299392
+      name: Standard_E32pds_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2ps_v5
+      id: Standard_E2ps_v5
+      memory: 17179869184
+      name: Standard_E2ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4ps_v5
+      id: Standard_E4ps_v5
+      memory: 34359738368
+      name: Standard_E4ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8ps_v5
+      id: Standard_E8ps_v5
+      memory: 68719476736
+      name: Standard_E8ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16ps_v5
+      id: Standard_E16ps_v5
+      memory: 137438953472
+      name: Standard_E16ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 20
+      generic_name: standard_e20ps_v5
+      id: Standard_E20ps_v5
+      memory: 171798691840
+      name: Standard_E20ps_v5
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32ps_v5
+      id: Standard_E32ps_v5
+      memory: 223338299392
+      name: Standard_E32ps_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128-32s_v6
+      id: Standard_E128-32s_v6
+      memory: 1099511627776
+      name: Standard_E128-32s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128-64s_v6
+      id: Standard_E128-64s_v6
+      memory: 1099511627776
+      name: Standard_E128-64s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128s_v6
+      id: Standard_E128s_v6
+      memory: 1099511627776
+      name: Standard_E128s_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 192
+      generic_name: standard_e192is_v6
+      id: Standard_E192is_v6
+      memory: 1967095021568
+      name: Standard_E192is_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128-32ds_v6
+      id: Standard_E128-32ds_v6
+      memory: 1099511627776
+      name: Standard_E128-32ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128-64ds_v6
+      id: Standard_E128-64ds_v6
+      memory: 1099511627776
+      name: Standard_E128-64ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128ds_v6
+      id: Standard_E128ds_v6
+      memory: 1099511627776
+      name: Standard_E128ds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 192
+      generic_name: standard_e192ids_v6
+      id: Standard_E192ids_v6
+      memory: 1967095021568
+      name: Standard_E192ids_v6
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_fx2ms_v2
+      id: Standard_FX2ms_v2
+      memory: 45097156608
+      name: Standard_FX2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_fx4-2ms_v2
+      id: Standard_FX4-2ms_v2
+      memory: 90194313216
+      name: Standard_FX4-2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_fx4ms_v2
+      id: Standard_FX4ms_v2
+      memory: 90194313216
+      name: Standard_FX4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_fx8-2ms_v2
+      id: Standard_FX8-2ms_v2
+      memory: 180388626432
+      name: Standard_FX8-2ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_fx8-4ms_v2
+      id: Standard_FX8-4ms_v2
+      memory: 180388626432
+      name: Standard_FX8-4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_fx8ms_v2
+      id: Standard_FX8ms_v2
+      memory: 180388626432
+      name: Standard_FX8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      generic_name: standard_fx12-6ms_v2
+      id: Standard_FX12-6ms_v2
+      memory: 270582939648
+      name: Standard_FX12-6ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      generic_name: standard_fx12ms_v2
+      id: Standard_FX12ms_v2
+      memory: 270582939648
+      name: Standard_FX12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_fx16-4ms_v2
+      id: Standard_FX16-4ms_v2
+      memory: 360777252864
+      name: Standard_FX16-4ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_fx16-8ms_v2
+      id: Standard_FX16-8ms_v2
+      memory: 360777252864
+      name: Standard_FX16-8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_fx16ms_v2
+      id: Standard_FX16ms_v2
+      memory: 360777252864
+      name: Standard_FX16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_fx24-6ms_v2
+      id: Standard_FX24-6ms_v2
+      memory: 541165879296
+      name: Standard_FX24-6ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_fx24-12ms_v2
+      id: Standard_FX24-12ms_v2
+      memory: 541165879296
+      name: Standard_FX24-12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_fx24ms_v2
+      id: Standard_FX24ms_v2
+      memory: 541165879296
+      name: Standard_FX24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_fx32-8ms_v2
+      id: Standard_FX32-8ms_v2
+      memory: 721554505728
+      name: Standard_FX32-8ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_fx32-16ms_v2
+      id: Standard_FX32-16ms_v2
+      memory: 721554505728
+      name: Standard_FX32-16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_fx32ms_v2
+      id: Standard_FX32ms_v2
+      memory: 721554505728
+      name: Standard_FX32ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_fx48-12ms_v2
+      id: Standard_FX48-12ms_v2
+      memory: 1082331758592
+      name: Standard_FX48-12ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_fx48-24ms_v2
+      id: Standard_FX48-24ms_v2
+      memory: 1082331758592
+      name: Standard_FX48-24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_fx48ms_v2
+      id: Standard_FX48ms_v2
+      memory: 1082331758592
+      name: Standard_FX48ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_fx64-16ms_v2
+      id: Standard_FX64-16ms_v2
+      memory: 1443109011456
+      name: Standard_FX64-16ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_fx64-32ms_v2
+      id: Standard_FX64-32ms_v2
+      memory: 1443109011456
+      name: Standard_FX64-32ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_fx64ms_v2
+      id: Standard_FX64ms_v2
+      memory: 1443109011456
+      name: Standard_FX64ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_fx96-24ms_v2
+      id: Standard_FX96-24ms_v2
+      memory: 1967095021568
+      name: Standard_FX96-24ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_fx96-48ms_v2
+      id: Standard_FX96-48ms_v2
+      memory: 1967095021568
+      name: Standard_FX96-48ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_fx96ms_v2
+      id: Standard_FX96ms_v2
+      memory: 1967095021568
+      name: Standard_FX96ms_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_fx2mds_v2
+      id: Standard_FX2mds_v2
+      memory: 45097156608
+      name: Standard_FX2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_fx4-2mds_v2
+      id: Standard_FX4-2mds_v2
+      memory: 90194313216
+      name: Standard_FX4-2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_fx4mds_v2
+      id: Standard_FX4mds_v2
+      memory: 90194313216
+      name: Standard_FX4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_fx8-2mds_v2
+      id: Standard_FX8-2mds_v2
+      memory: 180388626432
+      name: Standard_FX8-2mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_fx8-4mds_v2
+      id: Standard_FX8-4mds_v2
+      memory: 180388626432
+      name: Standard_FX8-4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_fx8mds_v2
+      id: Standard_FX8mds_v2
+      memory: 180388626432
+      name: Standard_FX8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      generic_name: standard_fx12-6mds_v2
+      id: Standard_FX12-6mds_v2
+      memory: 270582939648
+      name: Standard_FX12-6mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      generic_name: standard_fx12mds_v2
+      id: Standard_FX12mds_v2
+      memory: 270582939648
+      name: Standard_FX12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_fx16-4mds_v2
+      id: Standard_FX16-4mds_v2
+      memory: 360777252864
+      name: Standard_FX16-4mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_fx16-8mds_v2
+      id: Standard_FX16-8mds_v2
+      memory: 360777252864
+      name: Standard_FX16-8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_fx16mds_v2
+      id: Standard_FX16mds_v2
+      memory: 360777252864
+      name: Standard_FX16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_fx24-6mds_v2
+      id: Standard_FX24-6mds_v2
+      memory: 541165879296
+      name: Standard_FX24-6mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_fx24-12mds_v2
+      id: Standard_FX24-12mds_v2
+      memory: 541165879296
+      name: Standard_FX24-12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_fx24mds_v2
+      id: Standard_FX24mds_v2
+      memory: 541165879296
+      name: Standard_FX24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_fx32-8mds_v2
+      id: Standard_FX32-8mds_v2
+      memory: 721554505728
+      name: Standard_FX32-8mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_fx32-16mds_v2
+      id: Standard_FX32-16mds_v2
+      memory: 721554505728
+      name: Standard_FX32-16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_fx32mds_v2
+      id: Standard_FX32mds_v2
+      memory: 721554505728
+      name: Standard_FX32mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_fx48-12mds_v2
+      id: Standard_FX48-12mds_v2
+      memory: 1082331758592
+      name: Standard_FX48-12mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_fx48-24mds_v2
+      id: Standard_FX48-24mds_v2
+      memory: 1082331758592
+      name: Standard_FX48-24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_fx48mds_v2
+      id: Standard_FX48mds_v2
+      memory: 1082331758592
+      name: Standard_FX48mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_fx64-16mds_v2
+      id: Standard_FX64-16mds_v2
+      memory: 1443109011456
+      name: Standard_FX64-16mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_fx64-32mds_v2
+      id: Standard_FX64-32mds_v2
+      memory: 1443109011456
+      name: Standard_FX64-32mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_fx64mds_v2
+      id: Standard_FX64mds_v2
+      memory: 1443109011456
+      name: Standard_FX64mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_fx96-24mds_v2
+      id: Standard_FX96-24mds_v2
+      memory: 1967095021568
+      name: Standard_FX96-24mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_fx96-48mds_v2
+      id: Standard_FX96-48mds_v2
+      memory: 1967095021568
+      name: Standard_FX96-48mds_v2
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_fx96mds_v2
+      id: Standard_FX96mds_v2
+      memory: 1967095021568
+      name: Standard_FX96mds_v2
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_l2s_v4
+      id: Standard_L2s_v4
+      memory: 17179869184
+      name: Standard_L2s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_l4s_v4
+      id: Standard_L4s_v4
+      memory: 34359738368
+      name: Standard_L4s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_l8s_v4
+      id: Standard_L8s_v4
+      memory: 68719476736
+      name: Standard_L8s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_l16s_v4
+      id: Standard_L16s_v4
+      memory: 137438953472
+      name: Standard_L16s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_l32s_v4
+      id: Standard_L32s_v4
+      memory: 274877906944
+      name: Standard_L32s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_l48s_v4
+      id: Standard_L48s_v4
+      memory: 412316860416
+      name: Standard_L48s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_l64s_v4
+      id: Standard_L64s_v4
+      memory: 549755813888
+      name: Standard_L64s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_l80s_v4
+      id: Standard_L80s_v4
+      memory: 687194767360
+      name: Standard_L80s_v4
+    - category: storage_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_l96s_v4
+      id: Standard_L96s_v4
+      memory: 824633720832
+      name: Standard_L96s_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 6
+      generic_name: standard_nv6ads_a10_v5
+      id: Standard_NV6ads_A10_v5
+      memory: 59055800320
+      name: Standard_NV6ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 12
+      generic_name: standard_nv12ads_a10_v5
+      id: Standard_NV12ads_A10_v5
+      memory: 118111600640
+      name: Standard_NV12ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 18
+      generic_name: standard_nv18ads_a10_v5
+      id: Standard_NV18ads_A10_v5
+      memory: 236223201280
+      name: Standard_NV18ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 36
+      generic_name: standard_nv36adms_a10_v5
+      id: Standard_NV36adms_A10_v5
+      memory: 944892805120
+      name: Standard_NV36adms_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 36
+      generic_name: standard_nv36ads_a10_v5
+      id: Standard_NV36ads_A10_v5
+      memory: 472446402560
+      name: Standard_NV36ads_A10_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 72
+      generic_name: standard_nv72ads_a10_v5
+      id: Standard_NV72ads_A10_v5
+      memory: 944892805120
+      name: Standard_NV72ads_A10_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      generic_name: standard_e112ias_v5
+      id: Standard_E112ias_v5
+      memory: 721554505728
+      name: Standard_E112ias_v5
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 112
+      generic_name: standard_e112iads_v5
+      id: Standard_E112iads_v5
+      memory: 721554505728
+      name: Standard_E112iads_v5
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_fx4mds
+      id: Standard_FX4mds
+      memory: 90194313216
+      name: Standard_FX4mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 12
+      generic_name: standard_fx12mds
+      id: Standard_FX12mds
+      memory: 270582939648
+      name: Standard_FX12mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_fx24mds
+      id: Standard_FX24mds
+      memory: 541165879296
+      name: Standard_FX24mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 36
+      generic_name: standard_fx36mds
+      id: Standard_FX36mds
+      memory: 811748818944
+      name: Standard_FX36mds
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_fx48mds
+      id: Standard_FX48mds
+      memory: 1082331758592
+      name: Standard_FX48mds
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2pls_v6
+      id: Standard_D2pls_v6
+      memory: 4294967296
+      name: Standard_D2pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4pls_v6
+      id: Standard_D4pls_v6
+      memory: 8589934592
+      name: Standard_D4pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8pls_v6
+      id: Standard_D8pls_v6
+      memory: 17179869184
+      name: Standard_D8pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16pls_v6
+      id: Standard_D16pls_v6
+      memory: 34359738368
+      name: Standard_D16pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32pls_v6
+      id: Standard_D32pls_v6
+      memory: 68719476736
+      name: Standard_D32pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48pls_v6
+      id: Standard_D48pls_v6
+      memory: 103079215104
+      name: Standard_D48pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64pls_v6
+      id: Standard_D64pls_v6
+      memory: 137438953472
+      name: Standard_D64pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96pls_v6
+      id: Standard_D96pls_v6
+      memory: 206158430208
+      name: Standard_D96pls_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2pds_v6
+      id: Standard_D2pds_v6
+      memory: 8589934592
+      name: Standard_D2pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4pds_v6
+      id: Standard_D4pds_v6
+      memory: 17179869184
+      name: Standard_D4pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8pds_v6
+      id: Standard_D8pds_v6
+      memory: 34359738368
+      name: Standard_D8pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16pds_v6
+      id: Standard_D16pds_v6
+      memory: 68719476736
+      name: Standard_D16pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32pds_v6
+      id: Standard_D32pds_v6
+      memory: 137438953472
+      name: Standard_D32pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48pds_v6
+      id: Standard_D48pds_v6
+      memory: 206158430208
+      name: Standard_D48pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64pds_v6
+      id: Standard_D64pds_v6
+      memory: 274877906944
+      name: Standard_D64pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96pds_v6
+      id: Standard_D96pds_v6
+      memory: 412316860416
+      name: Standard_D96pds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2plds_v6
+      id: Standard_D2plds_v6
+      memory: 4294967296
+      name: Standard_D2plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4plds_v6
+      id: Standard_D4plds_v6
+      memory: 8589934592
+      name: Standard_D4plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8plds_v6
+      id: Standard_D8plds_v6
+      memory: 17179869184
+      name: Standard_D8plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16plds_v6
+      id: Standard_D16plds_v6
+      memory: 34359738368
+      name: Standard_D16plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32plds_v6
+      id: Standard_D32plds_v6
+      memory: 68719476736
+      name: Standard_D32plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48plds_v6
+      id: Standard_D48plds_v6
+      memory: 103079215104
+      name: Standard_D48plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64plds_v6
+      id: Standard_D64plds_v6
+      memory: 137438953472
+      name: Standard_D64plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96plds_v6
+      id: Standard_D96plds_v6
+      memory: 206158430208
+      name: Standard_D96plds_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ps_v6
+      id: Standard_D2ps_v6
+      memory: 8589934592
+      name: Standard_D2ps_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ps_v6
+      id: Standard_D4ps_v6
+      memory: 17179869184
+      name: Standard_D4ps_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ps_v6
+      id: Standard_D8ps_v6
+      memory: 34359738368
+      name: Standard_D8ps_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ps_v6
+      id: Standard_D16ps_v6
+      memory: 68719476736
+      name: Standard_D16ps_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ps_v6
+      id: Standard_D32ps_v6
+      memory: 137438953472
+      name: Standard_D32ps_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ps_v6
+      id: Standard_D48ps_v6
+      memory: 206158430208
+      name: Standard_D48ps_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ps_v6
+      id: Standard_D64ps_v6
+      memory: 274877906944
+      name: Standard_D64ps_v6
+    - architecture: arm64
+      category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96ps_v6
+      id: Standard_D96ps_v6
+      memory: 412316860416
+      name: Standard_D96ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2ps_v6
+      id: Standard_E2ps_v6
+      memory: 17179869184
+      name: Standard_E2ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4ps_v6
+      id: Standard_E4ps_v6
+      memory: 34359738368
+      name: Standard_E4ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8ps_v6
+      id: Standard_E8ps_v6
+      memory: 68719476736
+      name: Standard_E8ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16ps_v6
+      id: Standard_E16ps_v6
+      memory: 137438953472
+      name: Standard_E16ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32ps_v6
+      id: Standard_E32ps_v6
+      memory: 274877906944
+      name: Standard_E32ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48ps_v6
+      id: Standard_E48ps_v6
+      memory: 412316860416
+      name: Standard_E48ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64ps_v6
+      id: Standard_E64ps_v6
+      memory: 549755813888
+      name: Standard_E64ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96ps_v6
+      id: Standard_E96ps_v6
+      memory: 721554505728
+      name: Standard_E96ps_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2pds_v6
+      id: Standard_E2pds_v6
+      memory: 17179869184
+      name: Standard_E2pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4pds_v6
+      id: Standard_E4pds_v6
+      memory: 34359738368
+      name: Standard_E4pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8pds_v6
+      id: Standard_E8pds_v6
+      memory: 68719476736
+      name: Standard_E8pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16pds_v6
+      id: Standard_E16pds_v6
+      memory: 137438953472
+      name: Standard_E16pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32pds_v6
+      id: Standard_E32pds_v6
+      memory: 274877906944
+      name: Standard_E32pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48pds_v6
+      id: Standard_E48pds_v6
+      memory: 412316860416
+      name: Standard_E48pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64pds_v6
+      id: Standard_E64pds_v6
+      memory: 549755813888
+      name: Standard_E64pds_v6
+    - architecture: arm64
+      category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96pds_v6
+      id: Standard_E96pds_v6
+      memory: 721554505728
+      name: Standard_E96pds_v6
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_nc24ads_a100_v4
+      id: Standard_NC24ads_A100_v4
+      memory: 236223201280
+      name: Standard_NC24ads_A100_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_nc48ads_a100_v4
+      id: Standard_NC48ads_A100_v4
+      memory: 472446402560
+      name: Standard_NC48ads_A100_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_nc96ads_a100_v4
+      id: Standard_NC96ads_A100_v4
+      memory: 944892805120
+      name: Standard_NC96ads_A100_v4
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_dc2as_v6
+      id: Standard_DC2as_v6
+      memory: 8589934592
+      name: Standard_DC2as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_dc4as_v6
+      id: Standard_DC4as_v6
+      memory: 17179869184
+      name: Standard_DC4as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_dc8as_v6
+      id: Standard_DC8as_v6
+      memory: 34359738368
+      name: Standard_DC8as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_dc16as_v6
+      id: Standard_DC16as_v6
+      memory: 68719476736
+      name: Standard_DC16as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_dc32as_v6
+      id: Standard_DC32as_v6
+      memory: 137438953472
+      name: Standard_DC32as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_dc48as_v6
+      id: Standard_DC48as_v6
+      memory: 206158430208
+      name: Standard_DC48as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_dc64as_v6
+      id: Standard_DC64as_v6
+      memory: 274877906944
+      name: Standard_DC64as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_dc96as_v6
+      id: Standard_DC96as_v6
+      memory: 412316860416
+      name: Standard_DC96as_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_dc2ads_v6
+      id: Standard_DC2ads_v6
+      memory: 8589934592
+      name: Standard_DC2ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_dc4ads_v6
+      id: Standard_DC4ads_v6
+      memory: 17179869184
+      name: Standard_DC4ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_dc8ads_v6
+      id: Standard_DC8ads_v6
+      memory: 34359738368
+      name: Standard_DC8ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_dc16ads_v6
+      id: Standard_DC16ads_v6
+      memory: 68719476736
+      name: Standard_DC16ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_dc32ads_v6
+      id: Standard_DC32ads_v6
+      memory: 137438953472
+      name: Standard_DC32ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_dc48ads_v6
+      id: Standard_DC48ads_v6
+      memory: 206158430208
+      name: Standard_DC48ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_dc64ads_v6
+      id: Standard_DC64ads_v6
+      memory: 274877906944
+      name: Standard_DC64ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_dc96ads_v6
+      id: Standard_DC96ads_v6
+      memory: 412316860416
+      name: Standard_DC96ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_ec2as_v6
+      id: Standard_EC2as_v6
+      memory: 17179869184
+      name: Standard_EC2as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_ec4as_v6
+      id: Standard_EC4as_v6
+      memory: 34359738368
+      name: Standard_EC4as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_ec8as_v6
+      id: Standard_EC8as_v6
+      memory: 68719476736
+      name: Standard_EC8as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_ec16as_v6
+      id: Standard_EC16as_v6
+      memory: 137438953472
+      name: Standard_EC16as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_ec32as_v6
+      id: Standard_EC32as_v6
+      memory: 274877906944
+      name: Standard_EC32as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_ec48as_v6
+      id: Standard_EC48as_v6
+      memory: 412316860416
+      name: Standard_EC48as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_ec64as_v6
+      id: Standard_EC64as_v6
+      memory: 549755813888
+      name: Standard_EC64as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_ec96as_v6
+      id: Standard_EC96as_v6
+      memory: 721554505728
+      name: Standard_EC96as_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_ec2ads_v6
+      id: Standard_EC2ads_v6
+      memory: 17179869184
+      name: Standard_EC2ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_ec4ads_v6
+      id: Standard_EC4ads_v6
+      memory: 34359738368
+      name: Standard_EC4ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_ec8ads_v6
+      id: Standard_EC8ads_v6
+      memory: 68719476736
+      name: Standard_EC8ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_ec16ads_v6
+      id: Standard_EC16ads_v6
+      memory: 137438953472
+      name: Standard_EC16ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_ec32ads_v6
+      id: Standard_EC32ads_v6
+      memory: 274877906944
+      name: Standard_EC32ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_ec48ads_v6
+      id: Standard_EC48ads_v6
+      memory: 412316860416
+      name: Standard_EC48ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_ec64ads_v6
+      id: Standard_EC64ads_v6
+      memory: 549755813888
+      name: Standard_EC64ads_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_ec96ads_v6
+      id: Standard_EC96ads_v6
+      memory: 721554505728
+      name: Standard_EC96ads_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2als_v7
+      id: Standard_D2als_v7
+      memory: 4294967296
+      name: Standard_D2als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4als_v7
+      id: Standard_D4als_v7
+      memory: 8589934592
+      name: Standard_D4als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8als_v7
+      id: Standard_D8als_v7
+      memory: 17179869184
+      name: Standard_D8als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16als_v7
+      id: Standard_D16als_v7
+      memory: 34359738368
+      name: Standard_D16als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32als_v7
+      id: Standard_D32als_v7
+      memory: 68719476736
+      name: Standard_D32als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48als_v7
+      id: Standard_D48als_v7
+      memory: 103079215104
+      name: Standard_D48als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64als_v7
+      id: Standard_D64als_v7
+      memory: 137438953472
+      name: Standard_D64als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96als_v7
+      id: Standard_D96als_v7
+      memory: 206158430208
+      name: Standard_D96als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_d128als_v7
+      id: Standard_D128als_v7
+      memory: 274877906944
+      name: Standard_D128als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 160
+      generic_name: standard_d160als_v7
+      id: Standard_D160als_v7
+      memory: 343597383680
+      name: Standard_D160als_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2alds_v7
+      id: Standard_D2alds_v7
+      memory: 4294967296
+      name: Standard_D2alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4alds_v7
+      id: Standard_D4alds_v7
+      memory: 8589934592
+      name: Standard_D4alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8alds_v7
+      id: Standard_D8alds_v7
+      memory: 17179869184
+      name: Standard_D8alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16alds_v7
+      id: Standard_D16alds_v7
+      memory: 34359738368
+      name: Standard_D16alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32alds_v7
+      id: Standard_D32alds_v7
+      memory: 68719476736
+      name: Standard_D32alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48alds_v7
+      id: Standard_D48alds_v7
+      memory: 103079215104
+      name: Standard_D48alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64alds_v7
+      id: Standard_D64alds_v7
+      memory: 137438953472
+      name: Standard_D64alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96alds_v7
+      id: Standard_D96alds_v7
+      memory: 206158430208
+      name: Standard_D96alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_d128alds_v7
+      id: Standard_D128alds_v7
+      memory: 274877906944
+      name: Standard_D128alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 160
+      generic_name: standard_d160alds_v7
+      id: Standard_D160alds_v7
+      memory: 343597383680
+      name: Standard_D160alds_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2as_v7
+      id: Standard_D2as_v7
+      memory: 8589934592
+      name: Standard_D2as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4as_v7
+      id: Standard_D4as_v7
+      memory: 17179869184
+      name: Standard_D4as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8as_v7
+      id: Standard_D8as_v7
+      memory: 34359738368
+      name: Standard_D8as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16as_v7
+      id: Standard_D16as_v7
+      memory: 68719476736
+      name: Standard_D16as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32as_v7
+      id: Standard_D32as_v7
+      memory: 137438953472
+      name: Standard_D32as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48as_v7
+      id: Standard_D48as_v7
+      memory: 206158430208
+      name: Standard_D48as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64as_v7
+      id: Standard_D64as_v7
+      memory: 274877906944
+      name: Standard_D64as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96as_v7
+      id: Standard_D96as_v7
+      memory: 412316860416
+      name: Standard_D96as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_d128as_v7
+      id: Standard_D128as_v7
+      memory: 549755813888
+      name: Standard_D128as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 160
+      generic_name: standard_d160as_v7
+      id: Standard_D160as_v7
+      memory: 687194767360
+      name: Standard_D160as_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_d2ads_v7
+      id: Standard_D2ads_v7
+      memory: 8589934592
+      name: Standard_D2ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_d4ads_v7
+      id: Standard_D4ads_v7
+      memory: 17179869184
+      name: Standard_D4ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_d8ads_v7
+      id: Standard_D8ads_v7
+      memory: 34359738368
+      name: Standard_D8ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_d16ads_v7
+      id: Standard_D16ads_v7
+      memory: 68719476736
+      name: Standard_D16ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_d32ads_v7
+      id: Standard_D32ads_v7
+      memory: 137438953472
+      name: Standard_D32ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_d48ads_v7
+      id: Standard_D48ads_v7
+      memory: 206158430208
+      name: Standard_D48ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_d64ads_v7
+      id: Standard_D64ads_v7
+      memory: 274877906944
+      name: Standard_D64ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_d96ads_v7
+      id: Standard_D96ads_v7
+      memory: 412316860416
+      name: Standard_D96ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_d128ads_v7
+      id: Standard_D128ads_v7
+      memory: 549755813888
+      name: Standard_D128ads_v7
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 160
+      generic_name: standard_d160ads_v7
+      id: Standard_D160ads_v7
+      memory: 687194767360
+      name: Standard_D160ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2as_v7
+      id: Standard_E2as_v7
+      memory: 17179869184
+      name: Standard_E2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2as_v7
+      id: Standard_E4-2as_v7
+      memory: 34359738368
+      name: Standard_E4-2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4as_v7
+      id: Standard_E4as_v7
+      memory: 34359738368
+      name: Standard_E4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2as_v7
+      id: Standard_E8-2as_v7
+      memory: 68719476736
+      name: Standard_E8-2as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4as_v7
+      id: Standard_E8-4as_v7
+      memory: 68719476736
+      name: Standard_E8-4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8as_v7
+      id: Standard_E8as_v7
+      memory: 68719476736
+      name: Standard_E8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4as_v7
+      id: Standard_E16-4as_v7
+      memory: 137438953472
+      name: Standard_E16-4as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8as_v7
+      id: Standard_E16-8as_v7
+      memory: 137438953472
+      name: Standard_E16-8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16as_v7
+      id: Standard_E16as_v7
+      memory: 137438953472
+      name: Standard_E16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8as_v7
+      id: Standard_E32-8as_v7
+      memory: 274877906944
+      name: Standard_E32-8as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16as_v7
+      id: Standard_E32-16as_v7
+      memory: 274877906944
+      name: Standard_E32-16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32as_v7
+      id: Standard_E32as_v7
+      memory: 274877906944
+      name: Standard_E32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48as_v7
+      id: Standard_E48as_v7
+      memory: 412316860416
+      name: Standard_E48as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16as_v7
+      id: Standard_E64-16as_v7
+      memory: 549755813888
+      name: Standard_E64-16as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32as_v7
+      id: Standard_E64-32as_v7
+      memory: 549755813888
+      name: Standard_E64-32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64as_v7
+      id: Standard_E64as_v7
+      memory: 549755813888
+      name: Standard_E64as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24as_v7
+      id: Standard_E96-24as_v7
+      memory: 824633720832
+      name: Standard_E96-24as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48as_v7
+      id: Standard_E96-48as_v7
+      memory: 824633720832
+      name: Standard_E96-48as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96as_v7
+      id: Standard_E96as_v7
+      memory: 824633720832
+      name: Standard_E96as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128-32as_v7
+      id: Standard_E128-32as_v7
+      memory: 1099511627776
+      name: Standard_E128-32as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128-64as_v7
+      id: Standard_E128-64as_v7
+      memory: 1099511627776
+      name: Standard_E128-64as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128as_v7
+      id: Standard_E128as_v7
+      memory: 1099511627776
+      name: Standard_E128as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_e2ads_v7
+      id: Standard_E2ads_v7
+      memory: 17179869184
+      name: Standard_E2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4-2ads_v7
+      id: Standard_E4-2ads_v7
+      memory: 34359738368
+      name: Standard_E4-2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_e4ads_v7
+      id: Standard_E4ads_v7
+      memory: 34359738368
+      name: Standard_E4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-2ads_v7
+      id: Standard_E8-2ads_v7
+      memory: 68719476736
+      name: Standard_E8-2ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8-4ads_v7
+      id: Standard_E8-4ads_v7
+      memory: 68719476736
+      name: Standard_E8-4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_e8ads_v7
+      id: Standard_E8ads_v7
+      memory: 68719476736
+      name: Standard_E8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-4ads_v7
+      id: Standard_E16-4ads_v7
+      memory: 137438953472
+      name: Standard_E16-4ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16-8ads_v7
+      id: Standard_E16-8ads_v7
+      memory: 137438953472
+      name: Standard_E16-8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_e16ads_v7
+      id: Standard_E16ads_v7
+      memory: 137438953472
+      name: Standard_E16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-8ads_v7
+      id: Standard_E32-8ads_v7
+      memory: 274877906944
+      name: Standard_E32-8ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32-16ads_v7
+      id: Standard_E32-16ads_v7
+      memory: 274877906944
+      name: Standard_E32-16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_e32ads_v7
+      id: Standard_E32ads_v7
+      memory: 274877906944
+      name: Standard_E32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_e48ads_v7
+      id: Standard_E48ads_v7
+      memory: 412316860416
+      name: Standard_E48ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-16ads_v7
+      id: Standard_E64-16ads_v7
+      memory: 549755813888
+      name: Standard_E64-16ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64-32ads_v7
+      id: Standard_E64-32ads_v7
+      memory: 549755813888
+      name: Standard_E64-32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_e64ads_v7
+      id: Standard_E64ads_v7
+      memory: 549755813888
+      name: Standard_E64ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-24ads_v7
+      id: Standard_E96-24ads_v7
+      memory: 824633720832
+      name: Standard_E96-24ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96-48ads_v7
+      id: Standard_E96-48ads_v7
+      memory: 824633720832
+      name: Standard_E96-48ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96ads_v7
+      id: Standard_E96ads_v7
+      memory: 824633720832
+      name: Standard_E96ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128-32ads_v7
+      id: Standard_E128-32ads_v7
+      memory: 1099511627776
+      name: Standard_E128-32ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128-64ads_v7
+      id: Standard_E128-64ads_v7
+      memory: 1099511627776
+      name: Standard_E128-64ads_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_e128ads_v7
+      id: Standard_E128ads_v7
+      memory: 1099511627776
+      name: Standard_E128ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_f1als_v7
+      id: Standard_F1als_v7
+      memory: 2147483648
+      name: Standard_F1als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2als_v7
+      id: Standard_F2als_v7
+      memory: 4294967296
+      name: Standard_F2als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4als_v7
+      id: Standard_F4als_v7
+      memory: 8589934592
+      name: Standard_F4als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8als_v7
+      id: Standard_F8als_v7
+      memory: 17179869184
+      name: Standard_F8als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16als_v7
+      id: Standard_F16als_v7
+      memory: 34359738368
+      name: Standard_F16als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32als_v7
+      id: Standard_F32als_v7
+      memory: 68719476736
+      name: Standard_F32als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48als_v7
+      id: Standard_F48als_v7
+      memory: 103079215104
+      name: Standard_F48als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64als_v7
+      id: Standard_F64als_v7
+      memory: 137438953472
+      name: Standard_F64als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_f80als_v7
+      id: Standard_F80als_v7
+      memory: 171798691840
+      name: Standard_F80als_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_f1alds_v7
+      id: Standard_F1alds_v7
+      memory: 2147483648
+      name: Standard_F1alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2alds_v7
+      id: Standard_F2alds_v7
+      memory: 4294967296
+      name: Standard_F2alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4alds_v7
+      id: Standard_F4alds_v7
+      memory: 8589934592
+      name: Standard_F4alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8alds_v7
+      id: Standard_F8alds_v7
+      memory: 17179869184
+      name: Standard_F8alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16alds_v7
+      id: Standard_F16alds_v7
+      memory: 34359738368
+      name: Standard_F16alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32alds_v7
+      id: Standard_F32alds_v7
+      memory: 68719476736
+      name: Standard_F32alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48alds_v7
+      id: Standard_F48alds_v7
+      memory: 103079215104
+      name: Standard_F48alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64alds_v7
+      id: Standard_F64alds_v7
+      memory: 137438953472
+      name: Standard_F64alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_f80alds_v7
+      id: Standard_F80alds_v7
+      memory: 171798691840
+      name: Standard_F80alds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_f1as_v7
+      id: Standard_F1as_v7
+      memory: 4294967296
+      name: Standard_F1as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2as_v7
+      id: Standard_F2as_v7
+      memory: 8589934592
+      name: Standard_F2as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4as_v7
+      id: Standard_F4as_v7
+      memory: 17179869184
+      name: Standard_F4as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8as_v7
+      id: Standard_F8as_v7
+      memory: 34359738368
+      name: Standard_F8as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16as_v7
+      id: Standard_F16as_v7
+      memory: 68719476736
+      name: Standard_F16as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32as_v7
+      id: Standard_F32as_v7
+      memory: 137438953472
+      name: Standard_F32as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48as_v7
+      id: Standard_F48as_v7
+      memory: 206158430208
+      name: Standard_F48as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64as_v7
+      id: Standard_F64as_v7
+      memory: 274877906944
+      name: Standard_F64as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_f80as_v7
+      id: Standard_F80as_v7
+      memory: 343597383680
+      name: Standard_F80as_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_f1ads_v7
+      id: Standard_F1ads_v7
+      memory: 4294967296
+      name: Standard_F1ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2ads_v7
+      id: Standard_F2ads_v7
+      memory: 8589934592
+      name: Standard_F2ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4ads_v7
+      id: Standard_F4ads_v7
+      memory: 17179869184
+      name: Standard_F4ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8ads_v7
+      id: Standard_F8ads_v7
+      memory: 34359738368
+      name: Standard_F8ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16ads_v7
+      id: Standard_F16ads_v7
+      memory: 68719476736
+      name: Standard_F16ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32ads_v7
+      id: Standard_F32ads_v7
+      memory: 137438953472
+      name: Standard_F32ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48ads_v7
+      id: Standard_F48ads_v7
+      memory: 206158430208
+      name: Standard_F48ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64ads_v7
+      id: Standard_F64ads_v7
+      memory: 274877906944
+      name: Standard_F64ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_f80ads_v7
+      id: Standard_F80ads_v7
+      memory: 343597383680
+      name: Standard_F80ads_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_f1ams_v7
+      id: Standard_F1ams_v7
+      memory: 8589934592
+      name: Standard_F1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2-1ams_v7
+      id: Standard_F2-1ams_v7
+      memory: 17179869184
+      name: Standard_F2-1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2ams_v7
+      id: Standard_F2ams_v7
+      memory: 17179869184
+      name: Standard_F2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4-1ams_v7
+      id: Standard_F4-1ams_v7
+      memory: 34359738368
+      name: Standard_F4-1ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4-2ams_v7
+      id: Standard_F4-2ams_v7
+      memory: 34359738368
+      name: Standard_F4-2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4ams_v7
+      id: Standard_F4ams_v7
+      memory: 34359738368
+      name: Standard_F4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8-2ams_v7
+      id: Standard_F8-2ams_v7
+      memory: 68719476736
+      name: Standard_F8-2ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8-4ams_v7
+      id: Standard_F8-4ams_v7
+      memory: 68719476736
+      name: Standard_F8-4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8ams_v7
+      id: Standard_F8ams_v7
+      memory: 68719476736
+      name: Standard_F8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16-4ams_v7
+      id: Standard_F16-4ams_v7
+      memory: 137438953472
+      name: Standard_F16-4ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16-8ams_v7
+      id: Standard_F16-8ams_v7
+      memory: 137438953472
+      name: Standard_F16-8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16ams_v7
+      id: Standard_F16ams_v7
+      memory: 137438953472
+      name: Standard_F16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32-8ams_v7
+      id: Standard_F32-8ams_v7
+      memory: 274877906944
+      name: Standard_F32-8ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32-16ams_v7
+      id: Standard_F32-16ams_v7
+      memory: 274877906944
+      name: Standard_F32-16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32ams_v7
+      id: Standard_F32ams_v7
+      memory: 274877906944
+      name: Standard_F32ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48ams_v7
+      id: Standard_F48ams_v7
+      memory: 412316860416
+      name: Standard_F48ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_f64-16ams_v7
+      id: Standard_F64-16ams_v7
+      memory: 549755813888
+      name: Standard_F64-16ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64-32ams_v7
+      id: Standard_F64-32ams_v7
+      memory: 549755813888
+      name: Standard_F64-32ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64ams_v7
+      id: Standard_F64ams_v7
+      memory: 549755813888
+      name: Standard_F64ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_f80ams_v7
+      id: Standard_F80ams_v7
+      memory: 687194767360
+      name: Standard_F80ams_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 1
+      generic_name: standard_f1amds_v7
+      id: Standard_F1amds_v7
+      memory: 8589934592
+      name: Standard_F1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2-1amds_v7
+      id: Standard_F2-1amds_v7
+      memory: 17179869184
+      name: Standard_F2-1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_f2amds_v7
+      id: Standard_F2amds_v7
+      memory: 17179869184
+      name: Standard_F2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4-1amds_v7
+      id: Standard_F4-1amds_v7
+      memory: 34359738368
+      name: Standard_F4-1amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4-2amds_v7
+      id: Standard_F4-2amds_v7
+      memory: 34359738368
+      name: Standard_F4-2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_f4amds_v7
+      id: Standard_F4amds_v7
+      memory: 34359738368
+      name: Standard_F4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8-2amds_v7
+      id: Standard_F8-2amds_v7
+      memory: 68719476736
+      name: Standard_F8-2amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8-4amds_v7
+      id: Standard_F8-4amds_v7
+      memory: 68719476736
+      name: Standard_F8-4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_f8amds_v7
+      id: Standard_F8amds_v7
+      memory: 68719476736
+      name: Standard_F8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16-4amds_v7
+      id: Standard_F16-4amds_v7
+      memory: 137438953472
+      name: Standard_F16-4amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16-8amds_v7
+      id: Standard_F16-8amds_v7
+      memory: 137438953472
+      name: Standard_F16-8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_f16amds_v7
+      id: Standard_F16amds_v7
+      memory: 137438953472
+      name: Standard_F16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32-8amds_v7
+      id: Standard_F32-8amds_v7
+      memory: 274877906944
+      name: Standard_F32-8amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32-16amds_v7
+      id: Standard_F32-16amds_v7
+      memory: 274877906944
+      name: Standard_F32-16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_f32amds_v7
+      id: Standard_F32amds_v7
+      memory: 274877906944
+      name: Standard_F32amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_f48amds_v7
+      id: Standard_F48amds_v7
+      memory: 412316860416
+      name: Standard_F48amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64-16amds_v7
+      id: Standard_F64-16amds_v7
+      memory: 549755813888
+      name: Standard_F64-16amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64-32amds_v7
+      id: Standard_F64-32amds_v7
+      memory: 549755813888
+      name: Standard_F64-32amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_f64amds_v7
+      id: Standard_F64amds_v7
+      memory: 549755813888
+      name: Standard_F64amds_v7
+    - category: compute_optimized
+      cloud_provider_id: azure
+      cpu_cores: 80
+      generic_name: standard_f80amds_v7
+      id: Standard_F80amds_v7
+      memory: 687194767360
+      name: Standard_F80amds_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_e96ias_v4
+      id: Standard_E96ias_v4
+      memory: 721554505728
+      name: Standard_E96ias_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_nd96isr_h200_v5
+      id: Standard_ND96isr_H200_v5
+      memory: 1986422374400
+      name: Standard_ND96isr_H200_v5
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_nv4as_v4
+      id: Standard_NV4as_v4
+      memory: 15032385536
+      name: Standard_NV4as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_nv8as_v4
+      id: Standard_NV8as_v4
+      memory: 30064771072
+      name: Standard_NV8as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_nv16as_v4
+      id: Standard_NV16as_v4
+      memory: 60129542144
+      name: Standard_NV16as_v4
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_nv32as_v4
+      id: Standard_NV32as_v4
+      memory: 120259084288
+      name: Standard_NV32as_v4
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 160
+      generic_name: standard_e160as_v7
+      id: Standard_E160as_v7
+      memory: 1374389534720
+      name: Standard_E160as_v7
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 160
+      generic_name: standard_e160ads_v7
+      id: Standard_E160ads_v7
+      memory: 1374389534720
+      name: Standard_E160ads_v7
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 6
+      generic_name: standard_nc6s_v3
+      id: Standard_NC6s_v3
+      memory: 120259084288
+      name: Standard_NC6s_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 12
+      generic_name: standard_nc12s_v3
+      id: Standard_NC12s_v3
+      memory: 240518168576
+      name: Standard_NC12s_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_nc24rs_v3
+      id: Standard_NC24rs_v3
+      memory: 481036337152
+      name: Standard_NC24rs_v3
+    - category: gpu_workload
+      cloud_provider_id: azure
+      cpu_cores: 24
+      generic_name: standard_nc24s_v3
+      id: Standard_NC24s_v3
+      memory: 481036337152
+      name: Standard_NC24s_v3
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_dc2es_v6
+      id: Standard_DC2es_v6
+      memory: 8589934592
+      name: Standard_DC2es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_dc4es_v6
+      id: Standard_DC4es_v6
+      memory: 17179869184
+      name: Standard_DC4es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_dc8es_v6
+      id: Standard_DC8es_v6
+      memory: 34359738368
+      name: Standard_DC8es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_dc16es_v6
+      id: Standard_DC16es_v6
+      memory: 68719476736
+      name: Standard_DC16es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_dc32es_v6
+      id: Standard_DC32es_v6
+      memory: 137438953472
+      name: Standard_DC32es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_dc48es_v6
+      id: Standard_DC48es_v6
+      memory: 206158430208
+      name: Standard_DC48es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_dc64es_v6
+      id: Standard_DC64es_v6
+      memory: 274877906944
+      name: Standard_DC64es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_dc96es_v6
+      id: Standard_DC96es_v6
+      memory: 412316860416
+      name: Standard_DC96es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_dc128es_v6
+      id: Standard_DC128es_v6
+      memory: 549755813888
+      name: Standard_DC128es_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_dc2eds_v6
+      id: Standard_DC2eds_v6
+      memory: 8589934592
+      name: Standard_DC2eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_dc4eds_v6
+      id: Standard_DC4eds_v6
+      memory: 17179869184
+      name: Standard_DC4eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_dc8eds_v6
+      id: Standard_DC8eds_v6
+      memory: 34359738368
+      name: Standard_DC8eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_dc16eds_v6
+      id: Standard_DC16eds_v6
+      memory: 68719476736
+      name: Standard_DC16eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_dc32eds_v6
+      id: Standard_DC32eds_v6
+      memory: 137438953472
+      name: Standard_DC32eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_dc48eds_v6
+      id: Standard_DC48eds_v6
+      memory: 206158430208
+      name: Standard_DC48eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_dc64eds_v6
+      id: Standard_DC64eds_v6
+      memory: 274877906944
+      name: Standard_DC64eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 96
+      generic_name: standard_dc96eds_v6
+      id: Standard_DC96eds_v6
+      memory: 412316860416
+      name: Standard_DC96eds_v6
+    - category: general_purpose
+      cloud_provider_id: azure
+      cpu_cores: 128
+      generic_name: standard_dc128eds_v6
+      id: Standard_DC128eds_v6
+      memory: 549755813888
+      name: Standard_DC128eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_ec2es_v6
+      id: Standard_EC2es_v6
+      memory: 17179869184
+      name: Standard_EC2es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_ec4es_v6
+      id: Standard_EC4es_v6
+      memory: 34359738368
+      name: Standard_EC4es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_ec8es_v6
+      id: Standard_EC8es_v6
+      memory: 68719476736
+      name: Standard_EC8es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_ec16es_v6
+      id: Standard_EC16es_v6
+      memory: 137438953472
+      name: Standard_EC16es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_ec32es_v6
+      id: Standard_EC32es_v6
+      memory: 274877906944
+      name: Standard_EC32es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_ec48es_v6
+      id: Standard_EC48es_v6
+      memory: 412316860416
+      name: Standard_EC48es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_ec64es_v6
+      id: Standard_EC64es_v6
+      memory: 549755813888
+      name: Standard_EC64es_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 2
+      generic_name: standard_ec2eds_v6
+      id: Standard_EC2eds_v6
+      memory: 17179869184
+      name: Standard_EC2eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 4
+      generic_name: standard_ec4eds_v6
+      id: Standard_EC4eds_v6
+      memory: 34359738368
+      name: Standard_EC4eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 8
+      generic_name: standard_ec8eds_v6
+      id: Standard_EC8eds_v6
+      memory: 68719476736
+      name: Standard_EC8eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 16
+      generic_name: standard_ec16eds_v6
+      id: Standard_EC16eds_v6
+      memory: 137438953472
+      name: Standard_EC16eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 32
+      generic_name: standard_ec32eds_v6
+      id: Standard_EC32eds_v6
+      memory: 274877906944
+      name: Standard_EC32eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 48
+      generic_name: standard_ec48eds_v6
+      id: Standard_EC48eds_v6
+      memory: 412316860416
+      name: Standard_EC48eds_v6
+    - category: memory_optimized
+      cloud_provider_id: azure
+      cpu_cores: 64
+      generic_name: standard_ec64eds_v6
+      id: Standard_EC64eds_v6
+      memory: 549755813888
+      name: Standard_EC64eds_v6
+kind: ConfigMap
+metadata:
+  name: cloud-resources-config
+  namespace: 'clusters-service'
+---
+# Source: clusters-service/templates/cluster-proxy-service-config.configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-proxy-service-config
+  namespace: 'clusters-service'
+data:
+  config.yaml: |
+    # Hosts that should be added to noProxy for all clusters
+    noProxy: []
+    # Hosts that should be added to noProxy for AWS clusters
+    noProxy_aws: []
+    # Hosts that should be added to noProxy for GCP clusters
+    noProxy_gcp: []
+    # Readiness endpoints that verify proxy connectivity
+    readinessEndpoints:
+      - "https://api.openshift.com"
+---
+# Source: clusters-service/templates/region-constraints-config.configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: region-constraints-config
+  namespace: 'clusters-service'
+data:
+  config.yaml: |
+    cloud_providers:
+    - name: azure
+      regions:
+        - name: 'westus3'
+          version_constraints:
+            min_version: 4.11.0
+---
+# Source: clusters-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clusters-service
+  namespace: 'clusters-service'
+  labels:
+    app: clusters-service
+    port: api
+spec:
+  selector:
+    app: clusters-service
+  ports:
+  - port: 8000
+    targetPort: 8000
+    protocol: TCP
+---
+# Source: clusters-service/templates/service.yaml
+# Services for diagnostic ports (not part of main service because we
+# don't want exposing them externally through same route).
+apiVersion: v1
+kind: Service
+metadata:
+  name: clusters-service-metrics
+  namespace: 'clusters-service'
+  labels:
+    # {app, port} labels together identify this service for monitoring
+    app: clusters-service
+    port: metrics
+spec:
+  selector:
+    app: clusters-service
+  ports:
+  - port: 8080
+    targetPort: 8080
+    name: metrics
+    protocol: TCP
+---
+# Source: clusters-service/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clusters-service-healthcheck
+  namespace: 'clusters-service'
+  labels:
+    app: clusters-service
+    port: healthcheck
+spec:
+  selector:
+    app: clusters-service
+  ports:
+  - port: 8083
+    targetPort: 8083
+    name: healthcheck
+    protocol: TCP
+---
+# Source: clusters-service/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: clusters-service
+  namespace: 'clusters-service'
+  labels:
+    app: clusters-service
+spec:
+  selector:
+    matchLabels:
+      app: clusters-service
+  replicas: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: clusters-service
+        azure.workload.identity/use: "true"
+      annotations:
+        checksum/db: '7d748725a08edbe974bbd237e5dd517833a82eaa0f0b211fc2881961bf4515a8'
+        checksum/operatorcfg: '110eacb1e465d620a2c26da89d5b6246433bb53a2dd3f9853e2daaa035e53df5'
+        checksum/ocpversionscfg: '9e5cff6bf43f7b8d712e0b54656c6b1ec66693e7fe17ba6801070134b28b2900'
+        checksum/cskv: '9d2f2676d1e93dbd4633b77a7ab993e9b3a3d1d86dfd615cdeb3d901f11101f1'
+        checksum/provisionshard: 'd2d4582f46da482e7a0c56f8a4372d95839bf6ced1d48a964d7030dc7e1b5b4b'
+        checksum/cs: '7f91f7a8dc3a8b51073043defb13df2c3864a9c93f5a5588a2431f012bc2ae28'
+        checksum/runtime: 'a59b6e4224066ebe7cb35d89a9e9c179f9e90942d3b4173c91c0609299a983ef'
+        checksum/cloudres: '6db050cd35a77e565d80d2ba2c028450a8758e3ab0a4e524ede12cf207c3a73a'
+        checksum/sa: '0187a6f1019114e284fb5565a82e4e954460ac079f952f07b9602117c0d81e3f'
+    spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: 'topology.kubernetes.io/zone'
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: clusters-service
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: clusters-service
+      serviceAccount: 'clusters-service'
+      serviceAccountName: 'clusters-service'
+      volumes:
+      - name: service
+        secret:
+          secretName: clusters-service
+      - name: shards
+        secret:
+          secretName: provision-shards
+      - name: rds
+        secret:
+          secretName: ocm-cs-db
+      - name: oidc
+        secret:
+          secretName: rh-oidc-s3-secret
+      - name: authentication
+        configMap:
+          name: authentication
+      - name: region-constraints
+        configMap:
+          name: region-constraints-config
+      - name: instance-types
+        configMap:
+          name: cloud-resources-config
+      - name: instance-type-constraints
+        configMap:
+          name: cloud-resource-constraints-config
+      - name: cloud-regions
+        configMap:
+          name: cloud-resources-config
+      - name: cloud-region-constraints
+        configMap:
+          name: cloud-resource-constraints-config
+      - name: proxy
+        configMap:
+          name: cluster-proxy-service-config
+      - name: azure-runtime-config
+        configMap:
+          name: azure-runtime-config
+      - name: azure-operators-managed-identities-config
+        configMap:
+          name: azure-operators-managed-identities-config
+      - name: aro-hcp-ocp-versions-config
+        configMap:
+          name: aro-hcp-ocp-versions-config
+      - name: mixin-pull-secret
+        secret:
+          secretName: hive-ci-global-pull-secret
+          optional: true
+      - name: keyvault
+        csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: cs-keyvault
+      initContainers:
+      - name: clusters-service-init
+        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        imagePullPolicy: IfNotPresent
+        env:
+        # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
+        # Azure Workload Identity (azure.workload.identity/use); that effectively restricts other credential chains from being tried.
+        - name: AZURE_TOKEN_CREDENTIALS
+          value: "WorkloadIdentityCredential"
+        volumeMounts:
+        - name: rds
+          mountPath: /secrets/rds
+        - name: service
+          mountPath: /secrets/service
+        - name: azure-runtime-config
+          mountPath: /configs/azure-runtime-config
+        - name: keyvault
+          mountPath: "/secrets/keyvault"
+          readOnly: true
+        command:
+        - /usr/local/bin/clusters-service
+        - init
+        - --db-host=@/secrets/rds/db.host
+        - --db-port=@/secrets/rds/db.port
+        - --db-name=@/secrets/rds/db.name
+        - --db-user=@/secrets/rds/db.user
+        - --db-password=@/secrets/rds/db.password
+        - --db-disable-tls=__databaseDisableTls__
+        - --db-auth-method=__databaseAuthMethod__
+        - --force-migration=
+        - --batch-processes-dry-run=true
+        - --batch-processes=
+        - --azure-runtime-config-path=/configs/azure-runtime-config/config.json
+        - --azure-first-party-application-client-id=b3cb2fab-15cb-4583-ad06-f91da9bfe2d1
+        - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
+      containers:
+      - name: clusters-service-server
+        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: DENYASSIGNMENTS
+          value: disabled
+        # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
+        # Azure Workload Identity (azure.workload.identity/use); that effectively restricts other credential chains from being tried.
+        - name: AZURE_TOKEN_CREDENTIALS
+          value: "WorkloadIdentityCredential"
+        volumeMounts:
+        - name: service
+          mountPath: /secrets/service
+        - name: shards
+          mountPath: /secrets/shards
+        - name: rds
+          mountPath: /secrets/rds
+        - name: authentication
+          mountPath: /configs/authentication
+        - name: region-constraints
+          mountPath: /configs/region-constraints
+        - name: proxy
+          mountPath: /configs/proxy
+        - name: mixin-pull-secret
+          mountPath: /secrets/mixin-pull-secret
+        - name: instance-types
+          mountPath: /configs/cloud-resources/instance-types.yaml
+          subPath: instance-types.yaml
+        - name: instance-type-constraints
+          mountPath: /configs/cloud-resource-constraints/instance-type-constraints.yaml
+          subPath: instance-type-constraints.yaml
+        - name: cloud-regions
+          mountPath: /configs/cloud-resources/cloud-regions.yaml
+          subPath: cloud-regions.yaml
+        - name: cloud-region-constraints
+          mountPath: /configs/cloud-resource-constraints/cloud-region-constraints.yaml
+          subPath: cloud-region-constraints.yaml
+        - name: keyvault
+          mountPath: "/secrets/keyvault"
+          readOnly: true
+        - name: azure-runtime-config
+          mountPath: /configs/azure-runtime-config
+        - name: azure-operators-managed-identities-config
+          mountPath: /configs/azure-operators-managed-identities-config.yaml
+          subPath: azure-operators-managed-identities-config.yaml
+        - name: aro-hcp-ocp-versions-config
+          mountPath: /configs/aro-hcp-ocp-versions-config.yaml
+          subPath: aro-hcp-ocp-versions-config.yaml
+        command:
+        - /usr/local/bin/clusters-service
+        - serve
+        - --log-level=4
+        - --namespace=clusters-service
+        - --runtime-mode=aro-hcp
+        - --default-expiration=0
+        - --maximum-expiration=0
+        - --provision-shard-cluster-limit=100
+        - --db-host=@/secrets/rds/db.host
+        - --db-port=@/secrets/rds/db.port
+        - --db-name=@/secrets/rds/db.name
+        - --db-user=@/secrets/rds/db.user
+        - --db-password=@/secrets/rds/db.password
+        - --db-disable-tls=__databaseDisableTls__
+        - --db-auth-method=__databaseAuthMethod__
+        - --gateway-url=http://127.0.0.1:9090
+        - --client-id=@/secrets/service/client.id
+        - --client-secret=@/secrets/service/client.secret
+        - --client-scopes=openid
+        - --user-defined-dns-base-domain=i1.devshift.org
+        - --jwks-url=http://localhost
+        - --jwks-file=/configs/authentication/jwks.json
+        - --acl-file=/configs/authentication/acl.yml
+        - --token-url=http://localhost
+        - --insecure=false
+        - --api-listener-network=tcp
+        - --api-listener-address=:8000
+        - --metrics-listener-network=tcp
+        - --metrics-listener-address=:8080
+        - --healthcheck-listener-network=tcp
+        - --healthcheck-listener-address=:8083
+        - --environment=arohcpdev
+        - --backplane-url=
+        - --provision-shards-config=/secrets/shards/config
+        - --proxy-config-file=/configs/proxy/config.yaml
+        - --aws-sts-policy-directory=/configs/policies
+        - --mixin-pull-secret-path=/secrets/mixin-pull-secret
+        - --region-constraints-config=/configs/region-constraints/config.yaml
+        - --instance-type-config=/configs/cloud-resources/instance-types.yaml
+        - --instance-type-constraints-config=/configs/cloud-resource-constraints/instance-type-constraints.yaml
+        - --cloud-region-config=/configs/cloud-resources/cloud-regions.yaml
+        - --cloud-region-constraints-config=/configs/cloud-resource-constraints/cloud-region-constraints.yaml
+        - --azure-first-party-application-client-id=b3cb2fab-15cb-4583-ad06-f91da9bfe2d1
+        - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
+        - --azure-runtime-config-path=/configs/azure-runtime-config/config.json
+        - --azure-operators-managed-identities-config-path=/configs/azure-operators-managed-identities-config.yaml
+        - --aro-hcp-ocp-versions-config-path=/configs/aro-hcp-ocp-versions-config.yaml
+        - --azure-mi-mock-service-principal-certificate-bundle-path=/secrets/keyvault/mockMiServicePrincipalCertificateBundle
+        - --azure-mi-mock-service-principal-client-id=e8723db7-9b9e-46a4-9f7d-64d75c3534f0
+        - --azure-mi-mock-service-principal-principal-id=d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+        - --azure-arm-helper-identity-certificate-bundle-path=/secrets/keyvault/armHelperIndentityCertificateBundle
+        - --azure-arm-helper-identity-client-id=shared-client-id
+        - --azure-arm-helper-mock-fpa-principal-id=mock-fpa-principal-id
+        # Baggage items are populated by the RP frontend and defined in internal/tracing/attributes.go.
+        - --log-fields-from-baggage=aro.correlation_id=correlation_id,aro.client.request_id=client_request_id
+        
+        
+        livenessProbe:
+          httpGet:
+            path: /api/clusters_mgmt/v1
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 8083
+            scheme: HTTP
+            httpHeaders:
+            - name: User-Agent
+              value: Probe
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          timeoutSeconds: 10
+        resources:
+          requests:
+            memory: '150Mi'
+            cpu: '50m'
+---
+# Source: clusters-service/templates/postgres-breakglass.deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres-breakglass
+  namespace: 'clusters-service'
+  labels:
+    app: postgres-breakglass
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app: postgres-breakglass
+  template:
+    metadata:
+      labels:
+        app: postgres-breakglass
+        azure.workload.identity/use: "true"
+    spec:
+      serviceAccount: 'clusters-service'
+      serviceAccountName: 'clusters-service'
+      initContainers:
+      - name: init
+        image: 'mcr.microsoft.com/azure-cli:azurelinux3.0'
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -euo pipefail
+          echo "PostgreSQL breakglass init container started at $(date)"
+
+          # Check required environment variables
+          if [ -z "${AZURE_FEDERATED_TOKEN_FILE:-}" ]; then
+            echo "Error: AZURE_FEDERATED_TOKEN_FILE environment variable is not set, check workload identity settings"
+            exit 1
+          fi
+          if [ -z "${AZURE_CLIENT_ID:-}" ]; then
+            echo "Error: AZURE_CLIENT_ID environment variable is not set, check workload identity settings"
+            exit 1
+          fi
+          if [ -z "${AZURE_TENANT_ID:-}" ]; then
+            echo "Error: AZURE_TENANT_ID environment variable is not set, check workload identity settings"
+            exit 1
+          fi
+
+          echo "Logging into Azure using workload identity..."
+          FEDERATED_TOKEN="$(cat $AZURE_FEDERATED_TOKEN_FILE)"
+          az login --federated-token "$FEDERATED_TOKEN" --service-principal -u $AZURE_CLIENT_ID -t $AZURE_TENANT_ID
+
+          echo "Getting PostgreSQL access token..."
+          ACCESS_TOKEN=$(az account get-access-token --resource-type oss-rdbms -o json | jq .accessToken -r)
+
+          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
+            echo "Failed to get access token"
+            exit 1
+          fi
+
+          echo "Writing access token and connect script to shared volume..."
+          {
+            echo "#!/bin/sh"
+            echo "export PGPASSWORD=$ACCESS_TOKEN"
+            echo "exec psql"
+          } > /breakglass/connect.sh
+          chmod +x /breakglass/connect.sh
+
+          echo "Access token and script written successfully"
+          echo "Init container completed at $(date)"
+        volumeMounts:
+        - name: breakglass
+          mountPath: /breakglass
+      containers:
+      - name: postgres
+        image: mcr.microsoft.com/azurelinux/base/postgres:16
+        command:
+        - /bin/bash
+        - -c
+        - |
+          # Create welcome message for both bash and sh users
+          {
+            echo '# PostgreSQL Breakglass Access'
+            echo 'echo ""'
+            echo 'echo "PostgreSQL Breakglass Access Ready"'
+            echo 'echo "To connect to PostgreSQL, run: connect"'
+            echo 'echo ""'
+            echo ''
+            echo '# Connection alias'
+            echo 'alias connect="/breakglass/connect.sh"'
+          } > ~/.bashrc
+
+          # Copy to .profile for /bin/sh users
+          cp ~/.bashrc ~/.profile
+
+          echo "PostgreSQL breakglass container ready at $(date)"
+          sleep infinity
+        env:
+        - name: PGUSER
+          value: "__databaseUser__"
+        - name: PGDATABASE
+          value: "__databaseName__"
+        - name: PGHOST
+          value: "__databaseHost__"
+        - name: PGPORT
+          value: "5432"
+        volumeMounts:
+        - name: breakglass
+          mountPath: /breakglass
+      volumes:
+      - name: breakglass
+        emptyDir: {}
+---
+# Source: clusters-service/templates/acrpullbinding.yaml
+apiVersion: acrpull.microsoft.com/v1beta2
+kind: AcrPullBinding
+metadata:
+  name: pull-binding
+  namespace: 'clusters-service'
+spec:
+  acr:
+    environment: PublicCloud
+    server: 'arohcpsvcdev.azurecr.io'
+    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+  auth:
+    workloadIdentity:
+      serviceAccountRef: 'clusters-service'
+      clientID: '__imagePullerMsiClientId__'
+      tenantID: '__tenantId__'
+  serviceAccountName: 'clusters-service'
+---
+# Source: clusters-service/templates/istio.yml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-metrics
+  namespace: 'clusters-service'
+spec:
+  action: "ALLOW"
+  rules:
+  - to:
+    - operation:
+        paths: ["/metrics"]
+        methods: ["GET"]
+        ports: ["8080"]
+  selector:
+    matchLabels:
+      app: "clusters-service"
+---
+# Source: clusters-service/templates/istio.yml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-nothing
+  namespace: 'clusters-service'
+spec: {}
+---
+# Source: clusters-service/templates/istio.yml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-frontend
+  namespace: 'clusters-service'
+spec:
+  action: "ALLOW"
+  rules:
+  - from:
+    - source:
+        principals:
+        - "cluster.local/ns/aro-hcp/sa/frontend"
+        - "cluster.local/ns/aro-hcp/sa/backend"
+    to:
+    - operation:
+        ports:
+        - "8000"
+  selector:
+    matchLabels:
+      app: "clusters-service"
+---
+# Source: clusters-service/templates/istio.yml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-admin-api
+  namespace: 'clusters-service'
+spec:
+  action: "ALLOW"
+  rules:
+  - from:
+    - source:
+        principals:
+        - "cluster.local/ns/aro-hcp-admin-api/sa/admin-api"
+    to:
+    - operation:
+        ports:
+        - "8000"
+  selector:
+    matchLabels:
+      app: "clusters-service"
+---
+# Source: clusters-service/templates/istio.yml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-fleet-controller
+  namespace: 'clusters-service'
+spec:
+  action: "ALLOW"
+  rules:
+  - from:
+    - source:
+        principals:
+        - "cluster.local/ns/fleet/sa/fleet"
+    to:
+    - operation:
+        ports:
+        - "8000"
+  selector:
+    matchLabels:
+      app: "clusters-service"
+---
+# Source: clusters-service/templates/istio.yml
+# TODO: Remove when migration to Azure Postgres completes
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-intra-namespace
+  namespace: 'clusters-service'
+spec:
+  action: "ALLOW"
+  rules:
+  - from:
+    - source:
+        principals: ["cluster.local/ns/clusters-service/sa/clusters-service"]
+    to:
+    - operation:
+        ports:
+        - "5432"
+  selector:
+    matchLabels:
+      name: "ocm-cs-db"
+---
+# Source: clusters-service/templates/istio.yml
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: 'clusters-service'
+spec:
+  selector:
+    matchLabels:
+      app: clusters-service
+  portLevelMtls:
+    8080:
+      mode: PERMISSIVE
+---
+# Source: clusters-service/templates/cs-keyvault.secret.yaml
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: cs-keyvault
+  namespace: 'clusters-service'
+spec:
+  parameters:
+    clientID: '__azureCsMiClientId__'
+    cloudName: 'AzurePublicCloud'
+    keyvaultName: 'aro-hcp-dev-svc-kv'
+    objects: |-
+      array:
+        - |
+          objectName: 'firstPartyCert2'
+          objectType: secret
+          objectAlias: firstPartyApplicationCertificateBundle
+        - |
+          objectName: 'msiMockCert2'
+          objectType: secret
+          objectAlias: mockMiServicePrincipalCertificateBundle
+        - |
+          objectName: 'shared-cert-name'
+          objectType: secret
+          objectAlias: armHelperIndentityCertificateBundle
+    tenantId: '__tenantId__'
+    usePodIdentity: "false"
+  provider: azure
+---
+# Source: clusters-service/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clusters-service
+  namespace: 'clusters-service'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'clusters-service'
+  selector:
+    matchLabels:
+      app: clusters-service
+      port: metrics
+

--- a/cluster-service/values.yaml
+++ b/cluster-service/values.yaml
@@ -168,9 +168,9 @@ tlsCertificatesEnabled: true
 # Temporary deny assignment feature flag
 denyAssignments: "{{ .clustersService.denyAssignments }}"
 # The client id of the service principal that represents the ARM Helper Identity.
-azureArmHelperIdentityClientId: "{{ .armHelperClientId }}"
-# The name of the secret that contains the ARM Helper Indentity certificate bundle.
-azureArmHelperIdentityCertName: "{{ .armHelperCertName }}"
+azureArmHelperIdentityClientId: "{{ if .clustersServiceArmHelperClientId }}{{ .clustersServiceArmHelperClientId }}{{ else }}{{ .armHelperClientId }}{{ end }}"
+# The name of the secret that contains the ARM Helper Identity certificate bundle.
+azureArmHelperIdentityCertName: "{{ if .clustersServiceArmHelperCertName }}{{ .clustersServiceArmHelperCertName }}{{ else }}{{ .armHelperCertName }}{{ end }}"
 # The principal id of the service principal that represents the mock first party application identity.
 azureArmHelperMockFpaPrincipalId: "{{ .armHelperFPAPrincipalId }}"
 # The name of the secret that contains the mock managed identities certificate bundle.

--- a/config/config-dev-ci.schema.json
+++ b/config/config-dev-ci.schema.json
@@ -448,6 +448,9 @@
         "armHelper": {
           "$ref": "#/$defs/MockIdentityApp"
         },
+        "clustersServiceArmHelper": {
+          "$ref": "#/$defs/MockIdentityApp"
+        },
         "armHelperPool": {
           "$ref": "#/$defs/MockIdentityPool"
         },

--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -299,6 +299,10 @@ clouds:
               applicationName: "aro-hcp-int-arm-helper"
               certName: "intArmHelperCert"
               certDns: "intarmhelper.hcp.osadev.cloud"
+            clustersServiceArmHelper:
+              applicationName: "aro-hcp-int-cs-arm-helper"
+              certName: "intCsArmHelperCert"
+              certDns: "intcsarmhelper.hcp.osadev.cloud"
             msiMock:
               applicationName: "aro-hcp-int-msi-mock"
               certName: "intMsiMockCert"

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1319,6 +1319,12 @@
     "armHelperTenantId": {
       "type": "string"
     },
+    "clustersServiceArmHelperClientId": {
+      "type": "string"
+    },
+    "clustersServiceArmHelperCertName": {
+      "type": "string"
+    },
     "backend": {
       "type": "object",
       "properties": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1125,6 +1125,8 @@ defaults:
   armHelperFPAPrincipalId: ""
   armHelperTenantId: ""
   armHelperCertName: ""
+  clustersServiceArmHelperClientId: ""
+  clustersServiceArmHelperCertName: ""
   # OIDC
   oidc:
     storageAccount:
@@ -1256,6 +1258,8 @@ clouds:
       armHelperFPAPrincipalId: 47f69502-0065-4d9a-b19b-d403e183d2f4
       armHelperTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
       armHelperCertName: armHelperCert2
+      clustersServiceArmHelperClientId: 3331e670-0804-48e8-a086-6241671ddc93
+      clustersServiceArmHelperCertName: armHelperCert2
       # OIDC
       oidc:
         storageAccount:

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -212,6 +212,8 @@ clustersService:
   tracing:
     address: http://ingest.observability:4318
     exporter: otlp
+clustersServiceArmHelperCertName: armHelperCert2
+clustersServiceArmHelperClientId: 3331e670-0804-48e8-a086-6241671ddc93
 customExporter:
   clusterNameFilter: ci00-j7654321
   clusterTypes: svc-cluster,mgmt-cluster

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -212,6 +212,8 @@ clustersService:
   tracing:
     address: http://ingest.observability:4318
     exporter: otlp
+clustersServiceArmHelperCertName: armHelperCert2
+clustersServiceArmHelperClientId: 3331e670-0804-48e8-a086-6241671ddc93
 customExporter:
   clusterNameFilter: ci01-j7654321
   clusterTypes: svc-cluster,mgmt-cluster

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -212,6 +212,8 @@ clustersService:
   tracing:
     address: ""
     exporter: ""
+clustersServiceArmHelperCertName: armHelperCert2
+clustersServiceArmHelperClientId: 3331e670-0804-48e8-a086-6241671ddc93
 customExporter:
   clusterNameFilter: ""
   clusterTypes: svc-cluster,mgmt-cluster

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -212,6 +212,8 @@ clustersService:
   tracing:
     address: ""
     exporter: ""
+clustersServiceArmHelperCertName: armHelperCert2
+clustersServiceArmHelperClientId: 3331e670-0804-48e8-a086-6241671ddc93
 customExporter:
   clusterNameFilter: ""
   clusterTypes: svc-cluster,mgmt-cluster

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -212,6 +212,8 @@ clustersService:
   tracing:
     address: ""
     exporter: ""
+clustersServiceArmHelperCertName: armHelperCert2
+clustersServiceArmHelperClientId: 3331e670-0804-48e8-a086-6241671ddc93
 customExporter:
   clusterNameFilter: ""
   clusterTypes: svc-cluster,mgmt-cluster

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -212,6 +212,8 @@ clustersService:
   tracing:
     address: http://ingest.observability:4318
     exporter: otlp
+clustersServiceArmHelperCertName: armHelperCert2
+clustersServiceArmHelperClientId: 3331e670-0804-48e8-a086-6241671ddc93
 customExporter:
   clusterNameFilter: ""
   clusterTypes: svc-cluster,mgmt-cluster

--- a/dev-infrastructure/configurations/mock-identity-apps-int.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mock-identity-apps-int.tmpl.bicepparam
@@ -10,6 +10,10 @@ param identities = [
     certDns: '{{ .ci.int.mockIdentities.armHelper.certDns }}'
   }
   {
+    applicationName: '{{ .ci.int.mockIdentities.clustersServiceArmHelper.applicationName }}'
+    certDns: '{{ .ci.int.mockIdentities.clustersServiceArmHelper.certDns }}'
+  }
+  {
     applicationName: '{{ .ci.int.mockIdentities.msiMock.applicationName }}'
     certDns: '{{ .ci.int.mockIdentities.msiMock.certDns }}'
   }

--- a/dev-infrastructure/configurations/mock-identity-rbac-int.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mock-identity-rbac-int.tmpl.bicepparam
@@ -2,6 +2,7 @@ using '../templates/mock-identity-rbac.bicep'
 
 param firstPartyAppName = '{{ .ci.int.mockIdentities.firstParty.applicationName }}'
 param armHelperAppName = '{{ .ci.int.mockIdentities.armHelper.applicationName }}'
+param clustersServiceArmHelperAppName = '{{ .ci.int.mockIdentities.clustersServiceArmHelper.applicationName }}'
 param msiMockAppName = '{{ .ci.int.mockIdentities.msiMock.applicationName }}'
 param poolAppBaseName = '{{ .ci.int.mockIdentities.pool.appBaseName }}'
 param poolSize = {{ .ci.int.mockIdentities.pool.size }}

--- a/dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/e2e-subscription-rbac-grants/pipeline.yaml
@@ -170,6 +170,7 @@ resourceGroups:
         --vault-url "${VAULT_URL}" \
         --mapping "${FIRST_PARTY_APP_NAME};${FIRST_PARTY_CERT_NAME};${FIRST_PARTY_CERT_DNS}" \
         --mapping "${ARM_HELPER_APP_NAME};${ARM_HELPER_CERT_NAME};${ARM_HELPER_CERT_DNS}" \
+        --mapping "${CS_ARM_HELPER_APP_NAME};${CS_ARM_HELPER_CERT_NAME};${CS_ARM_HELPER_CERT_DNS}" \
         --mapping "${MSI_MOCK_APP_NAME};${MSI_MOCK_CERT_NAME};${MSI_MOCK_CERT_DNS}" \
         --create-missing
     workingDir: ../../..
@@ -192,6 +193,12 @@ resourceGroups:
       configRef: ci.int.mockIdentities.armHelper.certName
     - name: ARM_HELPER_CERT_DNS
       configRef: ci.int.mockIdentities.armHelper.certDns
+    - name: CS_ARM_HELPER_APP_NAME
+      configRef: ci.int.mockIdentities.clustersServiceArmHelper.applicationName
+    - name: CS_ARM_HELPER_CERT_NAME
+      configRef: ci.int.mockIdentities.clustersServiceArmHelper.certName
+    - name: CS_ARM_HELPER_CERT_DNS
+      configRef: ci.int.mockIdentities.clustersServiceArmHelper.certDns
     - name: MSI_MOCK_APP_NAME
       configRef: ci.int.mockIdentities.msiMock.applicationName
     - name: MSI_MOCK_CERT_NAME

--- a/dev-infrastructure/templates/e2e-subscription-rbac-assignment-subscription.bicep
+++ b/dev-infrastructure/templates/e2e-subscription-rbac-assignment-subscription.bicep
@@ -15,6 +15,9 @@ param msiMockPoolPrincipals array = []
 @description('Pooled ARM helper principals that need E2E customer-subscription access')
 param armHelperPoolPrincipals array = []
 
+@description('Clusters Service ARM helper principal that needs E2E customer-subscription access')
+param clustersServiceArmHelperPrincipalId string = ''
+
 @description('Custom role name for the first-party mock principal')
 param firstPartyRoleName string = 'dev-first-party-mock'
 
@@ -215,3 +218,23 @@ resource pooledArmHelperRbacAdminRoleAssignments 'Microsoft.Authorization/roleAs
     }
   }
 ]
+
+resource clustersServiceArmHelperContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(clustersServiceArmHelperPrincipalId)) {
+  name: guid(subscription().id, clustersServiceArmHelperPrincipalId, contributorRoleDefinitionId)
+  scope: subscription()
+  properties: {
+    principalId: clustersServiceArmHelperPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: contributorRoleDefinitionId
+  }
+}
+
+resource clustersServiceArmHelperRbacAdminRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (!empty(clustersServiceArmHelperPrincipalId)) {
+  name: guid(subscription().id, clustersServiceArmHelperPrincipalId, rbacAdminRoleDefinitionId)
+  scope: subscription()
+  properties: {
+    principalId: clustersServiceArmHelperPrincipalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: rbacAdminRoleDefinitionId
+  }
+}

--- a/dev-infrastructure/templates/mock-identity-rbac.bicep
+++ b/dev-infrastructure/templates/mock-identity-rbac.bicep
@@ -21,6 +21,9 @@ param armHelperPoolAppBaseName string = 'unused'
 @description('Number of pooled ARM helper identities')
 param armHelperPoolSize int = 0
 
+@description('Application name for the Clusters Service ARM helper identity')
+param clustersServiceArmHelperAppName string = ''
+
 @description('Subscription IDs that should receive mock identity role assignments')
 param e2eSubscriptionIds array = []
 
@@ -88,6 +91,15 @@ module armHelperPoolLookups './entra-app-lookup.bicep' = [
   }
 ]
 
+module clustersServiceArmHelperLookup './entra-app-lookup.bicep' = if (!empty(clustersServiceArmHelperAppName)) {
+  name: 'lookup-clusters-service-arm-helper'
+  params: {
+    applicationName: toLower(replace(clustersServiceArmHelperAppName, ' ', '-'))
+    manage: true
+    lookupSp: true
+  }
+}
+
 module homeSubscriptionRbac './e2e-subscription-rbac-assignment-subscription.bicep' = if (grantHomeSubscription) {
   name: 'mock-rbac-home'
   scope: subscription()
@@ -107,6 +119,9 @@ module homeSubscriptionRbac './e2e-subscription-rbac-assignment-subscription.bic
         principalId: armHelperPoolLookups[i].outputs.principalId
       }
     ]
+    clustersServiceArmHelperPrincipalId: empty(clustersServiceArmHelperAppName)
+      ? ''
+      : clustersServiceArmHelperLookup!.outputs.principalId
     firstPartyRoleName: firstPartyRoleName
     msiMockRoleName: msiMockRoleName
   }
@@ -132,6 +147,9 @@ module e2eSubscriptionRbac './e2e-subscription-rbac-assignment-subscription.bice
           principalId: armHelperPoolLookups[i].outputs.principalId
         }
       ]
+      clustersServiceArmHelperPrincipalId: empty(clustersServiceArmHelperAppName)
+        ? ''
+        : clustersServiceArmHelperLookup!.outputs.principalId
       firstPartyRoleName: firstPartyRoleName
       msiMockRoleName: msiMockRoleName
     }

--- a/docs/ci/dev-mock-identities.md
+++ b/docs/ci/dev-mock-identities.md
@@ -81,10 +81,18 @@ backend-local limiter. Leasing one clone per environment prevents those
 independent backends from aggregating their CheckAccess requests through
 `aro-dev-arm-helper2`.
 
-At runtime a lease overrides `armHelperClientId` and `armHelperCertName` only.
+At runtime the first lease overrides `armHelperClientId` and
+`armHelperCertName` for Backend. The second lease overrides
+`clustersServiceArmHelperClientId` and `clustersServiceArmHelperCertName`.
 `armHelperFPAPrincipalId` remains the shared first-party mock principal: despite
 its similar name, it identifies the principal that receives the simulated FPA
 grant, not the ARM helper authenticating the request.
+
+INT uses named ARM helper identities rather than the DEV lease pool. Backend
+uses `armHelperClientId` and `armHelperCertName`; Clusters Service can use the
+independent `clustersServiceArmHelperClientId` and
+`clustersServiceArmHelperCertName` values. If the Clusters Service-specific
+values are empty, its chart falls back to the shared Backend values.
 
 ## MSI Mock — `aro-dev-msi-mock2` and the pool
 

--- a/docs/ci/identity-leasing.md
+++ b/docs/ci/identity-leasing.md
@@ -362,15 +362,19 @@ Maintainer flow:
    the desired size directly from `config/config-dev-ci.yaml`.
 5. Add or update the `aro-hcp-arm-helper-sp-dev` Boskos inventory in
    `openshift/release`;
-   after that inventory has rolled out, request one lease as
+   after that inventory has rolled out, request two leases as
    `LEASED_ARM_HELPER_SP`.
 
 The runtime catalog is
 `dev-infrastructure/openshift-ci/arm-helper-pool.yaml`. An unknown or incomplete
-lease entry fails provisioning. A missing lease preserves the shared
-`armHelperClientId` and `armHelperCertName` defaults. The lease does **not**
-override `armHelperFPAPrincipalId`, which is the shared mock first-party
-principal rather than the authenticating ARM helper.
+lease entry fails provisioning. The first whitespace-separated lease configures
+Backend through `armHelperClientId` and `armHelperCertName`; the second configures
+Clusters Service through `clustersServiceArmHelperClientId` and
+`clustersServiceArmHelperCertName`. A single lease remains supported during the
+transition to the shared `hack/ci` provisioning scripts and leaves the Clusters
+Service defaults unchanged. A missing lease preserves all configured defaults.
+Neither lease overrides `armHelperFPAPrincipalId`, which is the shared mock
+first-party principal rather than an authenticating ARM helper.
 
 ## Where To Look
 

--- a/docs/sops/msit-int-credential-setup.md
+++ b/docs/sops/msit-int-credential-setup.md
@@ -58,6 +58,9 @@ The MSIT INT environment is unique because the first-party, MSI mock, and ARM he
     armHelperClientId: 3331e670-0804-48e8-a086-6241671ddc93
     armHelperFPAPrincipalId: 47f69502-0065-4d9a-b19b-d403e183d2f4
     armHelperCertName: intArmHelperCert
+    # Cluster Service ARM Helper - from RH Tenant
+    clustersServiceArmHelperClientId: <aro-hcp-int-cs-arm-helper application ID>
+    clustersServiceArmHelperCertName: intCsArmHelperCert
    ```
 
 1. **Download** the certificates from the `aro-hcp-int-kv`
@@ -74,6 +77,9 @@ The MSIT INT environment is unique because the first-party, MSI mock, and ARM he
    # Download the certificate bundles
    az keyvault secret download --vault-name aro-hcp-int-kv --name intArmHelperCert --file intArmHelperCert
    cat intArmHelperCert | base64 -d > intArmHelperCert.pfx
+
+   az keyvault secret download --vault-name aro-hcp-int-kv --name intCsArmHelperCert --file intCsArmHelperCert
+   cat intCsArmHelperCert | base64 -d > intCsArmHelperCert.pfx
 
    az keyvault secret download --vault-name aro-hcp-int-kv --name intFirstPartyCert --file intFirstPartyCert
    cat intFirstPartyCert | base64 -d > intFirstPartyCert.pfx
@@ -92,6 +98,7 @@ The MSIT INT environment is unique because the first-party, MSI mock, and ARM he
 
    ```bash
    az keyvault certificate import --vault-name arohcpint-svc-ln --name intArmHelperCert --file intArmHelperCert.pfx
+   az keyvault certificate import --vault-name arohcpint-svc-ln --name intCsArmHelperCert --file intCsArmHelperCert.pfx
    az keyvault certificate import --vault-name arohcpint-svc-ln --name intFirstPartyCert --file intFirstPartyCert.pfx
    az keyvault certificate import --vault-name arohcpint-svc-ln --name intMsiMockCert --file intMsiMockCert.pfx
    ```

--- a/hack/ci/build-config-override.sh
+++ b/hack/ci/build-config-override.sh
@@ -9,7 +9,7 @@
 # Optional env vars consumed:
 #   *_IMAGE (BACKEND_IMAGE, FRONTEND_IMAGE, etc.) — digest-based image refs
 #   LEASED_MSI_MOCK_SP      — MSI mock SP lease name
-#   LEASED_ARM_HELPER_SP    — ARM helper SP lease name
+#   LEASED_ARM_HELPER_SP    — one or two whitespace-separated ARM helper SP lease names
 #   LEASED_MSI_CONTAINERS   — MSI identity container lease (controls MGMT sizing)
 #
 # Outputs:
@@ -124,23 +124,55 @@ fi
 # remains unchanged: it identifies the mock first-party principal that receives
 # the simulated FPA grant, not the ARM helper that authenticates this client.
 if [[ -n "${LEASED_ARM_HELPER_SP:-}" ]]; then
-  ARM_HELPER_CLIENT_ID=$(yq ".armHelperPool.\"${LEASED_ARM_HELPER_SP}\".clientId" "${ARM_HELPER_POOL_CATALOG}")
-  ARM_HELPER_PRINCIPAL_ID=$(yq ".armHelperPool.\"${LEASED_ARM_HELPER_SP}\".principalId" "${ARM_HELPER_POOL_CATALOG}")
-  ARM_HELPER_CERT_NAME=$(yq ".armHelperPool.\"${LEASED_ARM_HELPER_SP}\".certName" "${ARM_HELPER_POOL_CATALOG}")
-  if [[ -z "${ARM_HELPER_CLIENT_ID}" || "${ARM_HELPER_CLIENT_ID}" == "null" || \
-        -z "${ARM_HELPER_PRINCIPAL_ID}" || "${ARM_HELPER_PRINCIPAL_ID}" == "null" || \
-        -z "${ARM_HELPER_CERT_NAME}" || "${ARM_HELPER_CERT_NAME}" == "null" ]]; then
-    echo "ERROR: LEASED_ARM_HELPER_SP='${LEASED_ARM_HELPER_SP}' not found or incomplete in ${ARM_HELPER_POOL_CATALOG}"
+  read -r -a ARM_HELPER_LEASES <<< "${LEASED_ARM_HELPER_SP}"
+  if [[ ${#ARM_HELPER_LEASES[@]} -gt 2 ]]; then
+    echo "ERROR: LEASED_ARM_HELPER_SP must contain at most two lease names, got ${#ARM_HELPER_LEASES[@]}"
     exit 1
   fi
-  echo "ARM helper SP override: ${LEASED_ARM_HELPER_SP} -> clientId=${ARM_HELPER_CLIENT_ID}"
-  export _YQ_ARM_HELPER_CID="${ARM_HELPER_CLIENT_ID}"
-  export _YQ_ARM_HELPER_CERT="${ARM_HELPER_CERT_NAME}"
+
+  BACKEND_ARM_HELPER_LEASE="${ARM_HELPER_LEASES[0]}"
+  BACKEND_ARM_HELPER_CLIENT_ID=$(yq ".armHelperPool.\"${BACKEND_ARM_HELPER_LEASE}\".clientId" "${ARM_HELPER_POOL_CATALOG}")
+  BACKEND_ARM_HELPER_PRINCIPAL_ID=$(yq ".armHelperPool.\"${BACKEND_ARM_HELPER_LEASE}\".principalId" "${ARM_HELPER_POOL_CATALOG}")
+  BACKEND_ARM_HELPER_CERT_NAME=$(yq ".armHelperPool.\"${BACKEND_ARM_HELPER_LEASE}\".certName" "${ARM_HELPER_POOL_CATALOG}")
+  if [[ -z "${BACKEND_ARM_HELPER_CLIENT_ID}" || "${BACKEND_ARM_HELPER_CLIENT_ID}" == "null" || \
+        -z "${BACKEND_ARM_HELPER_PRINCIPAL_ID}" || "${BACKEND_ARM_HELPER_PRINCIPAL_ID}" == "null" || \
+        -z "${BACKEND_ARM_HELPER_CERT_NAME}" || "${BACKEND_ARM_HELPER_CERT_NAME}" == "null" ]]; then
+    echo "ERROR: Backend ARM helper lease '${BACKEND_ARM_HELPER_LEASE}' not found or incomplete in ${ARM_HELPER_POOL_CATALOG}"
+    exit 1
+  fi
+
+  echo "Backend ARM helper SP override: ${BACKEND_ARM_HELPER_LEASE} -> clientId=${BACKEND_ARM_HELPER_CLIENT_ID}"
+  export _YQ_ARM_HELPER_CID="${BACKEND_ARM_HELPER_CLIENT_ID}"
+  export _YQ_ARM_HELPER_CERT="${BACKEND_ARM_HELPER_CERT_NAME}"
   yq -i "
     .clouds.dev.environments.${DEPLOY_ENV}.defaults.armHelperClientId = strenv(_YQ_ARM_HELPER_CID) |
     .clouds.dev.environments.${DEPLOY_ENV}.defaults.armHelperCertName = strenv(_YQ_ARM_HELPER_CERT)
   " "${OVERRIDE_CONFIG_FILE}"
   unset _YQ_ARM_HELPER_CID _YQ_ARM_HELPER_CERT
+
+  if [[ ${#ARM_HELPER_LEASES[@]} -eq 2 ]]; then
+    CLUSTERS_SERVICE_ARM_HELPER_LEASE="${ARM_HELPER_LEASES[1]}"
+    CLUSTERS_SERVICE_ARM_HELPER_CLIENT_ID=$(yq ".armHelperPool.\"${CLUSTERS_SERVICE_ARM_HELPER_LEASE}\".clientId" "${ARM_HELPER_POOL_CATALOG}")
+    CLUSTERS_SERVICE_ARM_HELPER_PRINCIPAL_ID=$(yq ".armHelperPool.\"${CLUSTERS_SERVICE_ARM_HELPER_LEASE}\".principalId" "${ARM_HELPER_POOL_CATALOG}")
+    CLUSTERS_SERVICE_ARM_HELPER_CERT_NAME=$(yq ".armHelperPool.\"${CLUSTERS_SERVICE_ARM_HELPER_LEASE}\".certName" "${ARM_HELPER_POOL_CATALOG}")
+    if [[ -z "${CLUSTERS_SERVICE_ARM_HELPER_CLIENT_ID}" || "${CLUSTERS_SERVICE_ARM_HELPER_CLIENT_ID}" == "null" || \
+          -z "${CLUSTERS_SERVICE_ARM_HELPER_PRINCIPAL_ID}" || "${CLUSTERS_SERVICE_ARM_HELPER_PRINCIPAL_ID}" == "null" || \
+          -z "${CLUSTERS_SERVICE_ARM_HELPER_CERT_NAME}" || "${CLUSTERS_SERVICE_ARM_HELPER_CERT_NAME}" == "null" ]]; then
+      echo "ERROR: Clusters Service ARM helper lease '${CLUSTERS_SERVICE_ARM_HELPER_LEASE}' not found or incomplete in ${ARM_HELPER_POOL_CATALOG}"
+      exit 1
+    fi
+
+    echo "Clusters Service ARM helper SP override: ${CLUSTERS_SERVICE_ARM_HELPER_LEASE} -> clientId=${CLUSTERS_SERVICE_ARM_HELPER_CLIENT_ID}"
+    export _YQ_CS_ARM_HELPER_CID="${CLUSTERS_SERVICE_ARM_HELPER_CLIENT_ID}"
+    export _YQ_CS_ARM_HELPER_CERT="${CLUSTERS_SERVICE_ARM_HELPER_CERT_NAME}"
+    yq -i "
+      .clouds.dev.environments.${DEPLOY_ENV}.defaults.clustersServiceArmHelperClientId = strenv(_YQ_CS_ARM_HELPER_CID) |
+      .clouds.dev.environments.${DEPLOY_ENV}.defaults.clustersServiceArmHelperCertName = strenv(_YQ_CS_ARM_HELPER_CERT)
+    " "${OVERRIDE_CONFIG_FILE}"
+    unset _YQ_CS_ARM_HELPER_CID _YQ_CS_ARM_HELPER_CERT
+  else
+    echo "No Clusters Service ARM helper SP lease provided, preserving its configured defaults"
+  fi
 else
   echo "No ARM helper SP lease provided, skipping ARM helper overrides"
 fi


### PR DESCRIPTION
https://issues.redhat.com/browse/AROSLSRE-1679

### What

- Add Cluster Service-specific ARM helper client ID and certificate settings, with fallback to the existing shared Backend settings.
- Update `hack/ci` provisioning to map the first leased ARM helper to Backend and the second to Cluster Service.
- Add the dedicated `aro-hcp-int-cs-arm-helper` INT application, certificate pinning, and subscription RBAC grants.
- Document the DEV lease mapping and INT credential handoff, and cover both dedicated and fallback Helm rendering.

### Why

Backend and Clusters Service currently authenticate through the same ARM helper identity. That causes their ARM traffic and throttling limits to be shared, even when CI leases multiple helper identities. Splitting the service configuration and provisioning overrides allows each workload to use an independent identity while preserving existing behavior until environment-specific overrides are supplied.

### Testing

- `cd config && make materialize`
- `make validate-config-pipelines`
- `make verify`
- `shellcheck hack/ci/build-config-override.sh`
- Exercised dual-lease, transitional single-lease, and invalid second-lease provisioning inputs
- Bicep compilation for both modified templates
- sdp-pipelines EV2 generator in resolve mode for the Global entrypoint

### Special notes for your reviewer

The new INT application ID must be added to the sensitive Microsoft configuration overlay in `sdp-pipelines` after the privileged pipeline creates the application. Until that override is present, Cluster Service falls back to the existing shared ARM helper settings.

No graph, UI, metrics, or performance visualization changes are included.

Suggested reviewers: @galchammat for mock-identity infrastructure and @tmstff for Cluster Service wiring.