### PR TITLE
OCPBUGS-99304: chore: backend/pkg/controllers/controlplaneversion: Scaffold version selection

### DIFF
--- a/backend/pkg/controllers/controlplaneversion/aro.go
+++ b/backend/pkg/controllers/controlplaneversion/aro.go
@@ -1,0 +1,30 @@
+package controlplaneversion
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// ARO-HCP specific user agent; put whatever you like in here to identify yourself.
+var userAgent = "AROHCPFixme/0.1"
+
+// SelectControlPlaneVersion retrieves a release from a chosen
+// OpenShift update service channel with a chosen offset.  For
+// example, the most recent release in the fast-4.20 channel.  Or the
+// penultimate release in the stable-4.22 channel.
+func SelectControlPlaneVersion(ctx context.Context, roundTripper RoundTrip, updateService *url.URL, channel string, offset uint) (*configv1.Release, error) {
+	releases, updateService, err := cincinnati(ctx, roundTripper, updateService, userAgent, channel)
+	if err != nil {
+		return nil, err
+	}
+	if len(releases) == 0 {
+		return nil, fmt.Errorf("no releases found in %s.", updateService)
+	}
+	if int(offset) >= len(releases) {
+		return nil, fmt.Errorf("%d releases found in %s, which is not enough for the requested %d offset.", len(releases), updateService, offset)
+	}
+	return &releases[offset], nil
+}

--- a/backend/pkg/controllers/controlplaneversion/aro_test.go
+++ b/backend/pkg/controllers/controlplaneversion/aro_test.go
@@ -1,0 +1,97 @@
+package controlplaneversion
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func makeNode(version string) node {
+	return node{
+		Version: version,
+		Payload: fmt.Sprintf("quay.io/openshift-release-dev/ocp-release:%s-multi", version),
+	}
+}
+
+func jsonBody(v interface{}) io.ReadCloser {
+	b, _ := json.Marshal(v)
+	return io.NopCloser(strings.NewReader(string(b)))
+}
+
+func TestSelectControlPlaneVersionInstall(t *testing.T) {
+	tests := []struct {
+		name            string
+		graph           graph
+		offset          uint
+		expectedVersion string
+		expectedError   string
+	}{
+		{
+			name: "returns highest version with offset 0",
+			graph: graph{
+				Nodes: []node{
+					makeNode("4.20.1"),
+					makeNode("4.20.2"),
+					makeNode("4.20.3"),
+				},
+			},
+			expectedVersion: "4.20.3",
+		},
+		{
+			name: "returns penultimate version with offset 1",
+			graph: graph{
+				Nodes: []node{
+					makeNode("4.20.1"),
+					makeNode("4.20.2"),
+					makeNode("4.20.3"),
+				},
+			},
+			offset:          1,
+			expectedVersion: "4.20.2",
+		},
+		{
+			name: "excessive offset",
+			graph: graph{
+				Nodes: []node{
+					makeNode("4.20.1"),
+				},
+			},
+			offset:        1,
+			expectedError: "1 releases found in https://api.openshift.com/api/upgrades_info/graph?arch=multi&channel=fast-4.20, which is not enough for the requested 1 offset.",
+		},
+		{
+			name:          "empty graph",
+			expectedError: "no releases found in https://api.openshift.com/api/upgrades_info/graph?arch=multi&channel=fast-4.20.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			roundTripper := func(request *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       jsonBody(tt.graph),
+				}, nil
+			}
+
+			version, err := SelectControlPlaneVersion(context.Background(), roundTripper, nil, "fast-4.20", tt.offset)
+			if len(tt.expectedError) == 0 && err != nil {
+				t.Error(err)
+			} else if len(tt.expectedError) > 0 && err == nil {
+				t.Errorf("expected error %q, but got %v", tt.expectedError, err)
+			} else if err != nil && err.Error() != tt.expectedError {
+				t.Errorf("expected error %q, but got %q", tt.expectedError, err)
+			}
+			if len(tt.expectedVersion) == 0 && version != nil {
+				t.Errorf("expected nil version, got %v", version)
+			} else if len(tt.expectedVersion) > 0 && version == nil {
+				t.Errorf("expected version %q, but got %v", tt.expectedVersion, version)
+			} else if version != nil && version.Version != tt.expectedVersion {
+				t.Errorf("expected version %q, but got %v", tt.expectedVersion, version)
+			}
+		})
+	}
+}

