### PR TITLE
test: increase dev e2e identity containers per slot

### DIFF
--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -7,34 +7,35 @@ environments:
     pools:
     # Jobs choose the runtime region; `region` is only the default when no runtime override is provided.
     # Identity containers are provisioned in westus3.
+    # Each managed subscription keeps 300 containers split into five 60-container job slots.
     - subscription_name: "ARO HCP E2E Hosted Clusters (EA Subscription)"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard0-slot
-      slot_count: 6
+      slot_count: 5
       identity_container_prefix: aro-hcp-msi-container-dev-shard0
-      identity_container_count: 50
+      identity_container_count: 60
     - subscription_name: "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard1-slot
-      slot_count: 6
+      slot_count: 5
       identity_container_prefix: aro-hcp-msi-container-dev-shard1
-      identity_container_count: 50
+      identity_container_count: 60
     - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 02"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard2-slot
-      slot_count: 6
+      slot_count: 5
       identity_container_prefix: aro-hcp-msi-container-dev-shard2
-      identity_container_count: 50
+      identity_container_count: 60
     - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 03"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard3-slot
-      slot_count: 6
+      slot_count: 5
       identity_container_prefix: aro-hcp-msi-container-dev-shard3
-      identity_container_count: 50
+      identity_container_count: 60
     - subscription_name: "Hypershift Managed Azure"
       region: westus3
       region_mode: runtime-selected


### PR DESCRIPTION
### What

Increase each internally managed DEV E2E slot from 50 to 60 managed identity containers and reduce each subscription from six slots to five.

The four managed subscriptions retain the same total capacity:

`6 slots x 50 containers = 5 slots x 60 containers = 300 containers`

The externally managed Hypershift pool is unchanged.

### Why

The current 50-container allocation is already saturated. In this `e2e-parallel` run, all 50 unique containers reached both assigned and busy state:

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/6477/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2086800253519925248/artifacts/e2e-parallel/aro-hcp-test-local/artifacts/identities-pool-state.yaml

Without additional per-job headroom, growth in the E2E suite will force specs to wait for a managed identity container to be released, increasing the overall presubmit duration.

No tracking ticket exists yet; this draft is the coordination point for the capacity change.

### Testing

- `make -C test`
- `go test ./cmd/aro-hcp-tests/slot-manager/...`
- `./test/aro-hcp-tests slot-manager validate-boskos-config --release-repo <release-worktree>`

### Special notes for your reviewer

- The companion `openshift/release` PR, https://github.com/openshift/release/pull/83190, must merge and roll out first so Boskos stops assigning slot `05`.
- Identity-pool reconciliation is a manual operational step and is not performed by this PR.
- Reconciliation updates slots `00` through `04` to 60 containers. It intentionally leaves the retired slot-05 ARM stacks unmanaged.
- The four slot-05 ARM stacks and resources require manual cleanup only after the coordinated rollout and DEV E2E validation.
- No specific reviewers are pinged while these PRs remain drafts.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [x] Screenshots included (not applicable: no graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
