### PR TITLE
Adding kasGoMemLimit for a small size clusters

### DIFF
--- a/hypershiftoperator/deploy/templates/cluster.clustersizingconfiguration.yaml
+++ b/hypershiftoperator/deploy/templates/cluster.clustersizingconfiguration.yaml
@@ -66,6 +66,7 @@ spec:
       from: 0
       to: 60
     effects:
+      kasGoMemLimit: 12GiB
       maximumMutatingRequestsInflight: 50
       maximumRequestsInflight: 150
       resourceRequests:


### PR DESCRIPTION
### What

kasGoMemLimit sets a soft cap on KAS memory during traffic surges. Without it, KAS on an HCP can grow without bound and trigger OOM kills on worker nodes. 

### Why

This is missing in one of the ClusterSize criteria 0-60, setting this limit equivalent to medium size cluster for now.