### PR TITLE
fix: clarify node pool VM quota validation error with vCPU calculation

### DIFF
--- a/backend/pkg/utils/validationutils/azure_nodepool_vm_quota_validation.go
+++ b/backend/pkg/utils/validationutils/azure_nodepool_vm_quota_validation.go
@@ -101,14 +101,20 @@ func (v *AzureNodePoolVMQuotaValidation) Validate(ctx context.Context, _ *api.HC
 	familyRemaining := *familyUsage.Limit - int64(*familyUsage.CurrentValue)
 	regionalRemaining := *regionalUsage.Limit - int64(*regionalUsage.CurrentValue)
 
+	// Describe the required vCPU total using replicas or autoscaling max × vCPUs per instance.
+	requiredVCPUDescription := fmt.Sprintf("%d vCPUs (%d replicas × %d vCPUs per instance)", requiredVCPUs, instanceCount, vcpusPerInstance)
+	if nodePool.Properties.AutoScaling != nil {
+		requiredVCPUDescription = fmt.Sprintf("%d vCPUs (autoscaling max %d × %d vCPUs per instance)", requiredVCPUs, instanceCount, vcpusPerInstance)
+	}
+
 	var errs []error
 	if requiredVCPUs > familyRemaining {
-		errs = append(errs, utils.TrackError(fmt.Errorf("insufficient quota for VM size %q family %q: need %d vCPUs, have %d remaining for %q (current %d, limit %d)",
-			vmSize, family, requiredVCPUs, familyRemaining, localizedNameFromComputeUsage(familyUsage), *familyUsage.CurrentValue, *familyUsage.Limit)))
+		errs = append(errs, utils.TrackError(fmt.Errorf("insufficient quota for VM size %q family %q: need %s, have %d remaining for %q (current %d, limit %d)",
+			vmSize, family, requiredVCPUDescription, familyRemaining, localizedNameFromComputeUsage(familyUsage), *familyUsage.CurrentValue, *familyUsage.Limit)))
 	}
 	if requiredVCPUs > regionalRemaining {
-		errs = append(errs, utils.TrackError(fmt.Errorf("insufficient total regional vCPU quota for VM size %q: need %d vCPUs, have %d remaining for %q (current %d, limit %d)",
-			vmSize, requiredVCPUs, regionalRemaining, localizedNameFromComputeUsage(regionalUsage), *regionalUsage.CurrentValue, *regionalUsage.Limit)))
+		errs = append(errs, utils.TrackError(fmt.Errorf("insufficient total regional vCPU quota for VM size %q: need %s, have %d remaining for %q (current %d, limit %d)",
+			vmSize, requiredVCPUDescription, regionalRemaining, localizedNameFromComputeUsage(regionalUsage), *regionalUsage.CurrentValue, *regionalUsage.Limit)))
 	}
 	return errors.Join(errs...)
 }

--- a/backend/pkg/utils/validationutils/azure_nodepool_vm_quota_validation_test.go
+++ b/backend/pkg/utils/validationutils/azure_nodepool_vm_quota_validation_test.go
@@ -165,7 +165,7 @@ func TestAzureNodePoolVMQuotaValidation_Validate(t *testing.T) {
 					Return(usageClient, nil)
 			},
 			wantErrs: []string{
-				`insufficient quota for VM size "Standard_D8ds_v5" family "standardDASv4Family": need 20 vCPUs, have 15 remaining for "Standard DASv4 Family vCPUs" (current 85, limit 100)`,
+				`insufficient quota for VM size "Standard_D8ds_v5" family "standardDASv4Family": need 20 vCPUs (autoscaling max 5 × 4 vCPUs per instance), have 15 remaining for "Standard DASv4 Family vCPUs" (current 85, limit 100)`,
 			},
 		},
 		{
@@ -189,7 +189,7 @@ func TestAzureNodePoolVMQuotaValidation_Validate(t *testing.T) {
 					Return(usageClient, nil)
 			},
 			wantErrs: []string{
-				`insufficient quota for VM size "Standard_D8ds_v5" family "standardDASv4Family": need 16 vCPUs, have 10 remaining for "Standard DASv4 Family vCPUs" (current 90, limit 100)`,
+				`insufficient quota for VM size "Standard_D8ds_v5" family "standardDASv4Family": need 16 vCPUs (4 replicas × 4 vCPUs per instance), have 10 remaining for "Standard DASv4 Family vCPUs" (current 90, limit 100)`,
 			},
 		},
 		{
@@ -213,7 +213,7 @@ func TestAzureNodePoolVMQuotaValidation_Validate(t *testing.T) {
 					Return(usageClient, nil)
 			},
 			wantErrs: []string{
-				`insufficient total regional vCPU quota for VM size "Standard_D8ds_v5": need 16 vCPUs, have 5 remaining for "Total Regional vCPUs" (current 195, limit 200)`,
+				`insufficient total regional vCPU quota for VM size "Standard_D8ds_v5": need 16 vCPUs (4 replicas × 4 vCPUs per instance), have 5 remaining for "Total Regional vCPUs" (current 195, limit 200)`,
 			},
 		},
 		{
@@ -237,8 +237,8 @@ func TestAzureNodePoolVMQuotaValidation_Validate(t *testing.T) {
 					Return(usageClient, nil)
 			},
 			wantErrs: []string{
-				`insufficient quota for VM size "Standard_D8ds_v5" family "standardDASv4Family": need 16 vCPUs, have 10 remaining for "Standard DASv4 Family vCPUs" (current 90, limit 100)`,
-				`insufficient total regional vCPU quota for VM size "Standard_D8ds_v5": need 16 vCPUs, have 5 remaining for "Total Regional vCPUs" (current 195, limit 200)`,
+				`insufficient quota for VM size "Standard_D8ds_v5" family "standardDASv4Family": need 16 vCPUs (4 replicas × 4 vCPUs per instance), have 10 remaining for "Standard DASv4 Family vCPUs" (current 90, limit 100)`,
+				`insufficient total regional vCPU quota for VM size "Standard_D8ds_v5": need 16 vCPUs (4 replicas × 4 vCPUs per instance), have 5 remaining for "Total Regional vCPUs" (current 195, limit 200)`,
 			},
 		},
 		{


### PR DESCRIPTION
<!-- Link to Jira issue -->
https://redhat.atlassian.net/browse/ARO-9533

### What

Improves `AzureNodePoolVMQuotaValidation` failure messages to show how required vCPUs are derived from the node pool request:
`replicas` (or autoscaling max) × vCPUs per instance.

Example before:
`need 4000 vCPUs, have 1618 remaining ...`
Example after:
`need 4000 vCPUs (500 replicas × 8 vCPUs per instance), have 1618 remaining ...`


### Why

To improve the clarity of the required vCPU value in the error message by including the calculation breakdown (instance count × vCPUs per instance).

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [X] PR is scoped to a single task (no mixed concerns)
- [X] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [X] Summary explains the "Why" behind the change
- [X] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [X] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [X] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
