### PR TITLE
fix: block Private KAS cluster creation without Swift networking

### DIFF
--- a/internal/validation/validate_cluster.go
+++ b/internal/validation/validate_cluster.go
@@ -88,12 +88,37 @@ func ValidateCluster(ctx context.Context, op operation.Operation, newCluster, ol
 	// there several resourceIDs that must be verified with respect to this ID.  This is the only level of validation with access to both
 	errs = append(errs, validateResourceIDsAgainstClusterID(ctx, op, newCluster, oldCluster)...)
 
+	// Private KAS requires Swift networking (vnetIntegrationSubnetId must be set).
+	// For API versions v20251223preview and later, vnetIntegrationSubnetId is already
+	// enforced as required during conversion, so this check only has practical effect
+	// for v20240610preview.
+	errs = append(errs, validatePrivateKASRequiresSwift(ctx, op, newCluster)...)
+
 	// there are pieces of clusterProperties that are dependent upon values in .identity
 	errs = append(errs, validateOperatorAuthenticationAgainstIdentities(ctx, op, newCluster, oldCluster)...)
 
 	RewriteValidationFieldPaths(errs, validationPathMapper)
 
 	return errs
+}
+
+func validatePrivateKASRequiresSwift(_ context.Context, op operation.Operation, newCluster *coreapi.HCPOpenShiftCluster) field.ErrorList {
+	if op.Type != operation.Create {
+		return nil
+	}
+	if newCluster.CustomerProperties.API.Visibility != metadataapi.VisibilityPrivate {
+		return nil
+	}
+	vnetSubnet := newCluster.CustomerProperties.Platform.VnetIntegrationSubnetID
+	if vnetSubnet == nil || vnetSubnet.String() == "" {
+		return field.ErrorList{
+			field.Required(
+				field.NewPath("customerProperties", "platform", "vnetIntegrationSubnetId"),
+				"required when customerProperties.api.visibility is Private",
+			),
+		}
+	}
+	return nil
 }
 
 func validateOperatorAuthenticationAgainstIdentities(ctx context.Context, op operation.Operation, newCluster, _ *coreapi.HCPOpenShiftCluster) field.ErrorList {

--- a/internal/validation/validate_cluster.go
+++ b/internal/validation/validate_cluster.go
@@ -88,11 +88,11 @@ func ValidateCluster(ctx context.Context, op operation.Operation, newCluster, ol
 	// there several resourceIDs that must be verified with respect to this ID.  This is the only level of validation with access to both
 	errs = append(errs, validateResourceIDsAgainstClusterID(ctx, op, newCluster, oldCluster)...)
 
-	// Private KAS requires Swift networking (vnetIntegrationSubnetId must be set).
+	// Private KAS requires vnetIntegrationSubnetId to be set.
 	// For API versions v20251223preview and later, vnetIntegrationSubnetId is already
 	// enforced as required during conversion, so this check only has practical effect
 	// for v20240610preview.
-	errs = append(errs, validatePrivateKASRequiresSwift(ctx, op, newCluster)...)
+	errs = append(errs, validatePrivateKASRequiresVNetIntegrationSubnetID(ctx, op, newCluster, oldCluster)...)
 
 	// there are pieces of clusterProperties that are dependent upon values in .identity
 	errs = append(errs, validateOperatorAuthenticationAgainstIdentities(ctx, op, newCluster, oldCluster)...)
@@ -102,23 +102,18 @@ func ValidateCluster(ctx context.Context, op operation.Operation, newCluster, ol
 	return errs
 }
 
-func validatePrivateKASRequiresSwift(_ context.Context, op operation.Operation, newCluster *coreapi.HCPOpenShiftCluster) field.ErrorList {
-	if op.Type != operation.Create {
-		return nil
+func validatePrivateKASRequiresVNetIntegrationSubnetID(_ context.Context, _ operation.Operation, newCluster, _ *coreapi.HCPOpenShiftCluster) field.ErrorList {
+	errs := field.ErrorList{}
+
+	if newCluster.CustomerProperties.API.Visibility == metadataapi.VisibilityPrivate &&
+		newCluster.CustomerProperties.Platform.VnetIntegrationSubnetID == nil {
+		errs = append(errs, field.Required(
+			field.NewPath("customerProperties", "platform", "vnetIntegrationSubnetId"),
+			"required when customerProperties.api.visibility is Private",
+		))
 	}
-	if newCluster.CustomerProperties.API.Visibility != metadataapi.VisibilityPrivate {
-		return nil
-	}
-	vnetSubnet := newCluster.CustomerProperties.Platform.VnetIntegrationSubnetID
-	if vnetSubnet == nil || vnetSubnet.String() == "" {
-		return field.ErrorList{
-			field.Required(
-				field.NewPath("customerProperties", "platform", "vnetIntegrationSubnetId"),
-				"required when customerProperties.api.visibility is Private",
-			),
-		}
-	}
-	return nil
+
+	return errs
 }
 
 func validateOperatorAuthenticationAgainstIdentities(ctx context.Context, op operation.Operation, newCluster, _ *coreapi.HCPOpenShiftCluster) field.ErrorList {

--- a/internal/validation/validate_cluster_comprehensive_test.go
+++ b/internal/validation/validate_cluster_comprehensive_test.go
@@ -334,6 +334,28 @@ func TestValidateClusterCreate(t *testing.T) {
 			},
 		},
 		{
+			name: "private KAS with Swift networking - create",
+			cluster: func() *coreapi.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.API.Visibility = metadataapi.VisibilityPrivate
+				// VnetIntegrationSubnetID is already set by createValidCluster
+				return c
+			}(),
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name: "private KAS without Swift networking (nil vnetIntegrationSubnetId) - create",
+			cluster: func() *coreapi.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.API.Visibility = metadataapi.VisibilityPrivate
+				c.CustomerProperties.Platform.VnetIntegrationSubnetID = nil
+				return c
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "required when customerProperties.api.visibility is Private", FieldPath: "customerProperties.platform.vnetIntegrationSubnetId"},
+			},
+		},
+		{
 			name: "missing subnet ID - create",
 			cluster: func() *coreapi.HCPOpenShiftCluster {
 				c := createValidCluster()


### PR DESCRIPTION
## Summary

- Private KAS (`api.visibility=Private`) requires Swift networking (`vnetIntegrationSubnetId` must be set)
- Adds cross-field validation in the shared validator that rejects Private KAS clusters without `vnetIntegrationSubnetId` on create
- For API versions `v20251223preview` and later, `vnetIntegrationSubnetId` is already mandatory during conversion, so this validation only has practical effect for `v20240610preview`

## Why

Currently it's possible to create a Private KAS cluster via the `v20240610preview` API without Swift networking (`vnetIntegrationSubnetId` not set). This cluster would fail at provisioning time since Private KAS requires Swift. This PR catches the misconfiguration early at the API validation layer.

## Jira

[ARO-28990](https://issues.redhat.com/browse/ARO-28990)

## Test plan

- [x] Unit tests added for both cases:
  - Private KAS + Swift (allowed)
  - Private KAS + non-Swift (blocked)
- [ ] Existing validation tests pass (`go test ./validation/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)