### PR TITLE
fix(config): update stg kusto cluster to hcp-stg-uk-3

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -73,18 +73,6 @@ clouds:
               # US-geography cluster (hcp-{env}-{geoShort} convention), separate from
               # the uksouth hcp-stg-uk-* cluster.
               kustoName: "hcp-{{ .ctx.environment }}-us-1"
-          # uksouth: the kustoName default below (in stg.defaults.kusto) points at
-          # the "-2" cluster it had to be recreated as (b7b54161a), but that commit
-          # only overrode kustoName, not rg. The base config.yaml template still
-          # resolves rg to the un-suffixed "hcp-kusto-stg-uk", so the region-pipeline
-          # "kusto" step (which scopes its ARM deployment to `{{ .kusto.rg }}`) looks
-          # up Microsoft.Kusto/clusters/hcp-stg-uk-2 in the wrong resource group and
-          # fails with ResourceNotFound (AROSLSRE-1744). Pin rg here, scoped to just
-          # uksouth, so westus3 (which inherits the un-suffixed rg templating
-          # correctly for its own "us-1" cluster) is unaffected.
-          uksouth:
-            kusto:
-              rg: "hcp-kusto-stg-uk-2"
         defaults:
           # Carry the environment in the subscription display names for stage, so the
           # stg subscriptions are distinguishable from the identically-named prod ones.
@@ -101,7 +89,7 @@ clouds:
               displayName: "Azure Red Hat OpenShift HCP - {{ .ctx.environment }} - {{ .ev2.regionFriendlyName }} - SVC"
           # This must be defined here, so our ci jobs can know this
           kusto:
-            kustoName: "hcp-stg-uk-2"
+            kustoName: "hcp-stg-uk-3"
           # Transient STG-global "V2" names for the parallel infra in the dedicated
           # hcp-stg-global sub during coexistence. Removed at decommission.
           stgGlobalV2:


### PR DESCRIPTION
## Why

The STG rollout failed with:

```
ResourceNotFound: The Resource 'Microsoft.Kusto/clusters/hcp-stg-uk-2' under resource group 'hcp-kusto-stg-uk-2' was not found.
```

The uksouth STG Kusto cluster was recreated as `hcp-stg-uk-3` in the original resource group `hcp-kusto-stg-uk`. The previous config (from #6444 + `b7b54161a`) pointed at the defunct `hcp-stg-uk-2` cluster with an incorrect rg override (`hcp-kusto-stg-uk-2`) that does not exist as a resource group.

## What

- Update `kustoName` from `hcp-stg-uk-2` to `hcp-stg-uk-3` (matching the actual cluster in Azure)
- Remove the uksouth `rg` override added by #6444 (the base template resolves to `hcp-kusto-stg-uk` which is correct)

## Testing

- `cd config && make materialize` passes
- Verified in Azure Portal: RG `hcp-kusto-stg-uk` exists with cluster `hcp-stg-uk-3` inside it

Jira: [AROSLSRE-1744](https://redhat.atlassian.net/browse/AROSLSRE-1744)

## PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)