### PR TITLE
fix: remove max without(prometheus_replica) from histogram_quantile (AROSLSRE-1746)

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
@@ -1727,7 +1727,7 @@ resource svcFrontendPathLatency 'Microsoft.AlertsManagement/prometheusRuleGroups
           summary: 'Frontend latency is high: 99th percentile exceeds 1 second for {{ $labels.method }} {{ $labels.route }}'
           title: 'Frontend latency is high: 99th percentile exceeds 1 second for {{ $labels.method }} {{ $labels.route }}'
         }
-        expression: 'histogram_quantile(0.99, sum by (le, route, method, cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))) > 1'
+        expression: 'histogram_quantile(0.99, sum by (le, route, method, cluster) (rate(frontend_http_requests_duration_seconds_bucket{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) > 1'
         for: 'PT1M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }

--- a/frontend/alerts/frontend-path-latency-prometheusRule.yaml
+++ b/frontend/alerts/frontend-path-latency-prometheusRule.yaml
@@ -18,14 +18,14 @@ spec:
     # severity: warning → Sev3 so gather-observability (--severity-threshold Sev3) fails CI.
     # Short rate window so the alert can fire within a typical e2e run (ARO-28090).
     # Keep cluster in the aggregation so firings stay per-cluster (correlationId uses $labels.cluster).
-    # Dedup HA Prometheus replicas before summing (same pattern as the control-plane latency dashboard).
+    # HA Prometheus replicas are handled by sum (not max): histogram_quantile works on
+    # ratios between buckets, so doubled counts from two replicas cancel out. Using max
+    # per-bucket broke cumulative monotonicity and caused false positives (AROSLSRE-1746).
     - alert: FrontendPathLatency
       expr: |
         histogram_quantile(0.99,
           sum by (le, route, method, cluster) (
-            max without(prometheus_replica) (
-              rate(frontend_http_requests_duration_seconds_bucket{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])
-            )
+            rate(frontend_http_requests_duration_seconds_bucket{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])
           )
         ) > 1
       for: 1m

--- a/frontend/alerts/frontend-path-latency-prometheusRule_test.yaml
+++ b/frontend/alerts/frontend-path-latency-prometheusRule_test.yaml
@@ -47,7 +47,7 @@ tests:
         description: 'The 99th percentile of frontend request latency for GET /api/clusters has exceeded 1 second over the past 5 minutes.'
         runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/frontend-tsg.html'
         summary: 'Frontend latency is high: 99th percentile exceeds 1 second for GET /api/clusters'
-# Test: HA Prometheus replicas with identical slow series still fire once (max without dedup)
+# Test: HA Prometheus replicas with identical slow series still fire once (sum dedup)
 - interval: 1m
   input_series:
   - series: 'frontend_http_requests_duration_seconds_bucket{le="0.1", route="/api/clusters", method="GET", cluster="test", prometheus_replica="prometheus-k8s-0"}'

--- a/observability/grafana-dashboards/frontend/frontend-control-plane-latency.json
+++ b/observability/grafana-dashboards/frontend/frontend-control-plane-latency.json
@@ -288,7 +288,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "editorMode": "code",
-          "expr": "sum by (method, route) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{cluster=\"$cluster\",route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\",le=~\"^1(\\\\.0)?$\"}[$__rate_interval])))\n/\nsum by (method, route) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{cluster=\"$cluster\",route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\",le=\"+Inf\"}[$__rate_interval])))",
+          "expr": "sum by (method, route) (rate(frontend_http_requests_duration_seconds_bucket{cluster=\"$cluster\",route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\",le=~\"^1(\\\\.0)?$\"}[$__rate_interval]))\n/\nsum by (method, route) (rate(frontend_http_requests_duration_seconds_bucket{cluster=\"$cluster\",route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\",le=\"+Inf\"}[$__rate_interval]))",
           "legendFormat": "{{method}} {{route}}",
           "refId": "A"
         }

--- a/observability/grafana-dashboards/frontend/frontend-control-plane-latency.json
+++ b/observability/grafana-dashboards/frontend/frontend-control-plane-latency.json
@@ -85,7 +85,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "editorMode": "code",
-          "expr": "histogram_quantile(\n  0.99,\n  sum by (le, route, method) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{cluster=\"$cluster\",route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"}[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(\n  0.99,\n  sum by (le, route, method) (\n    rate(frontend_http_requests_duration_seconds_bucket{cluster=\"$cluster\",route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"}[$__rate_interval])\n  )\n)",
           "legendFormat": "{{method}} {{route}}",
           "refId": "A"
         }
