### PR TITLE
feat: add grpc_server_handling_seconds to etcd SRE metrics set

### DIFF
--- a/hypershiftoperator/deploy/templates/sre-metrics-set.configmap.yaml
+++ b/hypershiftoperator/deploy/templates/sre-metrics-set.configmap.yaml
@@ -17,8 +17,12 @@ data:
         regex:        "grpc_(client|server)_(handled|started|msg_received|msg_sent)_total"
         sourceLabels: ["__name__"]
 {{- end }}
+      - action:       "drop"
+        sourceLabels: ["__name__", "grpc_service"]
+        separator:    ";"
+        regex:        "grpc_server_handling_seconds_(bucket|count|sum);grpc\\.health\\.v1\\.Health"
       - action:       "keep"
-        regex:        "etcd_debugging_.*|etcd_disk_(backend_(commit|defrag|snapshot)|wal_(fsync|write))_duration_seconds_(bucket|count|sum)|etcd_mvcc_(db_total_size_in_(bytes|use_in_bytes)|(delete|put)_total|(hash|hash_rev)_duration_seconds_(bucket|count|sum))|etcd_network_(client_grpc_(received|sent)_bytes_total|peer_(received_bytes_total|round_trip_time_seconds_(bucket|count|sum)|sent_bytes_total))|etcd_server_(apply_duration_seconds_(bucket|count|sum)|has_leader|health_failures|heartbeat_send_failures_total|leader_changes_seen_total|proposals_(applied_total|committed_total|failed_total|pending)|quota_backend_bytes|slow_(apply_total|read_indexes_total))|etcd_snap_(db_(fsync|save_total)|fsync)_duration_seconds_(bucket|count|sum)|go_gc_duration_seconds(_sum|_count)?|go_goroutines|go_memstats_(alloc_bytes(_total)?|heap_(alloc|inuse)_bytes|mallocs_total|stack_inuse_bytes)|grpc_(client|server)_(handled|started|msg_received|msg_sent)_total|process_(cpu_seconds_total|resident_memory_bytes)"
+        regex:        "etcd_debugging_.*|etcd_disk_(backend_(commit|defrag|snapshot)|wal_(fsync|write))_duration_seconds_(bucket|count|sum)|etcd_mvcc_(db_total_size_in_(bytes|use_in_bytes)|(delete|put)_total|(hash|hash_rev)_duration_seconds_(bucket|count|sum))|etcd_network_(client_grpc_(received|sent)_bytes_total|peer_(received_bytes_total|round_trip_time_seconds_(bucket|count|sum)|sent_bytes_total))|etcd_server_(apply_duration_seconds_(bucket|count|sum)|has_leader|health_failures|heartbeat_send_failures_total|leader_changes_seen_total|proposals_(applied_total|committed_total|failed_total|pending)|quota_backend_bytes|slow_(apply_total|read_indexes_total))|etcd_snap_(db_(fsync|save_total)|fsync)_duration_seconds_(bucket|count|sum)|go_gc_duration_seconds(_sum|_count)?|go_goroutines|go_memstats_(alloc_bytes(_total)?|heap_(alloc|inuse)_bytes|mallocs_total|stack_inuse_bytes)|grpc_(client|server)_(handled|started|msg_received|msg_sent)_total|grpc_server_handling_seconds_(bucket|count|sum)|process_(cpu_seconds_total|resident_memory_bytes)"
         sourceLabels: ["__name__"]
     kubeAPIServer:
 {{- if not .Values.metricsSet.performanceMetrics }}

--- a/hypershiftoperator/testdata/zz_fixture_TestHelmTemplate_hypershift_performance_metrics.yaml
+++ b/hypershiftoperator/testdata/zz_fixture_TestHelmTemplate_hypershift_performance_metrics.yaml
@@ -653,8 +653,12 @@ metadata:
 data:
   config: |
     etcd:
