### PR TITLE
feat: add --disable-capi-migration flag to HyperShift installation

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -378,7 +378,7 @@ defaults:
       repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
       digest: sha256:f74ffb720e622ff79fed6eb9f47b3af09b112fd3fc1e5b8406503130eeb40c2a # 0cd025471094cf9052255d5f2ac337662078fe49 (2026-08-04 18:25)
     namespace: hypershift
-    additionalInstallArg: '--enable-cpo-overrides'
+    additionalInstallArg: '--enable-cpo-overrides --disable-capi-migration'
     # By default we set it to empty as this tag is only required for msft environments. We override
     # this value in sdp pipelines for msft environments.
     sharedIngressIPTag: ''

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -449,7 +449,7 @@ hcpRecovery:
     replicas: 2
     serviceAccountName: hcp-recovery
 hypershift:
-  additionalInstallArg: --enable-cpo-overrides
+  additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
     digest: sha256:f74ffb720e622ff79fed6eb9f47b3af09b112fd3fc1e5b8406503130eeb40c2a
     registry: quay.io

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -449,7 +449,7 @@ hcpRecovery:
     replicas: 2
     serviceAccountName: hcp-recovery
 hypershift:
-  additionalInstallArg: --enable-cpo-overrides
+  additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
     digest: sha256:f74ffb720e622ff79fed6eb9f47b3af09b112fd3fc1e5b8406503130eeb40c2a
     registry: quay.io

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -449,7 +449,7 @@ hcpRecovery:
     replicas: 2
     serviceAccountName: hcp-recovery
 hypershift:
-  additionalInstallArg: --enable-cpo-overrides
+  additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
     digest: sha256:f74ffb720e622ff79fed6eb9f47b3af09b112fd3fc1e5b8406503130eeb40c2a
     registry: quay.io

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -449,7 +449,7 @@ hcpRecovery:
     replicas: 2
     serviceAccountName: hcp-recovery
 hypershift:
-  additionalInstallArg: --enable-cpo-overrides
+  additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
     digest: sha256:f74ffb720e622ff79fed6eb9f47b3af09b112fd3fc1e5b8406503130eeb40c2a
     registry: quay.io

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -449,7 +449,7 @@ hcpRecovery:
     replicas: 2
     serviceAccountName: hcp-recovery
 hypershift:
-  additionalInstallArg: --enable-cpo-overrides
+  additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
     digest: sha256:f74ffb720e622ff79fed6eb9f47b3af09b112fd3fc1e5b8406503130eeb40c2a
     registry: quay.io

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -449,7 +449,7 @@ hcpRecovery:
     replicas: 2
     serviceAccountName: hcp-recovery
 hypershift:
-  additionalInstallArg: --enable-cpo-overrides
+  additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
     digest: sha256:f74ffb720e622ff79fed6eb9f47b3af09b112fd3fc1e5b8406503130eeb40c2a
     registry: quay.io

--- a/hypershiftoperator/testdata/zz_fixture_TestHelmTemplate_hypershift_performance_metrics.yaml
+++ b/hypershiftoperator/testdata/zz_fixture_TestHelmTemplate_hypershift_performance_metrics.yaml
@@ -757,7 +757,7 @@ spec:
             --enable-size-tagging=true \
             --limit-crd-install=Azure \
             --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890 \
-            --enable-cpo-overrides
+            --enable-cpo-overrides --disable-capi-migration
       restartPolicy: Never
       serviceAccountName: hypershift-installer
 ---

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -778,7 +778,7 @@ spec:
             --enable-size-tagging=true \
             --limit-crd-install=Azure \
             --additional-operator-env-vars IMAGE_SHARED_INGRESS_HAPROXY=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890 \
-            --enable-cpo-overrides
+            --enable-cpo-overrides --disable-capi-migration
       restartPolicy: Never
       serviceAccountName: hypershift-installer
 ---

--- a/tooling/helmtest/testrunner/node_rollout_config.go
+++ b/tooling/helmtest/testrunner/node_rollout_config.go
@@ -75,6 +75,7 @@ var flagCategories = map[string]flagEffect{
 	"--limit-crd-install":                 flagSafe,
 	"--hypershift-image":                  flagSafe,
 	"--install-scope":                     flagSafe, // phase selector (crds vs resources), does not affect node config
+	"--disable-capi-migration":            flagSafe,
 
 	// Node-affecting: tracked in dedicated NodeRolloutConfig fields
 	"--registry-overrides": flagNodeAffecting,


### PR DESCRIPTION
## Summary
- Adds `--disable-capi-migration` to HyperShift's `additionalInstallArg` in all environments
- Classifies the new flag as `flagSafe` in the node rollout config (operator-level only, no node impact)
- Precautionary measure before the CAPI storage version migration feature PR ([hypershift#8938](https://github.com/openshift/hypershift/pull/8938)) merges — merging without the flag would trigger an automatic migration

Ref: [AROSLSRE-1751](https://redhat.atlassian.net/browse/AROSLSRE-1751)

🤖 Generated with [Claude Code](https://claude.ai/code)