@@ -131,7 +131,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "editorMode": "code",
-          "expr": "histogram_quantile(\n  0.95,\n  sum by (le, route, method) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{cluster=\"$cluster\",route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"}[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(\n  0.95,\n  sum by (le, route, method) (\n    rate(frontend_http_requests_duration_seconds_bucket{cluster=\"$cluster\",route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"}[$__rate_interval])\n  )\n)",
           "legendFormat": "{{method}} {{route}}",
           "refId": "A"
         }
@@ -169,7 +169,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "editorMode": "code",
-          "expr": "histogram_quantile(\n  0.50,\n  sum by (le, route, method) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{cluster=\"$cluster\",route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"}[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(\n  0.50,\n  sum by (le, route, method) (\n    rate(frontend_http_requests_duration_seconds_bucket{cluster=\"$cluster\",route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"}[$__rate_interval])\n  )\n)",
           "legendFormat": "{{method}} {{route}}",
           "refId": "A"
         }
@@ -213,7 +213,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by (le, route, method) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{cluster=\"$cluster\",route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"}[$__rate_interval]))))",
+          "expr": "histogram_quantile(0.50, sum by (le, route, method) (rate(frontend_http_requests_duration_seconds_bucket{cluster=\"$cluster\",route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"}[$__rate_interval])))",
           "format": "table",
           "instant": true,
           "legendFormat": "P50",
@@ -222,7 +222,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, route, method) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{cluster=\"$cluster\",route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"}[$__rate_interval]))))",
+          "expr": "histogram_quantile(0.95, sum by (le, route, method) (rate(frontend_http_requests_duration_seconds_bucket{cluster=\"$cluster\",route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"}[$__rate_interval])))",
           "format": "table",
           "instant": true,
           "legendFormat": "P95",
@@ -231,7 +231,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "${datasource}" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by (le, route, method) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{cluster=\"$cluster\",route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"}[$__rate_interval]))))",
+          "expr": "histogram_quantile(0.99, sum by (le, route, method) (rate(frontend_http_requests_duration_seconds_bucket{cluster=\"$cluster\",route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"}[$__rate_interval])))",
           "format": "table",
           "instant": true,
           "legendFormat": "P99",

--- a/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
@@ -43,5 +43,3 @@ knownIssues:
     namespace: "velero"
     pod: "ocm-.*"
   reason: "Velero DataUpload exposer pods are transient (short-lived ~30-90s) pods that mount CSI snapshot PVCs for kopia data upload during scheduled backups. They complete and are deleted well within 5 minutes, but Prometheus lookback delta keeps stale Pending-phase metrics queryable beyond the for:5m alert threshold."
-- name: "FrontendPathLatency"
-  reason: "histogram_quantile(0.99) produces false positives with sparse request volume in CI. E2E runs create all nodepools in a burst then traffic drops to 1-2 requests per 5-minute rate window; at that volume, rate() floating-point noise across HA Prometheus replicas breaks cumulative histogram monotonicity, causing the P99 estimate to land in empty high-latency buckets (e.g. 12.083s reported when actual max was 26ms). Tracked in AROSLSRE-1746."

--- a/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
@@ -6,9 +6,7 @@ panels:
     query: |
       histogram_quantile(0.99,
         sum by (le, route, method, cluster) (
-          max without (prometheus_replica) (
-            rate(frontend_http_requests_duration_seconds_bucket{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])
-          )
+          rate(frontend_http_requests_duration_seconds_bucket{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])
         )
       )
     unit: seconds


### PR DESCRIPTION
## Summary

