### PR TITLE
fix: restore CVO cluster version metric

### DIFF
--- a/hypershiftoperator/deploy/templates/sre-metrics-set.configmap.yaml
+++ b/hypershiftoperator/deploy/templates/sre-metrics-set.configmap.yaml
@@ -54,5 +54,5 @@ data:
         sourceLabels: ["__name__"]
     cvo:
       - action:       "keep"
-        regex:        "cluster_operator_conditions|go_gc_duration_seconds(_sum|_count)?|go_goroutines|go_memstats_(alloc_bytes(_total)?|heap_(alloc|inuse)_bytes|mallocs_total|stack_inuse_bytes)|process_(cpu_seconds_total|resident_memory_bytes)"
+        regex:        "cluster_operator_conditions|cluster_version|go_gc_duration_seconds(_sum|_count)?|go_goroutines|go_memstats_(alloc_bytes(_total)?|heap_(alloc|inuse)_bytes|mallocs_total|stack_inuse_bytes)|process_(cpu_seconds_total|resident_memory_bytes)"
         sourceLabels: ["__name__"]

--- a/hypershiftoperator/testdata/zz_fixture_TestHelmTemplate_hypershift_performance_metrics.yaml
+++ b/hypershiftoperator/testdata/zz_fixture_TestHelmTemplate_hypershift_performance_metrics.yaml
@@ -674,7 +674,7 @@ data:
         sourceLabels: ["__name__"]
     cvo:
       - action:       "keep"
-        regex:        "cluster_operator_conditions|go_gc_duration_seconds(_sum|_count)?|go_goroutines|go_memstats_(alloc_bytes(_total)?|heap_(alloc|inuse)_bytes|mallocs_total|stack_inuse_bytes)|process_(cpu_seconds_total|resident_memory_bytes)"
+        regex:        "cluster_operator_conditions|cluster_version|go_gc_duration_seconds(_sum|_count)?|go_goroutines|go_memstats_(alloc_bytes(_total)?|heap_(alloc|inuse)_bytes|mallocs_total|stack_inuse_bytes)|process_(cpu_seconds_total|resident_memory_bytes)"
         sourceLabels: ["__name__"]
 ---
 # Source: aro-hcp-hypershift-operator/templates/installer.clusterrolebinding.yaml

--- a/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
+++ b/hypershiftoperator/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_hypershift.yaml
@@ -695,7 +695,7 @@ data:
         sourceLabels: ["__name__"]
     cvo:
       - action:       "keep"
-        regex:        "cluster_operator_conditions|go_gc_duration_seconds(_sum|_count)?|go_goroutines|go_memstats_(alloc_bytes(_total)?|heap_(alloc|inuse)_bytes|mallocs_total|stack_inuse_bytes)|process_(cpu_seconds_total|resident_memory_bytes)"
+        regex:        "cluster_operator_conditions|cluster_version|go_gc_duration_seconds(_sum|_count)?|go_goroutines|go_memstats_(alloc_bytes(_total)?|heap_(alloc|inuse)_bytes|mallocs_total|stack_inuse_bytes)|process_(cpu_seconds_total|resident_memory_bytes)"
         sourceLabels: ["__name__"]
 ---
 # Source: aro-hcp-hypershift-operator/templates/installer.clusterrolebinding.yaml


### PR DESCRIPTION
## Why

The CVO `cluster_version` metric was unintentionally excluded when [#6243](https://github.com/Azure/ARO-HCP/pull/6243) replaced permissive collection with a keep-only allowlist. Without this metric, operators cannot determine the OpenShift versions currently running across the hosted-cluster fleet or count clusters by version.

No tracking ticket: this is an operational follow-up discovered while querying production fleet versions.

## What

Add `cluster_version` to the CVO metric allowlist and regenerate the Helm fixtures.

## Validation

- `make -C tooling/helmtest update`
- `make -C tooling/helmtest test`

## Screenshots

Not applicable: this changes metric collection rather than a dashboard or visualization. Before deployment, `cluster_version{type="current"}` returns no samples; an after screenshot can only be captured once the updated allowlist is deployed.