### PR TITLE
feat: enable option to restrict Grafana public network access and document future VPN requirement

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -826,6 +826,13 @@
         "Auto"
       ]
     },
+    "publicNetworkAccess": {
+      "type": "string",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ]
+    },
     "prometheus": {
       "type": "object",
       "additionalProperties": false,
@@ -3094,6 +3101,9 @@
         "grafanaZoneRedundantMode": {
           "$ref": "#/definitions/zoneRedundantMode"
         },
+        "grafanaPublicNetworkAccess": {
+          "$ref": "#/definitions/publicNetworkAccess"
+        },
         "grafanaRoles": {
           "type": "string",
           "description": "A space-separated list of Service Principals IDs, Types and their desired grafana roles The format is: <principalId>/<principalType>/<role>, e.g. 12345678-1234-1234-1234-123456789012/Group/Admin",
@@ -3207,6 +3217,7 @@
         "grafanaMajorVersion",
         "crossTenantSecurityGroup",
         "grafanaZoneRedundantMode",
+        "grafanaPublicNetworkAccess",
         "svcWorkspaceName",
         "hcpWorkspaceName",
         "amwScaling",

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -428,6 +428,7 @@ defaults:
     # to chage "" to >- when you add a value.
     grafanaRoles: ""
     crossTenantSecurityGroup: ""
+    grafanaPublicNetworkAccess: "Disabled"
     svcWorkspaceName: 'services-{{ .ctx.region }}'
     hcpWorkspaceName: 'hcps-{{ .ctx.region }}'
     amwScaling:
@@ -1450,6 +1451,7 @@ clouds:
         grafanaName: arohcp-dev
         grafanaMajorVersion: '12'
         grafanaZoneRedundantMode: Disabled
+        grafanaPublicNetworkAccess: Enabled
         grafanaRoles: >-
           6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
         svcWorkspaceName: 'services-{{ .ctx.regionShort }}'

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -428,7 +428,7 @@ defaults:
     # to chage "" to >- when you add a value.
     grafanaRoles: ""
     crossTenantSecurityGroup: ""
-    grafanaPublicNetworkAccess: "Disabled"
+    grafanaPublicNetworkAccess: "Enabled"
     svcWorkspaceName: 'services-{{ .ctx.region }}'
     hcpWorkspaceName: 'hcps-{{ .ctx.region }}'
     amwScaling:

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -845,6 +845,7 @@ monitoring:
     enabled: true
   grafanaMajorVersion: "12"
   grafanaName: arohcp-dev
+  grafanaPublicNetworkAccess: Enabled
   grafanaRoles: 6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
   grafanaSku: Standard
   grafanaZoneRedundantMode: Disabled

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -845,6 +845,7 @@ monitoring:
     enabled: true
   grafanaMajorVersion: "12"
   grafanaName: arohcp-dev
+  grafanaPublicNetworkAccess: Enabled
   grafanaRoles: 6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
   grafanaSku: Standard
   grafanaZoneRedundantMode: Disabled

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -843,6 +843,7 @@ monitoring:
     enabled: true
   grafanaMajorVersion: "12"
   grafanaName: arohcp-dev
+  grafanaPublicNetworkAccess: Enabled
   grafanaRoles: 6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
   grafanaSku: Standard
   grafanaZoneRedundantMode: Disabled

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -843,6 +843,7 @@ monitoring:
     enabled: true
   grafanaMajorVersion: "12"
   grafanaName: arohcp-dev
+  grafanaPublicNetworkAccess: Enabled
   grafanaRoles: 6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
   grafanaSku: Standard
   grafanaZoneRedundantMode: Disabled

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -843,6 +843,7 @@ monitoring:
     enabled: true
   grafanaMajorVersion: "12"
   grafanaName: arohcp-dev
+  grafanaPublicNetworkAccess: Enabled
   grafanaRoles: 6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
   grafanaSku: Standard
   grafanaZoneRedundantMode: Disabled

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -845,6 +845,7 @@ monitoring:
     enabled: true
   grafanaMajorVersion: "12"
   grafanaName: arohcp-dev
+  grafanaPublicNetworkAccess: Enabled
   grafanaRoles: 6b6d3adf-8476-4727-9812-20ffdef2b85c/Group/Admin
   grafanaSku: Standard
   grafanaZoneRedundantMode: Disabled

--- a/dev-infrastructure/global-pipeline-stg.yaml
+++ b/dev-infrastructure/global-pipeline-stg.yaml
@@ -72,6 +72,8 @@ resourceGroups:
       configRef: monitoring.grafanaMajorVersion
     zoneRedundancy:
       configRef: monitoring.grafanaZoneRedundantMode
+    publicNetworkAccess:
+      configRef: monitoring.grafanaPublicNetworkAccess
     crossTenantSecurityGroup:
       configRef: monitoring.crossTenantSecurityGroup
     timeout: "15m"

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -52,6 +52,8 @@ resourceGroups:
       configRef: monitoring.grafanaMajorVersion
     zoneRedundancy:
       configRef: monitoring.grafanaZoneRedundantMode
+    publicNetworkAccess:
+      configRef: monitoring.grafanaPublicNetworkAccess
     crossTenantSecurityGroup:
       configRef: monitoring.crossTenantSecurityGroup
     timeout: "15m"

--- a/dev-infrastructure/grafana-pipeline.yaml
+++ b/dev-infrastructure/grafana-pipeline.yaml
@@ -30,6 +30,8 @@ resourceGroups:
       configRef: monitoring.grafanaMajorVersion
     zoneRedundancy:
       configRef: monitoring.grafanaZoneRedundantMode
+    publicNetworkAccess:
+      configRef: monitoring.grafanaPublicNetworkAccess
     crossTenantSecurityGroup:
       configRef: monitoring.crossTenantSecurityGroup
     identityFrom:

--- a/docs/README.md
+++ b/docs/README.md
@@ -183,6 +183,8 @@ Welcome to the **ARO HCP** documentation. This guide provides an overview of the
   - Setting up first-party, MSI mock, and ARM helper credentials for MSIT INT
 - [Test Tenant Access](sops/test-test-tenant-access.md)
   - Requesting access to the Test Test ARO tenant used for E2E in Stage and Prod
+- [Grafana VPN Access](sops/grafana-vpn-access.md)
+  - Troubleshooting access to Grafana instances when public network access is restricted
 
 ### AI Agent Hints
 

--- a/docs/ai/grafana-debugging.md
+++ b/docs/ai/grafana-debugging.md
@@ -5,7 +5,7 @@
 
 ## Access Requirements
 
-In staging, integration, and production environments, public network access to Grafana may be disabled. If so, the user must be connected to the **MSFT Corp VPN** to reach Grafana. If a Grafana URL is unreachable, prompt the user to verify VPN connectivity before further troubleshooting. Dev environment Grafana instances are publicly accessible.
+In staging, integration, and production environments, public network access to Grafana may be disabled. If so, the user must be connected to the **MSFT Corp VPN** to reach Grafana. If a Grafana URL is unreachable, prompt the user to verify VPN connectivity before further troubleshooting; see [Grafana VPN Access](../sops/grafana-vpn-access.md) for the full procedure. Dev environment Grafana instances are publicly accessible.
 
 ## Data Sources
 

--- a/docs/ai/grafana-debugging.md
+++ b/docs/ai/grafana-debugging.md
@@ -3,6 +3,10 @@
 - IMPORTANT: this document is referenced by agentic workflows, DO NOT REMOVE IT.
 - If any of the info below turns out not to be accurate, suggest to the user an update PR at the end of the session.
 
+## Access Requirements
+
+In staging, integration, and production environments, public network access to Grafana is disabled. The user must be connected to the **MSFT Corp VPN** to reach Grafana in those environments. If a Grafana URL is unreachable, prompt the user to verify VPN connectivity before further troubleshooting. Dev environment Grafana instances remain publicly accessible.
+
 ## Data Sources
 
 ### Obsolete Data Sources

--- a/docs/ai/grafana-debugging.md
+++ b/docs/ai/grafana-debugging.md
@@ -5,7 +5,7 @@
 
 ## Access Requirements
 
-In staging, integration, and production environments, public network access to Grafana is disabled. The user must be connected to the **MSFT Corp VPN** to reach Grafana in those environments. If a Grafana URL is unreachable, prompt the user to verify VPN connectivity before further troubleshooting. Dev environment Grafana instances remain publicly accessible.
+In staging, integration, and production environments, public network access to Grafana may be disabled. If so, the user must be connected to the **MSFT Corp VPN** to reach Grafana. If a Grafana URL is unreachable, prompt the user to verify VPN connectivity before further troubleshooting. Dev environment Grafana instances are publicly accessible.
 
 ## Data Sources
 

--- a/docs/alert-verification.md
+++ b/docs/alert-verification.md
@@ -15,7 +15,7 @@ With [alert-tester][alert-tester-repo] we have a fast approach to verify alerts 
 
 > [!NOTE]
 >
-> In staging, integration, and production environments, Grafana may be restricted to the **MSFT Corp VPN**. If you cannot reach a non-dev Grafana instance, ensure you are connected to the VPN before further troubleshooting.
+> In staging, integration, and production environments, Grafana may be restricted to the **MSFT Corp VPN**. If you cannot reach a non-dev Grafana instance, ensure you are connected to the VPN before further troubleshooting. See [Grafana VPN Access](sops/grafana-vpn-access.md) for details.
 
 ## Verifying alerts with [alert-tester][alert-tester-repo]
 

--- a/docs/alert-verification.md
+++ b/docs/alert-verification.md
@@ -13,6 +13,10 @@ With [alert-tester][alert-tester-repo] we have a fast approach to verify alerts 
 >
 > All commands below need to be executed on a machine from which you can log in to your b- account!
 
+> [!NOTE]
+>
+> In staging, integration, and production environments, Grafana is restricted to the **MSFT Corp VPN**. Ensure you are connected to the VPN before running `atest` commands against non-dev Grafana instances.
+
 ## Verifying alerts with [alert-tester][alert-tester-repo]
 
 In a bash shell (on a machine from which you can log in to your b- account), e.g. WSL, Linux, or Git Bash:

--- a/docs/alert-verification.md
+++ b/docs/alert-verification.md
@@ -15,7 +15,7 @@ With [alert-tester][alert-tester-repo] we have a fast approach to verify alerts 
 
 > [!NOTE]
 >
-> In staging, integration, and production environments, Grafana is restricted to the **MSFT Corp VPN**. Ensure you are connected to the VPN before running `atest` commands against non-dev Grafana instances.
+> In staging, integration, and production environments, Grafana may be restricted to the **MSFT Corp VPN**. If you cannot reach a non-dev Grafana instance, ensure you are connected to the VPN before further troubleshooting.
 
 ## Verifying alerts with [alert-tester][alert-tester-repo]
 

--- a/docs/grafana-dashboards.md
+++ b/docs/grafana-dashboards.md
@@ -4,7 +4,7 @@ Grafana is deployed using a Managed Grafana instance. Data is available via prec
 
 ## Prerequisites
 
-In staging, integration, and production environments, public network access to the Azure Managed Grafana instance may be disabled. If so, you must be connected to the **MSFT Corp VPN** to access Grafana. Dev environment Grafana instances are publicly accessible.
+In staging, integration, and production environments, public network access to the Azure Managed Grafana instance may be disabled. If so, you must be connected to the **MSFT Corp VPN** to access Grafana. Dev environment Grafana instances are publicly accessible. See [Grafana VPN Access](sops/grafana-vpn-access.md) for troubleshooting.
 
 ## Managing Dashboards
 

--- a/docs/grafana-dashboards.md
+++ b/docs/grafana-dashboards.md
@@ -2,6 +2,10 @@
 
 Grafana is deployed using a Managed Grafana instance. Data is available via preconfigured Datasources.
 
+## Prerequisites
+
+In staging, integration, and production environments, public network access to the Azure Managed Grafana instance is disabled. You must be connected to the **MSFT Corp VPN** to access Grafana in those environments. In dev environments, Grafana remains publicly accessible.
+
 ## Managing Dashboards
 
 There is a pipeline step to import dashboards. You need to create a `grafana-dashboards` folder in the ARO-HCP repo. This dashboard *MUST* be within the `observability/grafana-dashboards` folder, cause only observability is packaged into the EV2 artifact.

--- a/docs/grafana-dashboards.md
+++ b/docs/grafana-dashboards.md
@@ -4,7 +4,7 @@ Grafana is deployed using a Managed Grafana instance. Data is available via prec
 
 ## Prerequisites
 
-In staging, integration, and production environments, public network access to the Azure Managed Grafana instance is disabled. You must be connected to the **MSFT Corp VPN** to access Grafana in those environments. In dev environments, Grafana remains publicly accessible.
+In staging, integration, and production environments, public network access to the Azure Managed Grafana instance may be disabled. If so, you must be connected to the **MSFT Corp VPN** to access Grafana. Dev environment Grafana instances are publicly accessible.
 
 ## Managing Dashboards
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -96,7 +96,7 @@ A single **Azure Managed Grafana** instance is deployed globally and configured 
 - Region-agnostic dashboard experience
 - Consolidated alerting and monitoring workflows
 
-> **Note**: In staging, integration, and production environments, public network access to the Grafana instance may be disabled. If so, access requires connection to the **MSFT Corp VPN**. Dev environment Grafana is publicly accessible.
+> **Note**: In staging, integration, and production environments, public network access to the Grafana instance may be disabled. If so, access requires connection to the **MSFT Corp VPN**. Dev environment Grafana is publicly accessible. See [Grafana VPN Access](sops/grafana-vpn-access.md) for troubleshooting.
 
 ### Regional Azure Monitor Workspace
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -96,6 +96,8 @@ A single **Azure Managed Grafana** instance is deployed globally and configured 
 - Region-agnostic dashboard experience
 - Consolidated alerting and monitoring workflows
 
+> **Note**: In staging, integration, and production environments, public network access to the Grafana instance is disabled. Access requires connection to the **MSFT Corp VPN**. Dev environment Grafana remains publicly accessible.
+
 ### Regional Azure Monitor Workspace
 
 Each region contains **two Azure Monitor Workspaces (AMW)**:

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -96,7 +96,7 @@ A single **Azure Managed Grafana** instance is deployed globally and configured 
 - Region-agnostic dashboard experience
 - Consolidated alerting and monitoring workflows
 
-> **Note**: In staging, integration, and production environments, public network access to the Grafana instance is disabled. Access requires connection to the **MSFT Corp VPN**. Dev environment Grafana remains publicly accessible.
+> **Note**: In staging, integration, and production environments, public network access to the Grafana instance may be disabled. If so, access requires connection to the **MSFT Corp VPN**. Dev environment Grafana is publicly accessible.
 
 ### Regional Azure Monitor Workspace
 

--- a/docs/network-security.md
+++ b/docs/network-security.md
@@ -66,7 +66,7 @@ In contrast using a private endpoint additional resources are needed. Using bice
 | Management | KeyVault | msi | SVC AKS</br> MGMT AKS</br> EV2 | NSP |
 | Management | KeyVault | MGTM AKS etcd | MGMT AKS | NSP |
 | Management | KeyVault | MGTM | MGMT AKS | NSP |
-| Global | Managed Grafana | arohcp-{env} | Public internet (VPN-only planned) | PublicNetworkAccess (currently Enabled; disabling requires a PE or `crossTenantSecurityGroup` to avoid locking out all users) |
+| Global | Managed Grafana | arohcp-{env} | Public internet (VPN-only planned) | PublicNetworkAccess (currently Enabled; disabling requires a Private Endpoint to be reachable first, or all users are locked out) |
 
 ## Choosing between the two
 

--- a/docs/network-security.md
+++ b/docs/network-security.md
@@ -66,7 +66,7 @@ In contrast using a private endpoint additional resources are needed. Using bice
 | Management | KeyVault | msi | SVC AKS</br> MGMT AKS</br> EV2 | NSP |
 | Management | KeyVault | MGTM AKS etcd | MGMT AKS | NSP |
 | Management | KeyVault | MGTM | MGMT AKS | NSP |
-| Global | Managed Grafana | arohcp-{env} | MSFT Corp VPN | PublicNetworkAccess (when Disabled) |
+| Global | Managed Grafana | arohcp-{env} | Public internet (VPN-only planned) | PublicNetworkAccess (currently Enabled; disabling requires a PE or `crossTenantSecurityGroup` to avoid locking out all users) |
 
 ## Choosing between the two
 

--- a/docs/network-security.md
+++ b/docs/network-security.md
@@ -66,7 +66,7 @@ In contrast using a private endpoint additional resources are needed. Using bice
 | Management | KeyVault | msi | SVC AKS</br> MGMT AKS</br> EV2 | NSP |
 | Management | KeyVault | MGTM AKS etcd | MGMT AKS | NSP |
 | Management | KeyVault | MGTM | MGMT AKS | NSP |
-| Global | Managed Grafana | arohcp-{env} | MSFT Corp VPN | PublicNetworkAccess: Disabled |
+| Global | Managed Grafana | arohcp-{env} | MSFT Corp VPN | PublicNetworkAccess (when Disabled) |
 
 ## Choosing between the two
 

--- a/docs/network-security.md
+++ b/docs/network-security.md
@@ -66,6 +66,7 @@ In contrast using a private endpoint additional resources are needed. Using bice
 | Management | KeyVault | msi | SVC AKS</br> MGMT AKS</br> EV2 | NSP |
 | Management | KeyVault | MGTM AKS etcd | MGMT AKS | NSP |
 | Management | KeyVault | MGTM | MGMT AKS | NSP |
+| Global | Managed Grafana | arohcp-{env} | MSFT Corp VPN | PublicNetworkAccess: Disabled |
 
 ## Choosing between the two
 

--- a/docs/ops/kubernetes-provisioning-diagnostics.md
+++ b/docs/ops/kubernetes-provisioning-diagnostics.md
@@ -193,7 +193,7 @@ To diagnose slow provisioning, cross-reference this dashboard with cluster servi
 
 ### From Grafana UI
 
-> **Note**: In non-dev environments, Grafana requires **MSFT Corp VPN** connectivity.
+> **Note**: In non-dev environments, Grafana may require **MSFT Corp VPN** connectivity.
 
 1. Log into Grafana for your target environment (dev/cspr/int/stg/prod)
 2. Navigate to **Dashboards** → **Performance & Scale** folder

--- a/docs/ops/kubernetes-provisioning-diagnostics.md
+++ b/docs/ops/kubernetes-provisioning-diagnostics.md
@@ -192,6 +192,9 @@ To diagnose slow provisioning, cross-reference this dashboard with cluster servi
 ## Accessing the Dashboard
 
 ### From Grafana UI
+
+> **Note**: In non-dev environments, Grafana requires **MSFT Corp VPN** connectivity.
+
 1. Log into Grafana for your target environment (dev/cspr/int/stg/prod)
 2. Navigate to **Dashboards** → **Performance & Scale** folder
 3. Select **HCP Kubernetes Provisioning Diagnostics**

--- a/docs/ops/kubernetes-provisioning-diagnostics.md
+++ b/docs/ops/kubernetes-provisioning-diagnostics.md
@@ -193,7 +193,7 @@ To diagnose slow provisioning, cross-reference this dashboard with cluster servi
 
 ### From Grafana UI
 
-> **Note**: In non-dev environments, Grafana may require **MSFT Corp VPN** connectivity.
+> **Note**: In non-dev environments, Grafana may require **MSFT Corp VPN** connectivity. See [Grafana VPN Access](../sops/grafana-vpn-access.md) for troubleshooting.
 
 1. Log into Grafana for your target environment (dev/cspr/int/stg/prod)
 2. Navigate to **Dashboards** → **Performance & Scale** folder

--- a/docs/sops/grafana-vpn-access.md
+++ b/docs/sops/grafana-vpn-access.md
@@ -1,0 +1,33 @@
+# Grafana VPN Access
+
+## Overview
+
+Azure Managed Grafana instances in staging, integration, and production environments are configured with `publicNetworkAccess: Disabled`. This restricts access to users connected to the MSFT Corp VPN. Dev environment Grafana instances remain publicly accessible.
+
+## Prerequisites
+
+- MSFT Corp VPN client installed and configured
+- Azure AD account with an appropriate Grafana role assignment (Viewer, Contributor, or Admin)
+- Active VPN connection to the MSFT corporate network
+
+## Procedure
+
+1. Connect to the MSFT Corp VPN
+2. Navigate to the Grafana URL for your target environment (e.g. `https://arohcp-<env>-<id>.grafana.azure.com/`)
+3. Authenticate with your Azure AD credentials
+
+## Troubleshooting
+
+| Symptom | Possible Cause | Resolution |
+|---------|---------------|------------|
+| Cannot reach Grafana URL (timeout/connection refused) | VPN not connected | Connect to MSFT Corp VPN and retry |
+| 403 Forbidden or network error | Connected to guest/partner network instead of Corp VPN | Switch to the MSFT Corp VPN |
+| Dev environment works but staging/prod does not | Dev has public access enabled; staging/int/prod require VPN | Connect to VPN for non-dev environments |
+| VPN connected but still cannot access | DNS resolution issue | Flush DNS cache and retry; verify VPN routes include Azure endpoints |
+
+## Related Documentation
+
+- [Grafana Dashboards](../grafana-dashboards.md)
+- [Alert Verification](../alert-verification.md)
+- [Monitoring](../monitoring.md)
+- [Network Security](../network-security.md)

--- a/docs/sops/grafana-vpn-access.md
+++ b/docs/sops/grafana-vpn-access.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Azure Managed Grafana instances in staging, integration, and production environments are configured with `publicNetworkAccess: Disabled`. This restricts access to users connected to the MSFT Corp VPN. Dev environment Grafana instances remain publicly accessible.
+Azure Managed Grafana instances in staging, integration, and production environments can be configured with `publicNetworkAccess: Disabled`, which restricts access to users connected to the MSFT Corp VPN. Dev environment Grafana instances are publicly accessible.
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ Azure Managed Grafana instances in staging, integration, and production environm
 |---------|---------------|------------|
 | Cannot reach Grafana URL (timeout/connection refused) | VPN not connected | Connect to MSFT Corp VPN and retry |
 | 403 Forbidden or network error | Connected to guest/partner network instead of Corp VPN | Switch to the MSFT Corp VPN |
-| Dev environment works but staging/prod does not | Dev has public access enabled; staging/int/prod require VPN | Connect to VPN for non-dev environments |
+| Dev environment works but staging/prod does not | Dev has public access enabled; staging/int/prod may require VPN | Connect to VPN for non-dev environments |
 | VPN connected but still cannot access | DNS resolution issue | Flush DNS cache and retry; verify VPN routes include Azure endpoints |
 
 ## Related Documentation

--- a/docs/sops/grafana-vpn-access.md
+++ b/docs/sops/grafana-vpn-access.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Azure Managed Grafana instances in staging, integration, and production environments can be configured with `publicNetworkAccess: Disabled`. On its own, this only removes the public internet path — it does **not** grant MSFT Corp VPN users access. A Private Endpoint (with private DNS and VPN routing) and/or the `crossTenantSecurityGroup` tag must also be in place for authorized users to reach Grafana once public access is disabled; otherwise everyone, including VPN users, is locked out. Dev environment Grafana instances are publicly accessible.
+Azure Managed Grafana instances in staging, integration, and production environments can be configured with `publicNetworkAccess: Disabled`. On its own, this only removes the public internet path — it does **not** grant MSFT Corp VPN users access. A Private Endpoint with private DNS and VPN routing must be in place before disabling public access, otherwise everyone, including VPN users, is locked out. The `crossTenantSecurityGroup` tag is a separate mechanism that authorizes identities from another Entra tenant — it does not provide network connectivity and cannot substitute for a Private Endpoint. Dev environment Grafana instances are publicly accessible.
 
 ## Prerequisites
 

--- a/docs/sops/grafana-vpn-access.md
+++ b/docs/sops/grafana-vpn-access.md
@@ -22,7 +22,7 @@ Azure Managed Grafana instances in staging, integration, and production environm
 |---------|---------------|------------|
 | Cannot reach Grafana URL (timeout/connection refused) | VPN not connected | Connect to MSFT Corp VPN and retry |
 | 403 Forbidden or network error | Connected to guest/partner network instead of Corp VPN | Switch to the MSFT Corp VPN |
-| Dev environment works but staging/prod does not | Dev has public access enabled; staging/int/prod may require VPN | Connect to VPN for non-dev environments |
+| Dev environment works but staging/int/prod does not | Dev has public access enabled; staging/int/prod may require VPN | Connect to VPN for non-dev environments |
 | VPN connected but still cannot access | DNS resolution issue | Flush DNS cache and retry; verify VPN routes include Azure endpoints |
 
 ## Related Documentation

--- a/docs/sops/grafana-vpn-access.md
+++ b/docs/sops/grafana-vpn-access.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Azure Managed Grafana instances in staging, integration, and production environments can be configured with `publicNetworkAccess: Disabled`, which restricts access to users connected to the MSFT Corp VPN. Dev environment Grafana instances are publicly accessible.
+Azure Managed Grafana instances in staging, integration, and production environments can be configured with `publicNetworkAccess: Disabled`. On its own, this only removes the public internet path — it does **not** grant MSFT Corp VPN users access. A Private Endpoint (with private DNS and VPN routing) and/or the `crossTenantSecurityGroup` tag must also be in place for authorized users to reach Grafana once public access is disabled; otherwise everyone, including VPN users, is locked out. Dev environment Grafana instances are publicly accessible.
 
 ## Prerequisites
 
@@ -13,15 +13,16 @@ Azure Managed Grafana instances in staging, integration, and production environm
 ## Procedure
 
 1. Connect to the MSFT Corp VPN
-2. Navigate to the Grafana URL for your target environment (e.g. `https://arohcp-<env>-<id>.grafana.azure.com/`)
+2. Look up the Grafana URL for your target environment — the endpoint includes an Azure-generated hash suffix and region code (e.g. `arohcp-dev-c9g7a4fjanb0c4gc.wus3.grafana.azure.com`) that cannot be guessed from the instance name alone. Retrieve it via the Azure Portal or `az grafana show --name <grafana-name> --resource-group <rg> --query properties.endpoint`
 3. Authenticate with your Azure AD credentials
 
 ## Troubleshooting
 
 | Symptom | Possible Cause | Resolution |
 |---------|---------------|------------|
-| Cannot reach Grafana URL (timeout/connection refused) | VPN not connected | Connect to MSFT Corp VPN and retry |
-| 403 Forbidden or network error | Connected to guest/partner network instead of Corp VPN | Switch to the MSFT Corp VPN |
+| Cannot reach Grafana URL (timeout/connection refused) | VPN not connected, or connected to a guest/partner network instead of Corp VPN | Connect to MSFT Corp VPN and retry |
+| "Public Network Address Denied" page | Public network access is disabled and the request did not arrive via the private path (PE not yet provisioned, or DNS not resolving to the private IP) | Verify VPN connectivity to the private endpoint's DNS zone; escalate to the platform team if the PE/DNS path is not configured |
+| 403 Forbidden (page loads, login succeeds) | The request reached Grafana — this is an authorization issue, not a network issue. The account/tenant lacks a Grafana role assignment | Request a Grafana role assignment (Viewer, Contributor, or Admin) for your account |
 | Dev environment works but staging/int/prod does not | Dev has public access enabled; staging/int/prod may require VPN | Connect to VPN for non-dev environments |
 | VPN connected but still cannot access | DNS resolution issue | Flush DNS cache and retry; verify VPN routes include Azure endpoints |
 

--- a/tooling/templatize/pkg/pipeline/grafana_reconcile.go
+++ b/tooling/templatize/pkg/pipeline/grafana_reconcile.go
@@ -37,13 +37,26 @@ func runGrafanaManageStep(id graph.Identifier, step *types.GrafanaManageStep, ct
 	outputs := state.GetOutputs(id.Stamp)
 	state.RUnlock()
 
-	grafanaName, err := resolveValue(step.GrafanaName, options.Configuration, outputs, id.ServiceGroup)
+	opts, err := buildGrafanaReconcileOptions(id, step, options.Configuration, outputs, executionTarget)
 	if err != nil {
-		return fmt.Errorf("failed to resolve grafanaName: %w", err)
+		return err
 	}
-	location, err := resolveValue(step.Location, options.Configuration, outputs, id.ServiceGroup)
+
+	return opts.Run(ctx)
+}
+
+// buildGrafanaReconcileOptions resolves the GrafanaManageStep's config-referenced
+// values and assembles the RawReconcileOptions that grafanactl will run. It is
+// extracted from runGrafanaManageStep so it can be unit tested without making
+// any real Azure API calls, which opts.Run(ctx) performs.
+func buildGrafanaReconcileOptions(id graph.Identifier, step *types.GrafanaManageStep, cfg configtypes.Configuration, outputs Outputs, executionTarget ExecutionTarget) (*manage.RawReconcileOptions, error) {
+	grafanaName, err := resolveValue(step.GrafanaName, cfg, outputs, id.ServiceGroup)
 	if err != nil {
-		return fmt.Errorf("failed to resolve location: %w", err)
+		return nil, fmt.Errorf("failed to resolve grafanaName: %w", err)
+	}
+	location, err := resolveValue(step.Location, cfg, outputs, id.ServiceGroup)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve location: %w", err)
 	}
 
 	opts := manage.DefaultReconcileOptions()
@@ -52,49 +65,49 @@ func runGrafanaManageStep(id graph.Identifier, step *types.GrafanaManageStep, ct
 	opts.ResourceGroup = executionTarget.GetResourceGroup()
 	opts.Location = location
 
-	sku, err := resolveOptionalValue(step.SKU, options.Configuration, outputs, id.ServiceGroup)
+	sku, err := resolveOptionalValue(step.SKU, cfg, outputs, id.ServiceGroup)
 	if err != nil {
-		return fmt.Errorf("failed to resolve sku: %w", err)
+		return nil, fmt.Errorf("failed to resolve sku: %w", err)
 	}
 	if sku != "" {
 		opts.SKU = sku
 	}
 
-	majorVersion, err := resolveOptionalValue(step.MajorVersion, options.Configuration, outputs, id.ServiceGroup)
+	majorVersion, err := resolveOptionalValue(step.MajorVersion, cfg, outputs, id.ServiceGroup)
 	if err != nil {
-		return fmt.Errorf("failed to resolve majorVersion: %w", err)
+		return nil, fmt.Errorf("failed to resolve majorVersion: %w", err)
 	}
 	opts.MajorVersion = majorVersion
 
-	zoneRedundancy, err := resolveOptionalValue(step.ZoneRedundancy, options.Configuration, outputs, id.ServiceGroup)
+	zoneRedundancy, err := resolveOptionalValue(step.ZoneRedundancy, cfg, outputs, id.ServiceGroup)
 	if err != nil {
-		return fmt.Errorf("failed to resolve zoneRedundancy: %w", err)
+		return nil, fmt.Errorf("failed to resolve zoneRedundancy: %w", err)
 	}
 	if zoneRedundancy != "" {
 		opts.ZoneRedundancy = zoneRedundancy
 	}
 
-	publicNetworkAccess, err := resolveOptionalValue(step.PublicNetworkAccess, options.Configuration, outputs, id.ServiceGroup)
+	publicNetworkAccess, err := resolveOptionalValue(step.PublicNetworkAccess, cfg, outputs, id.ServiceGroup)
 	if err != nil {
-		return fmt.Errorf("failed to resolve publicNetworkAccess: %w", err)
+		return nil, fmt.Errorf("failed to resolve publicNetworkAccess: %w", err)
 	}
 	if publicNetworkAccess != "" {
 		opts.PublicNetworkAccess = publicNetworkAccess
 	}
 
-	crossTenantSecurityGroup, err := resolveOptionalValue(step.CrossTenantSecurityGroup, options.Configuration, outputs, id.ServiceGroup)
+	crossTenantSecurityGroup, err := resolveOptionalValue(step.CrossTenantSecurityGroup, cfg, outputs, id.ServiceGroup)
 	if err != nil {
-		return fmt.Errorf("failed to resolve crossTenantSecurityGroup: %w", err)
+		return nil, fmt.Errorf("failed to resolve crossTenantSecurityGroup: %w", err)
 	}
 	opts.CrossTenantSecurityGroup = crossTenantSecurityGroup
 
 	if step.Timeout != "" {
 		d, err := time.ParseDuration(step.Timeout)
 		if err != nil {
-			return fmt.Errorf("failed to parse timeout %q: %w", step.Timeout, err)
+			return nil, fmt.Errorf("failed to parse timeout %q: %w", step.Timeout, err)
 		}
 		opts.Timeout = d
 	}
 
-	return opts.Run(ctx)
+	return opts, nil
 }

--- a/tooling/templatize/pkg/pipeline/grafana_reconcile.go
+++ b/tooling/templatize/pkg/pipeline/grafana_reconcile.go
@@ -74,6 +74,14 @@ func runGrafanaManageStep(id graph.Identifier, step *types.GrafanaManageStep, ct
 		opts.ZoneRedundancy = zoneRedundancy
 	}
 
+	publicNetworkAccess, err := resolveOptionalValue(step.PublicNetworkAccess, options.Configuration, outputs, id.ServiceGroup)
+	if err != nil {
+		return fmt.Errorf("failed to resolve publicNetworkAccess: %w", err)
+	}
+	if publicNetworkAccess != "" {
+		opts.PublicNetworkAccess = publicNetworkAccess
+	}
+
 	crossTenantSecurityGroup, err := resolveOptionalValue(step.CrossTenantSecurityGroup, options.Configuration, outputs, id.ServiceGroup)
 	if err != nil {
 		return fmt.Errorf("failed to resolve crossTenantSecurityGroup: %w", err)

--- a/tooling/templatize/pkg/pipeline/grafana_reconcile_test.go
+++ b/tooling/templatize/pkg/pipeline/grafana_reconcile_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"testing"
+
+	configtypes "github.com/Azure/ARO-Tools/config/types"
+	"github.com/Azure/ARO-Tools/pipelines/types"
+	"github.com/Azure/ARO-Tools/tools/grafanactl/cmd/manage"
+)
+
+func TestDefaultReconcileOptionsPublicNetworkAccess(t *testing.T) {
+	opts := manage.DefaultReconcileOptions()
+	if opts.PublicNetworkAccess != "Enabled" {
+		t.Fatalf("expected default PublicNetworkAccess 'Enabled' (backward compatible), got %q", opts.PublicNetworkAccess)
+	}
+}
+
+func TestResolvePublicNetworkAccess(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      configtypes.Configuration
+		step     types.Value
+		expected string
+	}{
+		{
+			name: "config ref resolves to Enabled",
+			cfg: configtypes.Configuration{
+				"monitoring": map[string]any{
+					"grafanaPublicNetworkAccess": "Enabled",
+				},
+			},
+			step:     types.Value{ConfigRef: "monitoring.grafanaPublicNetworkAccess"},
+			expected: "Enabled",
+		},
+		{
+			name: "config ref resolves to Disabled",
+			cfg: configtypes.Configuration{
+				"monitoring": map[string]any{
+					"grafanaPublicNetworkAccess": "Disabled",
+				},
+			},
+			step:     types.Value{ConfigRef: "monitoring.grafanaPublicNetworkAccess"},
+			expected: "Disabled",
+		},
+		{
+			name:     "empty value returns empty string (uses tool default)",
+			cfg:      configtypes.Configuration{},
+			step:     types.Value{},
+			expected: "",
+		},
+		{
+			name:     "direct value override",
+			cfg:      configtypes.Configuration{},
+			step:     types.Value{Value: "Disabled"},
+			expected: "Disabled",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveOptionalValue(tt.step, tt.cfg, Outputs{}, "")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.expected {
+				t.Errorf("resolveOptionalValue() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestPublicNetworkAccessOverridesDefault(t *testing.T) {
+	opts := manage.DefaultReconcileOptions()
+	if opts.PublicNetworkAccess != "Enabled" {
+		t.Fatalf("precondition: expected default 'Enabled', got %q", opts.PublicNetworkAccess)
+	}
+
+	cfg := configtypes.Configuration{
+		"monitoring": map[string]any{
+			"grafanaPublicNetworkAccess": "Disabled",
+		},
+	}
+
+	resolved, err := resolveOptionalValue(
+		types.Value{ConfigRef: "monitoring.grafanaPublicNetworkAccess"},
+		cfg, Outputs{}, "",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved != "" {
+		opts.PublicNetworkAccess = resolved
+	}
+
+	if opts.PublicNetworkAccess != "Disabled" {
+		t.Fatalf("expected config value 'Disabled' to override default, got %q", opts.PublicNetworkAccess)
+	}
+}

--- a/tooling/templatize/pkg/pipeline/grafana_reconcile_test.go
+++ b/tooling/templatize/pkg/pipeline/grafana_reconcile_test.go
@@ -15,9 +15,11 @@
 package pipeline
 
 import (
+	"strings"
 	"testing"
 
 	configtypes "github.com/Azure/ARO-Tools/config/types"
+	"github.com/Azure/ARO-Tools/pipelines/graph"
 	"github.com/Azure/ARO-Tools/pipelines/types"
 	"github.com/Azure/ARO-Tools/tools/grafanactl/cmd/manage"
 )
@@ -82,30 +84,123 @@ func TestResolvePublicNetworkAccess(t *testing.T) {
 	}
 }
 
-func TestPublicNetworkAccessOverridesDefault(t *testing.T) {
-	opts := manage.DefaultReconcileOptions()
-	if opts.PublicNetworkAccess != "Enabled" {
-		t.Fatalf("precondition: expected default 'Enabled', got %q", opts.PublicNetworkAccess)
-	}
+// testID is a graph.Identifier shared by the buildGrafanaReconcileOptions tests below.
+var testID = graph.Identifier{
+	ServiceGroup: "Microsoft.Azure.ARO.HCP.Grafana",
+	StepDependency: types.StepDependency{
+		ResourceGroup: "singleton",
+		Step:          "grafana-reconcile",
+	},
+}
 
-	cfg := configtypes.Configuration{
-		"monitoring": map[string]any{
-			"grafanaPublicNetworkAccess": "Disabled",
-		},
-	}
+// testExecutionTarget is a minimal, hand-populated ExecutionTarget used to verify that
+// buildGrafanaReconcileOptions wires subscription/resource-group values through correctly.
+var testExecutionTarget = &executionTargetImpl{
+	subscriptionID: "11111111-1111-1111-1111-111111111111",
+	resourceGroup:  "global",
+}
 
-	resolved, err := resolveOptionalValue(
-		types.Value{ConfigRef: "monitoring.grafanaPublicNetworkAccess"},
-		cfg, Outputs{}, "",
-	)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+// baseGrafanaManageStep returns a GrafanaManageStep with the fields that are always
+// required (GrafanaName, Location) pre-populated with literal values, leaving
+// PublicNetworkAccess unset so each test case can set it explicitly.
+func baseGrafanaManageStep() *types.GrafanaManageStep {
+	return &types.GrafanaManageStep{
+		GrafanaName: types.Value{Value: "arohcp-dev"},
+		Location:    types.Value{Value: "eastus"},
 	}
-	if resolved != "" {
-		opts.PublicNetworkAccess = resolved
-	}
+}
 
-	if opts.PublicNetworkAccess != "Disabled" {
-		t.Fatalf("expected config value 'Disabled' to override default, got %q", opts.PublicNetworkAccess)
-	}
+// TestBuildGrafanaReconcileOptions exercises buildGrafanaReconcileOptions directly —
+// the actual production wiring inside runGrafanaManageStep — rather than
+// re-implementing its resolve-then-assign logic inline. This is what catches a
+// regression like the PublicNetworkAccess resolution block being deleted or
+// wired to the wrong step field, since that block runs for real here.
+func TestBuildGrafanaReconcileOptions(t *testing.T) {
+	t.Run("PublicNetworkAccess Disabled propagates from config", func(t *testing.T) {
+		step := baseGrafanaManageStep()
+		step.PublicNetworkAccess = types.Value{ConfigRef: "monitoring.grafanaPublicNetworkAccess"}
+		cfg := configtypes.Configuration{
+			"monitoring": map[string]any{
+				"grafanaPublicNetworkAccess": "Disabled",
+			},
+		}
+
+		opts, err := buildGrafanaReconcileOptions(testID, step, cfg, Outputs{}, testExecutionTarget)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if opts.PublicNetworkAccess != "Disabled" {
+			t.Errorf("PublicNetworkAccess = %q, want %q", opts.PublicNetworkAccess, "Disabled")
+		}
+	})
+
+	t.Run("PublicNetworkAccess Enabled propagates from config", func(t *testing.T) {
+		step := baseGrafanaManageStep()
+		step.PublicNetworkAccess = types.Value{ConfigRef: "monitoring.grafanaPublicNetworkAccess"}
+		cfg := configtypes.Configuration{
+			"monitoring": map[string]any{
+				"grafanaPublicNetworkAccess": "Enabled",
+			},
+		}
+
+		opts, err := buildGrafanaReconcileOptions(testID, step, cfg, Outputs{}, testExecutionTarget)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if opts.PublicNetworkAccess != "Enabled" {
+			t.Errorf("PublicNetworkAccess = %q, want %q", opts.PublicNetworkAccess, "Enabled")
+		}
+	})
+
+	t.Run("unset PublicNetworkAccess keeps the tool default", func(t *testing.T) {
+		step := baseGrafanaManageStep() // PublicNetworkAccess left as zero-value types.Value{}
+
+		opts, err := buildGrafanaReconcileOptions(testID, step, configtypes.Configuration{}, Outputs{}, testExecutionTarget)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if opts.PublicNetworkAccess != "Enabled" {
+			t.Errorf("PublicNetworkAccess = %q, want tool default %q", opts.PublicNetworkAccess, "Enabled")
+		}
+	})
+
+	t.Run("resolution error on PublicNetworkAccess is propagated", func(t *testing.T) {
+		step := baseGrafanaManageStep()
+		step.PublicNetworkAccess = types.Value{ConfigRef: "monitoring.doesNotExist"}
+
+		_, err := buildGrafanaReconcileOptions(testID, step, configtypes.Configuration{}, Outputs{}, testExecutionTarget)
+		if err == nil {
+			t.Fatal("expected an error for an unresolvable configRef, got nil")
+		}
+		if !strings.Contains(err.Error(), "publicNetworkAccess") {
+			t.Errorf("expected error to mention publicNetworkAccess, got: %v", err)
+		}
+	})
+
+	t.Run("other fields are wired through alongside PublicNetworkAccess", func(t *testing.T) {
+		const crossTenantSecurityGroup = "11111111-1111-1111-1111-111111111111;22222222-2222-2222-2222-222222222222"
+		step := baseGrafanaManageStep()
+		step.PublicNetworkAccess = types.Value{Value: "Disabled"}
+		step.CrossTenantSecurityGroup = types.Value{Value: crossTenantSecurityGroup}
+
+		opts, err := buildGrafanaReconcileOptions(testID, step, configtypes.Configuration{}, Outputs{}, testExecutionTarget)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if opts.GrafanaName != "arohcp-dev" {
+			t.Errorf("GrafanaName = %q, want %q", opts.GrafanaName, "arohcp-dev")
+		}
+		if opts.SubscriptionID != testExecutionTarget.subscriptionID {
+			t.Errorf("SubscriptionID = %q, want %q", opts.SubscriptionID, testExecutionTarget.subscriptionID)
+		}
+		if opts.ResourceGroup != testExecutionTarget.resourceGroup {
+			t.Errorf("ResourceGroup = %q, want %q", opts.ResourceGroup, testExecutionTarget.resourceGroup)
+		}
+		if opts.CrossTenantSecurityGroup != crossTenantSecurityGroup {
+			t.Errorf("CrossTenantSecurityGroup = %q, want %q", opts.CrossTenantSecurityGroup, crossTenantSecurityGroup)
+		}
+		if opts.PublicNetworkAccess != "Disabled" {
+			t.Errorf("PublicNetworkAccess = %q, want %q", opts.PublicNetworkAccess, "Disabled")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Prerequisite change for restricting Azure Managed Grafana public network access ([ARO-28693](https://redhat.atlassian.net/browse/ARO-28693)). This PR adds the config parameter, pipeline wiring, and documentation **without changing current behavior** — all environments remain `Enabled`. The actual restriction to `Disabled` will be coordinated with the production access mechanism (PE and/or `crossTenantSecurityGroup`) in a follow-up sdp-pipelines change.

Changes:
- Add `grafanaPublicNetworkAccess` config parameter (default: `Enabled` — no behavior change)
- Wire `publicNetworkAccess` through pipeline YAML and Go reconciler to `grafanactl`
- Bump ARO-Tools dependency to include merged PublicNetworkAccess support ([ARO-Tools#279](https://github.com/Azure/ARO-Tools/pull/279))
- Update 6 documentation files with VPN access notes
- Add new SOP for Grafana VPN access troubleshooting

### How the defaults work

The `grafanactl` tool default is `Enabled` (backward compatible — an independent ARO-Tools dependency bump won't accidentally lock anyone out). The config.yaml base default is also `Enabled` (no behavior change on any environment). When the team is ready to restrict access, a coordinated change will:
1. Confirm the production access mechanism (PE and/or `crossTenantSecurityGroup`) is in place
2. Set `grafanaPublicNetworkAccess: Disabled` for the target environments (via sdp-pipelines or config overlay)

## Design decision: Private Endpoint vs Network ACL

Evaluated per [ARO-28696](https://issues.redhat.com/browse/ARO-28696). Azure Managed Grafana does not expose inbound IP allowlist or network ACL properties in the ARM API ([ARM template reference](https://learn.microsoft.com/en-us/azure/templates/microsoft.dashboard/2024-10-01/grafana)). The two viable inbound access restriction mechanisms are:

1. **Private Endpoint** — Creates a private IP for Grafana in a VNet. VPN users access Grafana through the private IP rather than the public endpoint. Production environments likely already have PE infrastructure configured outside this repo.

2. **`crossTenantSecurityGroup`** — An Azure Managed Grafana platform feature (`AMG.CrossTenant.SecurityGroup` tag) that grants access to an Entra ID security group in the MSFT Corp tenant. Already wired through the pipeline; the value is configured in sdp-pipelines for production environments.

Either mechanism (or both) must be confirmed as in place **before** setting `publicNetworkAccess: Disabled`, otherwise all users will be locked out. This PR does not change `publicNetworkAccess` from its current state — it only adds the config parameter and pipeline wiring so the restriction can be enabled in a follow-up change.

Full evaluation documented on [ARO-28696](https://issues.redhat.com/browse/ARO-28696).

## Integration test results

Tested against live Azure Managed Grafana instances in the dev subscription:
- ✅ `publicNetworkAccess` property correctly set via Go SDK `BeginCreate` (no silent drop)
- ✅ Toggling between `Enabled` and `Disabled` works on existing instances
- ✅ Default (no `--public-network-access` flag) correctly sets `Enabled` (backward compatible)
- ✅ `publicNetworkAccess: Disabled` blocks public internet access (verified off-VPN)
- ✅ `publicNetworkAccess: Enabled` allows public access (verified in browser)

## Jira

- [ARO-28693](https://issues.redhat.com/browse/ARO-28693) — Restrict Grafana to MSFT Corp VPN and add safeguards (parent story)
- [ARO-28696](https://issues.redhat.com/browse/ARO-28696) — Update Grafana network restriction config
- [ARO-28697](https://issues.redhat.com/browse/ARO-28697) — Add CI policy check to prevent Grafana public re-exposure
- [ARO-28771](https://issues.redhat.com/browse/ARO-28771) — Update existing documentation with Grafana VPN access requirements

## Test plan

- [x] `cd config && make materialize` passes (schema validation + rendering)
- [x] `go build ./...` passes for `tooling/templatize`
- [x] All rendered configs show `grafanaPublicNetworkAccess: Enabled` (no behavior change)
- [x] Integration tests against live Azure Managed Grafana (see above)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)