### PR TITLE
test: remove expired v20251223preview timebomb from ephemeral OS disk e2e

### DIFF
--- a/test/e2e/nodepool_ephemeral_osdisk.go
+++ b/test/e2e/nodepool_ephemeral_osdisk.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,15 +33,6 @@ import (
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
 )
 
-// mustParseDate parses a date string in "2006-01-02" format or panics.
-func mustParseDate(s string) time.Time {
-	t, err := time.Parse("2006-01-02", s)
-	if err != nil {
-		panic(fmt.Sprintf("invalid date %q: %v", s, err))
-	}
-	return t
-}
-
 // isAPINotDeployedError returns true if the error indicates the API version
 // has not been rolled out to this region yet.
 func isAPINotDeployedError(err error) bool {
@@ -55,10 +45,6 @@ func isAPINotDeployedError(err error) bool {
 }
 
 var _ = Describe("Nodepool Ephemeral OS Disk", func() {
-	// Set deadline to a reasonable date after which we expect the v20251223preview
-	// API to be deployed. Adjust as needed based on rollout schedule.
-	timeBombDeadline := mustParseDate("2026-04-01")
-
 	BeforeEach(func() {
 		// do nothing.  per test initialization usually ages better than shared.
 	})
@@ -77,18 +63,8 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 
 			tc := framework.NewTestContext()
 
-			By("checking API version availability")
-			apiAvailable, err := tc.IsHCPAPIVersionAvailable(ctx, "2025-12-23-preview")
-			Expect(err).NotTo(HaveOccurred(), "failed to check API version availability")
-			if !apiAvailable {
-				if time.Now().After(timeBombDeadline) {
-					Fail(fmt.Sprintf("API version 2025-12-23-preview should be fully available by %s", timeBombDeadline.Format(time.RFC3339)))
-				}
-				Skip("API version 2025-12-23-preview is not fully available in this environment")
-			}
-
 			if tc.UsePooledIdentities() {
-				err = tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
 				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
 			}
 
@@ -143,12 +119,6 @@ var _ = Describe("Nodepool Ephemeral OS Disk", func() {
 				framework.NodePoolCreationTimeout)
 
 			client20251223 := tc.Get20251223ClientFactoryOrDie(ctx)
-			if isAPINotDeployedError(err) {
-				if time.Now().Before(timeBombDeadline) {
-					Skip(fmt.Sprintf("v20251223preview API not yet deployed; skipping until %s", timeBombDeadline.Format(time.RFC3339)))
-				}
-				Fail(fmt.Sprintf("v20251223preview API still not deployed as of %s deadline", timeBombDeadline.Format(time.RFC3339)))
-			}
 			Expect(err).NotTo(HaveOccurred(), "failed to create nodepool %s with ephemeral OS disk", customerNodePoolName)
 
 			By("verifying nodepool ARM resource has diskType=Ephemeral from LRO result")


### PR DESCRIPTION
https://issues.redhat.com/browse/AROSLSRE-1784

### What

Removes the expired timebomb from `test/e2e/nodepool_ephemeral_osdisk.go`:

- `timeBombDeadline` (`2026-04-01`) and the `mustParseDate` helper, which is used only by it
- the `IsHCPAPIVersionAvailable(ctx, "2025-12-23-preview")` pre-check block
- the `isAPINotDeployedError(err)` branch around node pool creation
- the now-unused `time` import

`isAPINotDeployedError` itself is **kept**. It is defined in this file but consumed by four other specs — `cluster_create_private_ingress.go`, `cluster_create_v20260901preview.go`, `cluster_fips_mode.go`, and `kms_key_rotation.go` — so deleting it would break them.

Net: 31 deletions, 1 insertion. The single insertion is `err =` → `err :=` in the pooled-identities block, since `err` was previously first declared by the deleted pre-check.

### Why

The deadline expired over four months ago. Past that date there is no skip path left, so both guarded branches are only reachable if `2025-12-23-preview` disappears from the ARM provider manifest — which it has not. The code is dead, and the messages it would emit (`API version 2025-12-23-preview should be fully available by 2026-04-01`) are stale and would misdirect whoever hit them.

Three independent checks confirm the API version is available wherever this test runs:

1. The ARM provider manifest in the dev subscription advertises `2025-12-23-preview` on all three resource types `IsHCPAPIVersionAvailable` requires — `HCPOpenShiftClusters`, `locations/hcpOperationStatuses`, `locations/hcpOperationResults`.
2. A manual INT run of `branch-ci-Azure-ARO-HCP-main-e2e-integration-e2e-parallel` at `BASE_SHA=06acec5302a0370a3666910cc92a0cd5d90fab3a` — i.e. main with the timebomb still present — [completed successfully](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-e2e-integration-e2e-parallel/2086845890059833344). Had the version been unavailable in INT, the expired timebomb would have failed the spec rather than skipped it.
3. No `2025-12-23-preview` failure signature appears on the CIHealth failure-patterns dashboard across DEV/INT/STG/PROD over a 7-day window, while the analogous `2026-06-30-preview` signatures do appear.

This follows the precedent set by #6483, which removed an equivalent expired timebomb earlier today.

### Testing

No new tests — this only deletes dead code from an existing spec, and the spec's assertions are unchanged.

- Unit tests: N/A
- Integration tests: N/A
- E2E tests: `Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled` is unchanged apart from the removed guards, and is exercised by this PR's own e2e run. The pre-change behaviour was verified green in INT at the SHA linked above.

Local verification: `go build ./...` and `go vet ./e2e/...` pass in the `test` module, and the file is `gofmt` clean.

### Special notes for your reviewer

- The spec name is unchanged, so no suite fixtures under `test/testdata/` and no `nonlocal-e2e-specs.txt` regeneration are needed.
- Related but deliberately **not** in this PR: `V20260630PreviewDeploymentDeadline` in `test/util/framework/constants.go` is set to `2026-08-14`, four days out, and will flip `cluster_create_private_ingress.go`, `cluster_fips_mode.go` and `kms_key_rotation.go` from skip to hard failure while `2026-06-30-preview` is still unregistered (it is absent from all three required resource types today). That deserves its own change — either an extended deadline or a rollout push.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge