### PR TITLE
fix: exclude validation controllers from BackendControllerRetryHotLoo…

### DIFF
--- a/backend/alerts/backend-retryhotloop-prometheusRule.yaml
+++ b/backend/alerts/backend-retryhotloop-prometheusRule.yaml
@@ -23,13 +23,13 @@ spec:
         (
           sum by (name, cluster) (
             max without(prometheus_replica) (
-              rate(workqueue_retries_total{namespace="aro-hcp"}[10m])
+              rate(workqueue_retries_total{namespace="aro-hcp", name!~"(?i)clustervalidation.*|nodepoolvalidation.*"}[10m])
             )
           )
           /
           sum by (name, cluster) (
             max without(prometheus_replica) (
-              rate(workqueue_adds_total{namespace="aro-hcp"}[10m])
+              rate(workqueue_adds_total{namespace="aro-hcp", name!~"(?i)clustervalidation.*|nodepoolvalidation.*"}[10m])
             )
           )
         ) > 0.5

--- a/backend/alerts/backend-retryhotloop-prometheusRule_test.yaml
+++ b/backend/alerts/backend-retryhotloop-prometheusRule_test.yaml
@@ -33,3 +33,25 @@ tests:
   - eval_time: 20m
     alertname: BackendControllerRetryHotLoop
     exp_alerts: []
+# Test: BackendControllerRetryHotLoop does not fire for ClusterValidation controllers
+- interval: 1m
+  input_series:
+  - series: 'workqueue_retries_total{name="clustervalidationazureresourceprovidersregistrationvalidation", namespace="aro-hcp"}'
+    values: "0+80x25" # 80 retries per minute
+  - series: 'workqueue_adds_total{name="clustervalidationazureresourceprovidersregistrationvalidation", namespace="aro-hcp"}'
+    values: "0+100x25" # 100 adds per minute → retry ratio = 80%
+  alert_rule_test:
+  - eval_time: 20m
+    alertname: BackendControllerRetryHotLoop
+    exp_alerts: []
+# Test: BackendControllerRetryHotLoop does not fire for NodePoolValidation controllers
+- interval: 1m
+  input_series:
+  - series: 'workqueue_retries_total{name="nodepoolvalidationquotacheck", namespace="aro-hcp"}'
+    values: "0+80x25" # 80 retries per minute
+  - series: 'workqueue_adds_total{name="nodepoolvalidationquotacheck", namespace="aro-hcp"}'
+    values: "0+100x25" # 100 adds per minute → retry ratio = 80%
+  alert_rule_test:
+  - eval_time: 20m
+    alertname: BackendControllerRetryHotLoop
+    exp_alerts: []

--- a/dev-infrastructure/modules/metrics/rules/generatedSREServicePrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedSREServicePrometheusAlertingRules.bicep
@@ -17,15 +17,13 @@ resource frontendLatency 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-0
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'FrontendLatency'
         enabled: true
         labels: {
@@ -58,15 +56,13 @@ resource backendRetryhotloop 'Microsoft.AlertsManagement/prometheusRuleGroups@20
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'BackendControllerRetryHotLoop'
         enabled: true
         labels: {
@@ -81,7 +77,7 @@ resource backendRetryhotloop 'Microsoft.AlertsManagement/prometheusRuleGroups@20
           summary: 'Backend controller workqueue {{ $labels.name }} retry hot loop'
           title: 'Backend controller workqueue {{ $labels.name }} retry hot loop'
         }
-        expression: '(sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_retries_total{namespace="aro-hcp"}[10m]))) / sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_adds_total{namespace="aro-hcp"}[10m])))) > 0.5'
+        expression: '(sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_retries_total{name!~"(?i)clustervalidation.*|nodepoolvalidation.*",namespace="aro-hcp"}[10m]))) / sum by (name, cluster) (max without (prometheus_replica) (rate(workqueue_adds_total{name!~"(?i)clustervalidation.*|nodepoolvalidation.*",namespace="aro-hcp"}[10m])))) > 0.5'
         for: 'PT10M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }


### PR DESCRIPTION
Exclude cluster and nodepool validation controllers from the BackendControllerRetryHotLoop alert.

Validation controllers intentionally want to use retry-based requeue patterns, This causes their retry-to-adds ratio to legitimately exceed 50%, triggering false-positive BackendControllerRetryHotLoop alerts.