### PR TITLE
test: integration tests for unmarshalling errors propagated as http 400

### DIFF
--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/invalid-request-content/00-httpCreate-subscription/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/invalid-request-content/00-httpCreate-subscription/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "2f2d4ba3-1ee6-57b6-bde9-b61d09eaf989",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/invalid-request-content/00-httpCreate-subscription/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/invalid-request-content/00-httpCreate-subscription/subscription.json
@@ -1,0 +1,6 @@
+{
+	"properties": null,
+	"registrationDate": "2025-12-19T19:53:15+00:00",
+	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"state": "Registered"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/invalid-request-content/01-httpCreate-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/invalid-request-content/01-httpCreate-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "9e932a18-59fd-5883-acd0-766e867a5a8d",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/invalid-request-content/01-httpCreate-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/invalid-request-content/01-httpCreate-cluster/cluster.json
@@ -1,0 +1,3 @@
+{
+	"properties": "this-is-not-a-valid-object"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/invalid-request-content/01-httpCreate-cluster/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/invalid-request-content/01-httpCreate-cluster/expected-error.txt
@@ -1,0 +1,4 @@
+{
+    "code": "InvalidRequestContent",
+    "message": "The request content was invalid and could not be deserialized: \"unmarshalling type *generated.HcpOpenShiftCluster: struct field Properties: unmarshalling type *generated.HcpOpenShiftClusterProperties: json: cannot unmarshal string into Go value of type map[string]json.RawMessage\""
+  }

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/00-httpCreate-subscription/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/00-httpCreate-subscription/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "2f2d4ba3-1ee6-57b6-bde9-b61d09eaf989",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/00-httpCreate-subscription/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/00-httpCreate-subscription/subscription.json
@@ -1,0 +1,6 @@
+{
+	"properties": null,
+	"registrationDate": "2025-12-19T19:53:15+00:00",
+	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"state": "Registered"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/01-httpCreate-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/01-httpCreate-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "27da16c2-9239-5799-9838-f9a425ac1756",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/01-httpCreate-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/01-httpCreate-cluster/cluster.json
@@ -1,0 +1,50 @@
+{
+	"identity": {
+		"type": "UserAssigned",
+		"userAssignedIdentities": {}
+	},
+	"name": "update-invalid-request-content",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"clusterImageRegistry": {
+			"state": "Disabled"
+		},
+		"console": {},
+		"dns": {},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "encryptionKeyName",
+							"vaultName": "keyVaultName",
+							"version": "2024-12-01-preview"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-resource-group-name",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/02-setClusterServiceID-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/02-setClusterServiceID-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"_artifactStep": "setClusterServiceID",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/02-setClusterServiceID-cluster/cluster-service-id.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/02-setClusterServiceID-cluster/cluster-service-id.json
@@ -1,0 +1,3 @@
+{
+	"clusterServiceID": "/api/clusters_mgmt/v1/clusters/cs-update-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/03-loadClusterService-cluster/cs-update-to-illegal-value-autoscaler.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/03-loadClusterService-cluster/cs-update-to-illegal-value-autoscaler.json
@@ -1,0 +1,10 @@
+{
+	"href": "/api/clusters_mgmt/v1/clusters/cs-update-invalid-request-content",
+	"kind": "ClusterAutoscaler",
+	"max_node_provision_time": "15m",
+	"max_pod_grace_period": 600,
+	"pod_priority_threshold": -10,
+	"resource_limits": {
+		"max_nodes_total": 0
+	}
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/03-loadClusterService-cluster/cs-update-to-illegal-value-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/03-loadClusterService-cluster/cs-update-to-illegal-value-cluster.json
@@ -1,0 +1,86 @@
+{
+	"api": {
+		"cidr_block_access": {
+			"allow": {
+				"mode": "allow_all"
+			}
+		},
+		"listening": "external"
+	},
+	"azure": {
+		"etcd_encryption": {
+			"data_encryption": {
+				"customer_managed": {
+					"encryption_type": "kms",
+					"kms": {
+						"active_key": {
+							"key_name": "encryptionKeyName",
+							"key_vault_name": "keyVaultName",
+							"key_version": "2024-12-01-preview"
+						}
+					}
+				},
+				"key_management_mode": "customer_managed"
+			}
+		},
+		"managed_resource_group_name": "managed-resource-group-name",
+		"network_security_group_resource_id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+		"nodes_outbound_connectivity": {
+			"outbound_type": "load_balancer"
+		},
+		"operators_authentication": {
+			"managed_identities": {
+				"control_plane_operators_managed_identities": {},
+				"data_plane_operators_managed_identities": {},
+				"managed_identities_data_plane_identity_url": "https://dummyhost.identity.azure.net/otherinformation?aqueryarg=somevalue"
+			}
+		},
+		"resource_group_name": "resourcegroupname",
+		"resource_name": "update-invalid-request-content",
+		"subnet_resource_id": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet",
+		"subscription_id": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+		"tenant_id": "00000000-0000-0000-0000-000000000000"
+	},
+	"ccs": {
+		"enabled": true,
+		"kind": "CCS"
+	},
+	"cloud_provider": {
+		"id": "azure",
+		"kind": "CloudProvider"
+	},
+	"href": "/api/clusters_mgmt/v1/clusters/cs-update-invalid-request-content",
+	"hypershift": {
+		"enabled": true
+	},
+	"id": "cs-update-invalid-request-content",
+	"image_registry": {
+		"state": "disabled"
+	},
+	"kind": "Cluster",
+	"name": "update-invalid-request-content",
+	"network": {
+		"host_prefix": 23,
+		"machine_cidr": "10.0.0.0/16",
+		"pod_cidr": "10.128.0.0/14",
+		"service_cidr": "172.30.0.0/16",
+		"type": "OVNKubernetes"
+	},
+	"node_drain_grace_period": {
+		"unit": "minutes",
+		"value": 0
+	},
+	"product": {
+		"id": "aro",
+		"kind": "Product"
+	},
+	"region": {
+		"id": "fake-location",
+		"kind": "CloudRegion"
+	},
+	"version": {
+		"channel_group": "stable",
+		"id": "",
+		"kind": "Version"
+	}
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/04-completeOperation-op/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/04-completeOperation-op/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "27da16c2-9239-5799-9838-f9a425ac1756",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/05-httpReplace-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/05-httpReplace-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "27da16c2-9239-5799-9838-f9a425ac1756",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/05-httpReplace-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/05-httpReplace-cluster/cluster.json
@@ -1,0 +1,3 @@
+{
+	"properties": "this-is-not-a-valid-object"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/05-httpReplace-cluster/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/update-invalid-request-content/05-httpReplace-cluster/expected-error.txt
@@ -1,0 +1,4 @@
+{
+    "code": "InvalidRequestContent",
+    "message": "The request content was invalid and could not be deserialized: \"unmarshalling type *generated.HcpOpenShiftCluster: struct field Properties: unmarshalling type *generated.HcpOpenShiftClusterProperties: json: cannot unmarshal string into Go value of type map[string]json.RawMessage\""
+  }

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/00-httpCreate-subscription/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/00-httpCreate-subscription/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "2f2d4ba3-1ee6-57b6-bde9-b61d09eaf989",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/00-httpCreate-subscription/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/00-httpCreate-subscription/subscription.json
@@ -1,0 +1,6 @@
+{
+	"properties": null,
+	"registrationDate": "2025-12-19T19:53:15+00:00",
+	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"state": "Registered"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/01-httpCreate-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/01-httpCreate-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "973faa4c-835a-5dc9-a557-7487eebecfc0",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/ea-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/01-httpCreate-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/01-httpCreate-cluster/cluster.json
@@ -1,0 +1,50 @@
+{
+	"identity": {
+		"type": "UserAssigned",
+		"userAssignedIdentities": {}
+	},
+	"name": "ea-invalid-request-content",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"clusterImageRegistry": {
+			"state": "Disabled"
+		},
+		"console": {},
+		"dns": {},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "encryptionKeyName",
+							"vaultName": "keyVaultName",
+							"version": "2024-12-01-preview"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-resource-group-name",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/02-setClusterServiceID-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/02-setClusterServiceID-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"_artifactStep": "setClusterServiceID",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/ea-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/03-completeOperation-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/03-completeOperation-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "973faa4c-835a-5dc9-a557-7487eebecfc0",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/ea-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/04-httpCreate-externalauth/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/04-httpCreate-externalauth/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "88196a39-dac0-59eb-951b-ffcf7e4f388b",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/ea-invalid-request-content/externalAuths/invalid-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/04-httpCreate-externalauth/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/04-httpCreate-externalauth/expected-error.txt
@@ -1,0 +1,4 @@
+{
+    "code": "InvalidRequestContent",
+    "message": "The request content was invalid and could not be deserialized: \"unmarshalling type *generated.ExternalAuth: struct field Properties: unmarshalling type *generated.ExternalAuthProperties: json: cannot unmarshal string into Go value of type map[string]json.RawMessage\""
+  }

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/04-httpCreate-externalauth/externalauth.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-request-content/04-httpCreate-externalauth/externalauth.json
@@ -1,0 +1,3 @@
+{
+	"properties": "this-is-not-a-valid-object"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/00-httpCreate-subscription/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/00-httpCreate-subscription/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "2f2d4ba3-1ee6-57b6-bde9-b61d09eaf989",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/00-httpCreate-subscription/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/00-httpCreate-subscription/subscription.json
@@ -1,0 +1,6 @@
+{
+	"properties": null,
+	"registrationDate": "2025-12-19T19:53:15+00:00",
+	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"state": "Registered"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/01-httpCreate-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/01-httpCreate-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "c9f27832-e504-5883-ab9d-dcce0796309a",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/ea-update-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/01-httpCreate-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/01-httpCreate-cluster/cluster.json
@@ -1,0 +1,50 @@
+{
+	"identity": {
+		"type": "UserAssigned",
+		"userAssignedIdentities": {}
+	},
+	"name": "ea-update-invalid-request-content",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"clusterImageRegistry": {
+			"state": "Disabled"
+		},
+		"console": {},
+		"dns": {},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "encryptionKeyName",
+							"vaultName": "keyVaultName",
+							"version": "2024-12-01-preview"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-resource-group-name",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/02-setClusterServiceID-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/02-setClusterServiceID-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"_artifactStep": "setClusterServiceID",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/ea-update-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/03-completeOperation-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/03-completeOperation-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "c9f27832-e504-5883-ab9d-dcce0796309a",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/ea-update-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/04-httpCreate-externalauth/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/04-httpCreate-externalauth/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "ba97e005-9f1e-5e25-bf8d-17487c011298",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/ea-update-invalid-request-content/externalAuths/default"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/04-httpCreate-externalauth/externalauth.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/04-httpCreate-externalauth/externalauth.json
@@ -1,0 +1,42 @@
+{
+	"name": "default",
+	"properties": {
+		"claim": {
+			"mappings": {
+				"groups": {
+					"claim": "groups"
+				},
+				"username": {
+					"claim": "sub",
+					"prefix": "prefix-",
+					"prefixPolicy": "Prefix"
+				}
+			}
+		},
+		"clients": [
+			{
+				"clientId": "87654321-4321-4321-4321-abcdefghijkl",
+				"component": {
+					"authClientNamespace": "openshift-console",
+					"name": "console"
+				},
+				"type": "Confidential"
+			},
+			{
+				"clientId": "87654321-4321-4321-4321-abcdefghijkl",
+				"component": {
+					"authClientNamespace": "openshift-console",
+					"name": "cli"
+				},
+				"type": "Public"
+			}
+		],
+		"issuer": {
+			"audiences": [
+				"87654321-4321-4321-4321-abcdefghijkl"
+			],
+			"url": "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789abc/v2.0"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/externalAuths"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/05-completeOperation-externalauth/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/05-completeOperation-externalauth/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "ba97e005-9f1e-5e25-bf8d-17487c011298",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/ea-update-invalid-request-content/externalAuths/default"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/06-httpReplace-externalauth/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/06-httpReplace-externalauth/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "ba97e005-9f1e-5e25-bf8d-17487c011298",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/ea-update-invalid-request-content/externalAuths/default"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/06-httpReplace-externalauth/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/06-httpReplace-externalauth/expected-error.txt
@@ -1,0 +1,4 @@
+{
+    "code": "InvalidRequestContent",
+    "message": "The request content was invalid and could not be deserialized: \"unmarshalling type *generated.ExternalAuth: struct field Properties: unmarshalling type *generated.ExternalAuthProperties: json: cannot unmarshal string into Go value of type map[string]json.RawMessage\""
+  }

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/06-httpReplace-externalauth/externalauth.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/update-invalid-request-content/06-httpReplace-externalauth/externalauth.json
@@ -1,0 +1,3 @@
+{
+	"properties": "this-is-not-a-valid-object"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/00-httpCreate-subscription/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/00-httpCreate-subscription/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "2f2d4ba3-1ee6-57b6-bde9-b61d09eaf989",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/00-httpCreate-subscription/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/00-httpCreate-subscription/subscription.json
@@ -1,0 +1,6 @@
+{
+	"properties": null,
+	"registrationDate": "2025-12-19T19:53:15+00:00",
+	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"state": "Registered"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/01-httpCreate-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/01-httpCreate-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "4b7dda09-5efb-5ef7-bcba-cb8a889d11c6",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/np-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/01-httpCreate-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/01-httpCreate-cluster/cluster.json
@@ -1,0 +1,50 @@
+{
+	"identity": {
+		"type": "UserAssigned",
+		"userAssignedIdentities": {}
+	},
+	"name": "np-invalid-request-content",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"clusterImageRegistry": {
+			"state": "Disabled"
+		},
+		"console": {},
+		"dns": {},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "encryptionKeyName",
+							"vaultName": "keyVaultName",
+							"version": "2024-12-01-preview"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-resource-group-name",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/02-setClusterServiceID-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/02-setClusterServiceID-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"_artifactStep": "setClusterServiceID",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/np-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/03-completeOperation-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/03-completeOperation-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "4b7dda09-5efb-5ef7-bcba-cb8a889d11c6",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/np-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/04-httpCreate-nodepool/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/04-httpCreate-nodepool/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "ee5a23e3-e497-507a-9569-2809007cf594",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/np-invalid-request-content/nodePools/invalid-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/04-httpCreate-nodepool/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/04-httpCreate-nodepool/expected-error.txt
@@ -1,0 +1,4 @@
+{
+    "code": "InvalidRequestContent",
+    "message": "The request content was invalid and could not be deserialized: \"unmarshalling type *generated.NodePool: struct field Properties: unmarshalling type *generated.NodePoolProperties: json: cannot unmarshal string into Go value of type map[string]json.RawMessage\""
+  }

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/04-httpCreate-nodepool/nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-request-content/04-httpCreate-nodepool/nodepool.json
@@ -1,0 +1,3 @@
+{
+	"properties": "this-is-not-a-valid-object"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/00-httpCreate-subscription/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/00-httpCreate-subscription/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "2f2d4ba3-1ee6-57b6-bde9-b61d09eaf989",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/00-httpCreate-subscription/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/00-httpCreate-subscription/subscription.json
@@ -1,0 +1,6 @@
+{
+	"properties": null,
+	"registrationDate": "2025-12-19T19:53:15+00:00",
+	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"state": "Registered"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/01-httpCreate-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/01-httpCreate-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "623843c7-09e4-59bf-8508-fa9495e02500",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-np-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/01-httpCreate-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/01-httpCreate-cluster/cluster.json
@@ -1,0 +1,57 @@
+{
+	"identity": {
+		"type": "UserAssigned",
+		"userAssignedIdentities": {
+			"/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/different-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service-managed-identity": {}
+		}
+	},
+	"name": "update-np-invalid-request-content",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"clusterImageRegistry": {
+			"state": "Disabled"
+		},
+		"console": {},
+		"dns": {},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "encryptionKeyName",
+							"vaultName": "keyVaultName",
+							"version": "2024-12-01-preview"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-resource-group-name",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/some-resource-group/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"operatorsAuthentication": {
+				"userAssignedIdentities": {
+					"serviceManagedIdentity": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/different-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/service-managed-identity"
+				}
+			},
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/different-resource-group/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/02-setClusterServiceID-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/02-setClusterServiceID-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"_artifactStep": "setClusterServiceID",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-np-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/03-completeOperation-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/03-completeOperation-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "623843c7-09e4-59bf-8508-fa9495e02500",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-np-invalid-request-content"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/04-loadCosmos-serviceProviderCluster/serviceProviderCluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/04-loadCosmos-serviceProviderCluster/serviceProviderCluster.json
@@ -1,0 +1,24 @@
+{
+	"_etag": "\"b9a13664-eb2f-4fcf-8bde-3278a537ce7c\"",
+	"id": "9c06dc25-77b8-55c5-a7f9-129b199948b2",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-np-invalid-request-content/serviceProviderClusters/default",
+		"spec": {
+			"control_plane_version": {
+				"desired_version": "4.20.8"
+			}
+		},
+		"status": {
+			"control_plane_version": {
+				"active_versions": [
+					{
+						"version": "4.20.8"
+					}
+				]
+			}
+		}
+	},
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-np-invalid-request-content/serviceProviderClusters/default",
+	"resourceType": "microsoft.redhatopenshift/hcpopenshiftclusters/serviceproviderclusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/05-httpCreate-nodepool/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/05-httpCreate-nodepool/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "ea0ea2de-623e-5f5b-be17-80a1fddd6cb6",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-np-invalid-request-content/nodePools/invalid-np"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/05-httpCreate-nodepool/nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/05-httpCreate-nodepool/nodepool.json
@@ -1,0 +1,18 @@
+{
+	"name": "invalid-np",
+	"properties": {
+		"autoRepair": true,
+		"platform": {
+			"osDisk": {
+				"diskStorageAccountType": "Premium_LRS",
+				"sizeGiB": 64
+			},
+			"vmSize": "Standard_D8s_v3"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20.8"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/06-completeOperation-nodepool/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/06-completeOperation-nodepool/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "ea0ea2de-623e-5f5b-be17-80a1fddd6cb6",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-np-invalid-request-content/nodePools/invalid-np"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/07-loadCosmos-serviceProviderNodePool/serviceProviderNodePool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/07-loadCosmos-serviceProviderNodePool/serviceProviderNodePool.json
@@ -1,0 +1,24 @@
+{
+	"_etag": "\"8469f141-1d20-4fc1-b576-80763f10e4fb\"",
+	"id": "a363e15e-0d3c-50dc-8e16-1e8a66045871",
+	"partitionKey": "6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"properties": {
+		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-np-invalid-request-content/nodePools/invalid-np/serviceProviderNodePools/default",
+		"spec": {
+			"nodePoolVersion": {
+				"desiredVersion": "4.20.8"
+			}
+		},
+		"status": {
+			"nodePoolVersion": {
+				"activeVersions": [
+					{
+						"version": "4.20.8"
+					}
+				]
+			}
+		}
+	},
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-np-invalid-request-content/nodePools/invalid-np/serviceProviderNodePools/default",
+	"resourceType": "microsoft.redhatopenshift/hcpopenshiftclusters/nodepools/serviceprovidernodepools"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/08-httpReplace-nodepool/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/08-httpReplace-nodepool/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "ea0ea2de-623e-5f5b-be17-80a1fddd6cb6",
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/update-np-invalid-request-content/nodePools/invalid-np"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/08-httpReplace-nodepool/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/08-httpReplace-nodepool/expected-error.txt
@@ -1,0 +1,4 @@
+{
+    "code": "InvalidRequestContent",
+    "message": "The request content was invalid and could not be deserialized: \"unmarshalling type *generated.NodePool: struct field Properties: unmarshalling type *generated.NodePoolProperties: json: cannot unmarshal string into Go value of type map[string]json.RawMessage\""
+  }

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/08-httpReplace-nodepool/nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/update-invalid-request-content/08-httpReplace-nodepool/nodepool.json
@@ -1,0 +1,3 @@
+{
+	"properties": "this-is-not-a-valid-object"
+}


### PR DESCRIPTION
<!-- Link to Jira issue -->

https://redhat.atlassian.net/browse/ARO-28842

### What

<!-- Briefly describe what this PR does -->

This pull request changes the frontend behavior in situations when a PUT request payload contains invalid properties. Before, the frontend would catch an error during json unmarshalling and return http/500. With this fix in place, we're returning http/400.

EDIT: With https://github.com/Azure/ARO-HCP/pull/6498 being merged, this PR still adds the integration tests for the described scenario.

### Why

http/400 is more appropriate in these situations.

<!-- Briefly explain why this change is needed -->

### Testing

The PR contains integration tests for the described problem.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
