### PR TITLE
test: remove expired 5.0 HCCO ingress skip timebomb

### DIFF
--- a/test/e2e/complete_cluster_create_multiversion.go
+++ b/test/e2e/complete_cluster_create_multiversion.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -68,19 +67,6 @@ var _ = Describe("ARO-HCP", func() {
 				}
 			}
 			clusterParams.OpenshiftVersionId = openShiftControlPlaneVersion
-
-			// OCPBUGS-98571: HyperShift HCCO forces InternalLoadBalancer scope for
-			// PublicAndPrivate topology on ARO HCP, causing *.apps routes to point
-			// to an unreachable internal LB IP. The fix (PR #8992) merged to main
-			// on 2026-07-14 but 5.0.0-ec.4 (built 2026-07-03) does not include it.
-			// Skip 5.0 until an EC build with the fix is available.
-			if version == "5.0" {
-				timeBombDeadline := time.Date(2026, time.August, 10, 0, 0, 0, 0, time.UTC)
-				if time.Now().Before(timeBombDeadline) {
-					Skip(fmt.Sprintf("5.0 candidate releases do not yet include the HCCO ingress LB scope fix (https://issues.redhat.com/browse/OCPBUGS-98571); skipping until %s", timeBombDeadline.Format(time.RFC3339)))
-				}
-				Fail("5.0 HCCO ingress LB scope fix (OCPBUGS-98571) still not available; remove this skip or update the deadline")
-			}
 
 			tc := framework.NewTestContext()
 			if tc.UsePooledIdentities() {


### PR DESCRIPTION
<!-- Link to Jira issue -->
https://issues.redhat.com/browse/OCPBUGS-98571

### What

Removes the expired OCPBUGS-98571 timebomb/skip for 5.0 candidate install in `test/e2e/complete_cluster_create_multiversion.go` (added in #6163), including the unused `time` import.

### Why

The skip expired on `2026-08-10`. Past that date the block calls `Fail(...)`, so CI fails instead of skipping. Removing it restores the 5.0 candidate install coverage now that the HyperShift operator build ARO-HCP consumes includes the HCCO ingress LB scope fix (hypershift#8992, merged upstream 2026-07-14; the operator image digest currently pinned in `config/config.yaml` was built 2026-08-07, well after the fix landed).

### Testing

No new tests. This only deletes an expired e2e skip so the existing multiversion install table exercises 5.0 again.

- Unit tests: N/A
- Integration tests: N/A
- E2E tests: existing `complete_cluster_create_multiversion` path; this PR's own `e2e-parallel` run is the verification that the 5.0 candidate install now succeeds

### Special notes for your reviewer

- Confirm the HyperShift operator image pinned in `config/config.yaml` (currently digest `sha256:99bf7bd6a156e9deb3cbf943345710d64c621f9600d62666c3f9be8481f7da3a`, built 2026-08-07) includes hypershift#8992 before merge. If a regression/newer issue is found instead, re-add a skip with an updated deadline rather than reverting this removal outright.
- Related: OCPBUGS-98571 / #6163

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.