### PR TITLE
fix(ci): support periodic promoted image provisioning

### DIFF
--- a/hack/ci/provision-from-main.sh
+++ b/hack/ci/provision-from-main.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-# Provision a baseline ARO HCP environment from the base branch.
-# Used as the first phase of upgrade-path validation: the environment
-# is created from main, then upgraded to the PR branch in a subsequent step.
+# Provision an ARO HCP environment from a published main-branch revision.
+# Used for upgrade baselines and periodic regional provisioning healthchecks.
 #
 # Called by the aro-hcp-provision-from-main step-registry wrapper.
 # Callers must set: CLUSTER_PROFILE_DIR, ARO_HCP_DEPLOY_ENV, SHARED_DIR,
@@ -13,27 +12,29 @@ set -o pipefail
 # shellcheck source=hack/ci/az-login.sh
 source "$(dirname "$0")/az-login.sh"
 
-# Check out the base branch to provision the baseline environment.
-# The container has the PR merge commit baked in; we rewind to the base
-# so Bicep templates, Helm charts, config, and pipeline definitions all
-# come from what the PR is being merged into.
+# Check out the main-branch revision to provision.
+# Presubmits rewind the PR merge commit to its base, while periodics and
+# rehearsals fetch main because they do not have an ARO-HCP PULL_BASE_SHA.
 #
-# Prow sets PULL_BASE_SHA to the exact base-branch commit used for the
-# merge. That commit is already in the local clone, so no fetch needed.
-# Rehearsal runs (JOB_NAME prefixed with "rehearse-") fetch main
-# explicitly, since PULL_BASE_SHA belongs to the openshift/release repo.
+# Prow sets PULL_BASE_SHA to the exact base-branch commit used for a
+# presubmit merge. That commit is already in the local clone, so no fetch
+# is needed. Periodic and rehearsal runs fetch main explicitly.
 IS_REHEARSAL=false
 if [[ "${JOB_NAME:-}" == rehearse-* ]]; then
   IS_REHEARSAL=true
 fi
 
-if [[ "${IS_REHEARSAL}" == "true" ]]; then
-  echo "Rehearsal detected (JOB_NAME=${JOB_NAME:-unset}), fetching main ..."
+if [[ "${IS_REHEARSAL}" == "true" || "${JOB_TYPE:-}" == "periodic" ]]; then
+  if [[ "${IS_REHEARSAL}" == "true" ]]; then
+    echo "Rehearsal detected (JOB_NAME=${JOB_NAME:-unset}), fetching main ..."
+  else
+    echo "Periodic job detected (JOB_NAME=${JOB_NAME:-unset}), fetching main ..."
+  fi
   git fetch https://github.com/Azure/ARO-HCP.git main
   git checkout -f FETCH_HEAD
 else
   if [[ -z "${PULL_BASE_SHA:-}" ]]; then
-    echo "ERROR: PULL_BASE_SHA is not set and this is not a rehearsal. Cannot determine base commit."
+    echo "ERROR: PULL_BASE_SHA is not set for this non-periodic, non-rehearsal job. Cannot determine base commit."
     exit 1
   fi
   if ! git cat-file -e "${PULL_BASE_SHA}" 2>/dev/null; then

--- a/hack/ci/resolve-acr-images.sh
+++ b/hack/ci/resolve-acr-images.sh
@@ -31,15 +31,40 @@ EXPORTER_REPO=$(yq '.customExporter.image.repository' "${ACR_CONFIG_FILE}")
 echo "ACR: ${ACR_URL}, target SHA: ${TARGET_SHA}"
 echo "Repos: backend=${BACKEND_REPO} frontend=${FRONTEND_REPO} admin-api=${ADMIN_API_REPO} sessiongate=${SESSIONGATE_REPO} fleet=${FLEET_REPO} mgmt-agent=${MGMT_AGENT_REPO} kube-applier=${KUBE_APPLIER_REPO} exporter=${EXPORTER_REPO}"
 
+ACR_IMAGE_REPOS=(
+  "${BACKEND_REPO}"
+  "${FRONTEND_REPO}"
+  "${ADMIN_API_REPO}"
+  "${SESSIONGATE_REPO}"
+  "${FLEET_REPO}"
+  "${MGMT_AGENT_REPO}"
+  "${KUBE_APPLIER_REPO}"
+  "${EXPORTER_REPO}"
+)
+
+image_set_available() {
+  local tag=$1
+  local repo
+
+  # images-push publishes repositories sequentially, so one available image
+  # does not guarantee that the commit's complete service image set is ready.
+  for repo in "${ACR_IMAGE_REPOS[@]}"; do
+    if ! az acr manifest show -r "${ACR_NAME}" -n "${repo}:${tag}" &>/dev/null; then
+      return 1
+    fi
+  done
+  return 0
+}
+
 # Prefer the latest main commit's images. Poll ACR in case the postsubmit
 # images-push job is still running. If HEAD's images never appear, walk
 # back through history to find the newest commit with images available.
 MAX_POLL=30
 POLL_INTERVAL=30
-echo "Polling ACR for ${FLEET_REPO}:${TARGET_SHA} (up to $((MAX_POLL * POLL_INTERVAL))s) ..."
+echo "Polling ACR for the complete image set tagged ${TARGET_SHA} (${MAX_POLL} attempts, ${POLL_INTERVAL}s between attempts) ..."
 FOUND_HEAD=false
 for attempt in $(seq 1 ${MAX_POLL}); do
-  if az acr manifest show -r "${ACR_NAME}" -n "${FLEET_REPO}:${TARGET_SHA}" &>/dev/null; then
+  if image_set_available "${TARGET_SHA}"; then
     echo "Images for ${TARGET_SHA} available after attempt ${attempt}"
     FOUND_HEAD=true
     break
@@ -53,7 +78,7 @@ if [[ "${FOUND_HEAD}" != "true" ]]; then
   MAX_WALK=20
   IMAGE_SHA=""
   for sha in $(curl -sS "https://api.github.com/repos/Azure/ARO-HCP/commits?sha=${TARGET_SHA}&per_page=${MAX_WALK}" | jq -r '.[].sha' | cut -c1-7 | tail -n +2); do
-    if az acr manifest show -r "${ACR_NAME}" -n "${FLEET_REPO}:${sha}" &>/dev/null; then
+    if image_set_available "${sha}"; then
       IMAGE_SHA="${sha}"
       echo "Found images in ACR for commit ${sha}"
       break


### PR DESCRIPTION
Companion to https://github.com/openshift/release/pull/82772

### What

- Allow `hack/ci/provision-from-main.sh` to fetch ARO-HCP `main` for periodic Prow jobs that do not have `PULL_BASE_SHA`.
- Require all service image tags to exist before `resolve-acr-images.sh` accepts a commit, both while polling HEAD and while walking back through history.

### Why

Regional provisioning healthchecks should deploy the coherent service image set already published by the main postsubmit instead of rebuilding images. Checking only the fleet image can observe a partially published commit because images are pushed sequentially.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (not applicable)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP
- [x] Commit history is clean
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge
