### PR TITLE
feat: manage mock identity owners declaratively

### DIFF
--- a/config/config-dev-ci.schema.json
+++ b/config/config-dev-ci.schema.json
@@ -92,6 +92,10 @@
             }
           }
         },
+        "entraAppOwnerIds": {
+          "type": "string",
+          "description": "Comma-separated Entra object IDs that own CI-managed applications and service principals"
+        },
         "global": {
           "type": "object",
           "properties": {

--- a/config/config-dev-ci.schema.json
+++ b/config/config-dev-ci.schema.json
@@ -94,6 +94,7 @@
         },
         "entraAppOwnerIds": {
           "type": "string",
+          "minLength": 1,
           "description": "Comma-separated Entra object IDs that own CI-managed applications and service principals"
         },
         "global": {

--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -34,6 +34,7 @@ clouds:
         globalMSIName: "global-rollout-identity"
       dns:
         regionalSubdomain: "{{ .ctx.regionShort }}"
+      entraAppOwnerIds: "e4022ba9-7428-4de4-9afa-f40c521c1a33,cc1cceaf-e7fa-4cbb-9379-f6fbd70c9cf1,28c69853-0f40-49de-ad85-b9de0165e5b6,c1824db4-7152-429b-a58a-2170eaa74a53,772a02e3-1df6-48dd-86ab-dfe98438ab1e,9ff7a250-d897-41ee-982e-dc4ec28c4920,1daf5200-78ea-454d-84a1-a15f98876f5d,2a42baa4-f7b2-4856-8bc7-67fe5327cae7,55236c0a-cada-46da-8985-8282535f77ac,48522ac4-74b2-426d-b56c-4a4abca49d12,770ce6b0-5afe-472d-ac0d-1fae72acc4e4,d2f4cb88-b929-4f6c-8944-221108a41f57,f5b85e91-2303-4094-9cd1-73dab9585935,16ea1e12-7ef3-4613-bea4-3d4a20cbc38c,71185b05-072a-4683-ab19-0fb016b58101" # aro-hcp-owners members
       opstool:
         aks:
           name: "opstool-{{ .ctx.regionShort }}"

--- a/dev-infrastructure/configurations/mock-identity-apps-int.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mock-identity-apps-int.tmpl.bicepparam
@@ -1,5 +1,7 @@
 using '../templates/mock-identity-apps.bicep'
 
+param ownerIds = '{{ .entraAppOwnerIds }}'
+
 param identities = [
   {
     applicationName: '{{ .ci.int.mockIdentities.firstParty.applicationName }}'

--- a/dev-infrastructure/configurations/mock-identity-apps.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mock-identity-apps.tmpl.bicepparam
@@ -1,5 +1,7 @@
 using '../templates/mock-identity-apps.bicep'
 
+param ownerIds = '{{ .entraAppOwnerIds }}'
+
 param identities = [
   {
     applicationName: '{{ .ci.dev.mockIdentities.firstParty.applicationName }}'

--- a/dev-infrastructure/modules/entra/app.bicep
+++ b/dev-infrastructure/modules/entra/app.bicep
@@ -14,6 +14,9 @@ param uniqueName string = applicationName
 @description('Comma-separated list of owner object IDs for the application and service principal. When empty, Azure AD default behavior applies (caller is added as owner).')
 param ownerIds string = ''
 
+@description('Whether explicit owners are appended to or replace existing owner relationships')
+param ownerRelationshipSemantics 'append' | 'replace' = 'append'
+
 @description('Whether to create the service principal for this application')
 param manageSp bool
 
@@ -54,6 +57,7 @@ resource entraAppWithoutKeyCredentials 'Microsoft.Graph/applications@beta' = if 
   trustedSubjectNameAndIssuers: trustedSubjectNameAndIssuers
   owners: hasExplicitOwners
     ? {
+        relationshipSemantics: ownerRelationshipSemantics
         relationships: ownerIdArray
       }
     : null
@@ -72,6 +76,7 @@ resource entraAppWithKeyCredentials 'Microsoft.Graph/applications@beta' = if (!e
   trustedSubjectNameAndIssuers: trustedSubjectNameAndIssuers
   owners: hasExplicitOwners
     ? {
+        relationshipSemantics: ownerRelationshipSemantics
         relationships: ownerIdArray
       }
     : null
@@ -83,6 +88,7 @@ resource servicePrincipal 'Microsoft.Graph/servicePrincipals@beta' = if (manageS
   appId: empty(keyCredentials) ? entraAppWithoutKeyCredentials.appId : entraAppWithKeyCredentials.appId
   owners: hasExplicitOwners
     ? {
+        relationshipSemantics: ownerRelationshipSemantics
         relationships: ownerIdArray
       }
     : null

--- a/dev-infrastructure/templates/mock-identity-apps.bicep
+++ b/dev-infrastructure/templates/mock-identity-apps.bicep
@@ -46,6 +46,7 @@ module sharedApps '../modules/entra/app.bicep' = [
       applicationName: identity.applicationName
       uniqueName: toLower(replace(identity.applicationName, ' ', '-'))
       ownerIds: ownerIds
+      ownerRelationshipSemantics: 'replace'
       manageSp: true
     }
   }
@@ -58,6 +59,7 @@ module poolApps '../modules/entra/app.bicep' = [
       applicationName: '${poolAppBaseName}-${i}'
       uniqueName: toLower(replace('${poolAppBaseName}-${i}', ' ', '-'))
       ownerIds: ownerIds
+      ownerRelationshipSemantics: 'replace'
       manageSp: true
     }
   }
@@ -70,6 +72,7 @@ module armHelperPoolApps '../modules/entra/app.bicep' = [
       applicationName: '${armHelperPoolAppBaseName}-${i}'
       uniqueName: toLower(replace('${armHelperPoolAppBaseName}-${i}', ' ', '-'))
       ownerIds: ownerIds
+      ownerRelationshipSemantics: 'replace'
       manageSp: true
     }
   }

--- a/dev-infrastructure/templates/mock-identity-apps.bicep
+++ b/dev-infrastructure/templates/mock-identity-apps.bicep
@@ -22,6 +22,9 @@
 @description('Shared mock identity definitions: array of {applicationName, certDns}')
 param identities array
 
+@description('Comma-separated owner object IDs for every mock identity application and service principal')
+param ownerIds string
+
 @description('Number of pooled MSI mock identities to create')
 param poolSize int = 0
 
@@ -42,6 +45,7 @@ module sharedApps '../modules/entra/app.bicep' = [
     params: {
       applicationName: identity.applicationName
       uniqueName: toLower(replace(identity.applicationName, ' ', '-'))
+      ownerIds: ownerIds
       manageSp: true
     }
   }
@@ -53,6 +57,7 @@ module poolApps '../modules/entra/app.bicep' = [
     params: {
       applicationName: '${poolAppBaseName}-${i}'
       uniqueName: toLower(replace('${poolAppBaseName}-${i}', ' ', '-'))
+      ownerIds: ownerIds
       manageSp: true
     }
   }
@@ -64,6 +69,7 @@ module armHelperPoolApps '../modules/entra/app.bicep' = [
     params: {
       applicationName: '${armHelperPoolAppBaseName}-${i}'
       uniqueName: toLower(replace('${armHelperPoolAppBaseName}-${i}', ' ', '-'))
+      ownerIds: ownerIds
       manageSp: true
     }
   }

--- a/dev-infrastructure/templates/mock-identity-apps.bicep
+++ b/dev-infrastructure/templates/mock-identity-apps.bicep
@@ -23,6 +23,7 @@
 param identities array
 
 @description('Comma-separated owner object IDs for every mock identity application and service principal')
+@minLength(1)
 param ownerIds string
 
 @description('Number of pooled MSI mock identities to create')


### PR DESCRIPTION
[ARO-28965](https://redhat.atlassian.net/browse/ARO-28965)

### What

- declares the 15 current `aro-hcp-owners` members once in the dev-ci configuration
- passes that owner set to every DEV and INT mock identity application, pooled application, and service principal
- reuses the existing `modules/entra/app.bicep` owner relationship implementation

### Why

Mock identity owners were previously omitted from Bicep, so Entra's default behavior made the privileged pipeline runner the owner. Declaring the intended owner set makes access reproducible and prevents ownership from depending on who ran the pipeline.

### Testing

- `az bicep build --file dev-infrastructure/templates/mock-identity-apps.bicep --stdout`
- rendered and built both changed mock identity bicepparam templates with `az bicep build-params`
- compared the configured object IDs with the live `aro-hcp-owners` membership; the sets match
- canaried `relationshipSemantics: replace` against an identity with a legacy owner; the legacy owner was removed from both the application and service principal without changing IDs or key credentials
- reconciled all 63 DEV mock identities; all 63 applications and service principals now have exactly the authoritative 15-owner set, and all applications retain their pinned key credential
- reconciled all four INT mock identities; every application and service principal has exactly the authoritative 15-owner set, and every application retains its pinned key credential
- confirmed the privileged dev-ci target invokes templatize with `--skip-bicepparam-validation`; this is intentional because dev-ci entrypoints are not rolled out through EV2

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the Why behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots not applicable
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP
- [x] Commit history is clean
- [x] Tricky code blocks are commented or self-explanatory
- [ ] Specific reviewers tagged (intentionally deferred)
- [ ] All comment threads resolved before merge