### PR TITLE
chore: remove static role assignment quota config

### DIFF
--- a/config/config-dev-ci.schema.json
+++ b/config/config-dev-ci.schema.json
@@ -588,7 +588,6 @@
       "description": "Configuration for monitoring quota in a single subscription",
       "properties": {
         "name": { "type": "string", "description": "Subscription display name (used to resolve the subscription ID at runtime)" },
-        "roleAssignmentLimit": { "type": "integer", "description": "Role assignment limit for the subscription (default 4000)" },
         "regions": {
           "type": "array",
           "description": "Azure regions to monitor for regional quotas",

--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -180,55 +180,45 @@ clouds:
             directoryQuota: true
             subscriptions:
             - name: "ARO Hosted Control Planes (EA Subscription 1)"
-              roleAssignmentLimit: 4000
               regions:
               - westus3
               - centralus
               - canadacentral
             - name: "ARO HCP E2E Hosted Clusters (EA Subscription)"
-              roleAssignmentLimit: 8000
               regions:
               - westus3
               - centralus
               - canadacentral
             - name: "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
-              roleAssignmentLimit: 8000
               regions:
               - westus3
               - centralus
               - canadacentral
             - name: "ARO HCP E2E Hosted Clusters - Dev - 02"
-              roleAssignmentLimit: 8000
               regions:
               - westus3
               - centralus
               - canadacentral
             - name: "ARO HCP E2E Hosted Clusters - Dev - 03"
-              roleAssignmentLimit: 8000
               regions:
               - westus3
               - centralus
               - canadacentral
             - name: "ARO HCP E2E Infrastructure (EA Subscription)"
-              roleAssignmentLimit: 4000
               regions:
               - westus3
               - centralus
               - canadacentral
             - name: "ARO SRE Team - INT (EA Subscription 3)"
-              roleAssignmentLimit: 4000
               regions:
               - uksouth
             - name: "ARO HCP E2E Hosted Clusters - Stage - 00"
-              roleAssignmentLimit: 8000
               regions:
               - uksouth
             - name: "ARO HCP E2E Hosted Clusters - Prod - 00"
-              roleAssignmentLimit: 8000
               regions:
               - uksouth
             - name: "ARO HCP E2E Hosted Clusters - Prod - 01"
-              roleAssignmentLimit: 8000
               regions:
               - uksouth
           # Test Test Azure Red Hat OpenShift (Microsoft E2E tenant); directory quota off — subscription ARM only.
@@ -239,7 +229,6 @@ clouds:
             directoryQuota: false
             subscriptions:
             - name: "ARO HCP E2E"
-              roleAssignmentLimit: 4000
               regions:
               - eastus2euap
               - uksouth

--- a/tooling/tenant-quota/deploy/config.yaml.tmpl
+++ b/tooling/tenant-quota/deploy/config.yaml.tmpl
@@ -42,7 +42,6 @@ tenants:
   subscriptions:
 {{- range .subscriptions }}
   - name: "{{ .name }}"
-    roleAssignmentLimit: {{ .roleAssignmentLimit }}
     regions:
 {{- range .regions }}
     - "{{ . }}"

--- a/tooling/tenant-quota/deploy/templates/configmap.yaml
+++ b/tooling/tenant-quota/deploy/templates/configmap.yaml
@@ -30,7 +30,6 @@ data:
         subscriptions:
           {{- range .subscriptions }}
           - name: "{{ .name }}"
-            roleAssignmentLimit: {{ .roleAssignmentLimit | default 4000 }}
             regions:
               {{- range .regions }}
               - "{{ . }}"

--- a/tooling/tenant-quota/deploy/values.yaml.tmpl
+++ b/tooling/tenant-quota/deploy/values.yaml.tmpl
@@ -32,7 +32,6 @@ tenants:
   subscriptions:
 {{- range .subscriptions }}
     - name: "{{ .name }}"
-      roleAssignmentLimit: {{ .roleAssignmentLimit }}
       regions:
 {{- range .regions }}
         - "{{ . }}"


### PR DESCRIPTION
Tracking: https://redhat.atlassian.net/browse/AROSLSRE-1789

### What

- Remove `roleAssignmentLimit` from DEV CI source configuration and schema.
- Stop rendering the legacy field into Helm values and the exporter ConfigMap.

### Why

The API-backed exporter introduced by #6494 no longer consumes a static role-assignment limit. Removing the field avoids stale duplicated quota data.

### Rollout status

- #6494 merged as source commit `7130001c6c57c63f94e5b6689a28cf648f2b5ba4`.
- The latest ACR image is tag `7130001`, digest `sha256:85389f23b01d9bfbf6abe9963df8f0e619374ec7dbcd9b4a83a5c1e325fed20b`.
- That digest is already on `main`, and the DEV CI postsubmit deployment succeeded.

### Testing

- `make -C config materialize`
- `make verify-schema`
- `git diff --check`
- Confirmed rendered runtime config contains no `roleAssignmentLimit`.

Screenshots are not applicable because this only removes an obsolete configuration field and does not change metric names, labels, or visualizations.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes) — not applicable; no visualization change
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide) — running after force-push
- [x] Commit history is clean (rebased/squashed)
- [x] All comment threads resolved before merge