### PR TITLE
fix(test): extend 5.0 HCCO ingress LB timebomb deadline to Aug 17

### DIFF
--- a/test/e2e/complete_cluster_create_multiversion.go
+++ b/test/e2e/complete_cluster_create_multiversion.go
@@ -75,7 +75,7 @@ var _ = Describe("ARO-HCP", func() {
 			// on 2026-07-14 but 5.0.0-ec.4 (built 2026-07-03) does not include it.
 			// Skip 5.0 until an EC build with the fix is available.
 			if version == "5.0" {
-				timeBombDeadline := time.Date(2026, time.August, 10, 0, 0, 0, 0, time.UTC)
+				timeBombDeadline := time.Date(2026, time.August, 17, 0, 0, 0, 0, time.UTC)
 				if time.Now().Before(timeBombDeadline) {
 					Skip(fmt.Sprintf("5.0 candidate releases do not yet include the HCCO ingress LB scope fix (https://issues.redhat.com/browse/OCPBUGS-98571); skipping until %s", timeBombDeadline.Format(time.RFC3339)))
 				}


### PR DESCRIPTION
## Summary
- Extends the [OCPBUGS-98571](https://redhat.atlassian.net/browse/OCPBUGS-98571) timebomb skip deadline from Aug 10 to Aug 17 for the 5.0 multiversion E2E test
- The HCCO ingress LB scope fix (HyperShift PR [#8992](https://github.com/openshift/hypershift/pull/8992)) merged to main on 2026-07-14. It could be a problem that 
  - Changes not yet appeared in a 5.0 candidate EC build 
  - Or we haven't updated hypershift image

## Test plan
- [ ] Verify the 5.0 E2E test skips cleanly instead of failing until Aug 17
- [ ] Follow up to remove the skip once a 5.0 EC build with the fix is available