--- a/backend/pkg/controllers/controlplaneversion/cincinnati.go
+++ b/backend/pkg/controllers/controlplaneversion/cincinnati.go
@@ -1,0 +1,124 @@
+package controlplaneversion
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+
+	"github.com/blang/semver/v4"
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// RoundTrip allows customizing the RoundTripper (e.g. to support
+// testing or proxy/TLS configuration) without having to create a local
+// struct supplying the RoundTripper interface.  The interface only
+// requires a RoundTrip function, and it is easier to just pass the
+// function around.  https://github.com/golang/go/issues/38479 is
+// proposing the type become a stdlib declaration, but until then,
+// declare it locally.
+type RoundTrip func(*http.Request) (*http.Response, error)
+
+// node represents a single cluster version in the update graph.
+type node struct {
+	// Version is the semantic version of this release.
+	Version string `json:"version"`
+
+	// Payload is the release image pullspec (payload) for this version.
+	Payload string `json:"payload"`
+}
+
+// graph represents the update graph structure returned by the Cincinnati service.
+// It defines all available cluster versions and the valid upgrade paths between them.
+type graph struct {
+	// Nodes contains all cluster version releases available in this channel.
+	Nodes []node `json:"nodes"`
+}
+
+var defaultUpstreamUpdateService = "https://api.openshift.com/api/upgrades_info/graph"
+
+// roundTrip converts a RoundTrip function into a RoundTripper.
+type roundTrip struct {
+	roundTripper RoundTrip
+}
+
+// RoundTrip executes a single HTTP transaction, returning a Response
+// for the provided Request.
+func (rt *roundTrip) RoundTrip(request *http.Request) (*http.Response, error) {
+	return rt.roundTripper(request)
+}
+
+// cincinnati calls an update-service to retrieve a list of releases,
+// and the update recommendation graph connecting them.
+func cincinnati(ctx context.Context, roundTripper RoundTrip, updateService *url.URL, userAgent string, channel string) ([]configv1.Release, *url.URL, error) {
+	if updateService == nil {
+		var err error
+		updateService, err = url.Parse(defaultUpstreamUpdateService)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else { // copy to avoid mutating function arguments
+		u := *updateService
+		updateService = &u
+	}
+
+	queryParams := updateService.Query()
+	queryParams.Set("arch", "multi")
+	queryParams.Set("channel", channel)
+	updateService.RawQuery = queryParams.Encode()
+	req, err := http.NewRequest("GET", updateService.String(), nil)
+	if err != nil {
+		return nil, updateService, err
+	}
+	req.Header.Set("Accept", "application/vnd.redhat.cincinnati.v1+json")
+	if len(userAgent) > 0 {
+		req.Header.Set("User-Agent", userAgent)
+	}
+	client := &http.Client{}
+	if roundTripper != nil {
+		client.Transport = &roundTrip{roundTripper: roundTripper}
+	}
+	resp, err := client.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, updateService, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, updateService, fmt.Errorf("%s returned unexpected HTTP status %s", updateService, resp.Status)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, updateService, err
+	}
+	var graph graph
+	err = json.Unmarshal(body, &graph)
+	if err != nil {
+		return nil, updateService, err
+	}
+
+	releases, err := nodesToReleases(graph.Nodes)
+	return releases, updateService, err
+}
+
+// nodesToReleases converts a slice of update-service nodes to a slice
+// of Releases, sorted in descending SemVer order.
+func nodesToReleases(nodes []node) ([]configv1.Release, error) {
+	releases := make([]configv1.Release, 0, len(nodes))
+	for _, node := range nodes {
+		releases = append(releases, configv1.Release{
+			Version: node.Version,
+			Image:   node.Payload,
+		})
+	}
+
+	slices.SortFunc(releases, func(a, b configv1.Release) int {
+		vA := semver.MustParse(a.Version)
+		vB := semver.MustParse(b.Version)
+		return -vA.Compare(vB)
+	})
+
+	return releases, nil
+}


### PR DESCRIPTION
### What

Stubs in a library that implements the requested ARO-policy logic for selecting OpenShift install versions (for new clusters) and update targets (for existing clusters).

### Why

