### PR TITLE
fix: point stg uksouth Kusto back at hcp-stg-uk-2

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -87,9 +87,14 @@ clouds:
           serviceKeyVault:
             subscription:
               displayName: "Azure Red Hat OpenShift HCP - {{ .ctx.environment }} - {{ .ev2.regionFriendlyName }} - SVC"
-          # This must be defined here, so our ci jobs can know this
+          # This must be defined here, so our ci jobs can know this.
+          # This is the LIVE (V1) cluster in rg hcp-kusto-stg-uk of the
+          # `Azure Red Hat OpenShift v4.x - HCP Global` sub, which uksouth deploys
+          # into. Do NOT set it to hcp-stg-uk-3 — that is the transient V2 cluster
+          # under stgGlobalV2, in the separate hcp-stg-global sub. Both subs have an
+          # rg named hcp-kusto-stg-uk, and Kusto cluster names are globally unique.
           kusto:
-            kustoName: "hcp-stg-uk-3"
+            kustoName: "hcp-stg-uk-2"
           # Transient STG-global "V2" names for the parallel infra in the dedicated
           # hcp-stg-global sub during coexistence. Removed at decommission.
           stgGlobalV2:


### PR DESCRIPTION
## Why

The STG geography rollout is failing:

```
Status: Failed
Code: InvalidClusterName
Message: Name 'hcp-stg-uk-3' with type Engine is already taken. Please specify a different name
Target: /subscriptions/9a53d80e-.../resourceGroups/hcp-kusto-stg-uk/providers/Microsoft.Resources/deployments/kusto-uksouth
```

#6482 set `stg.defaults.kusto.kustoName` to `hcp-stg-uk-3`. That name does not belong to the V1 stack.

There are two STG global subscriptions during the [AROSLSRE-1657](https://redhat.atlassian.net/browse/AROSLSRE-1657) coexistence, and **both contain a resource group named `hcp-kusto-stg-uk`**:

| Subscription | RG | Kusto cluster | Deployed by |
|---|---|---|---|
| `Azure Red Hat OpenShift v4.x - HCP Global` (`hcp-global`) | `hcp-kusto-stg-uk` | **`hcp-stg-uk-2`** | `geography-pipeline.yaml` — this is what **stg uksouth** uses |
| `Azure Red Hat OpenShift HCP - stg - Global` (`hcp-stg-global`) | `hcp-kusto-stg-uk` | **`hcp-stg-uk-3`** | `geography-pipeline-stg.yaml` (V2, transient) |

`hcp-stg-uk-3` is sourced from `stgGlobalV2.kustoName` and only ever exists in the dedicated `hcp-stg-global` subscription. uksouth deliberately stays on `hcp-global` — see the existing comment in the overlay: *"westus3: second STG region, born on the dedicated hcp-stg-global sub … uksouth stays on hcp-global."*

Kusto cluster names are globally unique DNS names, so the V1 geography pipeline can never create `hcp-stg-uk-3` in a subscription that doesn't already own it. ARM treats it as a create against an already-registered name and rejects it.

## What

Restores `stg.defaults.kusto.kustoName` to `hcp-stg-uk-2` and adds a comment recording why `-3` must not be used here — the identically named resource group in both subscriptions makes this very easy to get wrong.

No change to `kusto.rg`: the base template in `config.yaml` already resolves it to `hcp-kusto-stg-uk`, which is correct for both stacks.

## Testing

- Confirmed via `az resource list --resource-type Microsoft.Kusto/clusters` in `9a53d80e-dae0-4c8a-af90-30575d253127` that `hcp-stg-uk-2` exists in RG `hcp-kusto-stg-uk`.
- Confirmed in the portal that `hcp-stg-uk-3` lives in RG `hcp-kusto-stg-uk` of the separate `Azure Red Hat OpenShift HCP - stg - Global` subscription (`d63a7f3d-…`).
- `cd config && make materialize` passes; `config/rendered/` is unaffected (only the dev cloud renders in this repo — public/stg renders downstream in sdp-pipelines).