+      - action:       "drop"
+        sourceLabels: ["__name__", "grpc_service"]
+        separator:    ";"
+        regex:        "grpc_server_handling_seconds_(bucket|count|sum);grpc\\.health\\.v1\\.Health"
       - action:       "keep"
-        regex:        "etcd_debugging_.*|etcd_disk_(backend_(commit|defrag|snapshot)|wal_(fsync|write))_duration_seconds_(bucket|count|sum)|etcd_mvcc_(db_total_size_in_(bytes|use_in_bytes)|(delete|put)_total|(hash|hash_rev)_duration_seconds_(bucket|count|sum))|etcd_network_(client_grpc_(received|sent)_bytes_total|peer_(received_bytes_total|round_trip_time_seconds_(bucket|count|sum)|sent_bytes_total))|etcd_server_(apply_duration_seconds_(bucket|count|sum)|has_leader|health_failures|heartbeat_send_failures_total|leader_changes_seen_total|proposals_(applied_total|committed_total|failed_total|pending)|quota_backend_bytes|slow_(apply_total|read_indexes_total))|etcd_snap_(db_(fsync|save_total)|fsync)_duration_seconds_(bucket|count|sum)|go_gc_duration_seconds(_sum|_count)?|go_goroutines|go_memstats_(alloc_bytes(_total)?|heap_(alloc|inuse)_bytes|mallocs_total|stack_inuse_bytes)|grpc_(client|server)_(handled|started|msg_received|msg_sent)_total|process_(cpu_seconds_total|resident_memory_bytes)"
+        regex:        "etcd_debugging_.*|etcd_disk_(backend_(commit|defrag|snapshot)|wal_(fsync|write))_duration_seconds_(bucket|count|sum)|etcd_mvcc_(db_total_size_in_(bytes|use_in_bytes)|(delete|put)_total|(hash|hash_rev)_duration_seconds_(bucket|count|sum))|etcd_network_(client_grpc_(received|sent)_bytes_total|peer_(received_bytes_total|round_trip_time_seconds_(bucket|count|sum)|sent_bytes_total))|etcd_server_(apply_duration_seconds_(bucket|count|sum)|has_leader|health_failures|heartbeat_send_failures_total|leader_changes_seen_total|proposals_(applied_total|committed_total|failed_total|pending)|quota_backend_bytes|slow_(apply_total|read_indexes_total))|etcd_snap_(db_(fsync|save_total)|fsync)_duration_seconds_(bucket|count|sum)|go_gc_duration_seconds(_sum|_count)?|go_goroutines|go_memstats_(alloc_bytes(_total)?|heap_(alloc|inuse)_bytes|mallocs_total|stack_inuse_bytes)|grpc_(client|server)_(handled|started|msg_received|msg_sent)_total|grpc_server_handling_seconds_(bucket|count|sum)|process_(cpu_seconds_total|resident_memory_bytes)"
         sourceLabels: ["__name__"]
     kubeAPIServer:
       - action:       "keep"

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -662,8 +662,12 @@ data:
       - action:       "drop"
         regex:        "grpc_(client|server)_(handled|started|msg_received|msg_sent)_total"
         sourceLabels: ["__name__"]
+      - action:       "drop"
+        sourceLabels: ["__name__", "grpc_service"]
+        separator:    ";"
+        regex:        "grpc_server_handling_seconds_(bucket|count|sum);grpc\\.health\\.v1\\.Health"
       - action:       "keep"