[OCPBUGS-99304](https://redhat.atlassian.net/browse/OCPBUGS-99304) asked me to do #6420, and subsequently @deads2k gave me a revised spec target, and this new pull request is delivering on that new ask.

### Testing

Unit tests included.  I'm happy to discuss coverage if you feel like I'm not sufficiently excercising some piece.

I have not added integration or end-to-end tests.  I'm leaving that responsibilty to the ARO engineer who picks up this library and integrates it into the rest of the repository.  Until then, the library is dead code with no user impact.

## Special notes for your reviewer

I'm an OpenShift core developer with a focus on cluster updates.  My personal preference for "which release should a customer in interested in `$CHANNEL` use?" is:

* Prefer the largest SemVer in that channel.  That gets the most of the target features and bugfixes you can get, given your current chosen channel.  [These][1] and similar docs help you choose the channel whose semenatics match your intentions.

* Sometimes there are regressions that would impact your cluster/workload.  In this case, it's a sticky balance between avoiding the regression (pushing you to pre-regression releases) and getting all the other bugfixes those more-recent releases provide (pushing you to post-regression releases).  Have a discussion with your security and workload teams about which way you want to go for that particular particular set of regressions vs. that particular set of recently-fixed bugs.

OpenShift has [a backport policy][2] that newer z-streams will recieve fixes before they are backported to older z-streams.  And we also do not release new patches in every supported z-stream every week. For example, looking at 4.16.63 in [graph-data][3]:

<details>
<summary>4.16.43 membership in fast and EUS channels; click to expand</summary>

```console
$ git log --first-parent --date=short --format='%ad %h %s' -G ' 4[.]16[.]63| 4[.]1[78][.]' internal-channels/fast.yaml channels/eus-4.* | grep -B1000 '4[.]16[.]63'
2026-08-04 18ebf6c36 Merge pull request #10217 from openshift-ota-bot/promote-4.18.49-to-eus-4.20
2026-07-29 687a6f1a3 Merge pull request #10160 from openshift-ota-bot/promote-4.18.49-to-eus-4.18
2026-07-29 2fb767f28 Merge pull request #10150 from openshift-ota-bot/promote-4.18.50-to-fast
2026-07-28 ed297c615 Merge pull request #10145 from openshift-ota-bot/promote-4.18.48-to-eus-4.20
2026-07-22 e2a840bf5 Merge pull request #10072 from openshift-ota-bot/promote-4.18.48-to-eus-4.18
2026-07-22 b8f5daf16 Merge pull request #10069 from openshift-ota-bot/promote-4.18.49-to-fast
2026-07-21 a939d88de Merge pull request #10063 from openshift-ota-bot/promote-4.18.47-to-eus-4.20
2026-07-20 cc5d181b4 Merge pull request #10036 from dis016/promote-4.16.63-to-eus-4.18
2026-07-16 c7f289850 Merge pull request #10004 from openshift-ota-bot/promote-4.17.55-to-eus-4.18
2026-07-15 a02cee33e Merge pull request #9990 from openshift-ota-bot/promote-4.18.47-to-eus-4.18
2026-07-15 d61139d51 Merge pull request #9985 from openshift-ota-bot/promote-4.18.48-to-fast
2026-07-14 5771d0847 Merge pull request #9981 from openshift-ota-bot/promote-4.18.46-to-eus-4.20
2026-07-09 b7c5f43a3 Merge pull request #9914 from openshift-ota-bot/promote-4.17.55-to-fast
2026-07-08 5f2474f82 Merge pull request #9892 from openshift-ota-bot/promote-4.18.46-to-eus-4.18
2026-07-08 5f9f7dd6f Merge pull request #9893 from openshift-ota-bot/promote-4.18.47-to-fast
2026-07-07 0da71d7ee Merge pull request #9889 from openshift-ota-bot/promote-4.18.45-to-eus-4.20
2026-07-01 98cfbf2ab Merge pull request #9823 from openshift-ota-bot/promote-4.18.45-to-eus-4.18
2026-07-01 0751145b5 Merge pull request #9814 from openshift-ota-bot/promote-4.18.46-to-fast
2026-06-24 b0afe128f Merge pull request #9755 from openshift-ota-bot/promote-4.18.44-to-eus-4.20
2026-06-24 e5aac24d4 Merge pull request #9747 from openshift-ota-bot/promote-4.18.45-to-fast
2026-06-24 ec0a68578 Merge pull request #9744 from openshift-ota-bot/promote-4.18.44-to-eus-4.18
2026-06-23 915e17dfa Merge pull request #9738 from openshift-ota-bot/promote-4.18.43-to-eus-4.20
2026-06-17 dce8d16aa Merge pull request #9676 from openshift-ota-bot/promote-4.18.44-to-fast
2026-06-10 8aa209b81 Merge pull request #9625 from openshift-ota-bot/promote-4.18.42-to-eus-4.20
2026-06-10 5c758e2a8 Merge pull request #9620 from openshift-ota-bot/promote-4.18.43-to-eus-4.18
2026-06-05 4c167147f Merge pull request #9596 from openshift-ota-bot/promote-4.16.63-to-eus-4.16
2026-06-03 c99103cda Merge pull request #9571 from openshift-ota-bot/promote-4.18.43-to-fast
2026-05-29 e83fb6c95 Merge pull request #9545 from openshift-ota-bot/promote-4.16.63-to-fast
```

</details>

That has 4.16.63 go GA on 2026-05-29, [carring some Important CVE and bug fixes into 4.16][4].  But until 4.17.55 and 4.18.47 arrived with a path from 4.16.63 to 4.17.newer to 4.18.newest on 2026-07-15 and the next few days, 4.16.63 did not have an `eus-4.18` path through 4.17 to 4.18.  Updating from 4.16.63 to the older 4.17.54 would risk regressing on bugfixes that landed in 4.17 and went back to 4.16.63 after 4.17.54 was cut.

For folks on 4.16.62 in `eus-*` channels on 2026-06-10, the world looked like:

<details>
<summary>4.16.62 EUS channel options on 2026-06-10; click to expand</summary>

```console
$ git grep 4.16.62 8aa209b81 channels/eus-*
8aa209b81:channels/eus-4.16.yaml:- 4.16.62
8aa209b81:channels/eus-4.18.yaml:- 4.16.62
$ git cat-file -p 8aa209b81:channels/eus-4.16.yaml | tail -n2
- 4.16.62
- 4.16.63
$ git cat-file -p 8aa209b81:channels/eus-4.18.yaml | grep ' 4[.]16[.]' | tail -n1
- 4.16.62
$ git cat-file -p 8aa209b81:channels/eus-4.18.yaml | grep ' 4[.]17[.]' | tail -n1
- 4.17.54
$ git cat-file -p 8aa209b81:channels/eus-4.18.yaml | tail -n1
- 4.18.43
```

</details>

I'd have recommended `eus-4.16` folks update to 4.16.63 to pick up those fixes.  And I'd have recommended `eus-4.18` folks update through 4.17.54 to 4.18.43 to pick up those new features (and bugfixes!).  I would not have recommended waiting on 4.16.62, unless they were aware of some regression with 4.16.63 (for `eus-4.16` folks) or 4.17.54 or 4.18.43 (for `eus-4.18` folks) that they'd decided was more painful than remaining exposed to the issues those updates would have fixed.

If, after updating to 4.16.63 in `eus-4.16`, the cluster owner decided they wanted to pick up 4.18 features, they'd have to wait until 2026-07-20 until that became an option.  That's over a month.  I'm fine with that, because [4.18 GAed back on 2025-02-25][5].  Not being interested in 4.18 features on 2026-06-10 (and using the `eus-4.16` channel says "I want 4.16 bug fixes, and am not interested in 4.18") and then not being able to wait until 2026-07-20 to get those 4.18 features seems unlikely to me.  I'd expect folks to be planning their update to future feature releases with a larger window for the transition than that.

However, that's just me.  For ARO-HCP, David Eads is asking for version-selection logic that selects the most modern release in a given channel with a configured offset from the that most-modern tip. This commit delivers the specified logic, with the ARO policy isolated into the `aro.go` file.  If ARO folks want to adjust the logic in `aro.go`, that's entirely up to them, and despite donating this commit, I have no stake in the semantics being delivered.

[1]: https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/updating_clusters/understanding-openshift-updates-1#fast-stable-channel-strategies_understanding-update-channels-releases
[2]: https://redhat.atlassian.net/browse/OTA-1352
[3]: https://github.com/openshift/cincinnati-graph-data
[4]: https://access.redhat.com/errata/RHSA-2026:20088
[5]: https://access.redhat.com/errata/RHSA-2024:6122

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) (there are no graph/UI/metrics changes to screenshot, because the donation is a Go library, and I'm deferring integration with the rest of the code base to an ARO-engineer in follow-up work)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable) (not applicable, I'm going straight to asking for feedback, after this pull passes my local testing)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented (I hope they are, but I'll defer to reviewers as to which bits are tricky enough to be worth comments.  Drop a comment on any lines where you want to see comments, and I'll push something).
- [ ] Specific reviewers tagged (I'll wait for passing presubmits before pinging anyone)
- [ ] All comment threads resolved before merge (I can't check this when I open the pull, we need some time for folks to make those comments)
