### PR TITLE
fix: align delayed role assignment test deadline with its creation timeout

### DIFF
--- a/test/e2e/cluster_delayed_role_assignments.go
+++ b/test/e2e/cluster_delayed_role_assignments.go
@@ -49,6 +49,11 @@ var _ = Describe("ARO HCP Service", func() {
 				customerVnetSubnetName = "customer-vnet-subnet1"
 				customerClusterName    = "delayed-rbac-cluster"
 
+				// Cluster creation takes longer than the default 20m because this
+				// test deliberately delays role assignments by consistentlyLoopDuration,
+				// causing CS to retry inflight checks until RBAC propagates. Todd Wolff
+				// observed ~28.5m in manual runs (PR #4760); 45m gives headroom for
+				// variable Azure RBAC propagation and CI load.
 				clusterCreationTimeout   = 45 * time.Minute
 				consistentlyLoopDuration = 3 * time.Minute
 			)

--- a/test/e2e/cluster_delayed_role_assignments.go
+++ b/test/e2e/cluster_delayed_role_assignments.go
@@ -49,12 +49,11 @@ var _ = Describe("ARO HCP Service", func() {
 				customerVnetSubnetName = "customer-vnet-subnet1"
 				customerClusterName    = "delayed-rbac-cluster"
 
-				// Cluster creation takes longer than the default 20m because this
-				// test deliberately delays role assignments by consistentlyLoopDuration,
-				// causing CS to retry inflight checks until RBAC propagates. Todd Wolff
-				// observed ~28.5m in manual runs (PR #4760); 45m gives headroom for
-				// variable Azure RBAC propagation and CI load.
-				clusterCreationTimeout   = 45 * time.Minute
+				// This test needs extra time beyond the default because it deliberately
+				// delays role assignments: 3m Consistently check + ~0.5m RBAC deployment
+				// + up to ~4m for CS retry and Azure RBAC propagation. Observed max delta
+				// over 24 CI runs is ~15m; 16m provides a small buffer.
+				clusterCreationTimeout   = framework.ClusterCreationTimeout + 16*time.Minute
 				consistentlyLoopDuration = 3 * time.Minute
 			)
 			tc := framework.NewTestContext()

--- a/test/e2e/cluster_delayed_role_assignments.go
+++ b/test/e2e/cluster_delayed_role_assignments.go
@@ -26,7 +26,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
+	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
 	hcpsdk20251223preview "github.com/Azure/ARO-HCP/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
@@ -65,6 +67,7 @@ var _ = Describe("ARO HCP Service", func() {
 			clusterParams := framework.NewDefaultClusterParams20251223()
 			clusterParams.ClusterName = customerClusterName
 			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.Tags[metadataapi.TagClusterMaxCreationDuration] = to.Ptr((clusterCreationTimeout - time.Minute).String())
 
 			By("deploying customer infrastructure (NSG, VNet, subnet, KeyVault)")
 			suffix := rand.String(6)


### PR DESCRIPTION
## Summary

Override `TagClusterMaxCreationDuration` in the delayed role assignment test, expressed as a delta from the default: `framework.ClusterCreationTimeout + 16 minutes`.

## Background

[ARO-25805](https://redhat.atlassian.net/browse/ARO-25805) identified a real customer scenario (Adobe) where MI role assignments haven't propagated in Azure AD by the time cluster creation begins, causing a terminal failure with no recovery path. The CS-side fix (merged in `aro-hcp-clusters-service` by Manyanda Chitimbo) made Clusters Service retry inflight checks indefinitely rather than failing terminally. This E2E test was added by Todd Wolff in PR #4760 to validate that fix.

## Root Cause

On **May 21**, Todd added the delayed role assignment test (PR #4760). At that time, `NewDefaultClusterParams20251223()` did not include a `TagClusterMaxCreationDuration` tag, and the backend had no creation deadline enforcement. The test worked as expected.

On **July 14**, David Eads landed PR #6078 ("implement CreateOperationCompletionDeadline for cluster and nodepool creation timeout"). That single commit added both backend deadline enforcement AND `TagClusterMaxCreationDuration` (set to `ClusterCreationTimeout - 1 minute` = 19m) to all `NewDefaultClusterParams` helpers. The delayed role assignment test inherited the 19-minute deadline but was never updated to account for its longer creation path.

On **July 23**, the test started failing — 9 days after PR #6078 landed.

## Why This Test Needs Extra Time

This test deliberately delays role assignments, adding time on top of normal cluster creation:

| Phase | Duration | Source |
|-------|----------|--------|
| Consistently check (intentional delay) | 3.0 min (fixed) | Test code |
| RBAC deployment via Bicep | 0.4-0.8 min | 24 CI runs |
| CS retry + Azure RBAC propagation | ~1-4 min (variable) | 24 CI runs |
| **Total extra over default** | **~11 min mean, ~15 min max** | 24 CI runs |

The timeout is set to `framework.ClusterCreationTimeout + 16 minutes` — the observed max delta (15 min) plus a 1-minute buffer.

## Kusto Evidence

Production Kusto logs from [a failed run](https://releases.dev.aro.azure-test.net/tests/hcp/job/branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel/run/2082330094562447360/test/aro-hcp-service-should-success--added-after-cluster-creation-51184848) confirm:

| Time | Event |
|------|-------|
| 05:13:59 | Frontend accepted cluster PUT |
| 05:14:06–05:17:06 | CS retried authorization failures (role assignments intentionally absent — **working as designed**) |
| 05:17:55 | CS inflight checks passed, cluster moved to `pending` |
| 05:24:52 | CS moved to `installing` |
| 05:32:59 | **19-minute backend deadline expired** |
| 05:33:06 | **Backend forced terminal `Failed`** |
| 05:33:33 | CS moved to `ready` — 35 seconds too late |

## Fix

Two changes:
1. Override `TagClusterMaxCreationDuration` to `clusterCreationTimeout - 1 minute`, aligning the backend deadline with the test's polling budget
2. Express `clusterCreationTimeout` as `framework.ClusterCreationTimeout + 16*time.Minute` rather than a magic constant, making the delta from default explicit

## Test plan

- [x] Compiles with `-tags E2Etests`
- [x] Lint passes
- [ ] CI validates the delayed role assignment test passes with the aligned deadline

Resolves: [ARO-28755](https://redhat.atlassian.net/browse/ARO-28755)

🤖 Generated with [Claude Code](https://claude.com/claude-code)