### PR TITLE
feat: add Prow CI health alerts

### DIFF
--- a/tooling/tenant-quota/alerting.bicep
+++ b/tooling/tenant-quota/alerting.bicep
@@ -18,6 +18,22 @@ var e2eExpiredCountInfoThreshold = 10 // TODO: tighten to 0 once cleanup-sweeper
 var e2eExpiredCountEscalationThreshold = 25 // TODO: tighten to 5 once cleanup-sweeper baseline improves
 var e2eMaxExpiredAgeSeconds = 604800 // 7 days; TODO: tighten to 86400 (1 day)
 
+// Prow CI alert thresholds
+var prowHighFrequencyMinRuns = 5
+var prowScheduledMinRuns = 3
+var prowHealthcheckMaxFailureRate = '0.40'
+var prowE2EParallelMinSuccessfulRuns = 20
+var prowE2EParallelP95MaxSeconds = 9000 // 2h30m
+var prowCollectionMaxAgeSeconds = 900 // 15 minutes
+var prowBatchMaxConsecutiveFailures = 4
+
+var prowHighFrequencyRuns = 'sum by (job_name, job_type) (prow_ci_job_info{job_type=~"presubmit|batch"})'
+var prowHighFrequencyFailures = 'sum by (job_name, job_type) (prow_ci_job_info{job_type=~"presubmit|batch",result=~"failure|error"})'
+var prowScheduledRuns = 'sum by (job_name, job_type) (prow_ci_job_info{job_type=~"periodic|postsubmit"})'
+var prowScheduledFailures = 'sum by (job_name, job_type) (prow_ci_job_info{job_type=~"periodic|postsubmit",result=~"failure|error"})'
+var prowHealthcheckRuns = 'sum by (job_name) (prow_ci_job_info{job_name=~"periodic-ci-Azure-ARO-HCP-main-periodic-healthcheck-provision-.*"})'
+var prowHealthcheckFailures = 'sum by (job_name) (prow_ci_job_info{job_name=~"periodic-ci-Azure-ARO-HCP-main-periodic-healthcheck-provision-.*",result=~"failure|error"})'
+
 // Prometheus Rule Group for tenant-quota alerts
 resource tenantQuotaAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
   name: 'tenant-quota-alerts'
@@ -360,6 +376,205 @@ resource e2eExpiredRGAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@202
   }
 }
 
