### PR TITLE
frontend: return unmarshal errors as 4xx to users

### DIFF
--- a/frontend/pkg/frontend/cluster.go
+++ b/frontend/pkg/frontend/cluster.go
@@ -214,7 +214,7 @@ func decodeDesiredClusterCreate(ctx context.Context, azureLocation string, reque
 
 	externalClusterFromRequest := versionedInterface.NewHCPOpenShiftCluster(nil)
 	if err := json.Unmarshal(body, &externalClusterFromRequest); err != nil {
-		return nil, utils.TrackError(err)
+		return nil, utils.TrackError(coreapi.NewInvalidRequestContentError(err))
 	}
 	newInternalCluster, err := externalClusterFromRequest.ConvertToInternal(nil)
 	if err != nil {
@@ -487,7 +487,7 @@ func decodeDesiredClusterReplace(ctx context.Context, oldInternalCluster *coreap
 	// Exact user request
 	externalClusterFromRequest := versionedInterface.NewHCPOpenShiftCluster(nil)
 	if err := json.Unmarshal(body, &externalClusterFromRequest); err != nil {
-		return nil, utils.TrackError(err)
+		return nil, utils.TrackError(coreapi.NewInvalidRequestContentError(err))
 	}
 
 	newInternalCluster, err := externalClusterFromRequest.ConvertToInternal(oldInternalCluster)

--- a/frontend/pkg/frontend/external_auth.go
+++ b/frontend/pkg/frontend/external_auth.go
@@ -194,7 +194,7 @@ func decodeDesiredExternalAuthCreate(ctx context.Context) (*coreapi.HCPOpenShift
 
 	externalExternalAuthFromRequest := versionedInterface.NewHCPOpenShiftClusterExternalAuth(nil)
 	if err := json.Unmarshal(body, &externalExternalAuthFromRequest); err != nil {
-		return nil, utils.TrackError(err)
+		return nil, utils.TrackError(coreapi.NewInvalidRequestContentError(err))
 	}
 	newInternalExternalAuth, err := externalExternalAuthFromRequest.ConvertToInternal(nil)
 	if err != nil {
@@ -369,7 +369,7 @@ func decodeDesiredExternalAuthReplace(ctx context.Context, oldInternalExternalAu
 	// Exact user request
 	externalExternalAuthFromRequest := versionedInterface.NewHCPOpenShiftClusterExternalAuth(nil)
 	if err := json.Unmarshal(body, &externalExternalAuthFromRequest); err != nil {
-		return nil, utils.TrackError(err)
+		return nil, utils.TrackError(coreapi.NewInvalidRequestContentError(err))
 	}
 
 	newInternalExternalAuth, err := externalExternalAuthFromRequest.ConvertToInternal(oldInternalExternalAuth)

--- a/frontend/pkg/frontend/node_pool.go
+++ b/frontend/pkg/frontend/node_pool.go
@@ -195,7 +195,7 @@ func decodeDesiredNodePoolCreate(ctx context.Context, azureLocation string) (*co
 
 	externalNodePoolFromRequest := versionedInterface.NewHCPOpenShiftClusterNodePool(nil)
 	if err := json.Unmarshal(body, &externalNodePoolFromRequest); err != nil {
-		return nil, utils.TrackError(err)
+		return nil, utils.TrackError(coreapi.NewInvalidRequestContentError(err))
 	}
 	newInternalNodePool, err := externalNodePoolFromRequest.ConvertToInternal(nil)
 	if err != nil {
@@ -397,7 +397,7 @@ func decodeDesiredNodePoolReplace(ctx context.Context, oldInternalNodePool *core
 	// Exact user request
 	externalNodePoolFromRequest := versionedInterface.NewHCPOpenShiftClusterNodePool(nil)
 	if err := json.Unmarshal(body, &externalNodePoolFromRequest); err != nil {
-		return nil, utils.TrackError(err)
+		return nil, utils.TrackError(coreapi.NewInvalidRequestContentError(err))
 	}
 
 	newInternalNodePool, err := externalNodePoolFromRequest.ConvertToInternal(oldInternalNodePool)


### PR DESCRIPTION
When a user passes an invalid JSON payload to our API endpoints, we were currently wrapping the unmarshalling errors and backstopping them with 500s, while in reality these are client-side errors.
