### PR TITLE
feat: discover role assignment quota from Azure

### DIFF
--- a/docs/ci/e2e-subscription-onboarding.md
+++ b/docs/ci/e2e-subscription-onboarding.md
@@ -84,7 +84,7 @@ az provider show --namespace Microsoft.Compute \
      - Public IP Addresses: `3000`
      - Role Assignments: `8000`
    - `Microsoft.Compute` and `Microsoft.Network` must already report `Registered` (see Prerequisites) before the DSv3 and public-IP requests can be filed.
-   - Quota approvals are asynchronous and routed through Microsoft support, so file them early — they gate identity-container provisioning (step 5) and the Role Assignment limit asserted by the monitoring entry (step 6).
+   - Quota approvals are asynchronous and routed through Microsoft support, so file them early — they gate identity-container provisioning (step 5) and determine the Role Assignment limit reported by monitoring (step 6).
 
 3. Sync the ARO-HCP-managed Boskos inventory in `openshift/release`.
    - Run:
@@ -110,7 +110,7 @@ az provider show --namespace Microsoft.Compute \
 6. Extend the DEV bootstrap RBAC and quota-monitoring inventory.
    - Add the subscription name and ID to `config/config-dev-ci.yaml` under `ci.dev.e2eSubscriptions`.
    - That list now feeds the `dev-ci` RBAC parameter templates directly, so a brand-new subscription does not require extra per-index template edits.
-   - In the same `config/config-dev-ci.yaml`, also add the subscription to the `opstool.tenantQuota` tenant's `subscriptions` list so the `tenant-quota-collector` tracks it. Set `roleAssignmentLimit: 8000` and list the same `regions` the pool runs in, matching the Role Assignment quota requested in step 2.
+   - In the same `config/config-dev-ci.yaml`, also add the subscription to the `opstool.tenantQuota` tenant's `subscriptions` list so the `tenant-quota-collector` tracks it. List the same `regions` the pool runs in; the collector retrieves the Role Assignment quota limit directly from Azure.
    - In a normal onboarding flow, `homeSubscription`, `sharedPrincipals`, and `msiMockPool.principals` should not need to change.
    - Apply the **privileged** customer-subscription grants (custom roles + shared-principal role assignments on the new subscription). This requires **Owner** on the target subscription, so it is **not** run by the `dev-ci` postsubmit — ask an OWNERS-group member to run it from the repo root:
      - `make dev-ci-privileged-local-run`

--- a/tooling/tenant-quota/README.md
+++ b/tooling/tenant-quota/README.md
@@ -46,6 +46,7 @@ The source of truth for deployed configuration is [`config/config-dev-ci.yaml`](
 Do not update tenant definitions in `deploy/values.yaml`. That file contains static chart defaults.
 
 Subscription IDs are resolved at runtime from configured subscription display names rather than stored in the config.
+Role assignment usage and limits are retrieved directly from Azure rather than configured per subscription.
 
 ## Secrets and Credential Reload
 

--- a/tooling/tenant-quota/go.mod
+++ b/tooling/tenant-quota/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/Azure/ARO-HCP/tooling/metricscache v0.0.0-00010101000000-000000000000
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
-	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6 v6.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6 v6.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0

--- a/tooling/tenant-quota/go.sum
+++ b/tooling/tenant-quota/go.sum
@@ -9,8 +9,6 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0 h1:xFaZZ+IubdftrDH
 github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache v0.4.0/go.mod h1:mCBhUhlMjLLJKr5aqw2TNS/VqJOie8MzWq3DAMJeKso=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0 h1:Hp+EScFOu9HeCbeW8WU2yQPJd4gGwhMgKxWe+G6jNzw=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2 v2.2.0/go.mod h1:/pz8dyNQe+Ey3yBp/XuYz7oqX8YDNWVpPB0hH3XWfbc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6 v6.3.0 h1:Dc9miZr1Mhaqbb3cmJCRokkG16uk8JKkqOADf084zy4=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6 v6.3.0/go.mod h1:CHo9QYhWEvrKVeXsEMJSl2bpmYYNu6aG12JsSaFBXlY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=

--- a/tooling/tenant-quota/pkg/config/config.go
+++ b/tooling/tenant-quota/pkg/config/config.go
@@ -27,13 +27,12 @@ import (
 )
 
 const (
-	DefaultTimeout             = 30 * time.Second
-	DefaultInterval            = 15 * time.Minute
-	DefaultCacheTTL            = 24 * time.Hour
-	DefaultRoleAssignmentLimit = 4000
-	DefaultScope               = "https://graph.microsoft.com/.default"
-	DefaultProwInterval        = 5 * time.Minute
-	DefaultProwRetention       = 24 * time.Hour
+	DefaultTimeout       = 30 * time.Second
+	DefaultInterval      = 15 * time.Minute
+	DefaultCacheTTL      = 24 * time.Hour
+	DefaultScope         = "https://graph.microsoft.com/.default"
+	DefaultProwInterval  = 5 * time.Minute
+	DefaultProwRetention = 24 * time.Hour
 )
 
 type Config struct {
@@ -76,9 +75,8 @@ type TenantConfig struct {
 }
 
 type SubscriptionConfig struct {
-	Name                string   `yaml:"name"`
-	RoleAssignmentLimit int      `yaml:"roleAssignmentLimit,omitempty"`
-	Regions             []string `yaml:"regions"`
+	Name    string   `yaml:"name"`
+	Regions []string `yaml:"regions"`
 
 	// SubscriptionID is resolved at runtime from the Name field using the
 	// Azure subscriptions API. Not parsed from config YAML.
@@ -251,11 +249,4 @@ func (t *TenantConfig) IsDirectoryQuotaEnabled() bool {
 		return true
 	}
 	return *t.DirectoryQuota
-}
-
-func (s *SubscriptionConfig) GetRoleAssignmentLimit() int {
-	if s.RoleAssignmentLimit > 0 {
-		return s.RoleAssignmentLimit
-	}
-	return DefaultRoleAssignmentLimit
 }

--- a/tooling/tenant-quota/pkg/config/config_test.go
+++ b/tooling/tenant-quota/pkg/config/config_test.go
@@ -420,6 +420,32 @@ tenants:
 			},
 		},
 		{
+			name: "ignores legacy role assignment limit",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return writeYAML(t, `
+tenants:
+  - tenantId: "tid-1"
+    servicePrincipalClientId: "sp-id"
+    keyVaultSecretName: "kv-secret"
+    subscriptions:
+      - name: "prod"
+        roleAssignmentLimit: 8000
+        regions:
+          - eastus
+`)
+			},
+			assertions: func(t *testing.T, cfg *Config, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if len(cfg.Tenants[0].Subscriptions) != 1 {
+					t.Fatalf("subscriptions: got %d, want 1", len(cfg.Tenants[0].Subscriptions))
+				}
+			},
+		},
+		{
 			name: "invalid yaml",
 			setup: func(t *testing.T) string {
 				t.Helper()
@@ -582,40 +608,6 @@ func TestTenantConfigIsDirectoryQuotaEnabled(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := tc.tenant.IsDirectoryQuotaEnabled(); got != tc.want {
 				t.Fatalf("IsDirectoryQuotaEnabled() = %v, want %v", got, tc.want)
-			}
-		})
-	}
-}
-
-func TestSubscriptionConfigGetRoleAssignmentLimit(t *testing.T) {
-	type testCase struct {
-		name         string
-		subscription SubscriptionConfig
-		want         int
-	}
-
-	testCases := []testCase{
-		{
-			name:         "custom limit",
-			subscription: SubscriptionConfig{RoleAssignmentLimit: 1000},
-			want:         1000,
-		},
-		{
-			name:         "zero falls back to default",
-			subscription: SubscriptionConfig{},
-			want:         DefaultRoleAssignmentLimit,
-		},
-		{
-			name:         "negative falls back to default",
-			subscription: SubscriptionConfig{RoleAssignmentLimit: -1},
-			want:         DefaultRoleAssignmentLimit,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.subscription.GetRoleAssignmentLimit(); got != tc.want {
-				t.Fatalf("GetRoleAssignmentLimit() = %d, want %d", got, tc.want)
 			}
 		})
 	}