+resource prowCIAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'prow-ci-alerts'
+  location: resourceGroup().location
+  properties: {
+    enabled: alertingEnabled
+    interval: 'PT1M'
+    scopes: [
+      azureMonitorWorkspaceId
+    ]
+    rules: [
+      {
+        alert: 'ProwCIHighFrequencyJobPermafailing'
+        enabled: true
+        expression: '(${prowHighFrequencyFailures} / ${prowHighFrequencyRuns}) == 1 and on (job_name, job_type) ${prowHighFrequencyRuns} >= ${prowHighFrequencyMinRuns}'
+        for: 'PT15M'
+        severity: 3
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          summary: 'Prow CI job is consistently failing'
+          description: '{{ $labels.job_name }} ({{ $labels.job_type }}) has failed every run in the 24-hour window with at least ${prowHighFrequencyMinRuns} completed runs.'
+        }
+        actions: [
+          {
+            actionGroupId: sharedActionGroupId
+          }
+        ]
+        resolveConfiguration: {
+          autoResolved: true
+          timeToResolve: 'PT10M'
+        }
+      }
+      {
+        alert: 'ProwCIScheduledJobPermafailing'
+        enabled: true
+        expression: '(${prowScheduledFailures} / ${prowScheduledRuns}) == 1 and on (job_name, job_type) ${prowScheduledRuns} >= ${prowScheduledMinRuns}'
+        for: 'PT30M'
+        severity: 3
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          summary: 'Scheduled Prow CI job is consistently failing'
+          description: '{{ $labels.job_name }} ({{ $labels.job_type }}) has failed every run in the 24-hour window with at least ${prowScheduledMinRuns} completed runs.'
+        }
+        actions: [
+          {
+            actionGroupId: sharedActionGroupId
+          }
+        ]
+        resolveConfiguration: {
+          autoResolved: true
+          timeToResolve: 'PT10M'
+        }
+      }
+      {
+        alert: 'ProwCIHealthcheckProvisionSuccessRateLow'
+        enabled: true
+        expression: 'label_replace((${prowHealthcheckFailures} / ${prowHealthcheckRuns}), "region", "$1", "job_name", ".*-provision-(.*)") > ${prowHealthcheckMaxFailureRate} and on (job_name) ${prowHealthcheckRuns} >= ${prowHighFrequencyMinRuns}'
+        for: 'PT30M'
+        severity: 3
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          summary: 'Regional Prow provision healthcheck success rate is below 60%'
+          description: 'Provision healthchecks in {{ $labels.region }} have a {{ $value | humanizePercentage }} failure rate over the 24-hour window.'
+        }
+        actions: [
+          {
+            actionGroupId: sharedActionGroupId
+          }
+        ]
+        resolveConfiguration: {
+          autoResolved: true
+          timeToResolve: 'PT10M'
+        }
+      }
+      {
+        alert: 'ProwCIE2EParallelDurationP95High'
+        enabled: true
+        expression: 'histogram_quantile(0.95, sum by (job_name, le) (prow_ci_job_duration_window_runs{job_name="pull-ci-Azure-ARO-HCP-main-e2e-parallel",result="success"})) > ${prowE2EParallelP95MaxSeconds} and on (job_name) sum by (job_name) (prow_ci_job_duration_window_runs{job_name="pull-ci-Azure-ARO-HCP-main-e2e-parallel",result="success",le="+Inf"}) >= ${prowE2EParallelMinSuccessfulRuns}'
+        for: 'PT30M'
+        severity: 3
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          summary: 'Prow e2e-parallel P95 duration exceeds 2h30m'
+          description: '{{ $labels.job_name }} successful-run P95 duration is {{ $value | humanizeDuration }} over the 24-hour window.'
+        }
+        actions: [
+          {
+            actionGroupId: sharedActionGroupId
+          }
+        ]
+        resolveConfiguration: {
+          autoResolved: true
+          timeToResolve: 'PT10M'
+        }
+      }
+      {
+        alert: 'ProwCICollectionStale'
+        enabled: true
+        expression: 'time() - prow_ci_collection_last_success_timestamp_seconds > ${prowCollectionMaxAgeSeconds}'
+        for: 'PT15M'
+        severity: 2
+        labels: {
+          severity: 'critical'
+        }
+        annotations: {
+          summary: 'Prow CI metrics collection is stale'
+          description: 'The last successful Prow collection was {{ $value | humanizeDuration }} ago. Check exporter logs and connectivity to prow.ci.openshift.org.'
+        }
+        actions: [
+          {
+            actionGroupId: sharedActionGroupId
+          }
+        ]
+        resolveConfiguration: {
+          autoResolved: true
+          timeToResolve: 'PT10M'
+        }
+      }
+      {
+        alert: 'ProwCIInvalidJobsDetected'
+        enabled: true
+        expression: 'increase(prow_ci_invalid_jobs_total[1h]) > 0'
+        for: 'PT1M'
+        severity: 3
+        labels: {
+          severity: 'warning'
+        }
+        annotations: {
+          summary: 'Malformed completed Prow CI jobs detected'
+          description: '{{ $value }} malformed completed Prow jobs with reason {{ $labels.reason }} were observed in the last hour.'
+        }
+        actions: [
+          {
+            actionGroupId: sharedActionGroupId
+          }
+        ]
+        resolveConfiguration: {
+          autoResolved: true
+          timeToResolve: 'PT10M'
+        }
+      }
+      {
+        alert: 'ProwCINoCachedRuns'
+        enabled: true
+        expression: 'prow_ci_collection_success == 1 and prow_ci_cached_runs == 0'
+        for: 'PT15M'
+        severity: 2
+        labels: {
+          severity: 'critical'
+        }
+        annotations: {
+          summary: 'Prow collection succeeds but exports no completed runs'
+          description: 'The exporter can reach Prow but has no cached ARO-HCP runs. Check repository matching and the Prow response format.'
+        }
+        actions: [
+          {
+            actionGroupId: sharedActionGroupId
+          }
+        ]
+        resolveConfiguration: {
+          autoResolved: true
+          timeToResolve: 'PT10M'
+        }
+      }
+      {
+        alert: 'ProwCIMergeQueueBlocked'
+        enabled: true
+        expression: 'prow_ci_job_consecutive_failures{job_type="batch"} >= ${prowBatchMaxConsecutiveFailures}'
+        for: 'PT1M'
+        severity: 2
+        labels: {
+          severity: 'critical'
+        }
+        annotations: {
+          summary: 'Prow merge queue job has failed ${prowBatchMaxConsecutiveFailures} consecutive times'
+          description: '{{ $labels.job_name }} has {{ $value }} consecutive Tide batch failures. Inspect the merge queue and failing job before retesting.'
+        }
+        actions: [
+          {
+            actionGroupId: sharedActionGroupId
+          }
+        ]
+        resolveConfiguration: {
+          autoResolved: true
+          timeToResolve: 'PT10M'
+        }
+      }
+    ]
+  }
+}
+
 output alertRuleGroupId string = tenantQuotaAlerts.id
 output subscriptionAlertRuleGroupId string = subscriptionQuotaAlerts.id
 output e2eExpiredRGAlertRuleGroupId string = e2eExpiredRGAlerts.id
