### PR TITLE
feat(hcpctl): add taxonomy classification to snapshot analyze

### DIFF
--- a/tooling/hcpctl/pkg/agent/classification_test.go
+++ b/tooling/hcpctl/pkg/agent/classification_test.go
@@ -1,0 +1,307 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/internal/tabular"
+)
+
+func TestParseDraftChain_WithClassification(t *testing.T) {
+	input := `{
+		"root_cause": "test",
+		"summary": "test summary",
+		"classification": {
+			"l1_category": "Product Failures",
+			"l2_subcategory": "HyperShift",
+			"confidence": 0.92
+		},
+		"chain": [{"question": "Why did this test fail?", "answer": "reason", "proof": [{"type": "log", "source": "error", "lines": [1, 2]}]}]
+	}`
+
+	chain, err := ParseDraftChain(input)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if chain.Classification == nil {
+		t.Fatal("expected classification to be non-nil")
+	}
+	if chain.Classification.L1Category != L1ProductFailures {
+		t.Errorf("L1Category = %q, want %q", chain.Classification.L1Category, L1ProductFailures)
+	}
+	if chain.Classification.L2Subcategory != L2HyperShift {
+		t.Errorf("L2Subcategory = %q, want %q", chain.Classification.L2Subcategory, L2HyperShift)
+	}
+	if chain.Classification.Confidence != 0.92 {
+		t.Errorf("Confidence = %g, want 0.92", chain.Classification.Confidence)
+	}
+}
+
+func TestParseDraftChain_WithoutClassification(t *testing.T) {
+	input := `{
+		"root_cause": "test",
+		"summary": "test summary",
+		"chain": [{"question": "Why did this test fail?", "answer": "reason", "proof": [{"type": "log", "source": "error", "lines": [1, 2]}]}]
+	}`
+
+	chain, err := ParseDraftChain(input)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if chain.Classification != nil {
+		t.Errorf("expected classification to be nil, got %+v", chain.Classification)
+	}
+}
+
+// noopKustoClient is a KustoClient that returns an empty table for any query.
+type noopKustoClient struct{}
+
+func (n *noopKustoClient) Query(_ context.Context, _ string) (*tabular.Table, error) {
+	return &tabular.Table{Columns: []string{"col"}, Rows: [][]string{{"val"}}}, nil
+}
+
+func validDraftWithClassification(c *Classification) *DraftChain {
+	return &DraftChain{
+		RootCause:      "root cause",
+		Summary:        "summary",
+		Classification: c,
+		Chain: []ChainLink{
+			{
+				Question: FirstChainQuestion,
+				Answer:   "answer",
+				Proof: []ProofItem{
+					{Type: "log", Source: "error", Lines: [2]int{1, 1}},
+					{Type: "code", Repo: "ARO-HCP", File: "main.go", Lines: [2]int{1, 1}},
+				},
+			},
+		},
+	}
+}
+
+func newValidationContext(t *testing.T) *ValidationContext {
+	t.Helper()
+	worktree := t.TempDir()
+	if err := os.WriteFile(filepath.Join(worktree, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("failed to create stub source file: %v", err)
+	}
+	return &ValidationContext{
+		ValidRepos:    map[string]bool{"ARO-HCP": true},
+		WorktreePaths: map[string]string{"ARO-HCP": worktree},
+		TestError:     "error line 1\n",
+	}
+}
+
+func classificationProblems(result ValidationResult) []ValidationProblem {
+	var filtered []ValidationProblem
+	for _, p := range result.Problems {
+		switch p.Category {
+		case "missing_classification", "invalid_l1_category",
+			"invalid_l2_subcategory", "unexpected_l2_subcategory",
+			"invalid_confidence":
+			filtered = append(filtered, p)
+		}
+	}
+	return filtered
+}
+
+func TestValidateDraft_Classification(t *testing.T) {
+	ctx := context.Background()
+	client := &noopKustoClient{}
+	vc := newValidationContext(t)
+
+	tests := []struct {
+		name           string
+		classification *Classification
+		wantCategory   string
+	}{
+		{
+			name:           "missing classification",
+			classification: nil,
+			wantCategory:   "missing_classification",
+		},
+		{
+			name:           "invalid L1 category",
+			classification: &Classification{L1Category: "Not Real", Confidence: 0.5},
+			wantCategory:   "invalid_l1_category",
+		},
+		{
+			name:           "Product Failures missing L2",
+			classification: &Classification{L1Category: L1ProductFailures, Confidence: 0.8},
+			wantCategory:   "invalid_l2_subcategory",
+		},
+		{
+			name:           "Product Failures invalid L2",
+			classification: &Classification{L1Category: L1ProductFailures, L2Subcategory: "NotAComponent", Confidence: 0.8},
+			wantCategory:   "invalid_l2_subcategory",
+		},
+		{
+			name:           "non-Product Failures with L2 set",
+			classification: &Classification{L1Category: L1AzureProblems, L2Subcategory: L2HyperShift, Confidence: 0.9},
+			wantCategory:   "unexpected_l2_subcategory",
+		},
+		{
+			name:           "confidence too low",
+			classification: &Classification{L1Category: L1AzureProblems, Confidence: -0.1},
+			wantCategory:   "invalid_confidence",
+		},
+		{
+			name:           "confidence too high",
+			classification: &Classification{L1Category: L1AzureProblems, Confidence: 1.5},
+			wantCategory:   "invalid_confidence",
+		},
+		{
+			name:           "valid Azure Problems",
+			classification: &Classification{L1Category: L1AzureProblems, Confidence: 0.85},
+			wantCategory:   "",
+		},
+		{
+			name:           "valid Product Failures with L2",
+			classification: &Classification{L1Category: L1ProductFailures, L2Subcategory: L2ClusterService, Confidence: 0.95},
+			wantCategory:   "",
+		},
+		{
+			name:           "valid Test Reliability",
+			classification: &Classification{L1Category: L1TestReliability, Confidence: 0.7},
+			wantCategory:   "",
+		},
+		{
+			name:           "valid Deployment Failures",
+			classification: &Classification{L1Category: L1DeploymentFailures, Confidence: 0.6},
+			wantCategory:   "",
+		},
+		{
+			name:           "confidence at boundary 0",
+			classification: &Classification{L1Category: L1AzureProblems, Confidence: 0},
+			wantCategory:   "",
+		},
+		{
+			name:           "confidence at boundary 1",
+			classification: &Classification{L1Category: L1AzureProblems, Confidence: 1},
+			wantCategory:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			draft := validDraftWithClassification(tt.classification)
+			result := ValidateDraft(ctx, client, draft, vc)
+			problems := classificationProblems(result)
+
+			if tt.wantCategory == "" {
+				if len(problems) > 0 {
+					t.Errorf("expected no classification problems, got %d: %v", len(problems), problems)
+				}
+				return
+			}
+
+			found := false
+			for _, p := range problems {
+				if p.Category == tt.wantCategory {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected problem category %q, got problems: %v", tt.wantCategory, problems)
+			}
+		})
+	}
+}
+
+func TestRenderMarkdown_WithClassification(t *testing.T) {
+	chain := &HydratedChain{
+		RootCause: "root cause",
+		Summary:   "summary",
+		Classification: &Classification{
+			L1Category:    L1ProductFailures,
+			L2Subcategory: L2Maestro,
+			Confidence:    0.88,
+		},
+		Chain: []HydratedLink{
+			{
+				Question: FirstChainQuestion,
+				Answer:   "answer",
+				Proof:    []HydratedProofItem{{ProofItem: ProofItem{Type: "log", Source: "error", Lines: [2]int{1, 1}}}},
+			},
+		},
+	}
+
+	rendered := RenderMarkdown(chain, "TestExample")
+
+	if !strings.Contains(rendered, "## Classification") {
+		t.Error("rendered markdown missing Classification section")
+	}
+	if !strings.Contains(rendered, "Product Failures") {
+		t.Error("rendered markdown missing L1 category")
+	}
+	if !strings.Contains(rendered, "Maestro") {
+		t.Error("rendered markdown missing L2 component")
+	}
+	if !strings.Contains(rendered, "88%") {
+		t.Error("rendered markdown missing confidence percentage")
+	}
+}
+
+func TestRenderMarkdown_WithoutL2(t *testing.T) {
+	chain := &HydratedChain{
+		RootCause: "root cause",
+		Summary:   "summary",
+		Classification: &Classification{
+			L1Category: L1AzureProblems,
+			Confidence: 0.95,
+		},
+		Chain: []HydratedLink{
+			{
+				Question: FirstChainQuestion,
+				Answer:   "answer",
+				Proof:    []HydratedProofItem{{ProofItem: ProofItem{Type: "log", Source: "error", Lines: [2]int{1, 1}}}},
+			},
+		},
+	}
+
+	rendered := RenderMarkdown(chain, "TestExample")
+
+	if !strings.Contains(rendered, "Azure Problems") {
+		t.Error("rendered markdown missing L1 category")
+	}
+	if strings.Contains(rendered, "**Component:**") {
+		t.Error("rendered markdown should not contain Component line when L2 is empty")
+	}
+}
+
+func TestRenderMarkdown_WithoutClassification(t *testing.T) {
+	chain := &HydratedChain{
+		RootCause: "root cause",
+		Summary:   "summary",
+		Chain: []HydratedLink{
+			{
+				Question: FirstChainQuestion,
+				Answer:   "answer",
+				Proof:    []HydratedProofItem{{ProofItem: ProofItem{Type: "log", Source: "error", Lines: [2]int{1, 1}}}},
+			},
+		},
+	}
+
+	rendered := RenderMarkdown(chain, "TestExample")
+
+	if strings.Contains(rendered, "## Classification") {
+		t.Error("rendered markdown should not contain Classification section when nil")
+	}
+}

--- a/tooling/hcpctl/pkg/agent/hydration.go
+++ b/tooling/hcpctl/pkg/agent/hydration.go
@@ -107,10 +107,11 @@ func queryToDeepLink(kustoEndpoint, kustoDatabase, query string) (string, error)
 // KQL queries and generating share URIs.
 func (h *Hydrator) Hydrate(ctx context.Context, draft *DraftChain) (*HydratedChain, error) {
 	result := &HydratedChain{
-		RootCause:   draft.RootCause,
-		Summary:     draft.Summary,
-		Notes:       draft.Notes,
-		Suggestions: draft.Suggestions,
+		RootCause:      draft.RootCause,
+		Summary:        draft.Summary,
+		Notes:          draft.Notes,
+		Classification: draft.Classification,
+		Suggestions:    draft.Suggestions,
 	}
 
 	// Backfill all discovery directories from the data dir. All pre-gathered

--- a/tooling/hcpctl/pkg/agent/prompts/exemplars/cluster-creation-timeout-z-stream-upgrade.md
+++ b/tooling/hcpctl/pkg/agent/prompts/exemplars/cluster-creation-timeout-z-stream-upgrade.md
@@ -9,6 +9,11 @@ backend kept reporting *"hosted cluster has no installed version"* through the t
 New kube-apiserver ReplicaSet `54b7f655f6` pods logged `etcd-client` dial failures while etcd quorum stayed healthy
 (`EtcdAvailable=True`).
 
+## Classification
+
+- **Category:** Product Failures
+- **Component:** Backend
+
 ## Summary
 
 [Prow job `pull-ci-Azure-ARO-HCP-main-e2e-parallel` #2069828891979026432](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/5771/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2069828891979026432).

--- a/tooling/hcpctl/pkg/agent/prompts/exemplars/cluster-installation-azure-disk-failure.md
+++ b/tooling/hcpctl/pkg/agent/prompts/exemplars/cluster-installation-azure-disk-failure.md
@@ -5,6 +5,10 @@ This document shows a proof chain for a failure to install a cluster coming from
 An ARO HCP cluster failed to install because an Azure Disk could not be mounted for an `etcd` pod in the hosted control
 plane due to internal Azure Disk errors.
 
+## Classification
+
+- **Category:** Azure Problems
+
 ## Summary
 
 An end-to-end test installing two ARO HCP clusters in one resource group installed one without issue, but failed on the

--- a/tooling/hcpctl/pkg/agent/prompts/exemplars/cluster-installation-ignition-failure.md
+++ b/tooling/hcpctl/pkg/agent/prompts/exemplars/cluster-installation-ignition-failure.md
@@ -4,6 +4,11 @@
 
 The test failed because a router Deployment rollout (triggered by the control-plane-operator adding the ignition-server backend to the `router` ConfigMap) could not complete: the new ReplicaSet's pod was stuck in `FailedCreatePodSandBox` due to Azure CNS errors (`network is not ready - mtpnc is not ready`). The old router pods remained running but served the old haproxy config without the ignition backend, so ignition requests fell through to the kube-apiserver via `default_backend kube_api`, causing a TLS certificate mismatch that left worker VMs stuck in an ignition fetch retry loop until Azure reported `OSProvisioningTimedOut`.
 
+## Classification
+
+- **Category:** Product Failures
+- **Component:** HyperShift
+
 ## Summary
 
 The test created a no-CNI private cluster, installed Cilium, then created node pool `cilium-np` and waited for nodes

--- a/tooling/hcpctl/pkg/agent/prompts/exemplars/clusters-service-worker-race-condition.md
+++ b/tooling/hcpctl/pkg/agent/prompts/exemplars/clusters-service-worker-race-condition.md
@@ -4,6 +4,11 @@
 
 A race condition between two independent Clusters Service workers caused the HyperShift NodePool `spec.replicas` to be reverted from `3` back to `2`, even though the CS database correctly stored `replicas=3`. The node pool worker and the upgrade policy worker both performed concurrent read-modify-write operations on the same ManifestWork, and the last writer (upgrade policy worker) overwrote the replica change applied by the first writer (node pool worker).
 
+## Classification
+
+- **Category:** Product Failures
+- **Component:** Cluster Service
+
 ## Summary
 
 The test triggered a single node-pool PATCH at **2026-07-20T21:32:57Z** to both upgrade `npupgrade-4-20` to `4.21.25` and scale replicas to `3`. Clusters Service correctly persisted both changes in its database and dispatched them to two independent workers:

--- a/tooling/hcpctl/pkg/agent/prompts/system.md
+++ b/tooling/hcpctl/pkg/agent/prompts/system.md
@@ -50,6 +50,11 @@ Your final output MUST be a valid JSON object with this structure:
     "root_cause": "Terse, one-sentence description of the root cause, as best we can tell",
     "summary": "Rich Markdown overview of the narrative that the chain links below will give full details over",
     "notes": "Free-form rich markdown content to expand on the summary",
+    "classification": {
+        "l1_category": "Product Failures",
+        "l2_subcategory": "HyperShift",
+        "confidence": 0.92
+    },
     "chain": [
         {
             "question": "Why did this test fail?",
@@ -141,6 +146,53 @@ Your final output MUST be a valid JSON object with this structure:
   `file` specifying which console log from the manifest's `node_console_logs`).
 - Use Markdown in all free-form text content to correctly format the output and
   improve communication efficacy.
+
+### Taxonomy Classification
+
+Every analysis MUST include a `classification` object that categorizes the
+failure. This enables automated aggregation and triage by downstream systems.
+
+#### L1 Categories
+
+Assign exactly one L1 category based on where the failure originates:
+
+- **Azure Problems** — ARM/RP throttling, quota exhaustion, regional outages,
+  Azure platform errors, networking issues from Azure infrastructure
+- **Deployment Failures** — configuration errors, secret issues, Helm/EV2
+  deployment failures, image pull failures, rollout problems
+- **Product Failures** — operator crashes, reconciliation errors, nil pointer
+  dereferences, component bugs in ARO-HCP services or dependencies
+- **Test Reliability** — cleanup/teardown failures, artifact upload issues,
+  test infrastructure problems, flaky assertions, test-side timeouts unrelated
+  to the product
+
+#### L2 Subcategories
+
+When `l1_category` is `"Product Failures"`, you MUST also set `l2_subcategory`
+to identify the responsible component:
+
+- **Frontend** — the ARM REST API endpoint (RP frontend)
+- **Cluster Service** — Clusters Service (CS) cluster lifecycle management
+- **Backend** — the RP backend for async operations
+- **Maestro** — multi-cluster orchestration (server or agent)
+- **HyperShift** — HyperShift operator, hosted control plane components, CAPI
+- **RH Upstream** — bugs in upstream Red Hat components (MCE, ACM, OLM, etc.)
+
+When `l1_category` is NOT `"Product Failures"`, omit `l2_subcategory`.
+
+#### Confidence Score
+
+Set `confidence` to a value between 0 and 1 indicating how certain you are
+about the classification:
+
+- **0.9–1.0** — strong evidence directly points to this category
+- **0.7–0.9** — evidence is clear but some ambiguity remains
+- **0.5–0.7** — classification is plausible but evidence is indirect
+- **below 0.5** — low confidence; consider whether the analysis has enough
+  evidence to support any classification
+
+Base your confidence on the strength of the evidence in the causal chain, not
+on the length of the chain itself.
 
 ## Markdown Formatting Rules
 

--- a/tooling/hcpctl/pkg/agent/render.go
+++ b/tooling/hcpctl/pkg/agent/render.go
@@ -33,6 +33,17 @@ func RenderMarkdown(chain *HydratedChain, testName string) string {
 	sb.WriteString(chain.RootCause)
 	sb.WriteString("\n\n")
 
+	// Classification.
+	if chain.Classification != nil {
+		sb.WriteString("## Classification\n\n")
+		sb.WriteString(fmt.Sprintf("- **Category:** %s\n", chain.Classification.L1Category))
+		if chain.Classification.L2Subcategory != "" {
+			sb.WriteString(fmt.Sprintf("- **Component:** %s\n", chain.Classification.L2Subcategory))
+		}
+		sb.WriteString(fmt.Sprintf("- **Confidence:** %.0f%%\n", chain.Classification.Confidence*100))
+		sb.WriteString("\n")
+	}
+
 	// Summary.
 	sb.WriteString("## Summary\n\n")
 	sb.WriteString(chain.Summary)

--- a/tooling/hcpctl/pkg/agent/schema.go
+++ b/tooling/hcpctl/pkg/agent/schema.go
@@ -20,15 +20,66 @@ import (
 	"github.com/Azure/ARO-HCP/tooling/hcpctl/internal/tabular"
 )
 
+// L1 failure taxonomy categories.
+const (
+	L1AzureProblems      = "Azure Problems"
+	L1DeploymentFailures = "Deployment Failures"
+	L1ProductFailures    = "Product Failures"
+	L1TestReliability    = "Test Reliability"
+)
+
+// ValidL1Categories is the set of allowed L1 taxonomy values.
+var ValidL1Categories = map[string]bool{
+	L1AzureProblems:      true,
+	L1DeploymentFailures: true,
+	L1ProductFailures:    true,
+	L1TestReliability:    true,
+}
+
+// L2 subcategories, valid only when L1 is "Product Failures".
+const (
+	L2Frontend       = "Frontend"
+	L2ClusterService = "Cluster Service"
+	L2Backend        = "Backend"
+	L2Maestro        = "Maestro"
+	L2HyperShift     = "HyperShift"
+	L2RHUpstream     = "RH Upstream"
+)
+
+// ValidL2Subcategories is the set of allowed L2 taxonomy values.
+var ValidL2Subcategories = map[string]bool{
+	L2Frontend:       true,
+	L2ClusterService: true,
+	L2Backend:        true,
+	L2Maestro:        true,
+	L2HyperShift:     true,
+	L2RHUpstream:     true,
+}
+
+// Classification holds the taxonomy classification for an analysis.
+type Classification struct {
+	// L1Category is the top-level failure category.
+	L1Category string `json:"l1_category"`
+
+	// L2Subcategory is the component-level subcategory, required only
+	// when L1Category is "Product Failures".
+	L2Subcategory string `json:"l2_subcategory,omitempty"`
+
+	// Confidence is a score from 0 to 1 indicating how certain the
+	// model is about this classification.
+	Confidence float64 `json:"confidence"`
+}
+
 // DraftChain is the structured output the agent must produce as its final message.
 // This is the pre-hydration format — KQL queries have no share URIs or result tables yet.
 type DraftChain struct {
-	RootCause   string          `json:"root_cause"`
-	Summary     string          `json:"summary"`
-	Notes       string          `json:"notes,omitempty"`
-	Discovery   []DiscoveryItem `json:"discovery,omitempty"`
-	Chain       []ChainLink     `json:"chain"`
-	Suggestions []string        `json:"suggestions,omitempty"`
+	RootCause      string          `json:"root_cause"`
+	Summary        string          `json:"summary"`
+	Notes          string          `json:"notes,omitempty"`
+	Classification *Classification `json:"classification,omitempty"`
+	Discovery      []DiscoveryItem `json:"discovery,omitempty"`
+	Chain          []ChainLink     `json:"chain"`
+	Suggestions    []string        `json:"suggestions,omitempty"`
 }
 
 // DiscoveryItem is an agent-authored KQL query with a label, used to establish
@@ -74,12 +125,13 @@ type ProofItem struct {
 
 // HydratedChain extends DraftChain with query results and share URIs.
 type HydratedChain struct {
-	RootCause   string              `json:"root_cause"`
-	Summary     string              `json:"summary"`
-	Notes       string              `json:"notes,omitempty"`
-	Discovery   []HydratedDiscovery `json:"discovery,omitempty"`
-	Chain       []HydratedLink      `json:"chain"`
-	Suggestions []string            `json:"suggestions,omitempty"`
+	RootCause      string              `json:"root_cause"`
+	Summary        string              `json:"summary"`
+	Notes          string              `json:"notes,omitempty"`
+	Classification *Classification     `json:"classification,omitempty"`
+	Discovery      []HydratedDiscovery `json:"discovery,omitempty"`
+	Chain          []HydratedLink      `json:"chain"`
+	Suggestions    []string            `json:"suggestions,omitempty"`
 }
 
 // HydratedDiscovery is a single leaf query directory from a discovery path,

--- a/tooling/hcpctl/pkg/agent/validation.go
+++ b/tooling/hcpctl/pkg/agent/validation.go
@@ -93,6 +93,72 @@ func ValidateDraft(ctx context.Context, client KustoClient, draft *DraftChain, v
 			Detail:   "- The summary is empty. Every analysis must include a non-empty summary.",
 		})
 	}
+	// Classification checks.
+	if draft.Classification == nil {
+		problems = append(problems, ValidationProblem{
+			Category: "missing_classification",
+			Chain:    -1,
+			Proof:    -1,
+			Detail:   "- The classification is missing. Every analysis must include a classification object with l1_category and confidence.",
+		})
+	} else {
+		if !ValidL1Categories[draft.Classification.L1Category] {
+			var allowed []string
+			for cat := range ValidL1Categories {
+				allowed = append(allowed, fmt.Sprintf("%q", cat))
+			}
+			sort.Strings(allowed)
+			problems = append(problems, ValidationProblem{
+				Category: "invalid_l1_category",
+				Chain:    -1,
+				Proof:    -1,
+				Detail: fmt.Sprintf(
+					"- The classification l1_category %q is not valid. Must be one of: %s.",
+					draft.Classification.L1Category, strings.Join(allowed, ", "),
+				),
+			})
+		}
+		if draft.Classification.L1Category == L1ProductFailures {
+			if !ValidL2Subcategories[draft.Classification.L2Subcategory] {
+				var allowed []string
+				for sub := range ValidL2Subcategories {
+					allowed = append(allowed, fmt.Sprintf("%q", sub))
+				}
+				sort.Strings(allowed)
+				problems = append(problems, ValidationProblem{
+					Category: "invalid_l2_subcategory",
+					Chain:    -1,
+					Proof:    -1,
+					Detail: fmt.Sprintf(
+						"- When l1_category is %q, l2_subcategory must be one of: %s. Got %q.",
+						L1ProductFailures, strings.Join(allowed, ", "), draft.Classification.L2Subcategory,
+					),
+				})
+			}
+		} else if draft.Classification.L2Subcategory != "" {
+			problems = append(problems, ValidationProblem{
+				Category: "unexpected_l2_subcategory",
+				Chain:    -1,
+				Proof:    -1,
+				Detail: fmt.Sprintf(
+					"- l2_subcategory should be omitted when l1_category is %q (l2 is only for %q).",
+					draft.Classification.L1Category, L1ProductFailures,
+				),
+			})
+		}
+		if draft.Classification.Confidence < 0 || draft.Classification.Confidence > 1 {
+			problems = append(problems, ValidationProblem{
+				Category: "invalid_confidence",
+				Chain:    -1,
+				Proof:    -1,
+				Detail: fmt.Sprintf(
+					"- The classification confidence must be between 0 and 1, got %g.",
+					draft.Classification.Confidence,
+				),
+			})
+		}
+	}
+
 	if len(draft.Chain) == 0 {
 		problems = append(problems, ValidationProblem{
 			Category: "empty_chain",


### PR DESCRIPTION
[ARO-28427](https://issues.redhat.com/browse/ARO-28427)

### What

Adds taxonomy classification to `hcpctl snapshot analyze` output. Each analysis now includes an L1 category, optional L2 subcategory (for Product Failures), and a confidence score assigned by the LLM.

### Why

Automated classification enables downstream aggregation and triage of test failures by category (Azure Problems, Deployment Failures, Product Failures, Test Reliability) without manual review of each analysis.

### Testing


**Unit tests** (`classification_test.go`): schema parsing (with/without classification), validation (14 subtests covering all L1/L2/confidence rules and boundary values), and markdown rendering (with L2, without L2, without classification).

**Manual verification** with `hcpctl snapshot analyze`:
1. Build hcpctl:
```
cd tooling/hcpctl && make build
```

2. Gather a snapshot from a failed Prow job:
```
hcpctl snapshot from-prow-job --url <prow-job-url> --test <test-name> --output-dir <snapshot-path>
```

3. Run the analysis:
```
hcpctl snapshot analyze <snapshot-path>/path/to/<test-name> \
--aro-hcp <path-to-aro-hcp-repo> \
--hypershift <path-to-hypershift-repo> \
--maestro <path-to-maestro-repo> \
--clusters-service <path-to-CS-repo>
```

4. Verify `analysis.json` contains a `classification` object with `l1_category`, `confidence`, and `l2_subcategory` (when applicable)
5. Verify `analysis.md` contains a "Classification" section with Category, Component (if Product Failures), and Confidence percentage


### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge