### PR TITLE
test: calculate latest z-stream for specific OCP version

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -75,6 +75,17 @@ $ export ARO_HCP_OPENSHIFT_CONTROLPLANE_VERSION=4.20
 $ export ARO_HCP_OPENSHIFT_NODEPOOL_VERSION=4.20.15
 ```
 
+When `ARO_HCP_OPENSHIFT_CONTROLPLANE_VERSION` is set, you can also set
+`ARO_HCP_OPENSHIFT_LATEST_Z_STREAM=true` to resolve that major.minor (or full
+semver) to the latest z-stream install version in the active channel group
+(`ARO_HCP_OPENSHIFT_CHANNEL_GROUP`, default `candidate`):
+
+```bash
+$ export ARO_HCP_OPENSHIFT_CONTROLPLANE_VERSION=4.20
+$ export ARO_HCP_OPENSHIFT_LATEST_Z_STREAM=true
+# e.g. resolves to 4.20.15 (whatever is latest in the channel)
+```
+
 So finally, you can run a particular test case:
 
 ```bash

--- a/test/util/framework/deployment_params.go
+++ b/test/util/framework/deployment_params.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -74,6 +76,21 @@ func resolveDefaultControlPlaneVersion() (string, error) {
 				}
 				version = resolved
 			}
+		} else if latestZStream, _ := strconv.ParseBool(strings.TrimSpace(os.Getenv("ARO_HCP_OPENSHIFT_LATEST_Z_STREAM"))); latestZStream {
+			// Resolve the configured major.minor (or full semver) to the latest
+			// z-stream install version in the active channel group.
+			parsed, err := semver.ParseTolerant(version)
+			if err != nil {
+				defaultCPVersionErr = fmt.Errorf("parse ARO_HCP_OPENSHIFT_CONTROLPLANE_VERSION %q: %w", version, err)
+				return
+			}
+			minor := fmt.Sprintf("%d.%d", parsed.Major, parsed.Minor)
+			resolved, err := GetLatestInstallVersion(context.Background(), DefaultOpenshiftChannelGroup(), minor)
+			if err != nil {
+				defaultCPVersionErr = err
+				return
+			}
+			version = resolved
 		}
 		defaultCPVersion = version
 	})


### PR DESCRIPTION
### What

This change adds support for ARO_HCP_OPENSHIFT_LATEST_Z_STREAM. When it is set to true together with ARO_HCP_OPENSHIFT_CONTROLPLANE_VERSION, the E2E framework no longer uses the configured value as a fixed install version. Instead, resolveDefaultControlPlaneVersion parses the configured major.minor (or full semver), looks up the latest z-stream for that minor in the active channel group, and uses that resolved version for default cluster params. Without the flag, an explicitly set control plane version continues to be used as-is.

### Why

This is necessary because CI and local runs often need to target a specific OpenShift minor (for example 4.20) while still installing the newest available patch in that line. Pinning only ARO_HCP_OPENSHIFT_CONTROLPLANE_VERSION=4.20 previously left the version unresolved when the env var was set, so tests could install an incomplete or outdated identifier, or required operators to hard-code a full z-stream and keep updating it. The new flag lets callers choose the minor and automatically track the latest z-stream, which reduces maintenance and keeps E2E coverage on current releases.

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