+output prowCIAlertRuleGroupId string = prowCIAlerts.id

--- a/tooling/tenant-quota/pkg/prow/collector.go
+++ b/tooling/tenant-quota/pkg/prow/collector.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -89,6 +90,11 @@ type durationMetrics struct {
 	buckets []float64
 }
 
+type jobMetricKey struct {
+	jobName string
+	jobType string
+}
+
 type Collector struct {
 	config *config.Config
 	logger *slog.Logger
@@ -101,6 +107,7 @@ type Collector struct {
 	lastSuccessDesc       *prometheus.Desc
 	cachedRunsDesc        *prometheus.Desc
 	invalidJobsDesc       *prometheus.Desc
+	consecutiveFailsDesc  *prometheus.Desc
 
 	mu                   sync.RWMutex
 	runs                 map[string]runMetrics
@@ -159,6 +166,12 @@ func NewCollector(cfg *config.Config, logger *slog.Logger, clients ...prowjobs.C
 			[]string{"reason"},
 			nil,
 		),
+		consecutiveFailsDesc: prometheus.NewDesc(
+			"prow_ci_job_consecutive_failures",
+			"Number of consecutive completed Prow CI job failures or errors since the most recent success within the retention window",
+			[]string{"job_name", "job_type"},
+			nil,
+		),
 		runs:             make(map[string]runMetrics),
 		seenInvalidJobs:  sets.New[string](),
 		invalidJobCounts: make(map[string]float64, len(invalidJobReasons)),
@@ -172,6 +185,7 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.lastSuccessDesc
 	ch <- c.cachedRunsDesc
 	ch <- c.invalidJobsDesc
+	ch <- c.consecutiveFailsDesc
 }
 
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
@@ -190,6 +204,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	c.mu.RUnlock()
 
 	durations := make(map[durationMetricKey]*durationMetrics)
+	runsByJob := make(map[jobMetricKey][]runMetrics)
 	for _, run := range runs {
 		labels := []string{run.jobName, run.jobType, run.buildID, run.result}
 		ch <- prometheus.MustNewConstMetric(c.infoDesc, prometheus.GaugeValue, 1, labels...)
@@ -210,6 +225,9 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			}
 		}
 		metrics.buckets[len(durationBuckets)]++
+
+		jobKey := jobMetricKey{jobName: run.jobName, jobType: run.jobType}
+		runsByJob[jobKey] = append(runsByJob[jobKey], run)
 	}
 	for key, metrics := range durations {
 		labels := []string{key.jobName, key.jobType, key.result}
@@ -227,6 +245,28 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 			prometheus.GaugeValue,
 			metrics.buckets[len(durationBuckets)],
 			append(labels, "+Inf")...,
+		)
+	}
+	for key, jobRuns := range runsByJob {
+		slices.SortFunc(jobRuns, func(a, b runMetrics) int {
+			if order := b.completionAt.Compare(a.completionAt); order != 0 {
+				return order
+			}
+			return strings.Compare(b.buildID, a.buildID)
+		})
+		consecutiveFailures := 0
+		for _, run := range jobRuns {
+			if run.result == "success" {
+				break
+			}
+			consecutiveFailures++
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.consecutiveFailsDesc,
+			prometheus.GaugeValue,
+			float64(consecutiveFailures),
+			key.jobName,
+			key.jobType,
 		)
 	}
 	ch <- prometheus.MustNewConstMetric(c.collectionSuccessDesc, prometheus.GaugeValue, collectionSuccess)

--- a/tooling/tenant-quota/pkg/prow/collector_test.go
+++ b/tooling/tenant-quota/pkg/prow/collector_test.go
@@ -225,6 +225,39 @@ func TestDurationMetricsAggregateRuns(t *testing.T) {
 	assertGauge(t, metrics, "prow_ci_job_duration_window_runs", withLabel(labels, "le", "+Inf"), 2)
 }
 
