### PR TITLE
fix(e2e): add pre-flight API version availability checks to preview API tests

### DIFF
--- a/test/e2e/cluster_create_private_ingress.go
+++ b/test/e2e/cluster_create_private_ingress.go
@@ -51,8 +51,18 @@ var _ = Describe("Customer", func() {
 
 			tc := framework.NewTestContext()
 
+			By("checking API version availability")
+			apiAvailable, err := tc.IsHCPAPIVersionAvailable(ctx, "2026-06-30-preview")
+			Expect(err).NotTo(HaveOccurred(), "failed to check API version availability")
+			if !apiAvailable {
+				if time.Now().After(framework.V20260630PreviewDeploymentDeadline) {
+					Fail(fmt.Sprintf("API version 2026-06-30-preview should be fully available by %s", framework.V20260630PreviewDeploymentDeadline.Format(time.RFC3339)))
+				}
+				Skip("API version 2026-06-30-preview is not fully available in this environment")
+			}
+
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				err = tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/cluster_create_v20260901preview.go
+++ b/test/e2e/cluster_create_v20260901preview.go
@@ -45,8 +45,18 @@ var _ = Describe("Customer", func() {
 
 			tc := framework.NewTestContext()
 
+			By("checking API version availability")
+			apiAvailable, err := tc.IsHCPAPIVersionAvailable(ctx, "2026-09-01-preview")
+			Expect(err).NotTo(HaveOccurred(), "failed to check API version availability")
+			if !apiAvailable {
+				if time.Now().After(timeBombDeadline) {
+					Fail(fmt.Sprintf("API version 2026-09-01-preview should be fully available by %s", timeBombDeadline.Format(time.RFC3339)))
+				}
+				Skip("API version 2026-09-01-preview is not fully available in this environment")
+			}
+
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				err = tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/cluster_fips_mode.go
+++ b/test/e2e/cluster_fips_mode.go
@@ -49,33 +49,13 @@ var _ = Describe("FIPS Mode Support", func() {
 				tc := framework.NewTestContext()
 
 				By("checking API version availability")
-				if !framework.IsDevelopmentEnvironment() {
-					resourcesFactory, err := tc.GetARMResourcesClientFactory(ctx)
-					Expect(err).NotTo(HaveOccurred(), "failed to get ARM resources client factory")
-
-					providersClient := resourcesFactory.NewProvidersClient()
-					provider, err := providersClient.Get(ctx, "Microsoft.RedHatOpenShift", nil)
-					Expect(err).NotTo(HaveOccurred(), "failed to get Microsoft.RedHatOpenShift resource provider")
-
-					available := false
-					for _, rt := range provider.ResourceTypes {
-						if rt.ResourceType == nil || !strings.EqualFold(*rt.ResourceType, "hcpOpenShiftClusters") {
-							continue
-						}
-						for _, v := range rt.APIVersions {
-							if v != nil && strings.EqualFold(*v, apiVersion) {
-								available = true
-								break
-							}
-						}
+				apiAvailable, err := tc.IsHCPAPIVersionAvailable(ctx, apiVersion)
+				Expect(err).NotTo(HaveOccurred(), "failed to check API version availability")
+				if !apiAvailable {
+					if time.Now().After(framework.V20260630PreviewDeploymentDeadline) {
+						Fail(fmt.Sprintf("API version %s should be fully available by %s", apiVersion, framework.V20260630PreviewDeploymentDeadline.Format(time.RFC3339)))
 					}
-					if !available {
-						if time.Now().After(framework.V20260630PreviewDeploymentDeadline) {
-							Fail(fmt.Sprintf("API version %s should be available for Microsoft.RedHatOpenShift/hcpOpenShiftClusters by %s", apiVersion, framework.V20260630PreviewDeploymentDeadline.Format(time.RFC3339)))
-						}
-						Skip(fmt.Sprintf("API version %s is not available for Microsoft.RedHatOpenShift/hcpOpenShiftClusters in this environment", apiVersion))
-					}
-					GinkgoLogr.Info("API version available", "version", apiVersion)
+					Skip(fmt.Sprintf("API version %s is not fully available in this environment", apiVersion))
 				}
 
 				if tc.UsePooledIdentities() {
@@ -117,6 +97,12 @@ var _ = Describe("FIPS Mode Support", func() {
 					clusterResource,
 					framework.ClusterCreationTimeout,
 				)
+				if isAPINotDeployedError(err) {
+					if time.Now().Before(framework.V20260630PreviewDeploymentDeadline) {
+						Skip(fmt.Sprintf("v20260630preview API not yet deployed; skipping until %s", framework.V20260630PreviewDeploymentDeadline.Format(time.RFC3339)))
+					}
+					Fail(fmt.Sprintf("v20260630preview API still not deployed as of %s deadline", framework.V20260630PreviewDeploymentDeadline.Format(time.RFC3339)))
+				}
 				Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with cryptoRestrictions set to FIPS", customerClusterName)
 
 				By("creating the node pool with FIPS enabled machines")

--- a/test/e2e/kms_key_rotation.go
+++ b/test/e2e/kms_key_rotation.go
@@ -44,8 +44,18 @@ var _ = Describe("Customer", func() {
 
 			tc := framework.NewTestContext()
 
+			By("checking API version availability")
+			apiAvailable, err := tc.IsHCPAPIVersionAvailable(ctx, "2026-06-30-preview")
+			Expect(err).NotTo(HaveOccurred(), "failed to check API version availability")
+			if !apiAvailable {
+				if time.Now().After(framework.V20260630PreviewDeploymentDeadline) {
+					Fail(fmt.Sprintf("API version 2026-06-30-preview should be fully available by %s", framework.V20260630PreviewDeploymentDeadline.Format(time.RFC3339)))
+				}
+				Skip("API version 2026-06-30-preview is not fully available in this environment")
+			}
+
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				err = tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/e2e/nodepool_ephemeral_osdisk.go
+++ b/test/e2e/nodepool_ephemeral_osdisk.go
@@ -77,8 +77,18 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 
 			tc := framework.NewTestContext()
 
+			By("checking API version availability")
+			apiAvailable, err := tc.IsHCPAPIVersionAvailable(ctx, "2025-12-23-preview")
+			Expect(err).NotTo(HaveOccurred(), "failed to check API version availability")
+			if !apiAvailable {
+				if time.Now().After(timeBombDeadline) {
+					Fail(fmt.Sprintf("API version 2025-12-23-preview should be fully available by %s", timeBombDeadline.Format(time.RFC3339)))
+				}
+				Skip("API version 2025-12-23-preview is not fully available in this environment")
+			}
+
 			if tc.UsePooledIdentities() {
-				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				err = tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 

--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -26,7 +26,10 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
+
+	"github.com/onsi/ginkgo/v2"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -285,4 +288,51 @@ func HasNodeTaint(nodes []corev1.Node, key, value string, effect corev1.TaintEff
 	}
 
 	return count == expectedCount[0]
+}
+
+// requiredResourceTypesForAPIVersion lists the ARM resource types that must all
+// support a given API version for async operations (create/delete/update) to work
+// end-to-end. The generated SDK uses the same api-version query parameter for both
+// the resource and its operation status polling endpoint.
+var requiredResourceTypesForAPIVersion = []string{
+	"hcpOpenShiftClusters",
+	"locations/hcpOperationStatuses",
+	"locations/hcpOperationResults",
+}
+
+// IsHCPAPIVersionAvailable checks whether apiVersion is registered in the ARM
+// provider manifest for all resource types required by the ARO-HCP SDK. In
+// development environments the check is skipped (always returns true).
+func (tc *perItOrDescribeTestContext) IsHCPAPIVersionAvailable(ctx context.Context, apiVersion string) (bool, error) {
+	if tc.perBinaryInvocationTestContext.isDevelopmentEnvironment {
+		return true, nil
+	}
+	factory, err := tc.GetARMResourcesClientFactory(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get ARM resources client factory: %w", err)
+	}
+	provider, err := factory.NewProvidersClient().Get(ctx, "Microsoft.RedHatOpenShift", nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to get Microsoft.RedHatOpenShift resource provider: %w", err)
+	}
+	for _, requiredRT := range requiredResourceTypesForAPIVersion {
+		found := false
+		for _, rt := range provider.ResourceTypes {
+			if rt.ResourceType == nil || !strings.EqualFold(*rt.ResourceType, requiredRT) {
+				continue
+			}
+			for _, v := range rt.APIVersions {
+				if v != nil && strings.EqualFold(*v, apiVersion) {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			ginkgo.GinkgoLogr.Info("API version not available for resource type",
+				"apiVersion", apiVersion, "resourceType", requiredRT)
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/test/util/framework/hcp_helper.go
+++ b/test/util/framework/hcp_helper.go
@@ -29,10 +29,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onsi/ginkgo/v2"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/onsi/ginkgo/v2"
 	"golang.org/x/crypto/ssh"
 
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
### What

Adds `tc.IsHCPAPIVersionAvailable()` to the E2E test framework and uses it in all five preview API tests to skip early when required ARM resource types don't yet support the target API version. Also retains existing `isAPINotDeployedError` guards after cluster/nodepool creation as defense-in-depth.

### Why

The FIPS test was failing in INT because `v20260630preview` was partially deployed -- `hcpOpenShiftClusters` accepted the API version but `locations/hcpOperationStatuses` did not. The SDK polls operation status using the same API version, and ARM rejects it with `NoRegisteredProviderFound`. The existing pre-flight check only validated `hcpOpenShiftClusters`, so the test proceeded to create resources before failing mid-create.

### Testing

- No new test cases; this fixes skip logic in existing E2E tests
- Verified resource type names against `az provider show --namespace Microsoft.RedHatOpenShift`
- `go vet` and lint pass

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [x] E2E tests follow Principles of Good E2E Test Case Design
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.