### PR TITLE
fix: extend v20260630preview timebomb deadline by 1 week to 2026-08-14

### DIFF
--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -47,4 +47,4 @@ const (
 )
 
 // API version deployment deadlines (timebombs)
-var V20260630PreviewDeploymentDeadline = Must(time.Parse(time.RFC3339, "2026-08-07T00:00:00Z"))
+var V20260630PreviewDeploymentDeadline = Must(time.Parse(time.RFC3339, "2026-08-14T00:00:00Z"))


### PR DESCRIPTION
## Summary
- Follows up on #6271, which set the v20260630preview API deployment timebomb deadline to 2026-08-07 (today).
- Extends `framework.V20260630PreviewDeploymentDeadline` from 2026-08-07 to 2026-08-14 to give the API rollout one more week before the E2E tests (`cluster_create_private_ingress`, `kms_key_rotation`, `cluster_fips_mode`) start failing instead of skipping.

## Evidence the timebomb already triggered
[branch-ci-Azure-ARO-HCP-main-e2e-integration-e2e-parallel #2085552497933422592](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-e2e-integration-e2e-parallel/2085552497933422592), run against `main@21271ccc7ed17bee277c997a1ea06ea4efb08238` on 2026-08-07 02:40 UTC, shows both tests now failing hard instead of skipping:

- `cluster_create_private_ingress.go:91`: `fail: v20260630preview API still not deployed as of 2026-08-07T00:00:00Z deadline`
- `cluster_fips_mode.go:120`: same failure reason (FIPS mode test with v2026-06-30 API)

Both are part of the "2 test(s) failed... out of 78 total" summary in that run's `aro-hcp-test-persistent` build log.

## Test plan
- [ ] Verify CI passes with updated deadline
