### PR TITLE
Remove shuf dependency in comos emulator

### DIFF
--- a/test-integration/hack/start-cosmos-emulator.sh
+++ b/test-integration/hack/start-cosmos-emulator.sh
@@ -24,5 +24,5 @@ if [ -n "${RUNNING_CONTAINER}" ]; then
     echo "Will start a new emulator container..."
 fi
 
-CONTAINER_NAME="local-cosmos-emulator-$(shuf -i 1000-9999 -n 1)"
+CONTAINER_NAME="local-cosmos-emulator-$((1000 + RANDOM % 9000))"
 start_emulator "${CONTAINER_NAME}"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-29013

### What

uses `$RANDOM` instead of `shuf` for generating a random number

### Why

To make it work on systems where `shuf` is not available

### Testing

- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration) run again on my machine

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