--- a/tooling/tenant-quota/pkg/subscriptionquota/collector.go
+++ b/tooling/tenant-quota/pkg/subscriptionquota/collector.go
@@ -64,7 +64,7 @@ func NewCollector(cfg *config.Config, logger *slog.Logger,
 
 	if len(sources) == 0 {
 		sources = []QuotaSource{
-			NewRoleAssignmentSource(cfg.Tenants),
+			NewRoleAssignmentSource(),
 			&ComputeQuotaSource{},
 			&NetworkQuotaSource{},
 		}

--- a/tooling/tenant-quota/pkg/subscriptionquota/roleassignmentmetrics.go
+++ b/tooling/tenant-quota/pkg/subscriptionquota/roleassignmentmetrics.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package subscriptionquota
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+const roleAssignmentMetricsAPIVersion = "2019-08-01-preview"
+
+type roleAssignmentMetrics struct {
+	currentCount int64
+	limit        int64
+}
+
+type roleAssignmentMetricsResponse struct {
+	RoleAssignmentsCurrentCount *int64 `json:"roleAssignmentsCurrentCount"`
+	RoleAssignmentsLimit        *int64 `json:"roleAssignmentsLimit"`
+}
+
+type roleAssignmentMetricsClient struct {
+	internal       *azcorearm.Client
+	subscriptionID string
+}
+
+func newRoleAssignmentMetricsClient(subscriptionID string, credential azcore.TokenCredential,
+	options *azcorearm.ClientOptions) (*roleAssignmentMetricsClient, error) {
+
+	client, err := azcorearm.NewClient("tenant-quota", "v1.0.0", credential, options)
+	if err != nil {
+		return nil, fmt.Errorf("create ARM client: %w", err)
+	}
+
+	return &roleAssignmentMetricsClient{
+		internal:       client,
+		subscriptionID: subscriptionID,
+	}, nil
+}
+
+func (c *roleAssignmentMetricsClient) Get(ctx context.Context) (roleAssignmentMetrics, error) {
+	path := fmt.Sprintf(
+		"/subscriptions/%s/providers/Microsoft.Authorization/roleAssignmentsUsageMetrics",
+		c.subscriptionID,
+	)
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(c.internal.Endpoint(), path))
+	if err != nil {
+		return roleAssignmentMetrics{}, fmt.Errorf("create role assignment metrics request: %w", err)
+	}
+
+	query := req.Raw().URL.Query()
+	query.Set("api-version", roleAssignmentMetricsAPIVersion)
+	req.Raw().URL.RawQuery = query.Encode()
+	req.Raw().Header.Set("Accept", "application/json")
+
+	resp, err := c.internal.Pipeline().Do(req)
+	if err != nil {
+		return roleAssignmentMetrics{}, fmt.Errorf("get role assignment metrics: %w", err)
+	}
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+		return roleAssignmentMetrics{}, runtime.NewResponseError(resp)
+	}
+
+	var result roleAssignmentMetricsResponse
+	if err := runtime.UnmarshalAsJSON(resp, &result); err != nil {
+		return roleAssignmentMetrics{}, fmt.Errorf("decode role assignment metrics: %w", err)
+	}
+	if result.RoleAssignmentsCurrentCount == nil {
+		return roleAssignmentMetrics{}, fmt.Errorf("role assignment metrics response is missing roleAssignmentsCurrentCount")
+	}
+	if *result.RoleAssignmentsCurrentCount < 0 {
+		return roleAssignmentMetrics{}, fmt.Errorf(
+			"role assignment metrics response has negative roleAssignmentsCurrentCount %d",
+			*result.RoleAssignmentsCurrentCount,
+		)
+	}
+	if result.RoleAssignmentsLimit == nil {
+		return roleAssignmentMetrics{}, fmt.Errorf("role assignment metrics response is missing roleAssignmentsLimit")
+	}
+	if *result.RoleAssignmentsLimit <= 0 {
+		return roleAssignmentMetrics{}, fmt.Errorf(
+			"role assignment metrics response has non-positive roleAssignmentsLimit %d",
+			*result.RoleAssignmentsLimit,
+		)
+	}
+
+	return roleAssignmentMetrics{
+		currentCount: *result.RoleAssignmentsCurrentCount,
+		limit:        *result.RoleAssignmentsLimit,
+	}, nil
+}