- Remove `max without(prometheus_replica)` from `histogram_quantile` expressions in the `FrontendPathLatency` alert and the control plane latency dashboard.
- Per [Prometheus docs](https://prometheus.io/docs/prometheus/latest/querying/functions/), `sum by (le, ...)` is the correct aggregation for histogram buckets — `histogram_quantile` works on ratios between buckets, so doubled counts from HA replicas cancel out.
- Remove `FrontendPathLatency` from known issues (added in #6449) since the root cause is fixed in this PR.
- The existing `FrontendLatency` alert (1h window, info severity) already uses `sum` without `max` and is unaffected.
- Also remove `max without` from the SLO fraction panel and the gather-observability query — both operate on histogram buckets and have the same per-bucket non-atomicity problem.
- Non-histogram panels (request rate) correctly retain `max without` for dedup.

## Root Cause

Using `max without(prometheus_replica)` per-bucket picks from different HA replicas independently, breaking cumulative histogram monotonicity. With sparse CI traffic (1–2 requests per 5m window), `histogram_quantile` interpolated into empty high-latency buckets — reporting **P99 = 12.083s when the actual max request was 26ms** (a 466x overestimate).

This is the same class of problem documented in [prometheus/prometheus#2610](https://github.com/prometheus/prometheus/pull/2610) and [prometheus/prometheus#13671](https://github.com/prometheus/prometheus/issues/13671): non-atomic data fed into `histogram_quantile` breaks the monotonicity invariant that the algorithm depends on.

The [Prometheus docs](https://prometheus.io/docs/prometheus/latest/querying/functions/) explicitly warn about this:

> *"if there are non-monotonic bucket counts even after this adjustment, they are increased to the value of the previous buckets to enforce monotonicity. The latter is evidence for an actual issue with the input data... If you encounter this annotation, you should find and remove the source of the invalid data."*

The source of the invalid data was `max without(prometheus_replica)`. This PR removes it.

## Why `sum` is correct

The [Prometheus docs](https://prometheus.io/docs/prometheus/latest/querying/functions/) say: *"To aggregate, use the `sum()` aggregator around the `rate()` function."* — no mention of `max` for histogram buckets anywhere.

`sum by (le, route, method, cluster)` sums across all other labels including `prometheus_replica`. The doubled counts from 2 replicas don't affect the quantile because `histogram_quantile` divides buckets by each other — the 2x factor cancels:

```
1 replica:  bucket{le="1.0"} = 990,  bucket{le="+Inf"} = 1000 → 99% under 1s
2 replicas: bucket{le="1.0"} = 1980, bucket{le="+Inf"} = 2000 → still 99% under 1s
```

## Evidence

**Failing E2E run:** [pull-ci-Azure-ARO-HCP-main-e2e-parallel/2085205020218757120](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/batch/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2085205020218757120)

**Kusto proof — alert fired with expressionValue=12.083:**
```kql
-- Database: MonitoringEvents, Cluster: https://hcp-dev-us-2.eastus2.kusto.windows.net
alertEvents
| where firedDateTime == datetime(2026-08-06T04:21:20.0868379Z)
| where alertRule has "FrontendPathLatency"
| where targetResourceId has "j8757120"
| where monitorCondition == "Fired"
| project firedDateTime, expressionValue = toreal(alertContext.expressionValue),
    cluster = tostring(alertContext.labels.cluster),
    method = tostring(alertContext.labels.method),
    route = tostring(alertContext.labels.route)
```

**Kusto proof — all 9,475 requests across the entire E2E run, none exceeded 1s:**
```kql
-- Database: ServiceLogs, Cluster: https://hcp-dev-us-2.eastus2.kusto.windows.net
frontendLogs
| where timestamp between (datetime(2026-08-06T03:50:00Z) .. datetime(2026-08-06T05:20:00Z))
| where cluster == "ci01-j8757120-svc"
| where msg == "response complete"
| extend duration_ms = round(toreal(log.duration) * 1000, 2)
| summarize count(), max(duration_ms), countif(duration_ms > 1000) by request_method
```
Result: 9,475 requests, max 791ms, **0 exceeded 1 second**.

Tracked in [AROSLSRE-1746](https://issues.redhat.com/browse/AROSLSRE-1746).

## Test plan

- [x] Verify `FrontendPathLatency` alert rule test passes (promtool via CI)
- [x] Verify dashboard JSON is valid (no broken expressions)
- [x] Confirm the `FrontendLatency` alert (1h window) is unchanged and already uses the same `sum` pattern
- [x] Confirm non-histogram panels (request rate) retain `max without` for correct dedup
- [x] Confirm SLO fraction panel and gather query also use `sum` (histogram buckets, same fix applies)
- [x] Verify `FrontendPathLatency` is removed from known issues (no longer needed with root cause fixed)