### PR TITLE
feat(ci): add EV2 automatedRetry for known-issue E2E gate failures (AROSLSRE-1721)

### DIFF
--- a/test/e2e-pipeline.yaml
+++ b/test/e2e-pipeline.yaml
@@ -33,3 +33,23 @@ resourceGroups:
       resourceGroup: global
       step: output
       name: globalMSIId
+    # Setting this explicitly replaces the default MSI/connection-failure retry
+    # (see sdp-pipelines graph_step.go buildOnFailure), so it must keep those
+    # phrases as well as the new marker prow-job-executor emits when finished.json
+    # marks a gate failure as a known, tracked issue safe to retry (AROSLSRE-1721).
+    # Do not reproduce ev2-retryable-known-issue-failure verbatim anywhere else this
+    # gate's inlined common.sh script could echo back into stdout, or a genuine,
+    # non-eligible failure would be spuriously retried (see AROSLSRE-1292).
+    # NOTE: this currently only takes effect in prod. stg and int set
+    # useExclusiveLocks in stages.yaml, and sdp-pipelines' generator ignores an
+    # explicit automatedRetry whenever the stage fails fast, so those stages
+    # still fall back to the default MSI/connection-failure-only retry. Tracked
+    # as a follow-up generator fix in AROSLSRE-1764.
+    automatedRetry:
+      errorContainsAny:
+      - "failed to establish a new connection"
+      - "failed to get token"
+      - "Failed to connect to MSI"
+      - "ev2-retryable-known-issue-failure"
+      maximumRetryCount: 1
+      durationBetweenRetries: 1m


### PR DESCRIPTION
[AROSLSRE-1721](https://redhat.atlassian.net/browse/AROSLSRE-1721)

### What

Adds an `automatedRetry` policy to the `regionalGating` EV2 ProwJob validation
step in `test/e2e-pipeline.yaml`, so EV2 itself retries the step once when
prow-job-executor fails with a matchable marker (`ev2-retryable-known-issue-failure`),
which it now emits when the failing E2E test's `finished.json` metadata marks
it as a known, tracked issue that's safe to retry (see [#6409](https://github.com/Azure/ARO-HCP/pull/6409)).

Setting `automatedRetry` explicitly replaces the generator's default retry
policy rather than extending it, so the existing MSI/connection-failure
phrases are kept in the list alongside the new marker.

### Why

Rollout gating E2E jobs sometimes fail on a single known-issue test. Today
that requires a human to notice, review the prow output, and manually retry:
a full new rollout for stage, or booting up the SAW device and clicking retry
for prod. This automates that retry so EV2 redrives the gate on its own.

### Testing

- Validated the generated EV2 manifests with sdp-pipelines'
  `make -C hcp/ generate-aro-hcp-ev2-manifests SERVICE_GROUP=E2E`: the prod
  `RolloutSpec.json` now carries the custom `errorsContainAny` list including
  the new marker on the `E2E.service.regionalGating` orchestrated step.
- No unit tests apply; this is a pipeline definition change consumed entirely
  by sdp-pipelines' EV2 manifest generator.

### Special notes for your reviewer

This currently only takes effect in **prod**. `stg` and `int` set
`useExclusiveLocks` in sdp-pipelines' `stages.yaml`, and the generator ignores
any custom `automatedRetry` whenever a stage fails fast, falling back to the
default MSI-only retry there. Extending this to stage needs a generator change
with a wider blast radius (it's a shared code path used by ~30 other
pipelines), tracked separately in
[AROSLSRE-1764](https://redhat.atlassian.net/browse/AROSLSRE-1764).

Companion changes:
- ARO-Tools: `prow-job-executor` fails with the matchable marker instead of
  resubmitting internally (fork PR, updates the existing PR for [AROSLSRE-1721](https://redhat.atlassian.net/browse/AROSLSRE-1721)).
- sdp-pipelines: wires `--allow-ev2-retry` unconditionally into the generated
  ProwJob step command (only takes effect when `gate-promotion` is also set).

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