--- a/tooling/tenant-quota/pkg/subscriptionquota/roleassignmentmetrics.go
+++ b/tooling/tenant-quota/pkg/subscriptionquota/roleassignmentmetrics.go
@@ -74,6 +74,8 @@ func (c *roleAssignmentMetricsClient) Get(ctx context.Context) (roleAssignmentMe
 	if err != nil {
 		return roleAssignmentMetrics{}, fmt.Errorf("get role assignment metrics: %w", err)
 	}
+	defer resp.Body.Close()
+
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
 		return roleAssignmentMetrics{}, runtime.NewResponseError(resp)
 	}

--- a/tooling/tenant-quota/pkg/subscriptionquota/roleassignmentmetrics_test.go
+++ b/tooling/tenant-quota/pkg/subscriptionquota/roleassignmentmetrics_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package subscriptionquota
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+type roleAssignmentMetricsTestCredential struct{}
+
+func (roleAssignmentMetricsTestCredential) GetToken(
+	context.Context,
+	policy.TokenRequestOptions,
+) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "token", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+type roleAssignmentMetricsTestTransport struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+func (t *roleAssignmentMetricsTestTransport) Do(req *http.Request) (*http.Response, error) {
+	return t.do(req)
+}
+
+func TestRoleAssignmentMetricsClientGet(t *testing.T) {
+	transport := &roleAssignmentMetricsTestTransport{
+		do: func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodGet {
+				t.Fatalf("request method = %q, want GET", req.Method)
+			}
+			wantPath := "/subscriptions/subscription-id/providers/Microsoft.Authorization/roleAssignmentsUsageMetrics"
+			if req.URL.Path != wantPath {
+				t.Fatalf("request path = %q, want %q", req.URL.Path, wantPath)
+			}
+			if got := req.URL.Query().Get("api-version"); got != roleAssignmentMetricsAPIVersion {
+				t.Fatalf("api-version = %q, want %q", got, roleAssignmentMetricsAPIVersion)
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(
+					`{"roleAssignmentsCurrentCount":123,"roleAssignmentsLimit":8000,"roleAssignmentsRemainingCount":7877}`,
+				)),
+				Request: req,
+			}, nil
+		},
+	}
+	client, err := newRoleAssignmentMetricsClient(
+		"subscription-id",
+		roleAssignmentMetricsTestCredential{},
+		&azcorearm.ClientOptions{ClientOptions: azcore.ClientOptions{
+			Transport: transport,
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		}},
+	)
+	if err != nil {
+		t.Fatalf("newRoleAssignmentMetricsClient() error = %v", err)
+	}
+
+	got, err := client.Get(context.Background())
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.currentCount != 123 {
+		t.Fatalf("currentCount = %d, want 123", got.currentCount)
+	}
+	if got.limit != 8000 {
+		t.Fatalf("limit = %d, want 8000", got.limit)
+	}
+}
+
+func TestRoleAssignmentMetricsClientGetErrors(t *testing.T) {
+	testCases := []struct {
+		name       string
+		statusCode int
+		body       string
+		transport  error
+		wantErrSub string
+	}{
+		{
+			name:       "transport error",
+			transport:  fmt.Errorf("connection failed"),
+			wantErrSub: "get role assignment metrics: connection failed",
+		},
+		{
+			name:       "http error",
+			statusCode: http.StatusForbidden,
+			body:       `{"error":{"code":"AuthorizationFailed","message":"forbidden"}}`,
+			wantErrSub: "AuthorizationFailed",
+		},
+		{
+			name:       "invalid json",
+			statusCode: http.StatusOK,
+			body:       `{`,
+			wantErrSub: "decode role assignment metrics",
+		},
+		{
+			name:       "missing current count",
+			statusCode: http.StatusOK,
+			body:       `{"roleAssignmentsLimit":8000}`,
+			wantErrSub: "missing roleAssignmentsCurrentCount",
+		},
+		{
+			name:       "negative current count",
+			statusCode: http.StatusOK,
+			body:       `{"roleAssignmentsCurrentCount":-1,"roleAssignmentsLimit":8000}`,
+			wantErrSub: "negative roleAssignmentsCurrentCount",
+		},
+		{
+			name:       "missing limit",
+			statusCode: http.StatusOK,
+			body:       `{"roleAssignmentsCurrentCount":123}`,
+			wantErrSub: "missing roleAssignmentsLimit",
+		},
+		{
+			name:       "zero limit",
+			statusCode: http.StatusOK,
+			body:       `{"roleAssignmentsCurrentCount":123,"roleAssignmentsLimit":0}`,
+			wantErrSub: "non-positive roleAssignmentsLimit",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			transport := &roleAssignmentMetricsTestTransport{
+				do: func(req *http.Request) (*http.Response, error) {
+					if tc.transport != nil {
+						return nil, tc.transport
+					}
+					return &http.Response{
+						StatusCode: tc.statusCode,
+						Header:     http.Header{"Content-Type": []string{"application/json"}},
+						Body:       io.NopCloser(strings.NewReader(tc.body)),
+						Request:    req,
+					}, nil
+				},
+			}
+			client, err := newRoleAssignmentMetricsClient(
+				"subscription-id",
+				roleAssignmentMetricsTestCredential{},
+				&azcorearm.ClientOptions{ClientOptions: azcore.ClientOptions{
+					Transport: transport,
+					Retry:     policy.RetryOptions{MaxRetries: -1},
+				}},
+			)
+			if err != nil {
+				t.Fatalf("newRoleAssignmentMetricsClient() error = %v", err)
+			}
+
+			_, err = client.Get(context.Background())
+			if err == nil {
+				t.Fatal("Get() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSub) {
+				t.Fatalf("Get() error = %q, want substring %q", err, tc.wantErrSub)
+			}
+		})
+	}
+}

