### PR TITLE
Refactor TypeSpec with separate update models

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@autorest/core": "^3.10.9",
         "@azure-tools/typespec-autorest": "^0.69.0",
         "@azure-tools/typespec-azure-core": "^0.69.0",
         "@azure-tools/typespec-azure-resource-manager": "^0.69.0",
@@ -87,6 +88,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@autorest/core": {
+      "version": "3.10.9",
+      "resolved": "https://registry.npmjs.org/@autorest/core/-/core-3.10.9.tgz",
+      "integrity": "sha512-k7vYHZMgzdu0FBC2j+ezj7mjptm+UOzQvtj/e3l78qAKi8L/SMLUQXTsw8Z2OL8vNG8MK4A/qlqVRwfM9k91vA==",
+      "license": "MIT",
+      "bin": {
+        "autorest-core": "entrypoints/app.js",
+        "autorest-language-service": "entrypoints/language-service.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@autorest/schemas": {

--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@autorest/core": "^3.10.9",
     "@azure-tools/typespec-autorest": "^0.69.0",
     "@azure-tools/typespec-azure-core": "^0.69.0",
     "@azure-tools/typespec-azure-resource-manager": "^0.69.0",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
@@ -207,12 +207,11 @@ model VersionProfile {
    *  Each version belongs to only a single set.
    *
    *  If not specified, the default value is 'stable'.
-   *
-   *  Note: The default value is not declared in the API specification because
-   *        of a TypeSpec bug with updatable fields. The default value will be
-   *        declared in a future API version once the TypeSpec bug is fixed.
-   *        https://github.com/Azure/typespec-azure/issues/1586
    */
+  //  Note: The default value is not declared in the API specification because
+  //        of a TypeSpec bug with updatable fields. The default value will be
+  //        declared in a future API version once the TypeSpec bug is fixed.
+  //        https://github.com/Azure/typespec-azure/issues/1586
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   channelGroup?: string;
 }
@@ -394,23 +393,22 @@ model ClusterAutoscalingProfile {
 
   /** maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.
    * The default is 600 seconds.
-   *
-   *  Note: The default value is not declared in the API specification because
-   *        of a TypeSpec bug with updatable fields. The default value will be
-   *        declared in a future API version once the TypeSpec bug is fixed.
-   *        https://github.com/Azure/typespec-azure/issues/1586
    */
+  // Note: The default value is not declared in the API specification because
+  //       of a TypeSpec bug with updatable fields. The default value will be
+  //       declared in a future API version once the TypeSpec bug is fixed.
+  //       https://github.com/Azure/typespec-azure/issues/1586
+  //
   @minValue(0)
   maxPodGracePeriodSeconds?: int32;
 
   /** maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the
    *  provisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.
-   *
-   *  Note: The default value is not declared in the API specification because
-   *        of a TypeSpec bug with updatable fields. The default value will be
-   *        declared in a future API version once the TypeSpec bug is fixed.
-   *        https://github.com/Azure/typespec-azure/issues/1586
    */
+  // Note: The default value is not declared in the API specification because
+  //       of a TypeSpec bug with updatable fields. The default value will be
+  //       declared in a future API version once the TypeSpec bug is fixed.
+  //       https://github.com/Azure/typespec-azure/issues/1586
   @minValue(0)
   maxNodeProvisionTimeSeconds?: int32;
 
@@ -418,12 +416,11 @@ model ClusterAutoscalingProfile {
    * but only run when there are spare resources available. The default is -10.
    * See the following for more details:
    * https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption
-   *
-   *  Note: The default value is not declared in the API specification because
-   *        of a TypeSpec bug with updatable fields. The default value will be
-   *        declared in a future API version once the TypeSpec bug is fixed.
-   *        https://github.com/Azure/typespec-azure/issues/1586
    */
+  // Note: The default value is not declared in the API specification because
+  //       of a TypeSpec bug with updatable fields. The default value will be
+  //       declared in a future API version once the TypeSpec bug is fixed.
+  //       https://github.com/Azure/typespec-azure/issues/1586
   podPriorityThreshold?: int32;
 }
 
@@ -864,12 +861,11 @@ model NodePoolVersionProfile {
    *  Each version belongs to only a single set.
    *
    *  If not specified, the default value is 'stable'.
-   *
-   *  Note: The default value is not declared in the API specification because
-   *        of a TypeSpec bug with updatable fields. The default value will be
-   *        declared in a future API version once the TypeSpec bug is fixed.
-   *        https://github.com/Azure/typespec-azure/issues/1586
    */
+  // Note: The default value is not declared in the API specification because
+  //       of a TypeSpec bug with updatable fields. The default value will be
+  //       declared in a future API version once the TypeSpec bug is fixed.
+  //       https://github.com/Azure/typespec-azure/issues/1586
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   channelGroup?: string;
 }
@@ -1388,12 +1384,11 @@ model UsernameClaimProfile {
    *    and `claim` is set to:
    *    - "username": the mapped value will be "https://myoidc.tld#userA"
    *    - "email": the mapped value will be "userA@myoidc.tld"
-   *
-   * Note: The default value is not declared in the API specification because
-   *       of a TypeSpec bug with updatable fields. The default value will be
-   *       declared in a future API version once the TypeSpec bug is fixed.
-   *       https://github.com/Azure/typespec-azure/issues/1586
    */
+  // Note: The default value is not declared in the API specification because
+  //       of a TypeSpec bug with updatable fields. The default value will be
+  //       declared in a future API version once the TypeSpec bug is fixed.
+  //       https://github.com/Azure/typespec-azure/issues/1586
   prefixPolicy?: UsernameClaimPrefixPolicy;
 }
 

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
@@ -304,12 +304,8 @@ model VersionProfile {
    *
    *  If not specified, the default value is 'stable'.
    */
-  //  Note: The default value is not declared in the API specification because
-  //        of a TypeSpec bug with updatable fields. The default value will be
-  //        declared in a future API version once the TypeSpec bug is fixed.
-  //        https://github.com/Azure/typespec-azure/issues/1586
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
-  channelGroup?: string;
+  channelGroup?: string = "stable";
 }
 
 /** Versions represents an OpenShift version. */
@@ -324,10 +320,6 @@ model VersionProfileUpdate {
    *
    *  If not specified, the default value is 'stable'.
    */
-  //  Note: The default value is not declared in the API specification because
-  //        of a TypeSpec bug with updatable fields. The default value will be
-  //        declared in a future API version once the TypeSpec bug is fixed.
-  //        https://github.com/Azure/typespec-azure/issues/1586
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   channelGroup?: string;
 }
@@ -517,34 +509,21 @@ model ClusterAutoscalingProfile {
   /** maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.
    * The default is 600 seconds.
    */
-  // Note: The default value is not declared in the API specification because
-  //       of a TypeSpec bug with updatable fields. The default value will be
-  //       declared in a future API version once the TypeSpec bug is fixed.
-  //       https://github.com/Azure/typespec-azure/issues/1586
-  //
   @minValue(0)
-  maxPodGracePeriodSeconds?: int32;
+  maxPodGracePeriodSeconds?: int32 = 600;
 
   /** maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the
    *  provisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.
    */
-  // Note: The default value is not declared in the API specification because
-  //       of a TypeSpec bug with updatable fields. The default value will be
-  //       declared in a future API version once the TypeSpec bug is fixed.
-  //       https://github.com/Azure/typespec-azure/issues/1586
   @minValue(0)
-  maxNodeProvisionTimeSeconds?: int32;
+  maxNodeProvisionTimeSeconds?: int32 = 900;
 
   /** podPriorityThreshold enables users to schedule "best-effort" pods, which shouldn't trigger autoscaler actions,
    * but only run when there are spare resources available. The default is -10.
    * See the following for more details:
    * https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption
    */
-  // Note: The default value is not declared in the API specification because
-  //       of a TypeSpec bug with updatable fields. The default value will be
-  //       declared in a future API version once the TypeSpec bug is fixed.
-  //       https://github.com/Azure/typespec-azure/issues/1586
-  podPriorityThreshold?: int32;
+  podPriorityThreshold?: int32 = -10;
 }
 
 /** ImageDigestMirror specifies a set of mirror registries to redirect image
@@ -1134,12 +1113,8 @@ model NodePoolVersionProfile {
    *
    *  If not specified, the default value is 'stable'.
    */
-  // Note: The default value is not declared in the API specification because
-  //       of a TypeSpec bug with updatable fields. The default value will be
-  //       declared in a future API version once the TypeSpec bug is fixed.
-  //       https://github.com/Azure/typespec-azure/issues/1586
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
-  channelGroup?: string;
+  channelGroup?: string = "stable";
 }
 
 /** Versions represents an OpenShift version. */
@@ -1153,10 +1128,6 @@ model NodePoolVersionProfileUpdate {
    *
    *  If not specified, the default value is 'stable'.
    */
-  // Note: The default value is not declared in the API specification because
-  //       of a TypeSpec bug with updatable fields. The default value will be
-  //       declared in a future API version once the TypeSpec bug is fixed.
-  //       https://github.com/Azure/typespec-azure/issues/1586
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   channelGroup?: string;
 }
@@ -1767,11 +1738,7 @@ model UsernameClaimProfile {
    *    - "username": the mapped value will be "https://myoidc.tld#userA"
    *    - "email": the mapped value will be "userA@myoidc.tld"
    */
-  // Note: The default value is not declared in the API specification because
-  //       of a TypeSpec bug with updatable fields. The default value will be
-  //       declared in a future API version once the TypeSpec bug is fixed.
-  //       https://github.com/Azure/typespec-azure/issues/1586
-  prefixPolicy?: UsernameClaimPrefixPolicy;
+  prefixPolicy?: UsernameClaimPrefixPolicy = UsernameClaimPrefixPolicy.None;
 }
 
 /** External Auth claim profile
@@ -1814,10 +1781,6 @@ model UsernameClaimProfileUpdate {
    *    - "username": the mapped value will be "https://myoidc.tld#userA"
    *    - "email": the mapped value will be "userA@myoidc.tld"
    */
-  // Note: The default value is not declared in the API specification because
-  //       of a TypeSpec bug with updatable fields. The default value will be
-  //       declared in a future API version once the TypeSpec bug is fixed.
-  //       https://github.com/Azure/typespec-azure/issues/1586
   prefixPolicy?: UsernameClaimPrefixPolicy;
 }
 

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
@@ -34,6 +34,7 @@ model HcpOpenShiftCluster is TrackedResource<HcpOpenShiftClusterProperties> {
 // - deleted when resource group is deleted
 // - allow cascade delete
 // more: https://armwiki.azurewebsites.net/rp_onboarding/tracked_vs_proxy_resources.html
+/** NodePool resource */
 @parentResource(HcpOpenShiftCluster)
 model NodePool is TrackedResource<NodePoolProperties> {
   ...ResourceNameParameter<
@@ -50,6 +51,47 @@ model ExternalAuth is ProxyResource<ExternalAuthProperties> {
     ExternalAuth,
     NamePattern = "^[a-zA-Z]([-a-zA-Z0-9]{0,13}[a-zA-Z0-9])?$"
   >;
+}
+
+/** Managed service identity (system assigned and/or user assigned identities) */
+// Copied from CommonTypes (v6), omitting the read-only principalId and tenantId fields.
+model ManagedServiceIdentityUpdate {
+  /** The type of managed identity assigned to this resource. */
+  type?: Azure.ResourceManager.CommonTypes.ManagedServiceIdentityType;
+
+  /** The identities assigned to this resource by the user. */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "copied from CommonTypes"
+  userAssignedIdentities?: Record<
+    | Azure.ResourceManager.CommonTypes.UserAssignedIdentity
+    | null>;
+}
+
+/** HCP cluster resource */
+model HcpOpenShiftClusterUpdate {
+  /** The resource-specific properties for this resource. */
+  properties?: HcpOpenShiftClusterPropertiesUpdate;
+
+  /** The managed service identities assigned to this resource. */
+  identity?: ManagedServiceIdentityUpdate;
+
+  ...Azure.ResourceManager.Foundations.ArmTagsProperty;
+}
+
+/** NodePool resource */
+model NodePoolUpdate {
+  /** The resource-specific properties for this resource. */
+  properties?: NodePoolPropertiesUpdate;
+
+  /** The managed service identities assigned to this resource. */
+  identity?: ManagedServiceIdentityUpdate;
+
+  ...Azure.ResourceManager.Foundations.ArmTagsProperty;
+}
+
+/** ExternalAuth resource */
+model ExternalAuthUpdate {
+  /** The resource-specific properties for this resource. */
+  properties?: ExternalAuthPropertiesUpdate;
 }
 
 /** HCP cluster properties */
@@ -148,6 +190,60 @@ model HcpOpenShiftClusterProperties {
   cryptoRestrictions?: CryptoRestrictions = CryptoRestrictions.None;
 }
 
+/** HCP cluster properties */
+model HcpOpenShiftClusterPropertiesUpdate {
+  /** Version of the control plane components */
+  @removed(Versions.v2025_12_23_preview)
+  @renamedFrom(Versions.v2025_12_23_preview, "version")
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  versionNoUpdate?: VersionProfile;
+
+  /** Version of the control plane components */
+  @added(Versions.v2025_12_23_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  version?: VersionProfileUpdate;
+
+  /** Azure platform configuration */
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  platform?: PlatformProfileUpdate;
+
+  /** Configure ClusterAutoscaling . */
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  autoscaling?: ClusterAutoscalingProfile;
+
+  /** Configure ETCD. */
+  @added(Versions.v2026_06_30_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  etcd?: EtcdProfileUpdate;
+
+  /** imageDigestMirrors is a set of rules to allow pulling images from a
+   * mirrored registry by using digest specifications.
+   *
+   * WARNING: Updating this array will redeploy all node pools in the cluster.
+   */
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  @added(Versions.v2025_12_23_preview)
+  @identifiers(#["source"])
+  @maxItems(240)
+  imageDigestMirrors?: ImageDigestMirror[];
+
+  /** nodeDrainTimeoutMinutes is the grace period for how long Pod Disruption Budget-protected workloads will be
+   * respected during any node draining operation. After this grace period, any workloads protected by Pod Disruption
+   * Budgets that have not been successfully drained from a node will be forcibly evicted. This is
+   * especially relevant to cluster upgrades.
+   *
+   * Valid values are in minutes and from 0 to 10080 minutes (1 week).
+   * 0 means that the MachinePool can be drained without any time limitation.
+   *
+   * This is the value is used a default for all NodePools. It can be overridden
+   * by specifying nodeDrainTimeoutMinutes for a given NodePool
+   */
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  @maxValue(10080)
+  @minValue(0)
+  nodeDrainTimeoutMinutes?: int32;
+}
+
 /** The resource provisioning state. */
 @lroStatus
 union ProvisioningState {
@@ -202,6 +298,26 @@ model VersionProfile {
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   @madeRequired(Versions.v2025_12_23_preview)
   id: string;
+
+  /** ChannelGroup is the name of the set to which this version belongs.
+   *  Each version belongs to only a single set.
+   *
+   *  If not specified, the default value is 'stable'.
+   */
+  //  Note: The default value is not declared in the API specification because
+  //        of a TypeSpec bug with updatable fields. The default value will be
+  //        declared in a future API version once the TypeSpec bug is fixed.
+  //        https://github.com/Azure/typespec-azure/issues/1586
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  channelGroup?: string;
+}
+
+/** Versions represents an OpenShift version. */
+model VersionProfileUpdate {
+  /** ID is the desired X.Y version of the cluster control plane. */
+  @added(Versions.v2025_12_23_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  id?: string;
 
   /** ChannelGroup is the name of the set to which this version belongs.
    *  Each version belongs to only a single set.
@@ -383,6 +499,13 @@ model PlatformProfile {
   issuerUrl: url;
 }
 
+/** Azure specific configuration */
+model PlatformProfileUpdate {
+  /** The configuration that the operators of the cluster have to authenticate to Azure */
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  operatorsAuthentication?: OperatorsAuthenticationProfileUpdate;
+}
+
 /** ClusterAutoscaling specifies auto-scaling behavior that
  *  applies to all NodePools associated with a control plane. */
 model ClusterAutoscalingProfile {
@@ -531,6 +654,13 @@ model OperatorsAuthenticationProfile {
   userAssignedIdentities: UserAssignedIdentitiesProfile;
 }
 
+/** The configuration that the operators of the cluster have to authenticate to Azure. */
+model OperatorsAuthenticationProfileUpdate {
+  /** Represents the information related to Azure User-Assigned managed identities needed
+   * to perform Operators authentication based on Azure User-Assigned Managed Identities */
+  userAssignedIdentities?: UserAssignedIdentitiesProfileUpdate;
+}
+
 /** Represents the information related to Azure User-Assigned managed identities needed
  * to perform Operators authentication based on Azure User-Assigned Managed Identities */
 model UserAssignedIdentitiesProfile {
@@ -552,6 +682,29 @@ model UserAssignedIdentitiesProfile {
    * purpose is to perform service level actions. */
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   serviceManagedIdentity: UserAssignedIdentityResourceId;
+}
+
+/** Represents the information related to Azure User-Assigned managed identities needed
+ * to perform Operators authentication based on Azure User-Assigned Managed Identities */
+model UserAssignedIdentitiesProfileUpdate {
+  /** The set of Azure User-Assigned Managed Identities leveraged for the Control Plane
+   * operators of the cluster. The set of required managed identities is dependent on the
+   * Cluster's OpenShift version. */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "operator name to user assigned identity pairings"
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  controlPlaneOperators?: Record<UserAssignedIdentityResourceId>;
+
+  /** The set of Azure User-Assigned Managed Identities leveraged for the Data Plane
+   * operators of the cluster. The set of required managed identities is dependent on the
+   * Cluster's OpenShift version. */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "operator name to user assigned identity pairings"
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  dataPlaneOperators?: Record<UserAssignedIdentityResourceId>;
+
+  /** Represents the information associated to an Azure User-Assigned Managed Identity whose
+   * purpose is to perform service level actions. */
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  serviceManagedIdentity?: UserAssignedIdentityResourceId;
 }
 
 scalar UserAssignedIdentityResourceId
@@ -590,6 +743,28 @@ model KmsKey {
   version: string;
 }
 
+/** A representation of a KeyVault Secret. */
+model KmsKeyUpdate {
+  /** vaultName is the name of the keyvault that contains the secret. */
+  @maxLength(255)
+  @minLength(1)
+  @removed(Versions.v2025_12_23_preview)
+  vaultName?: string;
+
+  /** name is the name of the keyvault key used for encryption/decryption. */
+  @maxLength(255)
+  @minLength(1)
+  @removed(Versions.v2026_06_30_preview)
+  @renamedFrom(Versions.v2026_06_30_preview, "name")
+  nameImplicitVisibility?: string;
+
+  /** version contains the version of the key to use. */
+  @maxLength(255)
+  @minLength(1)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  version?: string;
+}
+
 /** The internet visibility of a keyvault resource */
 union KeyVaultVisibility {
   string,
@@ -617,6 +792,16 @@ model EtcdProfile {
   @added(Versions.v2026_06_30_preview)
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   dataEncryption?: EtcdDataEncryptionProfile;
+}
+
+/** The ETCD settings and configuration options. */
+model EtcdProfileUpdate {
+  /** ETCD Data Encryption settings.
+   * If not specified platform managed keys are used.
+   */
+  @added(Versions.v2026_06_30_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  dataEncryption?: EtcdDataEncryptionProfileUpdate;
 }
 
 /** The ETCD data encryption settings. */
@@ -650,6 +835,16 @@ model EtcdDataEncryptionProfile {
   customerManaged?: CustomerManagedEncryptionProfile;
 }
 
+/** The ETCD data encryption settings. */
+model EtcdDataEncryptionProfileUpdate {
+  /** Specify customer managed encryption key details.
+   * Required when keyManagementMode is "CustomerManaged".
+   */
+  @added(Versions.v2026_06_30_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  customerManaged?: CustomerManagedEncryptionProfileUpdate;
+}
+
 /** Customer managed encryption key profile. */
 model CustomerManagedEncryptionProfile {
   /** The encryption type used.
@@ -674,6 +869,17 @@ model CustomerManagedEncryptionProfile {
   @added(Versions.v2026_06_30_preview)
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   kms?: KmsEncryptionProfile;
+}
+
+/** Customer managed encryption key profile. */
+model CustomerManagedEncryptionProfileUpdate {
+  /** The Key Management Service (KMS) encryption key details.
+   *
+   * Required when encryptionType is "KMS".
+   */
+  @added(Versions.v2026_06_30_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  kms?: KmsEncryptionProfileUpdate;
 }
 
 /** Configure etcd encryption Key Management Service (KMS) key.
@@ -703,6 +909,17 @@ model KmsEncryptionProfile {
   @added(Versions.v2026_06_30_preview)
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   activeKey: KmsKey;
+}
+
+/** Configure etcd encryption Key Management Service (KMS) key.
+ * Your Microsoft Entra application used to create the cluster must be authorized to access this keyvault,
+ * e.g using the AzureCLI: `az keyvault set-policy -n $KEYVAULT_NAME --key-permissions decrypt encrypt --spn (YOUR APPLICATION CLIENT ID)`
+ */
+model KmsEncryptionProfileUpdate {
+  /** The details of the active key. */
+  @added(Versions.v2026_06_30_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  activeKey?: KmsKeyUpdate;
 }
 
 /** The encryption types supported for a customer managed key. */
@@ -802,6 +1019,61 @@ model NodePoolProperties {
   status?: ResourceStatus;
 }
 
+/** Represents the node pool properties */
+model NodePoolPropertiesUpdate {
+  /** OpenShift version for the nodepool */
+  @removed(Versions.v2025_12_23_preview)
+  @renamedFrom(Versions.v2025_12_23_preview, "version")
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  versionNoUpdate?: NodePoolVersionProfile;
+
+  /** OpenShift version for the nodepool */
+  @added(Versions.v2025_12_23_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  version?: NodePoolVersionProfileUpdate;
+
+  /**
+   * The number of worker nodes, it cannot be used together with autoscaling.
+   * Validation:
+   * - Minimum: 0
+   * - Maximum: 200 (only when availabilityZone is not specified)
+   * - No maximum when availabilityZone is specified
+   */
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  @minValue(0)
+  replicas?: int32;
+
+  /** Representation of a autoscaling in a node pool. */
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  autoScaling?: NodePoolAutoScaling;
+
+  /** Kubernetes labels to propagate to the NodePool Nodes
+   * Note that when the labels are updated this is only applied to newly
+   * create nodes in the Nodepool, existing node labels remain unchanged.
+   */
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  @identifiers(#["key", "value"])
+  labels?: Label[];
+
+  /** Taints for the nodes */
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  @identifiers(#["key", "value", "effect"])
+  taints?: Taint[];
+
+  /** nodeDrainTimeoutMinutes is the grace period for how long Pod Disruption Budget-protected workloads will be
+   * respected during any node draining operation. After this grace period, any workloads protected by Pod Disruption
+   * Budgets that have not been successfully drained from a node will be forcibly evicted. This is
+   * especially relevant to cluster upgrades.
+   *
+   * Valid values are from 0 to 10080 minutes (1 week) .
+   * 0 means that the NodePool can be drained without any time limitation.
+   *
+   * If unset the cluster nodeDrainTimeoutMinutes value is used as a default.
+   */
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  nodeDrainTimeoutMinutes?: int32;
+}
+
 /** The taint effect the same as in Kubernetes */
 union Effect {
   string,
@@ -856,6 +1128,25 @@ model NodePoolVersionProfile {
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   @madeRequired(Versions.v2025_12_23_preview)
   id: string;
+
+  /** ChannelGroup is the name of the set to which this version belongs.
+   *  Each version belongs to only a single set.
+   *
+   *  If not specified, the default value is 'stable'.
+   */
+  // Note: The default value is not declared in the API specification because
+  //       of a TypeSpec bug with updatable fields. The default value will be
+  //       declared in a future API version once the TypeSpec bug is fixed.
+  //       https://github.com/Azure/typespec-azure/issues/1586
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  channelGroup?: string;
+}
+
+/** Versions represents an OpenShift version. */
+model NodePoolVersionProfileUpdate {
+  /** ID is the unique identifier of the version. */
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  id?: string;
 
   /** ChannelGroup is the name of the set to which this version belongs.
    *  Each version belongs to only a single set.
@@ -1086,6 +1377,24 @@ model ExternalAuthProperties {
   claim: ExternalAuthClaimProfile;
 }
 
+/** External Auth profile */
+model ExternalAuthPropertiesUpdate {
+  /** Token Issuer profile */
+  issuer?: TokenIssuerProfileUpdate;
+
+  /** External Auth OIDC clients
+   * There must not be more than 20 entries and entries must have unique namespace/name pairs.
+   */
+  @maxItems(20)
+  @identifiers(#["component", "clientId", "extraScopes"])
+  clients?: ExternalAuthClientProfile[];
+
+  /** External Auth claim
+   * This configures how claims are validated and applied.
+   */
+  claim?: ExternalAuthClaimProfileUpdate;
+}
+
 /** ResourceStatus represents the observed status of the resource. */
 @added(Versions.v2026_06_30_preview)
 model ResourceStatus {
@@ -1238,6 +1547,38 @@ model TokenIssuerProfile {
   ca?: string;
 }
 
+/** Token issuer profile
+ * This configures how the platform interacts with the identity provider and
+ * how tokens issued from the identity provider are evaluated by the Kubernetes API server.
+ */
+model TokenIssuerProfileUpdate {
+  /** This configures the URL used to issue tokens by the identity provider.
+   * The Kubernetes API server determines how authentication tokens should be handled
+   * by matching the 'iss' claim in the JWT to the issuerURL of configured identity providers.
+   *
+   * issuerURL must use the 'https' scheme.
+   * */
+  url?: url;
+
+  /** This configures the acceptable audiences the JWT token, issued by the identity
+   * provider, must be issued to. At least one of the entries must match the
+   * 'aud' claim in the JWT token.
+   *
+   * audiences must contain at least one entry and must not exceed ten entries.
+   */
+  @minItems(1)
+  @maxItems(10)
+  audiences?: string[];
+
+  /** The issuer of the token
+   *
+   * Certificate bundle to use to validate server certificates for the configured URL.
+   * It must be PEM encoded and when not specified, the system trust is used.
+   */
+  @clientName("CA")
+  ca?: string;
+}
+
 /** External Auth client profile
  * This configures how on-cluster, platform clients should request tokens from the identity provider.
  */
@@ -1314,6 +1655,16 @@ model ExternalAuthClaimProfile {
   validationRules?: TokenClaimValidationRule[];
 }
 
+/** External Auth claim profile */
+model ExternalAuthClaimProfileUpdate {
+  /** The claim mappings */
+  mappings?: TokenClaimMappingsProfileUpdate;
+
+  /** The claim validation rules */
+  @identifiers(#["type", "requiredClaim"])
+  validationRules?: TokenClaimValidationRule[];
+}
+
 /** External Auth claim mappings profile.
  * At a minimum username or groups must be defined.
  */
@@ -1323,6 +1674,17 @@ model TokenClaimMappingsProfile {
 
   /** The claim mappings groups. */
   groups?: GroupClaimProfile;
+}
+
+/** External Auth claim mappings profile.
+ * At a minimum username or groups must be defined.
+ */
+model TokenClaimMappingsProfileUpdate {
+  /** The claim mappings username. */
+  username?: UsernameClaimProfileUpdate;
+
+  /** The claim mappings groups. */
+  groups?: GroupClaimProfileUpdate;
 }
 
 /** External Auth claim profile
@@ -1346,6 +1708,26 @@ model GroupClaimProfile {
 }
 
 /** External Auth claim profile
+ * This configures how the groups of a cluster identity should be constructed
+ * from the claims in a JWT token issued by the identity provider. When
+ * referencing a claim, if the claim is present in the JWT token, its value
+ * must be a list of groups separated by a comma (',').
+ *
+ * For example - '"example"' and '"exampleOne", "exampleTwo", "exampleThree"' are valid claim values.
+ */
+model GroupClaimProfileUpdate {
+  /** Claim name of the external profile */
+  @minLength(1)
+  @maxLength(256)
+  claim?: string;
+
+  /** Prefix for the claim external profile
+   * If this is specified prefixPolicy will be set to "Prefix" by default
+   */
+  prefix?: string;
+}
+
+/** External Auth claim profile
  * This configures how the username of a cluster identity should be constructed
  * from the claims in a JWT token issued by the identity provider.
  */
@@ -1354,6 +1736,53 @@ model UsernameClaimProfile {
   @minLength(1)
   @maxLength(256)
   claim: string;
+
+  /** Prefix for the claim external profile
+   * Must be set when the prefixPolicy field is set to 'Prefix' and must be unset
+   * otherwise.
+   */
+  prefix?: string;
+
+  /** Prefix policy is an optional field that configures how a prefix should be
+   * applied to the value of the JWT claim specified in the 'claim' field.
+   *
+   * Allowed values are 'Prefix', 'NoPrefix', and 'None'. If not specified, the
+   * default policy is 'None'.
+   *
+   * When set to 'Prefix', the value specified in the prefix field will be
+   * prepended to the value of the JWT claim.
+   * The prefix field must be set when prefixPolicy is 'Prefix'.
+   *
+   * When set to 'NoPrefix', no prefix will be prepended to the value
+   * of the JWT claim.
+   *
+   * When set to 'None', this means no opinion and the platform is left to choose
+   * any prefixes that are applied which is subject to change over time.
+   * Currently, the platform prepends `{issuerURL}#` to the value of the JWT claim
+   * when the claim is not 'email'.
+   * As an example, consider the following scenario:
+   *    `prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,
+   *    the JWT claims include "username":"userA" and "email":"userA@myoidc.tld",
+   *    and `claim` is set to:
+   *    - "username": the mapped value will be "https://myoidc.tld#userA"
+   *    - "email": the mapped value will be "userA@myoidc.tld"
+   */
+  // Note: The default value is not declared in the API specification because
+  //       of a TypeSpec bug with updatable fields. The default value will be
+  //       declared in a future API version once the TypeSpec bug is fixed.
+  //       https://github.com/Azure/typespec-azure/issues/1586
+  prefixPolicy?: UsernameClaimPrefixPolicy;
+}
+
+/** External Auth claim profile
+ * This configures how the username of a cluster identity should be constructed
+ * from the claims in a JWT token issued by the identity provider.
+ */
+model UsernameClaimProfileUpdate {
+  /** Claim name of the external profile */
+  @minLength(1)
+  @maxLength(256)
+  claim?: string;
 
   /** Prefix for the claim external profile
    * Must be set when the prefixPolicy field is set to 'Prefix' and must be unset

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster.tsp
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster.tsp
@@ -16,10 +16,7 @@ namespace Microsoft.RedHatOpenShift;
 interface HcpOpenShiftClusters {
   get is ArmResourceRead<HcpOpenShiftCluster>;
   createOrUpdate is ArmResourceCreateOrReplaceAsync<HcpOpenShiftCluster>;
-  update is ArmResourcePatchAsync<
-    HcpOpenShiftCluster,
-    HcpOpenShiftClusterProperties
-  >;
+  update is ArmCustomPatchAsync<HcpOpenShiftCluster, HcpOpenShiftClusterUpdate>;
   delete is ArmResourceDeleteWithoutOkAsync<HcpOpenShiftCluster>;
   listByResourceGroup is ArmResourceListByParent<HcpOpenShiftCluster>;
   listBySubscription is ArmListBySubscription<HcpOpenShiftCluster>;
@@ -53,7 +50,7 @@ interface HcpOpenShiftClusters {
 interface NodePools {
   get is ArmResourceRead<NodePool>;
   createOrUpdate is ArmResourceCreateOrReplaceAsync<NodePool>;
-  update is ArmResourcePatchAsync<NodePool, NodePoolProperties>;
+  update is ArmCustomPatchAsync<NodePool, NodePoolUpdate>;
   delete is ArmResourceDeleteWithoutOkAsync<NodePool>;
   listByParent is ArmResourceListByParent<NodePool>;
 }
@@ -63,7 +60,7 @@ interface NodePools {
 interface ExternalAuths {
   get is ArmResourceRead<ExternalAuth>;
   createOrUpdate is ArmResourceCreateOrReplaceAsync<ExternalAuth>;
-  update is ArmResourcePatchAsync<ExternalAuth, ExternalAuthProperties>;
+  update is ArmCustomPatchAsync<ExternalAuth, ExternalAuthUpdate>;
   delete is ArmResourceDeleteWithoutOkAsync<ExternalAuth>;
   listByParent is ArmResourceListByParent<ExternalAuth>;
 }

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
@@ -1517,19 +1517,19 @@
         "maxPodGracePeriodSeconds": {
           "type": "integer",
           "format": "int32",
-          "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.",
           "minimum": 0
         },
         "maxNodeProvisionTimeSeconds": {
           "type": "integer",
           "format": "int32",
-          "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.",
           "minimum": 0
         },
         "podPriorityThreshold": {
           "type": "integer",
           "format": "int32",
-          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586"
+          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption"
         }
       }
     },
@@ -2975,7 +2975,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -3680,7 +3680,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
@@ -1467,43 +1467,6 @@
         "url"
       ]
     },
-    "Azure.ResourceManager.CommonTypes.ManagedServiceIdentityUpdate": {
-      "type": "object",
-      "description": "Managed service identity (system assigned and/or user assigned identities)",
-      "properties": {
-        "type": {
-          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentityType",
-          "description": "The type of managed identity assigned to this resource."
-        },
-        "userAssignedIdentities": {
-          "type": "object",
-          "description": "The identities assigned to this resource by the user.",
-          "additionalProperties": {
-            "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/UserAssignedIdentity",
-            "x-nullable": true
-          }
-        }
-      }
-    },
-    "Azure.ResourceManager.CommonTypes.TrackedResourceUpdate": {
-      "type": "object",
-      "title": "Tracked Resource",
-      "description": "The resource model definition for an Azure Resource Manager tracked top level resource which has 'tags' and a 'location'",
-      "properties": {
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/Resource"
-        }
-      ]
-    },
     "ClusterAutoscalingProfile": {
       "type": "object",
       "description": "ClusterAutoscaling specifies auto-scaling behavior that\napplies to all NodePools associated with a control plane.",
@@ -2104,12 +2067,7 @@
           "$ref": "#/definitions/ExternalAuthPropertiesUpdate",
           "description": "The resource-specific properties for this resource."
         }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
+      }
     },
     "GroupClaimProfile": {
       "type": "object",
@@ -2361,15 +2319,17 @@
           "description": "The resource-specific properties for this resource."
         },
         "identity": {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.ManagedServiceIdentityUpdate",
+          "$ref": "#/definitions/ManagedServiceIdentityUpdate",
           "description": "The managed service identities assigned to this resource."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
-        }
-      ]
+      }
     },
     "HcpOpenShiftVersion": {
       "type": "object",
@@ -2565,6 +2525,24 @@
         "key"
       ]
     },
+    "ManagedServiceIdentityUpdate": {
+      "type": "object",
+      "description": "Managed service identity (system assigned and/or user assigned identities)",
+      "properties": {
+        "type": {
+          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentityType",
+          "description": "The type of managed identity assigned to this resource."
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "The identities assigned to this resource by the user.",
+          "additionalProperties": {
+            "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/UserAssignedIdentity",
+            "x-nullable": true
+          }
+        }
+      }
+    },
     "NetworkProfile": {
       "type": "object",
       "description": "OpenShift networking configuration",
@@ -2654,7 +2632,7 @@
     },
     "NodePool": {
       "type": "object",
-      "description": "Concrete tracked resource types can be created by aliasing this type using a specific property type.",
+      "description": "NodePool resource",
       "properties": {
         "properties": {
           "$ref": "#/definitions/NodePoolProperties",
@@ -2943,22 +2921,24 @@
     },
     "NodePoolUpdate": {
       "type": "object",
-      "description": "Concrete tracked resource types can be created by aliasing this type using a specific property type.",
+      "description": "NodePool resource",
       "properties": {
         "properties": {
           "$ref": "#/definitions/NodePoolPropertiesUpdate",
           "description": "The resource-specific properties for this resource."
         },
         "identity": {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.ManagedServiceIdentityUpdate",
+          "$ref": "#/definitions/ManagedServiceIdentityUpdate",
           "description": "The managed service identities assigned to this resource."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
-        }
-      ]
+      }
     },
     "NodePoolVersionProfile": {
       "type": "object",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
@@ -1481,18 +1481,21 @@
           "type": "integer",
           "format": "int32",
           "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.",
+          "default": 600,
           "minimum": 0
         },
         "maxNodeProvisionTimeSeconds": {
           "type": "integer",
           "format": "int32",
           "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.",
+          "default": 900,
           "minimum": 0
         },
         "podPriorityThreshold": {
           "type": "integer",
           "format": "int32",
-          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption"
+          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption",
+          "default": -10
         }
       }
     },
@@ -2956,6 +2959,7 @@
         "channelGroup": {
           "type": "string",
           "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
+          "default": "stable",
           "x-ms-mutability": [
             "read",
             "update",
@@ -3618,8 +3622,35 @@
           "description": "Prefix for the claim external profile\nMust be set when the prefixPolicy field is set to 'Prefix' and must be unset\notherwise."
         },
         "prefixPolicy": {
-          "$ref": "#/definitions/UsernameClaimPrefixPolicy",
-          "description": "Prefix policy is an optional field that configures how a prefix should be\napplied to the value of the JWT claim specified in the 'claim' field.\n\nAllowed values are 'Prefix', 'NoPrefix', and 'None'. If not specified, the\ndefault policy is 'None'.\n\nWhen set to 'Prefix', the value specified in the prefix field will be\nprepended to the value of the JWT claim.\nThe prefix field must be set when prefixPolicy is 'Prefix'.\n\nWhen set to 'NoPrefix', no prefix will be prepended to the value\nof the JWT claim.\n\nWhen set to 'None', this means no opinion and the platform is left to choose\nany prefixes that are applied which is subject to change over time.\nCurrently, the platform prepends `{issuerURL}#` to the value of the JWT claim\nwhen the claim is not 'email'.\nAs an example, consider the following scenario:\n`prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\nthe JWT claims include \"username\":\"userA\" and \"email\":\"userA"
+          "type": "string",
+          "description": "Prefix policy is an optional field that configures how a prefix should be\napplied to the value of the JWT claim specified in the 'claim' field.\n\nAllowed values are 'Prefix', 'NoPrefix', and 'None'. If not specified, the\ndefault policy is 'None'.\n\nWhen set to 'Prefix', the value specified in the prefix field will be\nprepended to the value of the JWT claim.\nThe prefix field must be set when prefixPolicy is 'Prefix'.\n\nWhen set to 'NoPrefix', no prefix will be prepended to the value\nof the JWT claim.\n\nWhen set to 'None', this means no opinion and the platform is left to choose\nany prefixes that are applied which is subject to change over time.\nCurrently, the platform prepends `{issuerURL}#` to the value of the JWT claim\nwhen the claim is not 'email'.\nAs an example, consider the following scenario:\n`prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\nthe JWT claims include \"username\":\"userA\" and \"email\":\"userA",
+          "default": "None",
+          "enum": [
+            "None",
+            "Prefix",
+            "NoPrefix"
+          ],
+          "x-ms-enum": {
+            "name": "UsernameClaimPrefixPolicy",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "None",
+                "value": "None",
+                "description": "No opinion; the platform is left to choose a prefix for the JWT claim"
+              },
+              {
+                "name": "Prefix",
+                "value": "Prefix",
+                "description": "Add a user-provided prefix to the JWT claim"
+              },
+              {
+                "name": "NoPrefix",
+                "value": "NoPrefix",
+                "description": "Do not add a prefix to the JWT claim"
+              }
+            ]
+          }
         }
       },
       "required": [
@@ -3661,6 +3692,7 @@
         "channelGroup": {
           "type": "string",
           "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
+          "default": "stable",
           "x-ms-mutability": [
             "read",
             "update",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
@@ -1517,19 +1517,19 @@
         "maxPodGracePeriodSeconds": {
           "type": "integer",
           "format": "int32",
-          "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.",
           "minimum": 0
         },
         "maxNodeProvisionTimeSeconds": {
           "type": "integer",
           "format": "int32",
-          "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.",
           "minimum": 0
         },
         "podPriorityThreshold": {
           "type": "integer",
           "format": "int32",
-          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586"
+          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption"
         }
       }
     },
@@ -3073,7 +3073,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -3100,7 +3100,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -3844,7 +3844,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -3871,7 +3871,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
@@ -1481,18 +1481,21 @@
           "type": "integer",
           "format": "int32",
           "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.",
+          "default": 600,
           "minimum": 0
         },
         "maxNodeProvisionTimeSeconds": {
           "type": "integer",
           "format": "int32",
           "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.",
+          "default": 900,
           "minimum": 0
         },
         "podPriorityThreshold": {
           "type": "integer",
           "format": "int32",
-          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption"
+          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption",
+          "default": -10
         }
       }
     },
@@ -3054,6 +3057,7 @@
         "channelGroup": {
           "type": "string",
           "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
+          "default": "stable",
           "x-ms-mutability": [
             "read",
             "update",
@@ -3781,8 +3785,35 @@
           "description": "Prefix for the claim external profile\nMust be set when the prefixPolicy field is set to 'Prefix' and must be unset\notherwise."
         },
         "prefixPolicy": {
-          "$ref": "#/definitions/UsernameClaimPrefixPolicy",
-          "description": "Prefix policy is an optional field that configures how a prefix should be\napplied to the value of the JWT claim specified in the 'claim' field.\n\nAllowed values are 'Prefix', 'NoPrefix', and 'None'. If not specified, the\ndefault policy is 'None'.\n\nWhen set to 'Prefix', the value specified in the prefix field will be\nprepended to the value of the JWT claim.\nThe prefix field must be set when prefixPolicy is 'Prefix'.\n\nWhen set to 'NoPrefix', no prefix will be prepended to the value\nof the JWT claim.\n\nWhen set to 'None', this means no opinion and the platform is left to choose\nany prefixes that are applied which is subject to change over time.\nCurrently, the platform prepends `{issuerURL}#` to the value of the JWT claim\nwhen the claim is not 'email'.\nAs an example, consider the following scenario:\n`prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\nthe JWT claims include \"username\":\"userA\" and \"email\":\"userA"
+          "type": "string",
+          "description": "Prefix policy is an optional field that configures how a prefix should be\napplied to the value of the JWT claim specified in the 'claim' field.\n\nAllowed values are 'Prefix', 'NoPrefix', and 'None'. If not specified, the\ndefault policy is 'None'.\n\nWhen set to 'Prefix', the value specified in the prefix field will be\nprepended to the value of the JWT claim.\nThe prefix field must be set when prefixPolicy is 'Prefix'.\n\nWhen set to 'NoPrefix', no prefix will be prepended to the value\nof the JWT claim.\n\nWhen set to 'None', this means no opinion and the platform is left to choose\nany prefixes that are applied which is subject to change over time.\nCurrently, the platform prepends `{issuerURL}#` to the value of the JWT claim\nwhen the claim is not 'email'.\nAs an example, consider the following scenario:\n`prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\nthe JWT claims include \"username\":\"userA\" and \"email\":\"userA",
+          "default": "None",
+          "enum": [
+            "None",
+            "Prefix",
+            "NoPrefix"
+          ],
+          "x-ms-enum": {
+            "name": "UsernameClaimPrefixPolicy",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "None",
+                "value": "None",
+                "description": "No opinion; the platform is left to choose a prefix for the JWT claim"
+              },
+              {
+                "name": "Prefix",
+                "value": "Prefix",
+                "description": "Add a user-provided prefix to the JWT claim"
+              },
+              {
+                "name": "NoPrefix",
+                "value": "NoPrefix",
+                "description": "Do not add a prefix to the JWT claim"
+              }
+            ]
+          }
         }
       },
       "required": [
@@ -3825,6 +3856,7 @@
         "channelGroup": {
           "type": "string",
           "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
+          "default": "stable",
           "x-ms-mutability": [
             "read",
             "update",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
@@ -1467,43 +1467,6 @@
         "url"
       ]
     },
-    "Azure.ResourceManager.CommonTypes.ManagedServiceIdentityUpdate": {
-      "type": "object",
-      "description": "Managed service identity (system assigned and/or user assigned identities)",
-      "properties": {
-        "type": {
-          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentityType",
-          "description": "The type of managed identity assigned to this resource."
-        },
-        "userAssignedIdentities": {
-          "type": "object",
-          "description": "The identities assigned to this resource by the user.",
-          "additionalProperties": {
-            "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/UserAssignedIdentity",
-            "x-nullable": true
-          }
-        }
-      }
-    },
-    "Azure.ResourceManager.CommonTypes.TrackedResourceUpdate": {
-      "type": "object",
-      "title": "Tracked Resource",
-      "description": "The resource model definition for an Azure Resource Manager tracked top level resource which has 'tags' and a 'location'",
-      "properties": {
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/Resource"
-        }
-      ]
-    },
     "ClusterAutoscalingProfile": {
       "type": "object",
       "description": "ClusterAutoscaling specifies auto-scaling behavior that\napplies to all NodePools associated with a control plane.",
@@ -2104,12 +2067,7 @@
           "$ref": "#/definitions/ExternalAuthPropertiesUpdate",
           "description": "The resource-specific properties for this resource."
         }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
+      }
     },
     "GroupClaimProfile": {
       "type": "object",
@@ -2394,15 +2352,17 @@
           "description": "The resource-specific properties for this resource."
         },
         "identity": {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.ManagedServiceIdentityUpdate",
+          "$ref": "#/definitions/ManagedServiceIdentityUpdate",
           "description": "The managed service identities assigned to this resource."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
-        }
-      ]
+      }
     },
     "HcpOpenShiftVersion": {
       "type": "object",
@@ -2663,6 +2623,24 @@
         "key"
       ]
     },
+    "ManagedServiceIdentityUpdate": {
+      "type": "object",
+      "description": "Managed service identity (system assigned and/or user assigned identities)",
+      "properties": {
+        "type": {
+          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentityType",
+          "description": "The type of managed identity assigned to this resource."
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "The identities assigned to this resource by the user.",
+          "additionalProperties": {
+            "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/UserAssignedIdentity",
+            "x-nullable": true
+          }
+        }
+      }
+    },
     "NetworkProfile": {
       "type": "object",
       "description": "OpenShift networking configuration",
@@ -2752,7 +2730,7 @@
     },
     "NodePool": {
       "type": "object",
-      "description": "Concrete tracked resource types can be created by aliasing this type using a specific property type.",
+      "description": "NodePool resource",
       "properties": {
         "properties": {
           "$ref": "#/definitions/NodePoolProperties",
@@ -3041,22 +3019,24 @@
     },
     "NodePoolUpdate": {
       "type": "object",
-      "description": "Concrete tracked resource types can be created by aliasing this type using a specific property type.",
+      "description": "NodePool resource",
       "properties": {
         "properties": {
           "$ref": "#/definitions/NodePoolPropertiesUpdate",
           "description": "The resource-specific properties for this resource."
         },
         "identity": {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.ManagedServiceIdentityUpdate",
+          "$ref": "#/definitions/ManagedServiceIdentityUpdate",
           "description": "The managed service identities assigned to this resource."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
-        }
-      ]
+      }
     },
     "NodePoolVersionProfile": {
       "type": "object",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/openapi.json
@@ -1517,19 +1517,19 @@
         "maxPodGracePeriodSeconds": {
           "type": "integer",
           "format": "int32",
-          "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.",
           "minimum": 0
         },
         "maxNodeProvisionTimeSeconds": {
           "type": "integer",
           "format": "int32",
-          "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.",
           "minimum": 0
         },
         "podPriorityThreshold": {
           "type": "integer",
           "format": "int32",
-          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586"
+          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption"
         }
       }
     },
@@ -3262,7 +3262,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -3289,7 +3289,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -4052,7 +4052,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -4079,7 +4079,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/openapi.json
@@ -1467,43 +1467,6 @@
         "url"
       ]
     },
-    "Azure.ResourceManager.CommonTypes.ManagedServiceIdentityUpdate": {
-      "type": "object",
-      "description": "Managed service identity (system assigned and/or user assigned identities)",
-      "properties": {
-        "type": {
-          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentityType",
-          "description": "The type of managed identity assigned to this resource."
-        },
-        "userAssignedIdentities": {
-          "type": "object",
-          "description": "The identities assigned to this resource by the user.",
-          "additionalProperties": {
-            "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/UserAssignedIdentity",
-            "x-nullable": true
-          }
-        }
-      }
-    },
-    "Azure.ResourceManager.CommonTypes.TrackedResourceUpdate": {
-      "type": "object",
-      "title": "Tracked Resource",
-      "description": "The resource model definition for an Azure Resource Manager tracked top level resource which has 'tags' and a 'location'",
-      "properties": {
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/Resource"
-        }
-      ]
-    },
     "ClusterAutoscalingProfile": {
       "type": "object",
       "description": "ClusterAutoscaling specifies auto-scaling behavior that\napplies to all NodePools associated with a control plane.",
@@ -2158,12 +2121,7 @@
           "$ref": "#/definitions/ExternalAuthPropertiesUpdate",
           "description": "The resource-specific properties for this resource."
         }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
+      }
     },
     "GroupClaimProfile": {
       "type": "object",
@@ -2500,15 +2458,17 @@
           "description": "The resource-specific properties for this resource."
         },
         "identity": {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.ManagedServiceIdentityUpdate",
+          "$ref": "#/definitions/ManagedServiceIdentityUpdate",
           "description": "The managed service identities assigned to this resource."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
-        }
-      ]
+      }
     },
     "HcpOpenShiftVersion": {
       "type": "object",
@@ -2847,6 +2807,24 @@
         "key"
       ]
     },
+    "ManagedServiceIdentityUpdate": {
+      "type": "object",
+      "description": "Managed service identity (system assigned and/or user assigned identities)",
+      "properties": {
+        "type": {
+          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentityType",
+          "description": "The type of managed identity assigned to this resource."
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "The identities assigned to this resource by the user.",
+          "additionalProperties": {
+            "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/UserAssignedIdentity",
+            "x-nullable": true
+          }
+        }
+      }
+    },
     "NetworkProfile": {
       "type": "object",
       "description": "OpenShift networking configuration",
@@ -2936,7 +2914,7 @@
     },
     "NodePool": {
       "type": "object",
-      "description": "Concrete tracked resource types can be created by aliasing this type using a specific property type.",
+      "description": "NodePool resource",
       "properties": {
         "properties": {
           "$ref": "#/definitions/NodePoolProperties",
@@ -3230,22 +3208,24 @@
     },
     "NodePoolUpdate": {
       "type": "object",
-      "description": "Concrete tracked resource types can be created by aliasing this type using a specific property type.",
+      "description": "NodePool resource",
       "properties": {
         "properties": {
           "$ref": "#/definitions/NodePoolPropertiesUpdate",
           "description": "The resource-specific properties for this resource."
         },
         "identity": {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.ManagedServiceIdentityUpdate",
+          "$ref": "#/definitions/ManagedServiceIdentityUpdate",
           "description": "The managed service identities assigned to this resource."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
-        }
-      ]
+      }
     },
     "NodePoolVersionProfile": {
       "type": "object",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/openapi.json
@@ -1481,18 +1481,21 @@
           "type": "integer",
           "format": "int32",
           "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.",
+          "default": 600,
           "minimum": 0
         },
         "maxNodeProvisionTimeSeconds": {
           "type": "integer",
           "format": "int32",
           "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.",
+          "default": 900,
           "minimum": 0
         },
         "podPriorityThreshold": {
           "type": "integer",
           "format": "int32",
-          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption"
+          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption",
+          "default": -10
         }
       }
     },
@@ -3243,6 +3246,7 @@
         "channelGroup": {
           "type": "string",
           "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
+          "default": "stable",
           "x-ms-mutability": [
             "read",
             "update",
@@ -3989,8 +3993,35 @@
           "description": "Prefix for the claim external profile\nMust be set when the prefixPolicy field is set to 'Prefix' and must be unset\notherwise."
         },
         "prefixPolicy": {
-          "$ref": "#/definitions/UsernameClaimPrefixPolicy",
-          "description": "Prefix policy is an optional field that configures how a prefix should be\napplied to the value of the JWT claim specified in the 'claim' field.\n\nAllowed values are 'Prefix', 'NoPrefix', and 'None'. If not specified, the\ndefault policy is 'None'.\n\nWhen set to 'Prefix', the value specified in the prefix field will be\nprepended to the value of the JWT claim.\nThe prefix field must be set when prefixPolicy is 'Prefix'.\n\nWhen set to 'NoPrefix', no prefix will be prepended to the value\nof the JWT claim.\n\nWhen set to 'None', this means no opinion and the platform is left to choose\nany prefixes that are applied which is subject to change over time.\nCurrently, the platform prepends `{issuerURL}#` to the value of the JWT claim\nwhen the claim is not 'email'.\nAs an example, consider the following scenario:\n`prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\nthe JWT claims include \"username\":\"userA\" and \"email\":\"userA"
+          "type": "string",
+          "description": "Prefix policy is an optional field that configures how a prefix should be\napplied to the value of the JWT claim specified in the 'claim' field.\n\nAllowed values are 'Prefix', 'NoPrefix', and 'None'. If not specified, the\ndefault policy is 'None'.\n\nWhen set to 'Prefix', the value specified in the prefix field will be\nprepended to the value of the JWT claim.\nThe prefix field must be set when prefixPolicy is 'Prefix'.\n\nWhen set to 'NoPrefix', no prefix will be prepended to the value\nof the JWT claim.\n\nWhen set to 'None', this means no opinion and the platform is left to choose\nany prefixes that are applied which is subject to change over time.\nCurrently, the platform prepends `{issuerURL}#` to the value of the JWT claim\nwhen the claim is not 'email'.\nAs an example, consider the following scenario:\n`prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\nthe JWT claims include \"username\":\"userA\" and \"email\":\"userA",
+          "default": "None",
+          "enum": [
+            "None",
+            "Prefix",
+            "NoPrefix"
+          ],
+          "x-ms-enum": {
+            "name": "UsernameClaimPrefixPolicy",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "None",
+                "value": "None",
+                "description": "No opinion; the platform is left to choose a prefix for the JWT claim"
+              },
+              {
+                "name": "Prefix",
+                "value": "Prefix",
+                "description": "Add a user-provided prefix to the JWT claim"
+              },
+              {
+                "name": "NoPrefix",
+                "value": "NoPrefix",
+                "description": "Do not add a prefix to the JWT claim"
+              }
+            ]
+          }
         }
       },
       "required": [
@@ -4033,6 +4064,7 @@
         "channelGroup": {
           "type": "string",
           "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
+          "default": "stable",
           "x-ms-mutability": [
             "read",
             "update",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/openapi.json
@@ -1526,19 +1526,19 @@
         "maxPodGracePeriodSeconds": {
           "type": "integer",
           "format": "int32",
-          "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.",
           "minimum": 0
         },
         "maxNodeProvisionTimeSeconds": {
           "type": "integer",
           "format": "int32",
-          "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.",
           "minimum": 0
         },
         "podPriorityThreshold": {
           "type": "integer",
           "format": "int32",
-          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586"
+          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption"
         }
       }
     },
@@ -3281,7 +3281,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -3308,7 +3308,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -4071,7 +4071,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -4098,7 +4098,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/openapi.json
@@ -1476,43 +1476,6 @@
         "url"
       ]
     },
-    "Azure.ResourceManager.CommonTypes.ManagedServiceIdentityUpdate": {
-      "type": "object",
-      "description": "Managed service identity (system assigned and/or user assigned identities)",
-      "properties": {
-        "type": {
-          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentityType",
-          "description": "The type of managed identity assigned to this resource."
-        },
-        "userAssignedIdentities": {
-          "type": "object",
-          "description": "The identities assigned to this resource by the user.",
-          "additionalProperties": {
-            "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/UserAssignedIdentity",
-            "x-nullable": true
-          }
-        }
-      }
-    },
-    "Azure.ResourceManager.CommonTypes.TrackedResourceUpdate": {
-      "type": "object",
-      "title": "Tracked Resource",
-      "description": "The resource model definition for an Azure Resource Manager tracked top level resource which has 'tags' and a 'location'",
-      "properties": {
-        "tags": {
-          "type": "object",
-          "description": "Resource tags.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/Resource"
-        }
-      ]
-    },
     "ClusterAutoscalingProfile": {
       "type": "object",
       "description": "ClusterAutoscaling specifies auto-scaling behavior that\napplies to all NodePools associated with a control plane.",
@@ -2167,12 +2130,7 @@
           "$ref": "#/definitions/ExternalAuthPropertiesUpdate",
           "description": "The resource-specific properties for this resource."
         }
-      },
-      "allOf": [
-        {
-          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
-        }
-      ]
+      }
     },
     "GroupClaimProfile": {
       "type": "object",
@@ -2519,15 +2477,17 @@
           "description": "The resource-specific properties for this resource."
         },
         "identity": {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.ManagedServiceIdentityUpdate",
+          "$ref": "#/definitions/ManagedServiceIdentityUpdate",
           "description": "The managed service identities assigned to this resource."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
-        }
-      ]
+      }
     },
     "HcpOpenShiftVersion": {
       "type": "object",
@@ -2866,6 +2826,24 @@
         "key"
       ]
     },
+    "ManagedServiceIdentityUpdate": {
+      "type": "object",
+      "description": "Managed service identity (system assigned and/or user assigned identities)",
+      "properties": {
+        "type": {
+          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentityType",
+          "description": "The type of managed identity assigned to this resource."
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "The identities assigned to this resource by the user.",
+          "additionalProperties": {
+            "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/UserAssignedIdentity",
+            "x-nullable": true
+          }
+        }
+      }
+    },
     "NetworkProfile": {
       "type": "object",
       "description": "OpenShift networking configuration",
@@ -2955,7 +2933,7 @@
     },
     "NodePool": {
       "type": "object",
-      "description": "Concrete tracked resource types can be created by aliasing this type using a specific property type.",
+      "description": "NodePool resource",
       "properties": {
         "properties": {
           "$ref": "#/definitions/NodePoolProperties",
@@ -3249,22 +3227,24 @@
     },
     "NodePoolUpdate": {
       "type": "object",
-      "description": "Concrete tracked resource types can be created by aliasing this type using a specific property type.",
+      "description": "NodePool resource",
       "properties": {
         "properties": {
           "$ref": "#/definitions/NodePoolPropertiesUpdate",
           "description": "The resource-specific properties for this resource."
         },
         "identity": {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.ManagedServiceIdentityUpdate",
+          "$ref": "#/definitions/ManagedServiceIdentityUpdate",
           "description": "The managed service identities assigned to this resource."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
-        }
-      ]
+      }
     },
     "NodePoolVersionProfile": {
       "type": "object",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/openapi.json
@@ -1490,18 +1490,21 @@
           "type": "integer",
           "format": "int32",
           "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.",
+          "default": 600,
           "minimum": 0
         },
         "maxNodeProvisionTimeSeconds": {
           "type": "integer",
           "format": "int32",
           "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.",
+          "default": 900,
           "minimum": 0
         },
         "podPriorityThreshold": {
           "type": "integer",
           "format": "int32",
-          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption"
+          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption",
+          "default": -10
         }
       }
     },
@@ -3262,6 +3265,7 @@
         "channelGroup": {
           "type": "string",
           "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
+          "default": "stable",
           "x-ms-mutability": [
             "read",
             "update",
@@ -4008,8 +4012,35 @@
           "description": "Prefix for the claim external profile\nMust be set when the prefixPolicy field is set to 'Prefix' and must be unset\notherwise."
         },
         "prefixPolicy": {
-          "$ref": "#/definitions/UsernameClaimPrefixPolicy",
-          "description": "Prefix policy is an optional field that configures how a prefix should be\napplied to the value of the JWT claim specified in the 'claim' field.\n\nAllowed values are 'Prefix', 'NoPrefix', and 'None'. If not specified, the\ndefault policy is 'None'.\n\nWhen set to 'Prefix', the value specified in the prefix field will be\nprepended to the value of the JWT claim.\nThe prefix field must be set when prefixPolicy is 'Prefix'.\n\nWhen set to 'NoPrefix', no prefix will be prepended to the value\nof the JWT claim.\n\nWhen set to 'None', this means no opinion and the platform is left to choose\nany prefixes that are applied which is subject to change over time.\nCurrently, the platform prepends `{issuerURL}#` to the value of the JWT claim\nwhen the claim is not 'email'.\nAs an example, consider the following scenario:\n`prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\nthe JWT claims include \"username\":\"userA\" and \"email\":\"userA"
+          "type": "string",
+          "description": "Prefix policy is an optional field that configures how a prefix should be\napplied to the value of the JWT claim specified in the 'claim' field.\n\nAllowed values are 'Prefix', 'NoPrefix', and 'None'. If not specified, the\ndefault policy is 'None'.\n\nWhen set to 'Prefix', the value specified in the prefix field will be\nprepended to the value of the JWT claim.\nThe prefix field must be set when prefixPolicy is 'Prefix'.\n\nWhen set to 'NoPrefix', no prefix will be prepended to the value\nof the JWT claim.\n\nWhen set to 'None', this means no opinion and the platform is left to choose\nany prefixes that are applied which is subject to change over time.\nCurrently, the platform prepends `{issuerURL}#` to the value of the JWT claim\nwhen the claim is not 'email'.\nAs an example, consider the following scenario:\n`prefix` is unset, `issuerURL` is set to `https://myoidc.tld`,\nthe JWT claims include \"username\":\"userA\" and \"email\":\"userA",
+          "default": "None",
+          "enum": [
+            "None",
+            "Prefix",
+            "NoPrefix"
+          ],
+          "x-ms-enum": {
+            "name": "UsernameClaimPrefixPolicy",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "None",
+                "value": "None",
+                "description": "No opinion; the platform is left to choose a prefix for the JWT claim"
+              },
+              {
+                "name": "Prefix",
+                "value": "Prefix",
+                "description": "Add a user-provided prefix to the JWT claim"
+              },
+              {
+                "name": "NoPrefix",
+                "value": "NoPrefix",
+                "description": "Do not add a prefix to the JWT claim"
+              }
+            ]
+          }
         }
       },
       "required": [
@@ -4052,6 +4083,7 @@
         "channelGroup": {
           "type": "string",
           "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
+          "default": "stable",
           "x-ms-mutability": [
             "read",
             "update",

--- a/internal/api/defaults_test.go
+++ b/internal/api/defaults_test.go
@@ -16,7 +16,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"testing"
 )
@@ -24,9 +23,6 @@ import (
 // TestTypeSpecDefaultsConsistency verifies that default values declared in the
 // generated OpenAPI spec (from TypeSpec) match the canonical Go constants
 // defined in defaults.go and enums.go.
-//
-// Several fields lack "default" annotations in the OpenAPI spec due to a
-// TypeSpec bug (typespec-azure#1586). These are skipped with a comment.
 func TestTypeSpecDefaultsConsistency(t *testing.T) {
 	specPath := "../../api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/openapi.json"
 	specData, err := os.ReadFile(specPath)
@@ -73,9 +69,13 @@ func TestTypeSpecDefaultsConsistency(t *testing.T) {
 		{"OutboundType", "PlatformProfile", "outboundType", string(OutboundTypeLoadBalancer)},
 		{"DiskStorageAccountType", "OsDiskProfile", "diskStorageAccountType", string(DiskStorageAccountTypePremium_LRS)},
 		{"ClusterImageRegistryState", "ClusterImageRegistryProfile", "state", string(ClusterImageRegistryStateEnabled)},
+		{"ChannelGroup", "VersionProfile", "channelGroup", "stable"},
 		// Numeric defaults
 		{"HostPrefix", "NetworkProfile", "hostPrefix", DefaultClusterNetworkHostPrefix},
 		{"OSDiskSizeGiB", "OsDiskProfile", "sizeGiB", DefaultNodePoolOSDiskSizeGiB},
+		{"MaxPodGracePeriodSeconds", "ClusterAutoscalingProfile", "maxPodGracePeriodSeconds", DefaultClusterMaxPodGracePeriodSeconds},
+		{"MaxNodeProvisionTimeSeconds", "ClusterAutoscalingProfile", "maxNodeProvisionTimeSeconds", DefaultClusterMaxNodeProvisionTimeSeconds},
+		{"PodPriorityThreshold", "ClusterAutoscalingProfile", "podPriorityThreshold", DefaultClusterPodPriorityThreshold},
 		// Boolean defaults
 		{"AutoRepair", "NodePoolProperties", "autoRepair", true},
 	}
@@ -115,27 +115,6 @@ func TestTypeSpecDefaultsConsistency(t *testing.T) {
 				}
 			default:
 				t.Fatalf("unsupported goDefault type %T for %s", tc.goDefault, tc.name)
-			}
-		})
-	}
-
-	// Fields that SHOULD have TypeSpec defaults but don't due to
-	// typespec-azure#1586. This list documents the gap explicitly.
-	missingAnnotations := []struct {
-		definition string
-		property   string
-	}{
-		{"VersionProfile", "channelGroup"},
-		{"ClusterAutoscalingProfile", "maxPodGracePeriodSeconds"},
-		{"ClusterAutoscalingProfile", "maxNodeProvisionTimeSeconds"},
-		{"ClusterAutoscalingProfile", "podPriorityThreshold"},
-	}
-	for _, m := range missingAnnotations {
-		t.Run(fmt.Sprintf("Missing_%s_%s", m.definition, m.property), func(t *testing.T) {
-			_, ok := getDefault(m.definition, m.property)
-			if ok {
-				t.Errorf("TypeSpec bug may be fixed: %s.%s now has a default annotation — "+
-					"add a consistency check above and remove this entry", m.definition, m.property)
 			}
 		})
 	}

--- a/internal/azureapi/v20260901preview/generated/models.go
+++ b/internal/azureapi/v20260901preview/generated/models.go
@@ -33,9 +33,6 @@ type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate struct {
 type ClusterAutoscalingProfile struct {
 	// maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the provisioning to be
 	// unsuccessful. The default is 900 seconds, or 15 minutes.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxNodeProvisionTimeSeconds *int32
 
 	// maxNodesTotal is the maximum allowable number of nodes for the Autoscaler scale out to be operational. The autoscaler will
@@ -45,17 +42,11 @@ type ClusterAutoscalingProfile struct {
 
 	// maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool. The default
 	// is 600 seconds.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxPodGracePeriodSeconds *int32
 
 	// podPriorityThreshold enables users to schedule "best-effort" pods, which shouldn't trigger autoscaler actions, but only
 	// run when there are spare resources available. The default is -10. See the
 	// following for more details: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	PodPriorityThreshold *int32
 }
 
@@ -830,9 +821,6 @@ type NodePoolVersionProfile struct {
 
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 }
 
@@ -840,9 +828,6 @@ type NodePoolVersionProfile struct {
 type NodePoolVersionProfileUpdate struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the unique identifier of the version.
@@ -1205,9 +1190,6 @@ type VersionProfile struct {
 
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 }
 
@@ -1215,9 +1197,6 @@ type VersionProfile struct {
 type VersionProfileUpdate struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the desired X.Y version of the cluster control plane.

--- a/internal/azureapi/v20260901preview/generated/models.go
+++ b/internal/azureapi/v20260901preview/generated/models.go
@@ -18,16 +18,6 @@ type APIProfile struct {
 	AuthorizedCIDRs []*string
 }
 
-// AzureResourceManagerCommonTypesManagedServiceIdentityUpdate - Managed service identity (system assigned and/or user assigned
-// identities)
-type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate struct {
-	// The type of managed identity assigned to this resource.
-	Type *ManagedServiceIdentityType
-
-	// The identities assigned to this resource by the user.
-	UserAssignedIdentities map[string]*UserAssignedIdentity
-}
-
 // ClusterAutoscalingProfile - ClusterAutoscaling specifies auto-scaling behavior that applies to all NodePools associated
 // with a control plane.
 type ClusterAutoscalingProfile struct {
@@ -248,18 +238,6 @@ type ExternalAuthPropertiesUpdate struct {
 type ExternalAuthUpdate struct {
 	// The resource-specific properties for this resource.
 	Properties *ExternalAuthPropertiesUpdate
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
 }
 
 // GroupClaimProfile - External Auth claim profile This configures how the groups of a cluster identity should be constructed
@@ -425,25 +403,13 @@ type HcpOpenShiftClusterPropertiesUpdate struct {
 // HcpOpenShiftClusterUpdate - HCP cluster resource
 type HcpOpenShiftClusterUpdate struct {
 	// The managed service identities assigned to this resource.
-	Identity *AzureResourceManagerCommonTypesManagedServiceIdentityUpdate
+	Identity *ManagedServiceIdentityUpdate
 
 	// The resource-specific properties for this resource.
 	Properties *HcpOpenShiftClusterPropertiesUpdate
 
 	// Resource tags.
 	Tags map[string]*string
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
 }
 
 // HcpOpenShiftVersion represents a location based available HCP OpenShift version
@@ -627,6 +593,15 @@ type ManagedServiceIdentity struct {
 	TenantID *string
 }
 
+// ManagedServiceIdentityUpdate - Managed service identity (system assigned and/or user assigned identities)
+type ManagedServiceIdentityUpdate struct {
+	// The type of managed identity assigned to this resource.
+	Type *ManagedServiceIdentityType
+
+	// The identities assigned to this resource by the user.
+	UserAssignedIdentities map[string]*UserAssignedIdentity
+}
+
 // NetworkProfile - OpenShift networking configuration
 type NetworkProfile struct {
 	// Network host prefix
@@ -645,7 +620,7 @@ type NetworkProfile struct {
 	ServiceCIDR *string
 }
 
-// NodePool - Concrete tracked resource types can be created by aliasing this type using a specific property type.
+// NodePool resource
 type NodePool struct {
 	// REQUIRED; The geo-location where the resource lives
 	Location *string
@@ -790,28 +765,16 @@ type NodePoolPropertiesUpdate struct {
 	Version *NodePoolVersionProfileUpdate
 }
 
-// NodePoolUpdate - Concrete tracked resource types can be created by aliasing this type using a specific property type.
+// NodePoolUpdate - NodePool resource
 type NodePoolUpdate struct {
 	// The managed service identities assigned to this resource.
-	Identity *AzureResourceManagerCommonTypesManagedServiceIdentityUpdate
+	Identity *ManagedServiceIdentityUpdate
 
 	// The resource-specific properties for this resource.
 	Properties *NodePoolPropertiesUpdate
 
 	// Resource tags.
 	Tags map[string]*string
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
 }
 
 // NodePoolVersionProfile - Versions represents an OpenShift version.

--- a/internal/azureapi/v20260901preview/generated/models_serde.go
+++ b/internal/azureapi/v20260901preview/generated/models_serde.go
@@ -49,39 +49,6 @@ func (a *APIProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate.
-func (a AzureResourceManagerCommonTypesManagedServiceIdentityUpdate) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "type", a.Type)
-	populate(objectMap, "userAssignedIdentities", a.UserAssignedIdentities)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate.
-func (a *AzureResourceManagerCommonTypesManagedServiceIdentityUpdate) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", a, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "type":
-			err = unpopulate(val, "Type", &a.Type)
-			delete(rawMsg, key)
-		case "userAssignedIdentities":
-			err = unpopulate(val, "UserAssignedIdentities", &a.UserAssignedIdentities)
-			delete(rawMsg, key)
-		default:
-			err = fmt.Errorf("unmarshalling type %T, unknown field %q", a, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", a, err)
-		}
-	}
-	return nil
-}
-
 // MarshalJSON implements the json.Marshaller interface for type ClusterAutoscalingProfile.
 func (c ClusterAutoscalingProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -744,11 +711,7 @@ func (e *ExternalAuthPropertiesUpdate) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ExternalAuthUpdate.
 func (e ExternalAuthUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", e.ID)
-	populate(objectMap, "name", e.Name)
 	populate(objectMap, "properties", e.Properties)
-	populate(objectMap, "systemData", e.SystemData)
-	populate(objectMap, "type", e.Type)
 	return json.Marshal(objectMap)
 }
 
@@ -761,20 +724,8 @@ func (e *ExternalAuthUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &e.ID)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &e.Name)
-			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &e.Properties)
-			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &e.SystemData)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &e.Type)
 			delete(rawMsg, key)
 		default:
 			err = fmt.Errorf("unmarshalling type %T, unknown field %q", e, key)
@@ -1141,13 +1092,9 @@ func (h *HcpOpenShiftClusterPropertiesUpdate) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HcpOpenShiftClusterUpdate.
 func (h HcpOpenShiftClusterUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", h.ID)
 	populate(objectMap, "identity", h.Identity)
-	populate(objectMap, "name", h.Name)
 	populate(objectMap, "properties", h.Properties)
-	populate(objectMap, "systemData", h.SystemData)
 	populate(objectMap, "tags", h.Tags)
-	populate(objectMap, "type", h.Type)
 	return json.Marshal(objectMap)
 }
 
@@ -1160,26 +1107,14 @@ func (h *HcpOpenShiftClusterUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &h.ID)
-			delete(rawMsg, key)
 		case "identity":
 			err = unpopulate(val, "Identity", &h.Identity)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &h.Name)
 			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &h.Properties)
 			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &h.SystemData)
-			delete(rawMsg, key)
 		case "tags":
 			err = unpopulate(val, "Tags", &h.Tags)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &h.Type)
 			delete(rawMsg, key)
 		default:
 			err = fmt.Errorf("unmarshalling type %T, unknown field %q", h, key)
@@ -1681,6 +1616,39 @@ func (m *ManagedServiceIdentity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ManagedServiceIdentityUpdate.
+func (m ManagedServiceIdentityUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "type", m.Type)
+	populate(objectMap, "userAssignedIdentities", m.UserAssignedIdentities)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ManagedServiceIdentityUpdate.
+func (m *ManagedServiceIdentityUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", m, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "type":
+			err = unpopulate(val, "Type", &m.Type)
+			delete(rawMsg, key)
+		case "userAssignedIdentities":
+			err = unpopulate(val, "UserAssignedIdentities", &m.UserAssignedIdentities)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", m, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", m, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type NetworkProfile.
 func (n NetworkProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -2011,13 +1979,9 @@ func (n *NodePoolPropertiesUpdate) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type NodePoolUpdate.
 func (n NodePoolUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", n.ID)
 	populate(objectMap, "identity", n.Identity)
-	populate(objectMap, "name", n.Name)
 	populate(objectMap, "properties", n.Properties)
-	populate(objectMap, "systemData", n.SystemData)
 	populate(objectMap, "tags", n.Tags)
-	populate(objectMap, "type", n.Type)
 	return json.Marshal(objectMap)
 }
 
@@ -2030,26 +1994,14 @@ func (n *NodePoolUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &n.ID)
-			delete(rawMsg, key)
 		case "identity":
 			err = unpopulate(val, "Identity", &n.Identity)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &n.Name)
 			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &n.Properties)
 			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &n.SystemData)
-			delete(rawMsg, key)
 		case "tags":
 			err = unpopulate(val, "Tags", &n.Tags)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &n.Type)
 			delete(rawMsg, key)
 		default:
 			err = fmt.Errorf("unmarshalling type %T, unknown field %q", n, key)

--- a/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
+++ b/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
@@ -52,9 +52,6 @@ type AzureResourceManagerCommonTypesTrackedResourceUpdate struct {
 type ClusterAutoscalingProfile struct {
 	// maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the provisioning to be
 	// unsuccessful. The default is 900 seconds, or 15 minutes.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxNodeProvisionTimeSeconds *int32
 
 	// maxNodesTotal is the maximum allowable number of nodes for the Autoscaler scale out to be operational. The autoscaler will
@@ -64,17 +61,11 @@ type ClusterAutoscalingProfile struct {
 
 	// maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool. The default
 	// is 600 seconds.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxPodGracePeriodSeconds *int32
 
 	// podPriorityThreshold enables users to schedule "best-effort" pods, which shouldn't trigger autoscaler actions, but only
 	// run when there are spare resources available. The default is -10. See the
 	// following for more details: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	PodPriorityThreshold *int32
 }
 
@@ -776,9 +767,6 @@ type NodePoolUpdate struct {
 type NodePoolVersionProfile struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the unique identifier of the version.
@@ -874,9 +862,7 @@ type OsDiskProfile struct {
 	// Details on how to create a Disk Encryption Set can be found here: https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-customer-managed-keys-portal#set-up-your-disk-encryption-set
 	EncryptionSetID *string
 
-	// The OS disk size in GiB. Maximum is 4095 GiB for Managed disks. For Ephemeral disks, the maximum is 2040 GiB; Azure may
-	// enforce a lower effective limit based on the selected VM size's local cache,
-	// temp, or NVMe capacity.
+	// The OS disk size in GiB
 	SizeGiB *int32
 }
 
@@ -1176,9 +1162,6 @@ type UsernameClaimProfileUpdate struct {
 type VersionProfile struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the unique identifier of the version.

--- a/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
+++ b/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
@@ -18,35 +18,6 @@ type APIProfile struct {
 	AuthorizedCIDRs []*string
 }
 
-// AzureResourceManagerCommonTypesManagedServiceIdentityUpdate - Managed service identity (system assigned and/or user assigned
-// identities)
-type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate struct {
-	// The type of managed identity assigned to this resource.
-	Type *ManagedServiceIdentityType
-
-	// The identities assigned to this resource by the user.
-	UserAssignedIdentities map[string]*UserAssignedIdentity
-}
-
-// AzureResourceManagerCommonTypesTrackedResourceUpdate - The resource model definition for an Azure Resource Manager tracked
-// top level resource which has 'tags' and a 'location'
-type AzureResourceManagerCommonTypesTrackedResourceUpdate struct {
-	// Resource tags.
-	Tags map[string]*string
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
-}
-
 // ClusterAutoscalingProfile - ClusterAutoscaling specifies auto-scaling behavior that applies to all NodePools associated
 // with a control plane.
 type ClusterAutoscalingProfile struct {
@@ -282,18 +253,6 @@ type ExternalAuthPropertiesUpdate struct {
 type ExternalAuthUpdate struct {
 	// The resource-specific properties for this resource.
 	Properties *ExternalAuthPropertiesUpdate
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
 }
 
 // GroupClaimProfile - External Auth claim profile This configures how the groups of a cluster identity should be constructed
@@ -433,25 +392,13 @@ type HcpOpenShiftClusterPropertiesUpdate struct {
 // HcpOpenShiftClusterUpdate - HCP cluster resource
 type HcpOpenShiftClusterUpdate struct {
 	// The managed service identities assigned to this resource.
-	Identity *AzureResourceManagerCommonTypesManagedServiceIdentityUpdate
+	Identity *ManagedServiceIdentityUpdate
 
 	// The resource-specific properties for this resource.
 	Properties *HcpOpenShiftClusterPropertiesUpdate
 
 	// Resource tags.
 	Tags map[string]*string
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
 }
 
 // HcpOpenShiftVersion represents a location based available HCP OpenShift version
@@ -579,6 +526,15 @@ type ManagedServiceIdentity struct {
 	TenantID *string
 }
 
+// ManagedServiceIdentityUpdate - Managed service identity (system assigned and/or user assigned identities)
+type ManagedServiceIdentityUpdate struct {
+	// The type of managed identity assigned to this resource.
+	Type *ManagedServiceIdentityType
+
+	// The identities assigned to this resource by the user.
+	UserAssignedIdentities map[string]*UserAssignedIdentity
+}
+
 // NetworkProfile - OpenShift networking configuration
 type NetworkProfile struct {
 	// Network host prefix
@@ -597,7 +553,7 @@ type NetworkProfile struct {
 	ServiceCIDR *string
 }
 
-// NodePool - Concrete tracked resource types can be created by aliasing this type using a specific property type.
+// NodePool resource
 type NodePool struct {
 	// REQUIRED; The geo-location where the resource lives
 	Location *string
@@ -739,28 +695,16 @@ type NodePoolPropertiesUpdate struct {
 	Version *NodePoolVersionProfile
 }
 
-// NodePoolUpdate - Concrete tracked resource types can be created by aliasing this type using a specific property type.
+// NodePoolUpdate - NodePool resource
 type NodePoolUpdate struct {
 	// The managed service identities assigned to this resource.
-	Identity *AzureResourceManagerCommonTypesManagedServiceIdentityUpdate
+	Identity *ManagedServiceIdentityUpdate
 
 	// The resource-specific properties for this resource.
 	Properties *NodePoolPropertiesUpdate
 
 	// Resource tags.
 	Tags map[string]*string
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
 }
 
 // NodePoolVersionProfile - Versions represents an OpenShift version.

--- a/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models_serde.go
+++ b/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models_serde.go
@@ -47,80 +47,6 @@ func (a *APIProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate.
-func (a AzureResourceManagerCommonTypesManagedServiceIdentityUpdate) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "type", a.Type)
-	populate(objectMap, "userAssignedIdentities", a.UserAssignedIdentities)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate.
-func (a *AzureResourceManagerCommonTypesManagedServiceIdentityUpdate) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", a, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "type":
-			err = unpopulate(val, "Type", &a.Type)
-			delete(rawMsg, key)
-		case "userAssignedIdentities":
-			err = unpopulate(val, "UserAssignedIdentities", &a.UserAssignedIdentities)
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", a, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type AzureResourceManagerCommonTypesTrackedResourceUpdate.
-func (a AzureResourceManagerCommonTypesTrackedResourceUpdate) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "id", a.ID)
-	populate(objectMap, "name", a.Name)
-	populate(objectMap, "systemData", a.SystemData)
-	populate(objectMap, "tags", a.Tags)
-	populate(objectMap, "type", a.Type)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type AzureResourceManagerCommonTypesTrackedResourceUpdate.
-func (a *AzureResourceManagerCommonTypesTrackedResourceUpdate) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", a, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &a.ID)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &a.Name)
-			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &a.SystemData)
-			delete(rawMsg, key)
-		case "tags":
-			err = unpopulate(val, "Tags", &a.Tags)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &a.Type)
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", a, err)
-		}
-	}
-	return nil
-}
-
 // MarshalJSON implements the json.Marshaller interface for type ClusterAutoscalingProfile.
 func (c ClusterAutoscalingProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -765,11 +691,7 @@ func (e *ExternalAuthPropertiesUpdate) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ExternalAuthUpdate.
 func (e ExternalAuthUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", e.ID)
-	populate(objectMap, "name", e.Name)
 	populate(objectMap, "properties", e.Properties)
-	populate(objectMap, "systemData", e.SystemData)
-	populate(objectMap, "type", e.Type)
 	return json.Marshal(objectMap)
 }
 
@@ -782,20 +704,8 @@ func (e *ExternalAuthUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &e.ID)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &e.Name)
-			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &e.Properties)
-			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &e.SystemData)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &e.Type)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -1093,13 +1003,9 @@ func (h *HcpOpenShiftClusterPropertiesUpdate) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HcpOpenShiftClusterUpdate.
 func (h HcpOpenShiftClusterUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", h.ID)
 	populate(objectMap, "identity", h.Identity)
-	populate(objectMap, "name", h.Name)
 	populate(objectMap, "properties", h.Properties)
-	populate(objectMap, "systemData", h.SystemData)
 	populate(objectMap, "tags", h.Tags)
-	populate(objectMap, "type", h.Type)
 	return json.Marshal(objectMap)
 }
 
@@ -1112,26 +1018,14 @@ func (h *HcpOpenShiftClusterUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &h.ID)
-			delete(rawMsg, key)
 		case "identity":
 			err = unpopulate(val, "Identity", &h.Identity)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &h.Name)
 			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &h.Properties)
 			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &h.SystemData)
-			delete(rawMsg, key)
 		case "tags":
 			err = unpopulate(val, "Tags", &h.Tags)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &h.Type)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -1487,6 +1381,37 @@ func (m *ManagedServiceIdentity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ManagedServiceIdentityUpdate.
+func (m ManagedServiceIdentityUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "type", m.Type)
+	populate(objectMap, "userAssignedIdentities", m.UserAssignedIdentities)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ManagedServiceIdentityUpdate.
+func (m *ManagedServiceIdentityUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", m, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "type":
+			err = unpopulate(val, "Type", &m.Type)
+			delete(rawMsg, key)
+		case "userAssignedIdentities":
+			err = unpopulate(val, "UserAssignedIdentities", &m.UserAssignedIdentities)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", m, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type NetworkProfile.
 func (n NetworkProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -1799,13 +1724,9 @@ func (n *NodePoolPropertiesUpdate) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type NodePoolUpdate.
 func (n NodePoolUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", n.ID)
 	populate(objectMap, "identity", n.Identity)
-	populate(objectMap, "name", n.Name)
 	populate(objectMap, "properties", n.Properties)
-	populate(objectMap, "systemData", n.SystemData)
 	populate(objectMap, "tags", n.Tags)
-	populate(objectMap, "type", n.Type)
 	return json.Marshal(objectMap)
 }
 
@@ -1818,26 +1739,14 @@ func (n *NodePoolUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &n.ID)
-			delete(rawMsg, key)
 		case "identity":
 			err = unpopulate(val, "Identity", &n.Identity)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &n.Name)
 			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &n.Properties)
 			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &n.SystemData)
-			delete(rawMsg, key)
 		case "tags":
 			err = unpopulate(val, "Tags", &n.Tags)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &n.Type)
 			delete(rawMsg, key)
 		}
 		if err != nil {

--- a/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/responses.go
+++ b/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/responses.go
@@ -107,7 +107,7 @@ type HcpOperatorIdentityRoleSetsClientListResponse struct {
 
 // NodePoolsClientCreateOrUpdateResponse contains the response from method NodePoolsClient.BeginCreateOrUpdate.
 type NodePoolsClientCreateOrUpdateResponse struct {
-	// Concrete tracked resource types can be created by aliasing this type using a specific property type.
+	// NodePool resource
 	NodePool
 }
 
@@ -118,7 +118,7 @@ type NodePoolsClientDeleteResponse struct {
 
 // NodePoolsClientGetResponse contains the response from method NodePoolsClient.Get.
 type NodePoolsClientGetResponse struct {
-	// Concrete tracked resource types can be created by aliasing this type using a specific property type.
+	// NodePool resource
 	NodePool
 }
 
@@ -130,7 +130,7 @@ type NodePoolsClientListByParentResponse struct {
 
 // NodePoolsClientUpdateResponse contains the response from method NodePoolsClient.BeginUpdate.
 type NodePoolsClientUpdateResponse struct {
-	// Concrete tracked resource types can be created by aliasing this type using a specific property type.
+	// NodePool resource
 	NodePool
 }
 

--- a/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
+++ b/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
@@ -52,9 +52,6 @@ type AzureResourceManagerCommonTypesTrackedResourceUpdate struct {
 type ClusterAutoscalingProfile struct {
 	// maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the provisioning to be
 	// unsuccessful. The default is 900 seconds, or 15 minutes.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxNodeProvisionTimeSeconds *int32
 
 	// maxNodesTotal is the maximum allowable number of nodes for the Autoscaler scale out to be operational. The autoscaler will
@@ -64,17 +61,11 @@ type ClusterAutoscalingProfile struct {
 
 	// maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool. The default
 	// is 600 seconds.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxPodGracePeriodSeconds *int32
 
 	// podPriorityThreshold enables users to schedule "best-effort" pods, which shouldn't trigger autoscaler actions, but only
 	// run when there are spare resources available. The default is -10. See the
 	// following for more details: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	PodPriorityThreshold *int32
 }
 
@@ -823,9 +814,6 @@ type NodePoolVersionProfile struct {
 
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 }
 
@@ -833,9 +821,6 @@ type NodePoolVersionProfile struct {
 type NodePoolVersionProfileUpdate struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the unique identifier of the version.
@@ -935,9 +920,7 @@ type OsDiskProfile struct {
 	// Details on how to create a Disk Encryption Set can be found here: https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-customer-managed-keys-portal#set-up-your-disk-encryption-set
 	EncryptionSetID *string
 
-	// The OS disk size in GiB. Maximum is 4095 GiB for Managed disks. For Ephemeral disks, the maximum is 2040 GiB; Azure may
-	// enforce a lower effective limit based on the selected VM size's local cache,
-	// temp, or NVMe capacity.
+	// The OS disk size in GiB
 	SizeGiB *int32
 }
 
@@ -1245,9 +1228,6 @@ type VersionProfile struct {
 
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 }
 
@@ -1255,9 +1235,6 @@ type VersionProfile struct {
 type VersionProfileUpdate struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the desired X.Y version of the cluster control plane.

--- a/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
+++ b/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
@@ -18,35 +18,6 @@ type APIProfile struct {
 	AuthorizedCIDRs []*string
 }
 
-// AzureResourceManagerCommonTypesManagedServiceIdentityUpdate - Managed service identity (system assigned and/or user assigned
-// identities)
-type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate struct {
-	// The type of managed identity assigned to this resource.
-	Type *ManagedServiceIdentityType
-
-	// The identities assigned to this resource by the user.
-	UserAssignedIdentities map[string]*UserAssignedIdentity
-}
-
-// AzureResourceManagerCommonTypesTrackedResourceUpdate - The resource model definition for an Azure Resource Manager tracked
-// top level resource which has 'tags' and a 'location'
-type AzureResourceManagerCommonTypesTrackedResourceUpdate struct {
-	// Resource tags.
-	Tags map[string]*string
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
-}
-
 // ClusterAutoscalingProfile - ClusterAutoscaling specifies auto-scaling behavior that applies to all NodePools associated
 // with a control plane.
 type ClusterAutoscalingProfile struct {
@@ -282,18 +253,6 @@ type ExternalAuthPropertiesUpdate struct {
 type ExternalAuthUpdate struct {
 	// The resource-specific properties for this resource.
 	Properties *ExternalAuthPropertiesUpdate
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
 }
 
 // GroupClaimProfile - External Auth claim profile This configures how the groups of a cluster identity should be constructed
@@ -441,25 +400,13 @@ type HcpOpenShiftClusterPropertiesUpdate struct {
 // HcpOpenShiftClusterUpdate - HCP cluster resource
 type HcpOpenShiftClusterUpdate struct {
 	// The managed service identities assigned to this resource.
-	Identity *AzureResourceManagerCommonTypesManagedServiceIdentityUpdate
+	Identity *ManagedServiceIdentityUpdate
 
 	// The resource-specific properties for this resource.
 	Properties *HcpOpenShiftClusterPropertiesUpdate
 
 	// Resource tags.
 	Tags map[string]*string
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
 }
 
 // HcpOpenShiftVersion represents a location based available HCP OpenShift version
@@ -623,6 +570,15 @@ type ManagedServiceIdentity struct {
 	TenantID *string
 }
 
+// ManagedServiceIdentityUpdate - Managed service identity (system assigned and/or user assigned identities)
+type ManagedServiceIdentityUpdate struct {
+	// The type of managed identity assigned to this resource.
+	Type *ManagedServiceIdentityType
+
+	// The identities assigned to this resource by the user.
+	UserAssignedIdentities map[string]*UserAssignedIdentity
+}
+
 // NetworkProfile - OpenShift networking configuration
 type NetworkProfile struct {
 	// Network host prefix
@@ -641,7 +597,7 @@ type NetworkProfile struct {
 	ServiceCIDR *string
 }
 
-// NodePool - Concrete tracked resource types can be created by aliasing this type using a specific property type.
+// NodePool resource
 type NodePool struct {
 	// REQUIRED; The geo-location where the resource lives
 	Location *string
@@ -783,28 +739,16 @@ type NodePoolPropertiesUpdate struct {
 	Version *NodePoolVersionProfileUpdate
 }
 
-// NodePoolUpdate - Concrete tracked resource types can be created by aliasing this type using a specific property type.
+// NodePoolUpdate - NodePool resource
 type NodePoolUpdate struct {
 	// The managed service identities assigned to this resource.
-	Identity *AzureResourceManagerCommonTypesManagedServiceIdentityUpdate
+	Identity *ManagedServiceIdentityUpdate
 
 	// The resource-specific properties for this resource.
 	Properties *NodePoolPropertiesUpdate
 
 	// Resource tags.
 	Tags map[string]*string
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
 }
 
 // NodePoolVersionProfile - Versions represents an OpenShift version.

--- a/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models_serde.go
+++ b/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models_serde.go
@@ -47,80 +47,6 @@ func (a *APIProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate.
-func (a AzureResourceManagerCommonTypesManagedServiceIdentityUpdate) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "type", a.Type)
-	populate(objectMap, "userAssignedIdentities", a.UserAssignedIdentities)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate.
-func (a *AzureResourceManagerCommonTypesManagedServiceIdentityUpdate) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", a, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "type":
-			err = unpopulate(val, "Type", &a.Type)
-			delete(rawMsg, key)
-		case "userAssignedIdentities":
-			err = unpopulate(val, "UserAssignedIdentities", &a.UserAssignedIdentities)
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", a, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type AzureResourceManagerCommonTypesTrackedResourceUpdate.
-func (a AzureResourceManagerCommonTypesTrackedResourceUpdate) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "id", a.ID)
-	populate(objectMap, "name", a.Name)
-	populate(objectMap, "systemData", a.SystemData)
-	populate(objectMap, "tags", a.Tags)
-	populate(objectMap, "type", a.Type)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type AzureResourceManagerCommonTypesTrackedResourceUpdate.
-func (a *AzureResourceManagerCommonTypesTrackedResourceUpdate) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", a, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &a.ID)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &a.Name)
-			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &a.SystemData)
-			delete(rawMsg, key)
-		case "tags":
-			err = unpopulate(val, "Tags", &a.Tags)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &a.Type)
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", a, err)
-		}
-	}
-	return nil
-}
-
 // MarshalJSON implements the json.Marshaller interface for type ClusterAutoscalingProfile.
 func (c ClusterAutoscalingProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -765,11 +691,7 @@ func (e *ExternalAuthPropertiesUpdate) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ExternalAuthUpdate.
 func (e ExternalAuthUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", e.ID)
-	populate(objectMap, "name", e.Name)
 	populate(objectMap, "properties", e.Properties)
-	populate(objectMap, "systemData", e.SystemData)
-	populate(objectMap, "type", e.Type)
 	return json.Marshal(objectMap)
 }
 
@@ -782,20 +704,8 @@ func (e *ExternalAuthUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &e.ID)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &e.Name)
-			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &e.Properties)
-			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &e.SystemData)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &e.Type)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -1101,13 +1011,9 @@ func (h *HcpOpenShiftClusterPropertiesUpdate) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HcpOpenShiftClusterUpdate.
 func (h HcpOpenShiftClusterUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", h.ID)
 	populate(objectMap, "identity", h.Identity)
-	populate(objectMap, "name", h.Name)
 	populate(objectMap, "properties", h.Properties)
-	populate(objectMap, "systemData", h.SystemData)
 	populate(objectMap, "tags", h.Tags)
-	populate(objectMap, "type", h.Type)
 	return json.Marshal(objectMap)
 }
 
@@ -1120,26 +1026,14 @@ func (h *HcpOpenShiftClusterUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &h.ID)
-			delete(rawMsg, key)
 		case "identity":
 			err = unpopulate(val, "Identity", &h.Identity)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &h.Name)
 			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &h.Properties)
 			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &h.SystemData)
-			delete(rawMsg, key)
 		case "tags":
 			err = unpopulate(val, "Tags", &h.Tags)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &h.Type)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -1530,6 +1424,37 @@ func (m *ManagedServiceIdentity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ManagedServiceIdentityUpdate.
+func (m ManagedServiceIdentityUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "type", m.Type)
+	populate(objectMap, "userAssignedIdentities", m.UserAssignedIdentities)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ManagedServiceIdentityUpdate.
+func (m *ManagedServiceIdentityUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", m, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "type":
+			err = unpopulate(val, "Type", &m.Type)
+			delete(rawMsg, key)
+		case "userAssignedIdentities":
+			err = unpopulate(val, "UserAssignedIdentities", &m.UserAssignedIdentities)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", m, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type NetworkProfile.
 func (n NetworkProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -1842,13 +1767,9 @@ func (n *NodePoolPropertiesUpdate) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type NodePoolUpdate.
 func (n NodePoolUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", n.ID)
 	populate(objectMap, "identity", n.Identity)
-	populate(objectMap, "name", n.Name)
 	populate(objectMap, "properties", n.Properties)
-	populate(objectMap, "systemData", n.SystemData)
 	populate(objectMap, "tags", n.Tags)
-	populate(objectMap, "type", n.Type)
 	return json.Marshal(objectMap)
 }
 
@@ -1861,26 +1782,14 @@ func (n *NodePoolUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &n.ID)
-			delete(rawMsg, key)
 		case "identity":
 			err = unpopulate(val, "Identity", &n.Identity)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &n.Name)
 			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &n.Properties)
 			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &n.SystemData)
-			delete(rawMsg, key)
 		case "tags":
 			err = unpopulate(val, "Tags", &n.Tags)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &n.Type)
 			delete(rawMsg, key)
 		}
 		if err != nil {

--- a/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/responses.go
+++ b/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/responses.go
@@ -107,7 +107,7 @@ type HcpOperatorIdentityRoleSetsClientListResponse struct {
 
 // NodePoolsClientCreateOrUpdateResponse contains the response from method NodePoolsClient.BeginCreateOrUpdate.
 type NodePoolsClientCreateOrUpdateResponse struct {
-	// Concrete tracked resource types can be created by aliasing this type using a specific property type.
+	// NodePool resource
 	NodePool
 }
 
@@ -118,7 +118,7 @@ type NodePoolsClientDeleteResponse struct {
 
 // NodePoolsClientGetResponse contains the response from method NodePoolsClient.Get.
 type NodePoolsClientGetResponse struct {
-	// Concrete tracked resource types can be created by aliasing this type using a specific property type.
+	// NodePool resource
 	NodePool
 }
 
@@ -130,7 +130,7 @@ type NodePoolsClientListByParentResponse struct {
 
 // NodePoolsClientUpdateResponse contains the response from method NodePoolsClient.BeginUpdate.
 type NodePoolsClientUpdateResponse struct {
-	// Concrete tracked resource types can be created by aliasing this type using a specific property type.
+	// NodePool resource
 	NodePool
 }
 

--- a/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
+++ b/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
@@ -52,9 +52,6 @@ type AzureResourceManagerCommonTypesTrackedResourceUpdate struct {
 type ClusterAutoscalingProfile struct {
 	// maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the provisioning to be
 	// unsuccessful. The default is 900 seconds, or 15 minutes.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxNodeProvisionTimeSeconds *int32
 
 	// maxNodesTotal is the maximum allowable number of nodes for the Autoscaler scale out to be operational. The autoscaler will
@@ -64,17 +61,11 @@ type ClusterAutoscalingProfile struct {
 
 	// maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool. The default
 	// is 600 seconds.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxPodGracePeriodSeconds *int32
 
 	// podPriorityThreshold enables users to schedule "best-effort" pods, which shouldn't trigger autoscaler actions, but only
 	// run when there are spare resources available. The default is -10. See the
 	// following for more details: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	PodPriorityThreshold *int32
 }
 
@@ -877,9 +868,6 @@ type NodePoolVersionProfile struct {
 
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 }
 
@@ -887,9 +875,6 @@ type NodePoolVersionProfile struct {
 type NodePoolVersionProfileUpdate struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the unique identifier of the version.
@@ -1305,9 +1290,6 @@ type VersionProfile struct {
 
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 }
 
@@ -1315,9 +1297,6 @@ type VersionProfile struct {
 type VersionProfileUpdate struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the desired X.Y version of the cluster control plane.

--- a/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
+++ b/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
@@ -18,35 +18,6 @@ type APIProfile struct {
 	AuthorizedCIDRs []*string
 }
 
-// AzureResourceManagerCommonTypesManagedServiceIdentityUpdate - Managed service identity (system assigned and/or user assigned
-// identities)
-type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate struct {
-	// The type of managed identity assigned to this resource.
-	Type *ManagedServiceIdentityType
-
-	// The identities assigned to this resource by the user.
-	UserAssignedIdentities map[string]*UserAssignedIdentity
-}
-
-// AzureResourceManagerCommonTypesTrackedResourceUpdate - The resource model definition for an Azure Resource Manager tracked
-// top level resource which has 'tags' and a 'location'
-type AzureResourceManagerCommonTypesTrackedResourceUpdate struct {
-	// Resource tags.
-	Tags map[string]*string
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
-}
-
 // ClusterAutoscalingProfile - ClusterAutoscaling specifies auto-scaling behavior that applies to all NodePools associated
 // with a control plane.
 type ClusterAutoscalingProfile struct {
@@ -301,18 +272,6 @@ type ExternalAuthPropertiesUpdate struct {
 type ExternalAuthUpdate struct {
 	// The resource-specific properties for this resource.
 	Properties *ExternalAuthPropertiesUpdate
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
 }
 
 // GroupClaimProfile - External Auth claim profile This configures how the groups of a cluster identity should be constructed
@@ -472,25 +431,13 @@ type HcpOpenShiftClusterPropertiesUpdate struct {
 // HcpOpenShiftClusterUpdate - HCP cluster resource
 type HcpOpenShiftClusterUpdate struct {
 	// The managed service identities assigned to this resource.
-	Identity *AzureResourceManagerCommonTypesManagedServiceIdentityUpdate
+	Identity *ManagedServiceIdentityUpdate
 
 	// The resource-specific properties for this resource.
 	Properties *HcpOpenShiftClusterPropertiesUpdate
 
 	// Resource tags.
 	Tags map[string]*string
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
 }
 
 // HcpOpenShiftVersion represents a location based available HCP OpenShift version
@@ -674,6 +621,15 @@ type ManagedServiceIdentity struct {
 	TenantID *string
 }
 
+// ManagedServiceIdentityUpdate - Managed service identity (system assigned and/or user assigned identities)
+type ManagedServiceIdentityUpdate struct {
+	// The type of managed identity assigned to this resource.
+	Type *ManagedServiceIdentityType
+
+	// The identities assigned to this resource by the user.
+	UserAssignedIdentities map[string]*UserAssignedIdentity
+}
+
 // NetworkProfile - OpenShift networking configuration
 type NetworkProfile struct {
 	// Network host prefix
@@ -692,7 +648,7 @@ type NetworkProfile struct {
 	ServiceCIDR *string
 }
 
-// NodePool - Concrete tracked resource types can be created by aliasing this type using a specific property type.
+// NodePool resource
 type NodePool struct {
 	// REQUIRED; The geo-location where the resource lives
 	Location *string
@@ -837,28 +793,16 @@ type NodePoolPropertiesUpdate struct {
 	Version *NodePoolVersionProfileUpdate
 }
 
-// NodePoolUpdate - Concrete tracked resource types can be created by aliasing this type using a specific property type.
+// NodePoolUpdate - NodePool resource
 type NodePoolUpdate struct {
 	// The managed service identities assigned to this resource.
-	Identity *AzureResourceManagerCommonTypesManagedServiceIdentityUpdate
+	Identity *ManagedServiceIdentityUpdate
 
 	// The resource-specific properties for this resource.
 	Properties *NodePoolPropertiesUpdate
 
 	// Resource tags.
 	Tags map[string]*string
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
 }
 
 // NodePoolVersionProfile - Versions represents an OpenShift version.

--- a/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models_serde.go
+++ b/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models_serde.go
@@ -47,80 +47,6 @@ func (a *APIProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate.
-func (a AzureResourceManagerCommonTypesManagedServiceIdentityUpdate) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "type", a.Type)
-	populate(objectMap, "userAssignedIdentities", a.UserAssignedIdentities)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate.
-func (a *AzureResourceManagerCommonTypesManagedServiceIdentityUpdate) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", a, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "type":
-			err = unpopulate(val, "Type", &a.Type)
-			delete(rawMsg, key)
-		case "userAssignedIdentities":
-			err = unpopulate(val, "UserAssignedIdentities", &a.UserAssignedIdentities)
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", a, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type AzureResourceManagerCommonTypesTrackedResourceUpdate.
-func (a AzureResourceManagerCommonTypesTrackedResourceUpdate) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "id", a.ID)
-	populate(objectMap, "name", a.Name)
-	populate(objectMap, "systemData", a.SystemData)
-	populate(objectMap, "tags", a.Tags)
-	populate(objectMap, "type", a.Type)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type AzureResourceManagerCommonTypesTrackedResourceUpdate.
-func (a *AzureResourceManagerCommonTypesTrackedResourceUpdate) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", a, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &a.ID)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &a.Name)
-			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &a.SystemData)
-			delete(rawMsg, key)
-		case "tags":
-			err = unpopulate(val, "Tags", &a.Tags)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &a.Type)
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", a, err)
-		}
-	}
-	return nil
-}
-
 // MarshalJSON implements the json.Marshaller interface for type ClusterAutoscalingProfile.
 func (c ClusterAutoscalingProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -846,11 +772,7 @@ func (e *ExternalAuthPropertiesUpdate) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ExternalAuthUpdate.
 func (e ExternalAuthUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", e.ID)
-	populate(objectMap, "name", e.Name)
 	populate(objectMap, "properties", e.Properties)
-	populate(objectMap, "systemData", e.SystemData)
-	populate(objectMap, "type", e.Type)
 	return json.Marshal(objectMap)
 }
 
@@ -863,20 +785,8 @@ func (e *ExternalAuthUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &e.ID)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &e.Name)
-			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &e.Properties)
-			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &e.SystemData)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &e.Type)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -1198,13 +1108,9 @@ func (h *HcpOpenShiftClusterPropertiesUpdate) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HcpOpenShiftClusterUpdate.
 func (h HcpOpenShiftClusterUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", h.ID)
 	populate(objectMap, "identity", h.Identity)
-	populate(objectMap, "name", h.Name)
 	populate(objectMap, "properties", h.Properties)
-	populate(objectMap, "systemData", h.SystemData)
 	populate(objectMap, "tags", h.Tags)
-	populate(objectMap, "type", h.Type)
 	return json.Marshal(objectMap)
 }
 
@@ -1217,26 +1123,14 @@ func (h *HcpOpenShiftClusterUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &h.ID)
-			delete(rawMsg, key)
 		case "identity":
 			err = unpopulate(val, "Identity", &h.Identity)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &h.Name)
 			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &h.Properties)
 			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &h.SystemData)
-			delete(rawMsg, key)
 		case "tags":
 			err = unpopulate(val, "Tags", &h.Tags)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &h.Type)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -1708,6 +1602,37 @@ func (m *ManagedServiceIdentity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ManagedServiceIdentityUpdate.
+func (m ManagedServiceIdentityUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "type", m.Type)
+	populate(objectMap, "userAssignedIdentities", m.UserAssignedIdentities)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ManagedServiceIdentityUpdate.
+func (m *ManagedServiceIdentityUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", m, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "type":
+			err = unpopulate(val, "Type", &m.Type)
+			delete(rawMsg, key)
+		case "userAssignedIdentities":
+			err = unpopulate(val, "UserAssignedIdentities", &m.UserAssignedIdentities)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", m, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type NetworkProfile.
 func (n NetworkProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -2024,13 +1949,9 @@ func (n *NodePoolPropertiesUpdate) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type NodePoolUpdate.
 func (n NodePoolUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", n.ID)
 	populate(objectMap, "identity", n.Identity)
-	populate(objectMap, "name", n.Name)
 	populate(objectMap, "properties", n.Properties)
-	populate(objectMap, "systemData", n.SystemData)
 	populate(objectMap, "tags", n.Tags)
-	populate(objectMap, "type", n.Type)
 	return json.Marshal(objectMap)
 }
 
@@ -2043,26 +1964,14 @@ func (n *NodePoolUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &n.ID)
-			delete(rawMsg, key)
 		case "identity":
 			err = unpopulate(val, "Identity", &n.Identity)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &n.Name)
 			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &n.Properties)
 			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &n.SystemData)
-			delete(rawMsg, key)
 		case "tags":
 			err = unpopulate(val, "Tags", &n.Tags)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &n.Type)
 			delete(rawMsg, key)
 		}
 		if err != nil {

--- a/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/responses.go
+++ b/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/responses.go
@@ -107,7 +107,7 @@ type HcpOperatorIdentityRoleSetsClientListResponse struct {
 
 // NodePoolsClientCreateOrUpdateResponse contains the response from method NodePoolsClient.BeginCreateOrUpdate.
 type NodePoolsClientCreateOrUpdateResponse struct {
-	// Concrete tracked resource types can be created by aliasing this type using a specific property type.
+	// NodePool resource
 	NodePool
 }
 
@@ -118,7 +118,7 @@ type NodePoolsClientDeleteResponse struct {
 
 // NodePoolsClientGetResponse contains the response from method NodePoolsClient.Get.
 type NodePoolsClientGetResponse struct {
-	// Concrete tracked resource types can be created by aliasing this type using a specific property type.
+	// NodePool resource
 	NodePool
 }
 
@@ -130,7 +130,7 @@ type NodePoolsClientListByParentResponse struct {
 
 // NodePoolsClientUpdateResponse contains the response from method NodePoolsClient.BeginUpdate.
 type NodePoolsClientUpdateResponse struct {
-	// Concrete tracked resource types can be created by aliasing this type using a specific property type.
+	// NodePool resource
 	NodePool
 }
 

--- a/test/sdk/v20260901preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
+++ b/test/sdk/v20260901preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
@@ -52,9 +52,6 @@ type AzureResourceManagerCommonTypesTrackedResourceUpdate struct {
 type ClusterAutoscalingProfile struct {
 	// maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the provisioning to be
 	// unsuccessful. The default is 900 seconds, or 15 minutes.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxNodeProvisionTimeSeconds *int32
 
 	// maxNodesTotal is the maximum allowable number of nodes for the Autoscaler scale out to be operational. The autoscaler will
@@ -64,17 +61,11 @@ type ClusterAutoscalingProfile struct {
 
 	// maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool. The default
 	// is 600 seconds.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxPodGracePeriodSeconds *int32
 
 	// podPriorityThreshold enables users to schedule "best-effort" pods, which shouldn't trigger autoscaler actions, but only
 	// run when there are spare resources available. The default is -10. See the
 	// following for more details: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	PodPriorityThreshold *int32
 }
 
@@ -883,9 +874,6 @@ type NodePoolVersionProfile struct {
 
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 }
 
@@ -893,9 +881,6 @@ type NodePoolVersionProfile struct {
 type NodePoolVersionProfileUpdate struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the unique identifier of the version.
@@ -1311,9 +1296,6 @@ type VersionProfile struct {
 
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 }
 
@@ -1321,9 +1303,6 @@ type VersionProfile struct {
 type VersionProfileUpdate struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the desired X.Y version of the cluster control plane.

--- a/test/sdk/v20260901preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
+++ b/test/sdk/v20260901preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
@@ -18,35 +18,6 @@ type APIProfile struct {
 	AuthorizedCIDRs []*string
 }
 
-// AzureResourceManagerCommonTypesManagedServiceIdentityUpdate - Managed service identity (system assigned and/or user assigned
-// identities)
-type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate struct {
-	// The type of managed identity assigned to this resource.
-	Type *ManagedServiceIdentityType
-
-	// The identities assigned to this resource by the user.
-	UserAssignedIdentities map[string]*UserAssignedIdentity
-}
-
-// AzureResourceManagerCommonTypesTrackedResourceUpdate - The resource model definition for an Azure Resource Manager tracked
-// top level resource which has 'tags' and a 'location'
-type AzureResourceManagerCommonTypesTrackedResourceUpdate struct {
-	// Resource tags.
-	Tags map[string]*string
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
-}
-
 // ClusterAutoscalingProfile - ClusterAutoscaling specifies auto-scaling behavior that applies to all NodePools associated
 // with a control plane.
 type ClusterAutoscalingProfile struct {
@@ -301,18 +272,6 @@ type ExternalAuthPropertiesUpdate struct {
 type ExternalAuthUpdate struct {
 	// The resource-specific properties for this resource.
 	Properties *ExternalAuthPropertiesUpdate
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
 }
 
 // GroupClaimProfile - External Auth claim profile This configures how the groups of a cluster identity should be constructed
@@ -478,25 +437,13 @@ type HcpOpenShiftClusterPropertiesUpdate struct {
 // HcpOpenShiftClusterUpdate - HCP cluster resource
 type HcpOpenShiftClusterUpdate struct {
 	// The managed service identities assigned to this resource.
-	Identity *AzureResourceManagerCommonTypesManagedServiceIdentityUpdate
+	Identity *ManagedServiceIdentityUpdate
 
 	// The resource-specific properties for this resource.
 	Properties *HcpOpenShiftClusterPropertiesUpdate
 
 	// Resource tags.
 	Tags map[string]*string
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
 }
 
 // HcpOpenShiftVersion represents a location based available HCP OpenShift version
@@ -680,6 +627,15 @@ type ManagedServiceIdentity struct {
 	TenantID *string
 }
 
+// ManagedServiceIdentityUpdate - Managed service identity (system assigned and/or user assigned identities)
+type ManagedServiceIdentityUpdate struct {
+	// The type of managed identity assigned to this resource.
+	Type *ManagedServiceIdentityType
+
+	// The identities assigned to this resource by the user.
+	UserAssignedIdentities map[string]*UserAssignedIdentity
+}
+
 // NetworkProfile - OpenShift networking configuration
 type NetworkProfile struct {
 	// Network host prefix
@@ -698,7 +654,7 @@ type NetworkProfile struct {
 	ServiceCIDR *string
 }
 
-// NodePool - Concrete tracked resource types can be created by aliasing this type using a specific property type.
+// NodePool resource
 type NodePool struct {
 	// REQUIRED; The geo-location where the resource lives
 	Location *string
@@ -843,28 +799,16 @@ type NodePoolPropertiesUpdate struct {
 	Version *NodePoolVersionProfileUpdate
 }
 
-// NodePoolUpdate - Concrete tracked resource types can be created by aliasing this type using a specific property type.
+// NodePoolUpdate - NodePool resource
 type NodePoolUpdate struct {
 	// The managed service identities assigned to this resource.
-	Identity *AzureResourceManagerCommonTypesManagedServiceIdentityUpdate
+	Identity *ManagedServiceIdentityUpdate
 
 	// The resource-specific properties for this resource.
 	Properties *NodePoolPropertiesUpdate
 
 	// Resource tags.
 	Tags map[string]*string
-
-	// READ-ONLY; Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-	ID *string
-
-	// READ-ONLY; The name of the resource
-	Name *string
-
-	// READ-ONLY; Azure Resource Manager metadata containing createdBy and modifiedBy information.
-	SystemData *SystemData
-
-	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string
 }
 
 // NodePoolVersionProfile - Versions represents an OpenShift version.

--- a/test/sdk/v20260901preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models_serde.go
+++ b/test/sdk/v20260901preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models_serde.go
@@ -47,80 +47,6 @@ func (a *APIProfile) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate.
-func (a AzureResourceManagerCommonTypesManagedServiceIdentityUpdate) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "type", a.Type)
-	populate(objectMap, "userAssignedIdentities", a.UserAssignedIdentities)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate.
-func (a *AzureResourceManagerCommonTypesManagedServiceIdentityUpdate) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", a, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "type":
-			err = unpopulate(val, "Type", &a.Type)
-			delete(rawMsg, key)
-		case "userAssignedIdentities":
-			err = unpopulate(val, "UserAssignedIdentities", &a.UserAssignedIdentities)
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", a, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type AzureResourceManagerCommonTypesTrackedResourceUpdate.
-func (a AzureResourceManagerCommonTypesTrackedResourceUpdate) MarshalJSON() ([]byte, error) {
-	objectMap := make(map[string]any)
-	populate(objectMap, "id", a.ID)
-	populate(objectMap, "name", a.Name)
-	populate(objectMap, "systemData", a.SystemData)
-	populate(objectMap, "tags", a.Tags)
-	populate(objectMap, "type", a.Type)
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type AzureResourceManagerCommonTypesTrackedResourceUpdate.
-func (a *AzureResourceManagerCommonTypesTrackedResourceUpdate) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", a, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &a.ID)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &a.Name)
-			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &a.SystemData)
-			delete(rawMsg, key)
-		case "tags":
-			err = unpopulate(val, "Tags", &a.Tags)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &a.Type)
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", a, err)
-		}
-	}
-	return nil
-}
-
 // MarshalJSON implements the json.Marshaller interface for type ClusterAutoscalingProfile.
 func (c ClusterAutoscalingProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -846,11 +772,7 @@ func (e *ExternalAuthPropertiesUpdate) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ExternalAuthUpdate.
 func (e ExternalAuthUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", e.ID)
-	populate(objectMap, "name", e.Name)
 	populate(objectMap, "properties", e.Properties)
-	populate(objectMap, "systemData", e.SystemData)
-	populate(objectMap, "type", e.Type)
 	return json.Marshal(objectMap)
 }
 
@@ -863,20 +785,8 @@ func (e *ExternalAuthUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &e.ID)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &e.Name)
-			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &e.Properties)
-			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &e.SystemData)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &e.Type)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -1225,13 +1135,9 @@ func (h *HcpOpenShiftClusterPropertiesUpdate) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HcpOpenShiftClusterUpdate.
 func (h HcpOpenShiftClusterUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", h.ID)
 	populate(objectMap, "identity", h.Identity)
-	populate(objectMap, "name", h.Name)
 	populate(objectMap, "properties", h.Properties)
-	populate(objectMap, "systemData", h.SystemData)
 	populate(objectMap, "tags", h.Tags)
-	populate(objectMap, "type", h.Type)
 	return json.Marshal(objectMap)
 }
 
@@ -1244,26 +1150,14 @@ func (h *HcpOpenShiftClusterUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &h.ID)
-			delete(rawMsg, key)
 		case "identity":
 			err = unpopulate(val, "Identity", &h.Identity)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &h.Name)
 			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &h.Properties)
 			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &h.SystemData)
-			delete(rawMsg, key)
 		case "tags":
 			err = unpopulate(val, "Tags", &h.Tags)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &h.Type)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -1735,6 +1629,37 @@ func (m *ManagedServiceIdentity) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type ManagedServiceIdentityUpdate.
+func (m ManagedServiceIdentityUpdate) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "type", m.Type)
+	populate(objectMap, "userAssignedIdentities", m.UserAssignedIdentities)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type ManagedServiceIdentityUpdate.
+func (m *ManagedServiceIdentityUpdate) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", m, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "type":
+			err = unpopulate(val, "Type", &m.Type)
+			delete(rawMsg, key)
+		case "userAssignedIdentities":
+			err = unpopulate(val, "UserAssignedIdentities", &m.UserAssignedIdentities)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", m, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type NetworkProfile.
 func (n NetworkProfile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
@@ -2051,13 +1976,9 @@ func (n *NodePoolPropertiesUpdate) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type NodePoolUpdate.
 func (n NodePoolUpdate) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", n.ID)
 	populate(objectMap, "identity", n.Identity)
-	populate(objectMap, "name", n.Name)
 	populate(objectMap, "properties", n.Properties)
-	populate(objectMap, "systemData", n.SystemData)
 	populate(objectMap, "tags", n.Tags)
-	populate(objectMap, "type", n.Type)
 	return json.Marshal(objectMap)
 }
 
@@ -2070,26 +1991,14 @@ func (n *NodePoolUpdate) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &n.ID)
-			delete(rawMsg, key)
 		case "identity":
 			err = unpopulate(val, "Identity", &n.Identity)
-			delete(rawMsg, key)
-		case "name":
-			err = unpopulate(val, "Name", &n.Name)
 			delete(rawMsg, key)
 		case "properties":
 			err = unpopulate(val, "Properties", &n.Properties)
 			delete(rawMsg, key)
-		case "systemData":
-			err = unpopulate(val, "SystemData", &n.SystemData)
-			delete(rawMsg, key)
 		case "tags":
 			err = unpopulate(val, "Tags", &n.Tags)
-			delete(rawMsg, key)
-		case "type":
-			err = unpopulate(val, "Type", &n.Type)
 			delete(rawMsg, key)
 		}
 		if err != nil {

--- a/test/sdk/v20260901preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/responses.go
+++ b/test/sdk/v20260901preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/responses.go
@@ -107,7 +107,7 @@ type HcpOperatorIdentityRoleSetsClientListResponse struct {
 
 // NodePoolsClientCreateOrUpdateResponse contains the response from method NodePoolsClient.BeginCreateOrUpdate.
 type NodePoolsClientCreateOrUpdateResponse struct {
-	// Concrete tracked resource types can be created by aliasing this type using a specific property type.
+	// NodePool resource
 	NodePool
 }
 
@@ -118,7 +118,7 @@ type NodePoolsClientDeleteResponse struct {
 
 // NodePoolsClientGetResponse contains the response from method NodePoolsClient.Get.
 type NodePoolsClientGetResponse struct {
-	// Concrete tracked resource types can be created by aliasing this type using a specific property type.
+	// NodePool resource
 	NodePool
 }
 
@@ -130,7 +130,7 @@ type NodePoolsClientListByParentResponse struct {
 
 // NodePoolsClientUpdateResponse contains the response from method NodePoolsClient.BeginUpdate.
 type NodePoolsClientUpdateResponse struct {
-	// Concrete tracked resource types can be created by aliasing this type using a specific property type.
+	// NodePool resource
 	NodePool
 }
 


### PR DESCRIPTION
### What

Refactors the TypeSpec API definition files for public preview compliance.

Primarily, we've been instructed to discontinue use of the `ArmResourcePatchAsync` template in favor of `ArmCustomPatchAsync`.

This sucks.

`ArmResourcePatchAsync` is nice because it auto-generates update model definitions in the JSON Swagger files.  But it doesn't provide that benefit for generated SDKs and we've been largely disregarding SDK generation until now.

`ArmCustomPatchAsync` requires a separate set of models for patch operations.  These "update" models only include properties with `Lifecycle.Update` visibility.  This means we now have to maintain two copies of most of our TypeSpec models: one for PUT, another for PATCH.

### Testing

No new tests necessary.  If I did this right then current tests should all pass.

### Special notes for your reviewer

I tried my best to avoid churn in the JSON Swagger files, but the `Azure.ResourceManager.CommonTypes` package does not provide "update" models.  So there is some unfortunate churn around the definitions for patching MSI and tags fields for tracked resource types.

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
