### PR TITLE
test: log full ARM response when delayed role assignment test hits Failed

### DIFF
--- a/test/e2e/cluster_delayed_role_assignments.go
+++ b/test/e2e/cluster_delayed_role_assignments.go
@@ -16,7 +16,9 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -160,6 +162,11 @@ var _ = Describe("ARO HCP Service", func() {
 					GinkgoLogr.Info("cluster provisioning state", "state", state)
 					lastConsistentlyState = state
 				}
+				if state == hcpsdk20251223preview.ProvisioningStateFailed {
+					body, _ := json.MarshalIndent(resp.HcpOpenShiftCluster, "", "  ")
+					GinkgoLogr.Info("cluster entered Failed during Consistently check — dumping full ARM response for root cause analysis (ARO-28755)",
+						"responseBody", string(body))
+				}
 				g.Expect(state).NotTo(Equal(hcpsdk20251223preview.ProvisioningStateFailed),
 					"cluster entered terminal Failed state — CS inflight validation should retry, not fail terminally (ARO-25805)")
 			}, consistentlyLoopDuration, 30*time.Second).Should(Succeed())
@@ -213,8 +220,13 @@ var _ = Describe("ARO HCP Service", func() {
 					GinkgoLogr.Info("cluster provisioning state", "state", state)
 					lastEventuallyState = state
 				}
+				if state == hcpsdk20251223preview.ProvisioningStateFailed {
+					body, _ := json.MarshalIndent(resp.HcpOpenShiftCluster, "", "  ")
+					GinkgoLogr.Info("cluster entered Failed after role assignment deployment — dumping full ARM response for root cause analysis (ARO-28755)",
+						"responseBody", string(body))
+				}
 				g.Expect(state).NotTo(Equal(hcpsdk20251223preview.ProvisioningStateFailed),
-					"cluster entered terminal Failed state after role assignment deployment")
+					"cluster entered terminal Failed state after role assignment deployment — see preceding log for full ARM response (ARO-28755)")
 				g.Expect(state).To(Equal(hcpsdk20251223preview.ProvisioningStateSucceeded),
 					"cluster has not yet reached Succeeded state")
 			}, clusterCreationTimeout-consistentlyLoopDuration, 30*time.Second).Should(Succeed(),

--- a/test/e2e/cluster_delayed_role_assignments.go
+++ b/test/e2e/cluster_delayed_role_assignments.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -163,9 +162,12 @@ var _ = Describe("ARO HCP Service", func() {
 					lastConsistentlyState = state
 				}
 				if state == hcpsdk20251223preview.ProvisioningStateFailed {
-					body, _ := json.MarshalIndent(resp.HcpOpenShiftCluster, "", "  ")
-					GinkgoLogr.Info("cluster entered Failed during Consistently check — dumping full ARM response for root cause analysis (ARO-28755)",
-						"responseBody", string(body))
+					if body, err := json.MarshalIndent(resp.HcpOpenShiftCluster, "", "  "); err != nil {
+						GinkgoLogr.Error(err, "failed to marshal ARM response for diagnostics (ARO-28755)")
+					} else {
+						GinkgoLogr.Info("cluster entered Failed during Consistently check — dumping full ARM response for root cause analysis (ARO-28755)",
+							"responseBody", string(body))
+					}
 				}
 				g.Expect(state).NotTo(Equal(hcpsdk20251223preview.ProvisioningStateFailed),
 					"cluster entered terminal Failed state — CS inflight validation should retry, not fail terminally (ARO-25805)")
@@ -221,9 +223,12 @@ var _ = Describe("ARO HCP Service", func() {
 					lastEventuallyState = state
 				}
 				if state == hcpsdk20251223preview.ProvisioningStateFailed {
-					body, _ := json.MarshalIndent(resp.HcpOpenShiftCluster, "", "  ")
-					GinkgoLogr.Info("cluster entered Failed after role assignment deployment — dumping full ARM response for root cause analysis (ARO-28755)",
-						"responseBody", string(body))
+					if body, err := json.MarshalIndent(resp.HcpOpenShiftCluster, "", "  "); err != nil {
+						GinkgoLogr.Error(err, "failed to marshal ARM response for diagnostics (ARO-28755)")
+					} else {
+						GinkgoLogr.Info("cluster entered Failed after role assignment deployment — dumping full ARM response for root cause analysis (ARO-28755)",
+							"responseBody", string(body))
+					}
 				}
 				g.Expect(state).NotTo(Equal(hcpsdk20251223preview.ProvisioningStateFailed),
 					"cluster entered terminal Failed state after role assignment deployment — see preceding log for full ARM response (ARO-28755)")


### PR DESCRIPTION
## Summary

- When the delayed role assignment E2E test detects `ProvisioningState = Failed`, it now dumps the full ARM GET response as JSON before the assertion fails
- Added to both the Consistently check (no-role-assignments window) and the Eventually check (after role assignments deployed)

## Context

[ARO-28755](https://redhat.atlassian.net/browse/ARO-28755) reports that the delayed role assignment E2E test fails ~7% of the time when the cluster enters terminal `Failed` state. A fix was proposed in #6463 (on hold) that treats OCM4001 (inflight check failure) as non-terminal during CREATE operations. However, PR feedback correctly identified that we lack direct evidence that OCM4001 is the root cause.

Our root cause analysis was based on code path analysis — we traced the `ConvertClusterStatus` function and confirmed it maps all `ClusterStateError` to terminal `Failed` — but we never found the actual error code in any failed CI run. The test only checks `provisioningState` and doesn't log the error details, and the `azure.log` CI artifact only captures HTTP headers, not response bodies.

This PR adds instrumentation so the next failure occurrence will capture the full ARM response body, providing the evidence needed to confirm or refute the OCM4001 hypothesis before proceeding with the fix in #6463.

## Test plan

- [x] Compiles with `-tags E2Etests`
- [x] Lint passes (no new issues in changed file)
- [ ] Next test failure in CI will include the full ARM response in logs

Related: [ARO-28755](https://redhat.atlassian.net/browse/ARO-28755), #6463

🤖 Generated with [Claude Code](https://claude.com/claude-code)