### PR TITLE
fix(observability): add KubePodNotReady known issue for Velero DataUpload

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/known-issues/knownIssues.yaml
@@ -38,5 +38,10 @@ knownIssues:
     namespace: "ocm-.*"
     pod: "capi-provider-.*"
   reason: "capi-provider pods are transiently not-ready during HCP provisioning due to a deliberate bootstrap dependency cycle: the pod mounts the service-network-admin-kubeconfig secret (created by the KAS component), but capi-provider is intentionally excluded from the KAS dependency gate in HyperShift (componentsExcludedFromKubeAPIServerDependency) because node provisioning cannot wait for KAS to fully roll out. The pod sits in ContainerCreating with FailedMount errors until KAS reconciles and creates the secret, then the availability-prober init container gates on KAS /livez before starting the main container. This is by design and consistently exceeds the 5-minute KubePodNotReady threshold during provisioning (~56 alerts/day across 32 pods)."
+- name: "KubePodNotReady"
+  labels:
+    namespace: "velero"
+    pod: "ocm-.*"
+  reason: "Velero DataUpload exposer pods are transient (short-lived ~30-90s) pods that mount CSI snapshot PVCs for kopia data upload during scheduled backups. They complete and are deleted well within 5 minutes, but Prometheus lookback delta keeps stale Pending-phase metrics queryable beyond the for:5m alert threshold."
 - name: "FrontendPathLatency"
   reason: "histogram_quantile(0.99) produces false positives with sparse request volume in CI. E2E runs create all nodepools in a burst then traffic drops to 1-2 requests per 5-minute rate window; at that volume, rate() floating-point noise across HA Prometheus replicas breaks cumulative histogram monotonicity, causing the P99 estimate to land in empty high-latency buckets (e.g. 12.083s reported when actual max was 26ms). Tracked in AROSLSRE-1746."


### PR DESCRIPTION
refer: https://github.com/Azure/ARO-HCP/pull/6261

### What

Add a `KubePodNotReady` known-issue entry for Velero DataUpload exposer pods in the `velero` namespace.

### Why

PR #6261 introduces Velero backup schedules for HCP clusters. Each backup creates short-lived (~30-90s) DataUpload exposer pods in the `velero` namespace that mount CSI snapshot PVCs for kopia data upload.

These pods complete so fast that their entire lifecycle fits inside a single Prometheus scrape interval (30s). Prometheus captures the pod once in `Pending` phase, but the pod transitions through Running --> Succeeded --> Deleted before the next scrape. Because Prometheus never sees the transition out of Pending, the last data point it has is `Pending=1`, which stays queryable long enough to exceed the `for:5m` KubePodNotReady threshold, causing a false positive alert.

This follows the established pattern of four existing KubePodNotReady known-issue entries (klusterlet, OLM, HCCO, capi-provider) that suppress the same alert for other transient pods in expected states.

The pod pattern `ocm-.*` targets only DataUpload exposer pods (named after HCP cluster namespaces), preserving alerting for the Velero server Deployment and node-agent DaemonSet.
### Testing

No tests required — this is a CI observability configuration change (known-issue suppression list). Validated by verifying the `[aro-hcp-observability] [svc] alert KubePodNotReady does not fire` test no longer fails when backup schedules are active.

### Special notes for your reviewer

- The `for:5m` threshold (reduced from upstream `for:15m` in commit `118d52f5b7`) is the root enabler — with the original 15m, the stale metric would expire before the alert fires.
- This PR does not modify the alert rule itself, only the CI known-issues suppression list.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