--- a/tooling/tenant-quota/pkg/subscriptionquota/roleassignmentmetrics_test.go
+++ b/tooling/tenant-quota/pkg/subscriptionquota/roleassignmentmetrics_test.go
@@ -45,7 +45,20 @@ func (t *roleAssignmentMetricsTestTransport) Do(req *http.Request) (*http.Respon
 	return t.do(req)
 }
 
+type trackingReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (r *trackingReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
 func TestRoleAssignmentMetricsClientGet(t *testing.T) {
+	body := &trackingReadCloser{Reader: strings.NewReader(
+		`{"roleAssignmentsCurrentCount":123,"roleAssignmentsLimit":8000,"roleAssignmentsRemainingCount":7877}`,
+	)}
 	transport := &roleAssignmentMetricsTestTransport{
 		do: func(req *http.Request) (*http.Response, error) {
 			if req.Method != http.MethodGet {
@@ -62,10 +75,8 @@ func TestRoleAssignmentMetricsClientGet(t *testing.T) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Header:     http.Header{"Content-Type": []string{"application/json"}},
-				Body: io.NopCloser(strings.NewReader(
-					`{"roleAssignmentsCurrentCount":123,"roleAssignmentsLimit":8000,"roleAssignmentsRemainingCount":7877}`,
-				)),
-				Request: req,
+				Body:       body,
+				Request:    req,
 			}, nil
 		},
 	}
@@ -90,6 +101,9 @@ func TestRoleAssignmentMetricsClientGet(t *testing.T) {
 	}
 	if got.limit != 8000 {
 		t.Fatalf("limit = %d, want 8000", got.limit)
+	}
+	if !body.closed {
+		t.Fatal("response body was not closed")
 	}
 }
 
@@ -146,15 +160,17 @@ func TestRoleAssignmentMetricsClientGetErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			var body *trackingReadCloser
 			transport := &roleAssignmentMetricsTestTransport{
 				do: func(req *http.Request) (*http.Response, error) {
 					if tc.transport != nil {
 						return nil, tc.transport
 					}
+					body = &trackingReadCloser{Reader: strings.NewReader(tc.body)}
 					return &http.Response{
 						StatusCode: tc.statusCode,
 						Header:     http.Header{"Content-Type": []string{"application/json"}},
-						Body:       io.NopCloser(strings.NewReader(tc.body)),
+						Body:       body,
 						Request:    req,
 					}, nil
 				},
@@ -176,7 +192,10 @@ func TestRoleAssignmentMetricsClientGetErrors(t *testing.T) {
 				t.Fatal("Get() error = nil, want error")
 			}
 			if !strings.Contains(err.Error(), tc.wantErrSub) {
-				t.Fatalf("Get() error = %q, want substring %q", err, tc.wantErrSub)
+				t.Fatalf("Get() error = %v, want substring %q", err, tc.wantErrSub)
+			}
+			if tc.transport == nil && !body.closed {
+				t.Fatal("response body was not closed")
 			}
 		})
 	}

