### PR TITLE
fix: treat OCM4001 inflight check failure as non-terminal during cluster create

### DIFF
--- a/backend/pkg/utils/operationutils/utils.go
+++ b/backend/pkg/utils/operationutils/utils.go
@@ -457,6 +457,12 @@ func ConvertClusterStatus(ctx context.Context, clusterServiceClient ocm.ClusterS
 			if err != nil {
 				return newOperationStatus, opError, err
 			}
+			// During CREATE, keep the operation non-terminal so the controller
+			// continues polling CS. CS may recover once role assignments propagate.
+			// The CreateOperationCompletionDeadline (60 min) provides a backstop.
+			if operation.Request == cosmosstorageutils.OperationRequestCreate {
+				newOperationStatus = arm.ProvisioningStateProvisioning
+			}
 		default:
 			opError = &arm.CloudErrorBody{Code: code, Message: message}
 		}

--- a/backend/pkg/utils/operationutils/utils_test.go
+++ b/backend/pkg/utils/operationutils/utils_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/go-logr/logr/testr"
 	"github.com/tj/assert"
 
+	"go.uber.org/mock/gomock"
+
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
 	"github.com/Azure/ARO-HCP/internal/api"
@@ -336,4 +338,85 @@ func TestConvertClusterStatus(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("Convert ClusterStateError with OCM4001 during create stays Provisioning", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+		mockCSClient.EXPECT().
+			GetClusterInflightChecks(gomock.Any(), gomock.Any()).
+			Return(&arohcpv1alpha1.InflightCheckList{}, nil)
+
+		clusterStatus, err := arohcpv1alpha1.NewClusterStatus().
+			State(arohcpv1alpha1.ClusterStateError).
+			ProvisionErrorCode(InflightChecksFailedProvisionErrorCode).
+			ProvisionErrorMessage("inflight checks failed").
+			Build()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+		op := &api.Operation{
+			Request: api.OperationRequestCreate,
+			Status:  arm.ProvisioningStateAccepted,
+		}
+
+		opState, opError, err := ConvertClusterStatus(ctx, mockCSClient, op, clusterStatus, ocm.InternalID{})
+
+		assert.Equal(t, arm.ProvisioningStateProvisioning, opState)
+		assert.NotNil(t, opError)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Convert ClusterStateError with OCM4001 during update stays Failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+		mockCSClient.EXPECT().
+			GetClusterInflightChecks(gomock.Any(), gomock.Any()).
+			Return(&arohcpv1alpha1.InflightCheckList{}, nil)
+
+		clusterStatus, err := arohcpv1alpha1.NewClusterStatus().
+			State(arohcpv1alpha1.ClusterStateError).
+			ProvisionErrorCode(InflightChecksFailedProvisionErrorCode).
+			ProvisionErrorMessage("inflight checks failed").
+			Build()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+		op := &api.Operation{
+			Request: api.OperationRequestUpdate,
+			Status:  arm.ProvisioningStateUpdating,
+		}
+
+		opState, opError, err := ConvertClusterStatus(ctx, mockCSClient, op, clusterStatus, ocm.InternalID{})
+
+		assert.Equal(t, arm.ProvisioningStateFailed, opState)
+		assert.NotNil(t, opError)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Convert ClusterStateError with non-OCM4001 during create stays Failed", func(t *testing.T) {
+		clusterStatus, err := arohcpv1alpha1.NewClusterStatus().
+			State(arohcpv1alpha1.ClusterStateError).
+			ProvisionErrorCode("ERR001").
+			ProvisionErrorMessage("some other error").
+			Build()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+		op := &api.Operation{
+			Request: api.OperationRequestCreate,
+			Status:  arm.ProvisioningStateAccepted,
+		}
+
+		opState, opError, err := ConvertClusterStatus(ctx, nil, op, clusterStatus, ocm.InternalID{})
+
+		assert.Equal(t, arm.ProvisioningStateFailed, opState)
+		assert.NotNil(t, opError)
+		assert.NoError(t, err)
+	})
 }

--- a/backend/pkg/utils/operationutils/utils_test.go
+++ b/backend/pkg/utils/operationutils/utils_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/go-logr/logr/testr"
 	"github.com/tj/assert"
-
 	"go.uber.org/mock/gomock"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"


### PR DESCRIPTION
## Summary

- When Cluster Service (CS) reports `ClusterStateError` with error code `OCM4001` (inflight MI permission checks failed) during a **CREATE** operation, the backend now keeps the operation in `Provisioning` state instead of marking it as terminal `Failed`
- This allows the operation controller to continue polling CS, giving time for delayed role assignments to propagate through Azure RBAC
- The 60-minute `CreateOperationCompletionDeadline` provides a hard backstop if CS never recovers
- Scoped to CREATE only — UPDATE and DELETE operations continue to treat OCM4001 as terminal `Failed`

## Root Cause ([ARO-28755](https://redhat.atlassian.net/browse/ARO-28755))

The E2E test `cluster_delayed_role_assignments.go` fails ~7% of the time because of a timing race: when Managed Identity role assignments are deployed after cluster creation begins, CS's inflight MI permission checks may exhaust their retry window before the role assignments propagate through Azure RBAC. Once CS reports `ClusterStateError`, the backend unconditionally mapped this to terminal `ProvisioningStateFailed`, preventing any recovery even after role assignments were in place.

## Test plan

- [x] Unit tests: 3 new test cases in `TestConvertClusterStatus` covering OCM4001 during CREATE (stays Provisioning), OCM4001 during UPDATE (stays Failed), and non-OCM4001 during CREATE (stays Failed)
- [x] All existing backend tests pass with no regressions
- [ ] CI E2E `prod/parallel` suite validates the delayed role assignment test passes

Resolves: https://redhat.atlassian.net/browse/ARO-28755

🤖 Generated with [Claude Code](https://claude.com/claude-code)