-        regex:        "etcd_debugging_.*|etcd_disk_(backend_(commit|defrag|snapshot)|wal_(fsync|write))_duration_seconds_(bucket|count|sum)|etcd_mvcc_(db_total_size_in_(bytes|use_in_bytes)|(delete|put)_total|(hash|hash_rev)_duration_seconds_(bucket|count|sum))|etcd_network_(client_grpc_(received|sent)_bytes_total|peer_(received_bytes_total|round_trip_time_seconds_(bucket|count|sum)|sent_bytes_total))|etcd_server_(apply_duration_seconds_(bucket|count|sum)|has_leader|health_failures|heartbeat_send_failures_total|leader_changes_seen_total|proposals_(applied_total|committed_total|failed_total|pending)|quota_backend_bytes|slow_(apply_total|read_indexes_total))|etcd_snap_(db_(fsync|save_total)|fsync)_duration_seconds_(bucket|count|sum)|go_gc_duration_seconds(_sum|_count)?|go_goroutines|go_memstats_(alloc_bytes(_total)?|heap_(alloc|inuse)_bytes|mallocs_total|stack_inuse_bytes)|grpc_(client|server)_(handled|started|msg_received|msg_sent)_total|process_(cpu_seconds_total|resident_memory_bytes)"
+        regex:        "etcd_debugging_.*|etcd_disk_(backend_(commit|defrag|snapshot)|wal_(fsync|write))_duration_seconds_(bucket|count|sum)|etcd_mvcc_(db_total_size_in_(bytes|use_in_bytes)|(delete|put)_total|(hash|hash_rev)_duration_seconds_(bucket|count|sum))|etcd_network_(client_grpc_(received|sent)_bytes_total|peer_(received_bytes_total|round_trip_time_seconds_(bucket|count|sum)|sent_bytes_total))|etcd_server_(apply_duration_seconds_(bucket|count|sum)|has_leader|health_failures|heartbeat_send_failures_total|leader_changes_seen_total|proposals_(applied_total|committed_total|failed_total|pending)|quota_backend_bytes|slow_(apply_total|read_indexes_total))|etcd_snap_(db_(fsync|save_total)|fsync)_duration_seconds_(bucket|count|sum)|go_gc_duration_seconds(_sum|_count)?|go_goroutines|go_memstats_(alloc_bytes(_total)?|heap_(alloc|inuse)_bytes|mallocs_total|stack_inuse_bytes)|grpc_(client|server)_(handled|started|msg_received|msg_sent)_total|grpc_server_handling_seconds_(bucket|count|sum)|process_(cpu_seconds_total|resident_memory_bytes)"
         sourceLabels: ["__name__"]
     kubeAPIServer:
       - action:       "drop"


### PR DESCRIPTION
## Summary
- Add `grpc_server_handling_seconds_(bucket|count|sum)` to the etcd keep regex in the `sre-metric-set` ConfigMap
- Add a drop rule for `grpc.health.v1.Health` service to filter out health check timeseries that add noise without monitoring value

## Testing
- Deployed personal dev environment using code changes on `etcd-metric-enablement` branch
- Created HCP cluster via e2e test (`ARO_E2E_SKIP_CLEANUP=true TEST_NAME="Customer should be able to create an HCP cluster with custom autoscaling" make e2e-local/run-test`)
- Patched etcd StatefulSet with `ETCD_METRICS=extensive` env variable to enable gRPC histograms for testing
```
❯ NS="ocm-arohcppers-2s3nvhp8fa6qt6q80u4cubueju3epp9v-s9p3d3h1s7z7t5h"                      

❯ kubectl get statefulset etcd -n "$NS" -o jsonpath='{.spec.template.spec.containers[0].env[*]}' 2>/dev/null | tr '}' '\n' | grep -i "ETCD_METRICS"
 {"name":"ETCD_METRICS","value":"extensive"
```
- Verified on Grafana (Managed_Prometheus_hcps-usw3shsa):
  - `grpc_server_handling_seconds_bucket` metric is available with all 6 `etcdserverpb.*` services (auth, cluster, kv, lease, maintenance, watch)
  - `grpc.health.v1.Health` timeseries is NOT present — drop rule is working correctly

<img width="757" height="354" alt="image" src="https://github.com/user-attachments/assets/cc2dadb0-2e25-4d4f-8acd-2687b7c72aeb" />


## Test plan
- [x] Helm fixture tests pass
- [x] Metric available in Grafana with correct grpc_service labels
- [x] Health check noise filtered by drop rule

🔗 [ARO-26896](https://redhat.atlassian.net/browse/ARO-26896)
