### PR TITLE
fix: retry transient ARM deployment polling 404s

### DIFF
--- a/tooling/templatize/pkg/pipeline/arm.go
+++ b/tooling/templatize/pkg/pipeline/arm.go
@@ -32,6 +32,8 @@ import (
 	"github.com/Azure/ARO-Tools/pipelines/types"
 	"github.com/Azure/ARO-Tools/tools/cmdutils"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -58,7 +60,13 @@ func newArmClient(subscriptionID, region string, bicepClient *bicep.LSPClient) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to get credentials: %w", err)
 	}
-	deploymentClient, err := armresources.NewDeploymentsClient(subscriptionID, cred, nil)
+	deploymentClient, err := armresources.NewDeploymentsClient(subscriptionID, cred, &azcorearm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			PerCallPolicies: []policy.Policy{
+				newLROPollerRetryDeploymentNotFoundPolicy(),
+			},
+		},
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create deployment client: %w", err)
 	}

--- a/tooling/templatize/pkg/pipeline/arm_retry_policy.go
+++ b/tooling/templatize/pkg/pipeline/arm_retry_policy.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+// lroPollerRetryDeploymentNotFoundPolicy retries transient 404
+// DeploymentNotFound errors from ARM deployment LRO operation status polling.
+type lroPollerRetryDeploymentNotFoundPolicy struct {
+	backoff wait.Backoff
+}
+
+func newLROPollerRetryDeploymentNotFoundPolicy() *lroPollerRetryDeploymentNotFoundPolicy {
+	return &lroPollerRetryDeploymentNotFoundPolicy{
+		backoff: wait.Backoff{
+			Duration: time.Second,
+			Factor:   2,
+			Jitter:   0.1,
+			Steps:    3,
+		},
+	}
+}
+
+func (p *lroPollerRetryDeploymentNotFoundPolicy) Do(req *policy.Request) (*http.Response, error) {
+	if !strings.EqualFold(req.Raw().Method, http.MethodGet) {
+		return req.Next()
+	}
+	path := req.Raw().URL.Path
+	if !strings.Contains(path, "/providers/Microsoft.Resources/deployments/") || !strings.Contains(path, "/operationStatuses/") {
+		return req.Next()
+	}
+
+	logger := logr.FromContextOrDiscard(req.Raw().Context())
+	var resp *http.Response
+	var lastRetryableErr error
+
+	err := wait.ExponentialBackoffWithContext(req.Raw().Context(), p.backoff, func(ctx context.Context) (bool, error) {
+		retryReq := req.Clone(ctx)
+		if err := retryReq.RewindBody(); err != nil {
+			return false, err
+		}
+
+		var err error
+		resp, err = retryReq.Next()
+		if err == nil {
+			return true, nil
+		}
+		if resp != nil {
+			if resp.Body != nil {
+				if closeErr := resp.Body.Close(); closeErr != nil {
+					logger.Error(closeErr, "failed to close response body")
+				}
+			}
+			resp = nil
+		}
+
+		var respErr *azcore.ResponseError
+		if !errors.As(err, &respErr) ||
+			respErr.StatusCode != http.StatusNotFound ||
+			!strings.EqualFold(respErr.ErrorCode, "DeploymentNotFound") {
+			return false, err
+		}
+
+		lastRetryableErr = err
+		return false, nil
+	})
+	if err == nil {
+		return resp, nil
+	}
+	if req.Raw().Context().Err() != nil {
+		return nil, req.Raw().Context().Err()
+	}
+	if wait.Interrupted(err) && lastRetryableErr != nil {
+		return resp, lastRetryableErr
+	}
+	return resp, err
+}