--- a/tooling/tenant-quota/pkg/subscriptionquota/roleassignments.go
+++ b/tooling/tenant-quota/pkg/subscriptionquota/roleassignments.go
@@ -18,29 +18,31 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
-
-	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/config"
 )
 
-// RoleAssignmentSource counts role assignments per subscription using the ARM
-// Authorization API. This matches the count from `az role assignment list --all`
-// and reflects the actual number that counts against the subscription limit.
-// The limit itself is not discoverable from Azure and must be provided via
-// configuration.
-type RoleAssignmentSource struct {
-	limits map[string]int // subscriptionID -> configured limit
+type roleAssignmentMetricsGetter interface {
+	Get(ctx context.Context) (roleAssignmentMetrics, error)
 }
 
-func NewRoleAssignmentSource(tenants []config.TenantConfig) *RoleAssignmentSource {
-	limits := make(map[string]int)
-	for _, t := range tenants {
-		for _, s := range t.Subscriptions {
-			limits[s.SubscriptionID] = s.GetRoleAssignmentLimit()
-		}
+type roleAssignmentMetricsClientFactory func(
+	subscriptionID string,
+	credential azcore.TokenCredential,
+) (roleAssignmentMetricsGetter, error)
+
+// RoleAssignmentSource retrieves role assignment usage and limits per
+// subscription from the ARM Authorization API.
+type RoleAssignmentSource struct {
+	newClient roleAssignmentMetricsClientFactory
+}
+
+func NewRoleAssignmentSource() *RoleAssignmentSource {
+	return &RoleAssignmentSource{
+		newClient: func(subscriptionID string, credential azcore.TokenCredential) (roleAssignmentMetricsGetter, error) {
+			return newRoleAssignmentMetricsClient(subscriptionID, credential, nil)
+		},
 	}
-	return &RoleAssignmentSource{limits: limits}
 }
 
 func (s *RoleAssignmentSource) Name() string     { return "rbac" }
@@ -49,27 +51,21 @@ func (s *RoleAssignmentSource) IsRegional() bool { return false }
 func (s *RoleAssignmentSource) Collect(ctx context.Context, cred *azidentity.ClientSecretCredential,
 	subscriptionID string, _ string) ([]QuotaResult, []error) {
 
-	client, err := armauthorization.NewRoleAssignmentsClient(subscriptionID, cred, nil)
+	client, err := s.newClient(subscriptionID, cred)
 	if err != nil {
-		return nil, []error{fmt.Errorf("create role assignments client: %w", err)}
+		return nil, []error{fmt.Errorf("create role assignment metrics client: %w", err)}
 	}
 
-	var count int64
-	pager := client.NewListForSubscriptionPager(nil)
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		if err != nil {
-			return nil, []error{fmt.Errorf("list role assignments: %w", err)}
-		}
-		count += int64(len(page.Value))
+	metrics, err := client.Get(ctx)
+	if err != nil {
+		return nil, []error{fmt.Errorf("get role assignment metrics: %w", err)}
 	}
 
-	limit := s.limits[subscriptionID]
 	return []QuotaResult{{
 		QuotaName:      "roleAssignments",
 		LocalizedName:  "Role Assignments",
-		CurrentValue:   float64(count),
-		Limit:          float64(limit),
+		CurrentValue:   float64(metrics.currentCount),
+		Limit:          float64(metrics.limit),
 		SubscriptionID: subscriptionID,
 		Region:         "",
 	}}, nil

--- a/tooling/tenant-quota/pkg/subscriptionquota/roleassignments_test.go
+++ b/tooling/tenant-quota/pkg/subscriptionquota/roleassignments_test.go
@@ -15,69 +15,109 @@
 package subscriptionquota
 
 import (
-	"reflect"
+	"context"
+	"fmt"
+	"strings"
 	"testing"
 
-	"github.com/Azure/ARO-HCP/tooling/tenant-quota/pkg/config"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
-func TestNewRoleAssignmentSource(t *testing.T) {
-	type testCase struct {
-		name    string
-		tenants []config.TenantConfig
-		want    map[string]int
+type fakeRoleAssignmentMetricsGetter struct {
+	metrics roleAssignmentMetrics
+	err     error
+}
+
+func (f *fakeRoleAssignmentMetricsGetter) Get(context.Context) (roleAssignmentMetrics, error) {
+	return f.metrics, f.err
+}
+
+func TestRoleAssignmentSource(t *testing.T) {
+	source := NewRoleAssignmentSource()
+	if got := source.Name(); got != "rbac" {
+		t.Fatalf("Name() = %q, want %q", got, "rbac")
+	}
+	if source.IsRegional() {
+		t.Fatal("IsRegional() = true, want false")
 	}
 
-	testCases := []testCase{
+	var gotSubscriptionID string
+	source.newClient = func(subscriptionID string, _ azcore.TokenCredential) (roleAssignmentMetricsGetter, error) {
+		gotSubscriptionID = subscriptionID
+		return &fakeRoleAssignmentMetricsGetter{
+			metrics: roleAssignmentMetrics{
+				currentCount: 123,
+				limit:        8000,
+			},
+		}, nil
+	}
+
+	results, errs := source.Collect(context.Background(), nil, "subscription-id", "")
+	if len(errs) != 0 {
+		t.Fatalf("Collect() errors = %v, want none", errs)
+	}
+	if gotSubscriptionID != "subscription-id" {
+		t.Fatalf("client subscription ID = %q, want %q", gotSubscriptionID, "subscription-id")
+	}
+	if len(results) != 1 {
+		t.Fatalf("Collect() returned %d results, want 1", len(results))
+	}
+
+	got := results[0]
+	if got.QuotaName != "roleAssignments" {
+		t.Fatalf("QuotaName = %q, want %q", got.QuotaName, "roleAssignments")
+	}
+	if got.LocalizedName != "Role Assignments" {
+		t.Fatalf("LocalizedName = %q, want %q", got.LocalizedName, "Role Assignments")
+	}
+	if got.CurrentValue != 123 {
+		t.Fatalf("CurrentValue = %v, want 123", got.CurrentValue)
+	}
+	if got.Limit != 8000 {
+		t.Fatalf("Limit = %v, want 8000", got.Limit)
+	}
+	if got.SubscriptionID != "subscription-id" {
+		t.Fatalf("SubscriptionID = %q, want %q", got.SubscriptionID, "subscription-id")
+	}
+	if got.Region != "" {
+		t.Fatalf("Region = %q, want empty", got.Region)
+	}
+}
+
+func TestRoleAssignmentSourceErrors(t *testing.T) {
+	testCases := []struct {
+		name       string
+		newClient  roleAssignmentMetricsClientFactory
+		wantErrSub string
+	}{
 		{
-			name:    "no subscriptions yields empty limits map",
-			tenants: []config.TenantConfig{{TenantID: "tenant-a"}},
-			want:    map[string]int{},
+			name: "client creation failure",
+			newClient: func(string, azcore.TokenCredential) (roleAssignmentMetricsGetter, error) {
+				return nil, fmt.Errorf("create failed")
+			},
+			wantErrSub: "create role assignment metrics client: create failed",
 		},
 		{
-			name: "uses default role assignment limit",
-			tenants: []config.TenantConfig{
-				{
-					TenantID: "tenant-a",
-					Subscriptions: []config.SubscriptionConfig{
-						{Name: "sub-a", SubscriptionID: "sub-a-id"},
-					},
-				},
+			name: "metrics request failure",
+			newClient: func(string, azcore.TokenCredential) (roleAssignmentMetricsGetter, error) {
+				return &fakeRoleAssignmentMetricsGetter{err: fmt.Errorf("request failed")}, nil
 			},
-			want: map[string]int{
-				"sub-a-id": config.DefaultRoleAssignmentLimit,
-			},
-		},
-		{
-			name: "uses explicit role assignment limits",
-			tenants: []config.TenantConfig{
-				{
-					TenantID: "tenant-a",
-					Subscriptions: []config.SubscriptionConfig{
-						{Name: "sub-a", SubscriptionID: "sub-a-id", RoleAssignmentLimit: 1234},
-						{Name: "sub-b", SubscriptionID: "sub-b-id", RoleAssignmentLimit: 5678},
-					},
-				},
-			},
-			want: map[string]int{
-				"sub-a-id": 1234,
-				"sub-b-id": 5678,
-			},
+			wantErrSub: "get role assignment metrics: request failed",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			source := NewRoleAssignmentSource(tc.tenants)
-
-			if got := source.Name(); got != "rbac" {
-				t.Fatalf("Name() = %q, want %q", got, "rbac")
+			source := &RoleAssignmentSource{newClient: tc.newClient}
+			results, errs := source.Collect(context.Background(), nil, "subscription-id", "")
+			if len(results) != 0 {
+				t.Fatalf("Collect() returned %d results, want none", len(results))
 			}
-			if source.IsRegional() {
-				t.Fatal("IsRegional() = true, want false")
+			if len(errs) != 1 {
+				t.Fatalf("Collect() returned %d errors, want 1", len(errs))
 			}
-			if !reflect.DeepEqual(source.limits, tc.want) {
-				t.Fatalf("limits = %#v, want %#v", source.limits, tc.want)
+			if !strings.Contains(errs[0].Error(), tc.wantErrSub) {
+				t.Fatalf("Collect() error = %q, want substring %q", errs[0], tc.wantErrSub)
 			}
 		})
 	}

--- a/tooling/tenant-quota/pkg/subscriptionquota/roleassignments_test.go
+++ b/tooling/tenant-quota/pkg/subscriptionquota/roleassignments_test.go
@@ -117,7 +117,7 @@ func TestRoleAssignmentSourceErrors(t *testing.T) {
 				t.Fatalf("Collect() returned %d errors, want 1", len(errs))
 			}
 			if !strings.Contains(errs[0].Error(), tc.wantErrSub) {
-				t.Fatalf("Collect() error = %q, want substring %q", errs[0], tc.wantErrSub)
+				t.Fatalf("Collect() error = %v, want substring %q", errs[0], tc.wantErrSub)
 			}
 		})
 	}


### PR DESCRIPTION
Tracking: https://redhat.atlassian.net/browse/AROSLSRE-1789

### What

- Query `Microsoft.Authorization/roleAssignmentsUsageMetrics` for each configured subscription.
- Export both role-assignment usage and the subscription-specific limit returned by Azure.
- Replace the paginated role-assignment listing with one authoritative API request.
- Keep the existing `roleAssignmentLimit` deployment configuration temporarily for rollout compatibility.
- Update subscription onboarding documentation because static limit configuration is no longer required by the new exporter.
- Keep the existing Prometheus metric names and labels unchanged.

### Why

Role-assignment limits can differ between subscriptions and change after quota increases. Azure already exposes the authoritative current count and limit, so the exporter should not depend on a static value.

This code PR must land and its image digest must be rolled out before the follow-up config cleanup PR. The new binary safely ignores the legacy `roleAssignmentLimit` field; the old binary would default missing values to `4000`, producing incorrect limits for subscriptions configured at `8000`.

Follow-up config cleanup: https://github.com/Azure/ARO-HCP/pull/6505

### Testing

- `go test ./...` in `tooling/tenant-quota`
- `go build ./...` in `tooling/tenant-quota`
- targeted `golangci-lint` for `tooling/tenant-quota/...`
- compatibility unit test proving the new config parser accepts the legacy `roleAssignmentLimit` field
- audited `docs/` for other static role-assignment-limit configuration references
- `make run` with live DEV credentials; `/healthz` and `/readyz` returned `OK` and all 11 configured subscriptions exported RBAC usage and API-reported limits

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) — metric schema and visualizations are unchanged
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide) — pending draft PR CI
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged — intentionally deferred until author review
- [x] All comment threads resolved before merge