+func TestConsecutiveFailuresUsesCompletionOrder(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	jobs := []prowjobs.Job{
+		completedJob("pull-ci-Azure-ARO-HCP-main-e2e-parallel", "old-success", "success", now.Add(-7*time.Hour)),
+		completedJob("pull-ci-Azure-ARO-HCP-main-e2e-parallel", "failure-3", "failure", now.Add(-3*time.Hour)),
+		completedJob("pull-ci-Azure-ARO-HCP-main-e2e-parallel", "failure-1", "failure", now.Add(-time.Hour)),
+		completedJob("pull-ci-Azure-ARO-HCP-main-e2e-parallel", "failure-5", "error", now.Add(-5*time.Hour)),
+		completedJob("pull-ci-Azure-ARO-HCP-main-e2e-parallel", "failure-2", "failure", now.Add(-2*time.Hour)),
+		completedJob("pull-ci-Azure-ARO-HCP-main-e2e-parallel", "failure-4", "failure", now.Add(-4*time.Hour)),
+		completedJob("pull-ci-Azure-ARO-HCP-main-lint", "latest-success", "success", now.Add(-time.Hour)),
+		completedJob("pull-ci-Azure-ARO-HCP-main-lint", "old-failure", "failure", now.Add(-2*time.Hour)),
+	}
+	for i := range jobs {
+		jobs[i].Spec.Type = "batch"
+	}
+
+	collector := NewCollector(testConfig(t), testLogger(), &fakeClient{jobs: jobs})
+	collector.now = func() time.Time { return now }
+	if err := collector.collectOnce(context.Background()); err != nil {
+		t.Fatalf("collectOnce() error = %v", err)
+	}
+
+	metrics := gatherMetrics(t, collector)
+	assertGauge(t, metrics, "prow_ci_job_consecutive_failures", map[string]string{
+		"job_name": "pull-ci-Azure-ARO-HCP-main-e2e-parallel",
+		"job_type": "batch",
+	}, 5)
+	assertGauge(t, metrics, "prow_ci_job_consecutive_failures", map[string]string{
+		"job_name": "pull-ci-Azure-ARO-HCP-main-lint",
+		"job_type": "batch",
+	}, 0)
+}
+
 func TestDurationBuckets(t *testing.T) {
 	want := []float64{
 		60,


### PR DESCRIPTION
## Why

ARO-HCP Prow health currently requires manual inspection, which delays detection of persistently failing jobs, degraded regional provision healthchecks, slow e2e runs, stale telemetry, and a blocked Tide merge queue.

This is a follow-up to #6374. There is no separate tracking ticket because these alert thresholds and failure modes were defined during review of that telemetry work.

## What

- Add Azure Monitor alerts for:
  - permafailing high-frequency and scheduled jobs
  - regional provision healthcheck success below 60%
  - `e2e-parallel` successful-run P95 above 2h30m
  - stale or empty Prow collection and malformed jobs
  - four consecutive Tide batch failures
- Add `prow_ci_job_consecutive_failures` because an ordered failure streak cannot be derived from the existing per-run metric series.

## Live baseline

Evaluated against the opstool Azure Monitor workspace on 2026-08-10. Only `ProwCIScheduledJobPermafailing` would fire, for these four periodic cleanup jobs:

- `periodic-ci-azure-aro-hcp-main-periodic-cleanup-delete-expired-integration-resource-groups`
- `periodic-ci-azure-aro-hcp-main-periodic-cleanup-delete-expired-prod-00-resource-groups`
- `periodic-ci-azure-aro-hcp-main-periodic-cleanup-delete-expired-prod-resource-groups`
- `periodic-ci-azure-aro-hcp-main-periodic-cleanup-delete-expired-stage-resource-groups`

The regional provision healthcheck is at 91.7% success and `e2e-parallel` successful-run P95 is 2h26m30s, so neither crosses its threshold. Collection is healthy with 839 cached runs and no malformed jobs in the last hour. The undeployed Tide batch-streak rule is excluded from this live evaluation.

![Prow CI alert live baseline on 2026-08-10](https://github.com/user-attachments/assets/b610a8ac-9fbb-46e7-938f-2cb62a5458b1)

## Validation

- `go test -race ./pkg/prow/...`
- tenant-quota `golangci-lint`
- `az bicep build --file tooling/tenant-quota/alerting.bicep`
- live Azure Monitor evaluation of the proposed PromQL expressions
