### PR TITLE
CNTRLPLANE-4009: feat(test): add HyperShift presubmit e2e test and nightly version support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ e2e-local/run: $(ARO_HCP_TESTS)
 	export ADMIN_API_ADDRESS=$${ADMIN_API_ADDRESS:-http://localhost:8444}; \
 	export HCPCTL_BINARY="$$(pwd)/tooling/hcpctl/hcpctl"; \
 	mkdir -p "$$ARTIFACT_DIR"; \
-	$(ARO_HCP_TESTS) run-suite "rp-api-compat-all/parallel" --junit-path="$$JUNIT_PATH" --html-path="$$HTML_PATH" --max-concurrency 100
+	$(ARO_HCP_TESTS) run-suite "$${ARO_HCP_E2E_SUITE:-rp-api-compat-all/parallel}" --junit-path="$$JUNIT_PATH" --html-path="$$HTML_PATH" --max-concurrency 100
 .PHONY: e2e-local/run
 
 e2e-local/run-test:

--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -425,7 +425,7 @@ func setupCli() *cobra.Command {
 
 	// The tests that a suite is composed of can be filtered by CEL expressions. By
 	// default, the qualifiers only apply to tests from this extension.
-	integrationQuery := fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.DevelopmentOnly[0], labels.StageAndProdOnly[0])
+	integrationQuery := fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.DevelopmentOnly[0], labels.StageAndProdOnly[0], labels.HypershiftPresubmit[0])
 	integrationTestTimeout := 150 * time.Minute
 	ext.AddSuite(e.Suite{
 		Name: "integration/parallel",
@@ -451,7 +451,7 @@ func setupCli() *cobra.Command {
 		ResourcePools: miPools,
 	})
 
-	stageQuery := fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.IntegrationOnly[0], labels.DevelopmentOnly[0])
+	stageQuery := fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.IntegrationOnly[0], labels.DevelopmentOnly[0], labels.HypershiftPresubmit[0])
 	stageTestTimeout := 150 * time.Minute
 	ext.AddSuite(e.Suite{
 		Name: "stage/parallel",
@@ -476,7 +476,7 @@ func setupCli() *cobra.Command {
 		ResourcePools: miPools,
 	})
 
-	prodQuery := fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.IntegrationOnly[0], labels.DevelopmentOnly[0])
+	prodQuery := fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.IntegrationOnly[0], labels.DevelopmentOnly[0], labels.HypershiftPresubmit[0])
 	prodTestTimeout := 150 * time.Minute
 	ext.AddSuite(e.Suite{
 		Name: "prod/parallel",
@@ -539,6 +539,16 @@ func setupCli() *cobra.Command {
 		// Override parallelism at runtime via ARO_HCP_SUITE_PARALLELISM.
 		Parallelism:   parallelism(24),
 		TestTimeout:   &rpApiCompatTestTimeout,
+		ResourcePools: miPools,
+	})
+
+	hypershiftPresubmitQuery := fmt.Sprintf(`labels.exists(l, l=="%s")`, labels.HypershiftPresubmit[0])
+	hypershiftPresubmitTimeout := 150 * time.Minute
+	ext.AddSuite(e.Suite{
+		Name:          "hypershift-presubmit/parallel",
+		Qualifiers:    []string{hypershiftPresubmitQuery},
+		Parallelism:   parallelism(24),
+		TestTimeout:   &hypershiftPresubmitTimeout,
 		ResourcePools: miPools,
 	})
 

--- a/test/cmd/aro-hcp-tests/main_test.go
+++ b/test/cmd/aro-hcp-tests/main_test.go
@@ -37,6 +37,7 @@ func TestMainListSuitesForEachSuite(t *testing.T) {
 		{suite: "dev-cd-check/parallel", suffix: "dev-cd-check-parallel"},
 		{suite: "rp-api-compat-all/parallel", suffix: "rp-api-compat-all-parallel"},
 		{suite: "rp-api-compat-all/parallel", suffix: "rp-api-compat-all-parallel-development", setDevelopmentEnv: true},
+		{suite: "hypershift-presubmit/parallel", suffix: "hypershift-presubmit-parallel"},
 		{suite: "upgrade/in-place", suffix: "upgrade-in-place"},
 	}
 

--- a/test/e2e/cluster_create_hypershift_presubmit.go
+++ b/test/e2e/cluster_create_hypershift_presubmit.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+	"github.com/Azure/ARO-HCP/test/util/verifiers"
+)
+
+var _ = Describe("ARO-HCP HyperShift Presubmit", func() {
+	It("should create a cluster and nodepool to completion",
+		labels.HypershiftPresubmit,
+		labels.RequireNothing,
+		labels.Critical,
+		labels.Positive,
+		labels.AroRpApiCompatible,
+		labels.MIContainers(1),
+		func(ctx context.Context) {
+			clusterParams := framework.NewDefaultClusterParams20251223()
+
+			suffix := rand.String(6)
+			clusterName := "cluster-hs-pre-" + suffix
+			clusterParams.ClusterName = clusterName
+
+			tc := framework.NewTestContext()
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
+			}
+
+			By("creating resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "rg-hs-pre-", tc.Location())
+			Expect(err).NotTo(HaveOccurred(), "failed to create resource group")
+
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name+"-"+suffix, "-managed", 64)
+			clusterParams.ManagedResourceGroupName = managedResourceGroupName
+
+			By("creating customer resources")
+			clusterParams, err = tc.CreateClusterCustomerResources20251223(ctx,
+				resourceGroup,
+				clusterParams,
+				map[string]interface{}{
+					"customerNsgName":        "customer-nsg-hs-pre-" + suffix,
+					"customerVnetName":       "customer-vnet-hs-pre-" + suffix,
+					"customerVnetSubnetName": "customer-vnet-subnet-hs-pre-" + suffix,
+				},
+				TestArtifactsFS,
+				framework.RBACScopeResourceGroup,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for cluster %q", clusterName)
+
+			By(fmt.Sprintf("creating the HCP cluster with version '%s' on %s channel", clusterParams.OpenshiftVersionId, clusterParams.ChannelGroup))
+			err = tc.CreateHCPClusterFromParam20251223(
+				ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				nil,
+				framework.ClusterCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "HCP cluster %s/%s should provision", *resourceGroup.Name, clusterName)
+
+			By("verifying the cluster is viable")
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
+				ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				*resourceGroup.Name,
+				clusterName,
+				framework.GetAdminRESTConfigTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for cluster %q", clusterName)
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to verify HCP cluster %q is viable", clusterName)
+
+			nodePoolName := "np-" + suffix
+			nodePoolParams := framework.NewDefaultNodePoolParams20251223()
+			nodePoolParams.ClusterName = clusterName
+			nodePoolParams.NodePoolName = nodePoolName
+
+			By(fmt.Sprintf("creating node pool %q with version '%s' on %s channel", nodePoolName, nodePoolParams.OpenshiftVersionId, nodePoolParams.ChannelGroup))
+			err = tc.CreateNodePoolFromParam20251223(
+				ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				managedResourceGroupName,
+				clusterName,
+				nodePoolParams,
+				framework.NodePoolCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create node pool %q for cluster %q", nodePoolName, clusterName)
+
+			By("verifying a simple web app can run")
+			err = verifiers.VerifySimpleWebApp().Verify(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to verify simple web app runs on cluster %q", clusterName)
+		},
+	)
+})

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -8,6 +8,7 @@ Customer should be able to create an HCP cluster with custom autoscaling and upd
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create a cluster and node pools with aggregated advanced features
+ARO-HCP HyperShift Presubmit should create a cluster and nodepool to completion
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_hypershift_presubmit_parallelhypershift_presubmit_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_hypershift_presubmit_parallelhypershift_presubmit_parallel.txt
@@ -1,0 +1,1 @@
+ARO-HCP HyperShift Presubmit should create a cluster and nodepool to completion

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -10,6 +10,7 @@ Customer should be able to create an HCP cluster with custom autoscaling and upd
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create a cluster and node pools with aggregated advanced features
+ARO-HCP HyperShift Presubmit should create a cluster and nodepool to completion
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -7,6 +7,7 @@ Customer should be able to create an HCP cluster with custom autoscaling and upd
 Customer should be able to create a HCP cluster and use cilium CNI plugin
 Customer should be able to create a no-CNI private cluster with a private key vault, a nodepool and install cilium CNI successfully
 Customer should be able to create a cluster and node pools with aggregated advanced features
+ARO-HCP HyperShift Presubmit should create a cluster and nodepool to completion
 Customer should be able to create an HCP cluster and custom node pool osDisk size
 Customer should create a cluster with private ingress using v20260630preview and verify the ingress is internal
 Customer should create a cluster with private KAS and verify API server is only reachable from VNet while ingress remains public

--- a/test/util/framework/deployment_params.go
+++ b/test/util/framework/deployment_params.go
@@ -65,6 +65,9 @@ func resolveDefaultControlPlaneVersion() (string, error) {
 		version := os.Getenv("ARO_HCP_OPENSHIFT_CONTROLPLANE_VERSION")
 		if len(version) == 0 {
 			version = DefaultOCPVersionId
+			if v := os.Getenv("ARO_HCP_OPENSHIFT_VERSION_ID"); v != "" {
+				version = v
+			}
 			channelGroup := DefaultOpenshiftChannelGroup()
 			if channelGroup != "stable" {
 				resolved, err := GetLatestInstallVersion(context.Background(), channelGroup, version)

--- a/test/util/labels/labels.go
+++ b/test/util/labels/labels.go
@@ -48,6 +48,10 @@ var (
 	// exclusively by the upgrade/in-place suite — not part of any happy-path or
 	// api-compat suite.
 	UpgradeInPlace = ginkgo.Label("Upgrade-In-Place")
+	// HypershiftPresubmit marks tests that validate Control Plane Operator (CPO)
+	// behavior. Selected by the hypershift-presubmit/parallel suite so that
+	// HyperShift presubmit PRs can run a targeted subset of ARO-HCP e2e tests.
+	HypershiftPresubmit = ginkgo.Label("Hypershift-Presubmit")
 )
 
 var (


### PR DESCRIPTION
## Summary

- Adds `HypershiftPresubmit` label and `hypershift-presubmit/parallel` test suite for running ARO-HCP e2e tests triggered by openshift/hypershift PRs
- Adds a version-agnostic e2e test (`cluster_create_hypershift_presubmit.go`) that creates a cluster with CPO override, verifies viability, creates a nodepool, and runs a web app verification
- Adds `ARO_HCP_OPENSHIFT_VERSION_ID` env var to override the default OCP minor version (4.20) used for nightly release stream resolution — hypershift main targets OCP 5.0, so the presubmit CI needs to query `5.0.0-0.nightly-multi` instead of `4.20.0-0.nightly-multi`
- Excludes `HypershiftPresubmit` tests from integration/stage/prod suites — these tests require `CPO_IMAGE_OVERRIDE` and nightly channel group env vars only set in the presubmit job
- Makes the e2e suite configurable via `ARO_HCP_E2E_SUITE` env var (defaults to `rp-api-compat-all/parallel`) so the presubmit job can run `hypershift-presubmit/parallel`

## Why

[CNTRLPLANE-4009](https://redhat.atlassian.net/browse/CNTRLPLANE-4009) / [CNTRLPLANE-3980](https://redhat.atlassian.net/browse/CNTRLPLANE-3980)

We need a CI job on openshift/hypershift PRs that tests HO and CPO from the PR against an ARO-HCP environment. CPO is not backwards compatible — it needs a matching nightly release image from the same OCP development stream. The approach uses the existing nightly channel group support in Cluster Service and the test framework (`ARO_HCP_OPENSHIFT_CHANNEL_GROUP=nightly`), with the CPO override flowing through the existing ARM API experimental tag pipeline.

Companion PR: https://github.com/openshift/release/pull/83108 (CI job and step registry changes)

## Test plan

- [ ] Verify `go build ./util/framework/` compiles
- [ ] Verify `go test ./util/framework/` passes
- [ ] Verify the new test file builds with `go build -tags E2Etests ./e2e/...`
- [ ] Verify `TestMainListSuitesForEachSuite` passes — hypershift presubmit test only in `hypershift-presubmit/parallel`, not in integration/stage/prod
- [ ] Verify `make e2e-local/run` still defaults to `rp-api-compat-all/parallel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)