--- a/tooling/templatize/pkg/pipeline/arm_retry_policy_test.go
+++ b/tooling/templatize/pkg/pipeline/arm_retry_policy_test.go
@@ -1,0 +1,220 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+const deploymentOperationStatusPath = "/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.Resources/deployments/my-deploy/operationStatuses/op-id"
+
+func newRetryPolicyTestPipeline(pol policy.Policy, transport policy.Transporter) runtime.Pipeline {
+	return runtime.NewPipeline("test", "v0.0.0",
+		runtime.PipelineOptions{
+			PerCall: []policy.Policy{pol},
+		},
+		&policy.ClientOptions{
+			Transport: transport,
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	)
+}
+
+func successfulResponse() (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+		Body:       http.NoBody,
+	}, nil
+}
+
+func TestLROPollerRetryDeploymentNotFoundPolicy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("passes through non-matching requests", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name   string
+			method string
+			path   string
+		}{
+			{
+				name:   "non-GET request",
+				method: http.MethodPost,
+				path:   deploymentOperationStatusPath,
+			},
+			{
+				name:   "deployment resource GET",
+				method: http.MethodGet,
+				path:   "/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.Resources/deployments/my-deploy",
+			},
+			{
+				name:   "unrelated resource GET",
+				method: http.MethodGet,
+				path:   "/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				callCount := 0
+				transport := &fakeTransport{
+					interceptor: func(_ *http.Request) (*http.Response, error) {
+						callCount++
+						return successfulResponse()
+					},
+				}
+				pipeline := newRetryPolicyTestPipeline(newLROPollerRetryDeploymentNotFoundPolicy(), transport)
+				req, err := runtime.NewRequest(t.Context(), tt.method, "https://management.azure.com"+tt.path)
+				require.NoError(t, err)
+
+				resp, err := pipeline.Do(req)
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				assert.Equal(t, 1, callCount)
+			})
+		}
+	})
+
+	t.Run("retries DeploymentNotFound then succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		callCount := 0
+		pol := &lroPollerRetryDeploymentNotFoundPolicy{
+			backoff: wait.Backoff{
+				Duration: time.Millisecond,
+				Steps:    3,
+			},
+		}
+		transport := &fakeTransport{
+			interceptor: func(_ *http.Request) (*http.Response, error) {
+				callCount++
+				if callCount <= 2 {
+					return nil, &azcore.ResponseError{
+						StatusCode: http.StatusNotFound,
+						ErrorCode:  "DeploymentNotFound",
+					}
+				}
+				return successfulResponse()
+			},
+		}
+		pipeline := newRetryPolicyTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(t.Context(), http.MethodGet, "https://management.azure.com"+deploymentOperationStatusPath)
+		require.NoError(t, err)
+
+		resp, err := pipeline.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, 3, callCount)
+	})
+
+	t.Run("exhausts retries on persistent DeploymentNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		callCount := 0
+		pol := &lroPollerRetryDeploymentNotFoundPolicy{
+			backoff: wait.Backoff{
+				Duration: time.Millisecond,
+				Steps:    3,
+			},
+		}
+		transport := &fakeTransport{
+			interceptor: func(_ *http.Request) (*http.Response, error) {
+				callCount++
+				return nil, &azcore.ResponseError{
+					StatusCode: http.StatusNotFound,
+					ErrorCode:  "DeploymentNotFound",
+				}
+			},
+		}
+		pipeline := newRetryPolicyTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(t.Context(), http.MethodGet, "https://management.azure.com"+deploymentOperationStatusPath)
+		require.NoError(t, err)
+
+		_, err = pipeline.Do(req)
+		var responseErr *azcore.ResponseError
+		require.ErrorAs(t, err, &responseErr)
+		assert.Equal(t, "DeploymentNotFound", responseErr.ErrorCode)
+		assert.Equal(t, 3, callCount)
+	})
+
+	t.Run("does not retry other errors", func(t *testing.T) {
+		t.Parallel()
+
+		callCount := 0
+		pol := &lroPollerRetryDeploymentNotFoundPolicy{
+			backoff: wait.Backoff{
+				Duration: time.Millisecond,
+				Steps:    3,
+			},
+		}
+		transport := &fakeTransport{
+			interceptor: func(_ *http.Request) (*http.Response, error) {
+				callCount++
+				return nil, &azcore.ResponseError{
+					StatusCode: http.StatusInternalServerError,
+					ErrorCode:  "InternalServerError",
+				}
+			},
+		}
+		pipeline := newRetryPolicyTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(t.Context(), http.MethodGet, "https://management.azure.com"+deploymentOperationStatusPath)
+		require.NoError(t, err)
+
+		_, err = pipeline.Do(req)
+		assert.Error(t, err)
+		assert.Equal(t, 1, callCount)
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		pol := &lroPollerRetryDeploymentNotFoundPolicy{
+			backoff: wait.Backoff{
+				Duration: time.Millisecond,
+				Steps:    3,
+			},
+		}
+		transport := &fakeTransport{
+			interceptor: func(_ *http.Request) (*http.Response, error) {
+				cancel()
+				return nil, &azcore.ResponseError{
+					StatusCode: http.StatusNotFound,
+					ErrorCode:  "DeploymentNotFound",
+				}
+			},
+		}
+		pipeline := newRetryPolicyTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(ctx, http.MethodGet, "https://management.azure.com"+deploymentOperationStatusPath)
+		require.NoError(t, err)
+
+		_, err = pipeline.Do(req)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+}


### PR DESCRIPTION
Related: [AROSLSRE-1787](https://redhat.atlassian.net/browse/AROSLSRE-1787)

Historical context: [ARO-23706](https://redhat.atlassian.net/browse/ARO-23706)

### What

Ports the E2E test client's ARM deployment LRO retry handling into templatize and attaches it to the deployment client.

The policy retries only `GET` requests to `Microsoft.Resources/deployments/.../operationStatuses/...` that fail with HTTP 404 and error code `DeploymentNotFound`. It uses the codebase-standard `k8s.io/apimachinery/pkg/util/wait.Backoff` helper for two short retries with 1-second initial delay, exponential growth, and jitter.

### Why

ARM can briefly return `DeploymentNotFound` when templatize polls a deployment immediately after creating it. CIHealth recorded five provision failures from August 5-11 where polling failed within 142 ms of deployment creation; the deployments subsequently appeared as `Succeeded`.

[ARO-23706](https://redhat.atlassian.net/browse/ARO-23706) tracked the same ARM eventual-consistency failure and was closed after the E2E test binary gained retry handling. Applying the same narrowly scoped handling to templatize prevents valid provision pipelines from failing without delaying ordinary deployment-resource GETs used for cache lookup.

### Testing

- Unit tests cover matching and non-matching requests, retry success, retry exhaustion, non-retryable errors, and context cancellation
- `cd tooling/templatize && go test ./pkg/pipeline -count=1`

### Special notes for your reviewer

This intentionally does not use the broader implementation from `origin/arm-deployment-retry-policy`, which also retries ordinary deployment GETs and could delay expected cache misses.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes) — not applicable
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide) — pending draft PR CI
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged — intentionally omitted for this draft
- [x] All comment threads resolved before merge
