### PR TITLE
Backport typespec changes for public preview

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@autorest/core": "^3.10.9",
         "@azure-tools/typespec-autorest": "^0.69.0",
         "@azure-tools/typespec-azure-core": "^0.69.0",
         "@azure-tools/typespec-azure-resource-manager": "^0.69.0",
@@ -87,6 +88,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@autorest/core": {
+      "version": "3.10.9",
+      "resolved": "https://registry.npmjs.org/@autorest/core/-/core-3.10.9.tgz",
+      "integrity": "sha512-k7vYHZMgzdu0FBC2j+ezj7mjptm+UOzQvtj/e3l78qAKi8L/SMLUQXTsw8Z2OL8vNG8MK4A/qlqVRwfM9k91vA==",
+      "license": "MIT",
+      "bin": {
+        "autorest-core": "entrypoints/app.js",
+        "autorest-language-service": "entrypoints/language-service.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@autorest/schemas": {

--- a/api/package.json
+++ b/api/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@autorest/core": "^3.10.9",
     "@azure-tools/typespec-autorest": "^0.69.0",
     "@azure-tools/typespec-azure-core": "^0.69.0",
     "@azure-tools/typespec-azure-resource-manager": "^0.69.0",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/client.tsp
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/client.tsp
@@ -1,0 +1,204 @@
+import "@azure-tools/typespec-client-generator-core";
+import "@typespec/versioning";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.ClientGenerator.Core;
+using Azure.ResourceManager;
+using Microsoft.RedHatOpenShift;
+
+// JavaScript SDK visibility workaround:
+// For write operations whose body models contain server-side read-only properties
+// that are also required, provide write-specific models that omit those fields so
+// JS SDK users are not forced to supply server-computed values.
+// Pattern: https://github.com/Azure/azure-rest-api-specs/pull/42784
+#suppress "@azure-tools/typespec-azure-resource-manager/missing-operations-endpoint" "Write-only helper models for JS SDK alternate types; operations are defined on the original resources in hcpCluster.tsp"
+namespace Microsoft.RedHatOpenShift {
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" ""
+  @doc("API profile for create/update operations, omitting server-side read-only field url.")
+  model ApiProfileCreate {
+    /** The internet visibility of the OpenShift API server. */
+    visibility?: Visibility = Visibility.Public;
+
+    /** The list of authorized IPv4 CIDR blocks allowed to access the API server. Maximum 500 entries. */
+    @clientName("authorizedCIDRs")
+    @maxItems(500)
+    authorizedCidrs?: string[];
+  }
+
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" ""
+  @doc("Azure platform configuration for create/update operations, omitting server-side read-only field issuerUrl.")
+  model PlatformProfileCreate {
+    /** Resource group name to put cluster resources. */
+    managedResourceGroup?: string;
+
+    /** The Azure resource ID of the worker subnet. */
+    subnetId: SubnetResourceId;
+
+    /** The Azure resource ID of the VNet integration subnet. */
+    @added(Versions.v2025_12_23_preview)
+    vnetIntegrationSubnetId: SubnetResourceId;
+
+    /** The core outgoing configuration. */
+    outboundType?: OutboundType = OutboundType.LoadBalancer;
+
+    /** Resource ID for the NSG attached to the cluster subnet. */
+    networkSecurityGroupId: NetworkSecurityGroupResourceId;
+
+    /** The configuration for operator authentication to Azure. */
+    operatorsAuthentication: OperatorsAuthenticationProfile;
+  }
+
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" ""
+  @doc("HCP cluster properties for create/update operations, omitting server-side read-only fields (console and status on the root model; api.url and platform.issuerUrl in nested models).")
+  model HcpOpenShiftClusterPropertiesCreate {
+    /** Version of the control plane components. */
+    @madeRequired(Versions.v2025_12_23_preview)
+    version: VersionProfile;
+
+    /** Cluster DNS configuration. */
+    dns?: DnsProfile;
+
+    /** Cluster network configuration. */
+    network?: NetworkProfile;
+
+    /** Shows the cluster API server profile. */
+    api?: ApiProfileCreate;
+
+    /** The cluster ingress configuration. */
+    @added(Versions.v2026_06_30_preview)
+    ingress?: IngressProfile;
+
+    /** Azure platform configuration. */
+    platform: PlatformProfileCreate;
+
+    /** Configure ClusterAutoscaling. */
+    autoscaling?: ClusterAutoscalingProfile;
+
+    /** Configure ETCD. */
+    @removed(Versions.v2026_06_30_preview)
+    @renamedFrom(Versions.v2026_06_30_preview, "etcd")
+    etcdNoUpdate?: EtcdProfile;
+
+    /** Configure ETCD. */
+    @added(Versions.v2026_06_30_preview)
+    etcd?: EtcdProfile;
+
+    /** Rules to allow pulling images from mirrored registries by digest. */
+    @added(Versions.v2025_12_23_preview)
+    @identifiers(#["source"])
+    @maxItems(240)
+    imageDigestMirrors?: ImageDigestMirror[];
+
+    /** Grace period in minutes for node draining during upgrades and scale operations. */
+    @maxValue(10080)
+    @minValue(0)
+    nodeDrainTimeoutMinutes?: int32;
+
+    /** OpenShift internal image registry. */
+    clusterImageRegistry?: ClusterImageRegistryProfile;
+
+    /** Cryptographic restrictions for kernel and userspace libraries. */
+    @added(Versions.v2026_06_30_preview)
+    cryptoRestrictions?: CryptoRestrictions = CryptoRestrictions.None;
+  }
+
+  @doc("HCP cluster resource for create/update operations.")
+  model HcpOpenShiftClusterResourceCreate
+    is TrackedResource<HcpOpenShiftClusterPropertiesCreate> {
+    ...ResourceNameParameter<
+      HcpOpenShiftClusterResourceCreate,
+      KeyName = "hcpOpenShiftClusterName",
+      SegmentName = "hcpOpenShiftClusters",
+      NamePattern = "^[a-zA-Z]([-a-zA-Z0-9]{0,52}[a-zA-Z0-9])?$"
+    >;
+    ...ManagedServiceIdentityProperty;
+  }
+
+  /** Represents the node pool properties */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" ""
+  model NodePoolPropertiesUpdate {
+    /** Provisioning state */
+    @visibility(Lifecycle.Read)
+    provisioningState?: ProvisioningState;
+
+    /** OpenShift version for the nodepool */
+    @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+    version?: NodePoolVersionProfile;
+
+    /** Azure node pool platform configuration */
+    @visibility(Lifecycle.Read, Lifecycle.Create)
+    platform?: NodePoolPlatformProfile;
+
+    /**
+     * The number of worker nodes, it cannot be used together with autoscaling.
+     * Validation:
+     * - Minimum: 0
+     * - Maximum: 200 (only when availabilityZone is not specified)
+     * - No maximum when availabilityZone is specified
+     */
+    @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+    @minValue(0)
+    replicas?: int32;
+
+    /** Auto-repair */
+    @visibility(Lifecycle.Read, Lifecycle.Create)
+    autoRepair?: boolean = true;
+
+    /** Representation of a autoscaling in a node pool. */
+    @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+    autoScaling?: NodePoolAutoScaling;
+
+    /** Kubernetes labels to propagate to the NodePool Nodes
+     * Note that when the labels are updated this is only applied to newly
+     * create nodes in the Nodepool, existing node labels remain unchanged.
+     */
+    @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+    @identifiers(#["key", "value"])
+    labels?: Label[];
+
+    /** Taints for the nodes */
+    @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+    @identifiers(#["key", "value", "effect"])
+    taints?: Taint[];
+
+    /** nodeDrainTimeoutMinutes is the grace period for how long Pod Disruption Budget-protected workloads will be
+     * respected during any node draining operation. After this grace period, any workloads protected by Pod Disruption
+     * Budgets that have not been successfully drained from a node will be forcibly evicted. This is
+     * especially relevant to cluster upgrades.
+     *
+     * Valid values are from 0 to 10080 minutes (1 week) .
+     * 0 means that the NodePool can be drained without any time limitation.
+     *
+     * If unset the cluster nodeDrainTimeoutMinutes value is used as a default.
+     */
+    @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+    nodeDrainTimeoutMinutes?: int32;
+  }
+}
+
+@@alternateType(
+  HcpOpenShiftClusters.createOrUpdate::parameters.resource,
+  HcpOpenShiftClusterResourceCreate,
+  "javascript"
+);
+
+// The JavaScript SDK thinks properties required for resource creation
+// are also required in PATCH request bodies. This is a bug in the SDK
+// generation but we have to make validation pass regardless.
+
+@Azure.Core.Foundations.omitKeyProperties
+model HcpOpenShiftClusterUpdate is UpdateableProperties<HcpOpenShiftCluster>;
+
+@@alternateType(
+  HcpOpenShiftClusters.update::parameters.properties,
+  HcpOpenShiftClusterUpdate,
+  "javascript"
+);
+
+@@alternateType(
+  NodePools.update::parameters.properties,
+  UpdateableProperties<NodePoolProperties>,
+  "javascript"
+);

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/hcpCluster-models.tsp
@@ -207,12 +207,11 @@ model VersionProfile {
    *  Each version belongs to only a single set.
    *
    *  If not specified, the default value is 'stable'.
-   *
-   *  Note: The default value is not declared in the API specification because
-   *        of a TypeSpec bug with updatable fields. The default value will be
-   *        declared in a future API version once the TypeSpec bug is fixed.
-   *        https://github.com/Azure/typespec-azure/issues/1586
    */
+  //  Note: The default value is not declared in the API specification because
+  //        of a TypeSpec bug with updatable fields. The default value will be
+  //        declared in a future API version once the TypeSpec bug is fixed.
+  //        https://github.com/Azure/typespec-azure/issues/1586
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   channelGroup?: string;
 }
@@ -394,23 +393,22 @@ model ClusterAutoscalingProfile {
 
   /** maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.
    * The default is 600 seconds.
-   *
-   *  Note: The default value is not declared in the API specification because
-   *        of a TypeSpec bug with updatable fields. The default value will be
-   *        declared in a future API version once the TypeSpec bug is fixed.
-   *        https://github.com/Azure/typespec-azure/issues/1586
    */
+  // Note: The default value is not declared in the API specification because
+  //       of a TypeSpec bug with updatable fields. The default value will be
+  //       declared in a future API version once the TypeSpec bug is fixed.
+  //       https://github.com/Azure/typespec-azure/issues/1586
+  //
   @minValue(0)
   maxPodGracePeriodSeconds?: int32;
 
   /** maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the
    *  provisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.
-   *
-   *  Note: The default value is not declared in the API specification because
-   *        of a TypeSpec bug with updatable fields. The default value will be
-   *        declared in a future API version once the TypeSpec bug is fixed.
-   *        https://github.com/Azure/typespec-azure/issues/1586
    */
+  // Note: The default value is not declared in the API specification because
+  //       of a TypeSpec bug with updatable fields. The default value will be
+  //       declared in a future API version once the TypeSpec bug is fixed.
+  //       https://github.com/Azure/typespec-azure/issues/1586
   @minValue(0)
   maxNodeProvisionTimeSeconds?: int32;
 
@@ -418,12 +416,11 @@ model ClusterAutoscalingProfile {
    * but only run when there are spare resources available. The default is -10.
    * See the following for more details:
    * https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption
-   *
-   *  Note: The default value is not declared in the API specification because
-   *        of a TypeSpec bug with updatable fields. The default value will be
-   *        declared in a future API version once the TypeSpec bug is fixed.
-   *        https://github.com/Azure/typespec-azure/issues/1586
    */
+  // Note: The default value is not declared in the API specification because
+  //       of a TypeSpec bug with updatable fields. The default value will be
+  //       declared in a future API version once the TypeSpec bug is fixed.
+  //       https://github.com/Azure/typespec-azure/issues/1586
   podPriorityThreshold?: int32;
 }
 
@@ -864,12 +861,11 @@ model NodePoolVersionProfile {
    *  Each version belongs to only a single set.
    *
    *  If not specified, the default value is 'stable'.
-   *
-   *  Note: The default value is not declared in the API specification because
-   *        of a TypeSpec bug with updatable fields. The default value will be
-   *        declared in a future API version once the TypeSpec bug is fixed.
-   *        https://github.com/Azure/typespec-azure/issues/1586
    */
+  // Note: The default value is not declared in the API specification because
+  //       of a TypeSpec bug with updatable fields. The default value will be
+  //       declared in a future API version once the TypeSpec bug is fixed.
+  //       https://github.com/Azure/typespec-azure/issues/1586
   @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
   channelGroup?: string;
 }
@@ -1388,12 +1384,11 @@ model UsernameClaimProfile {
    *    and `claim` is set to:
    *    - "username": the mapped value will be "https://myoidc.tld#userA"
    *    - "email": the mapped value will be "userA@myoidc.tld"
-   *
-   * Note: The default value is not declared in the API specification because
-   *       of a TypeSpec bug with updatable fields. The default value will be
-   *       declared in a future API version once the TypeSpec bug is fixed.
-   *       https://github.com/Azure/typespec-azure/issues/1586
    */
+  // Note: The default value is not declared in the API specification because
+  //       of a TypeSpec bug with updatable fields. The default value will be
+  //       declared in a future API version once the TypeSpec bug is fixed.
+  //       https://github.com/Azure/typespec-azure/issues/1586
   prefixPolicy?: UsernameClaimPrefixPolicy;
 }
 

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/main.tsp
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/main.tsp
@@ -4,6 +4,7 @@ import "@azure-tools/typespec-azure-resource-manager";
 import "./hcpCluster.tsp";
 import "./hcpVersion.tsp";
 import "./hcpOperatorIdentityRoleSet.tsp";
+import "./client.tsp";
 
 using TypeSpec.Versioning;
 using Azure.ResourceManager;

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2024-06-10-preview/openapi.json
@@ -1517,19 +1517,19 @@
         "maxPodGracePeriodSeconds": {
           "type": "integer",
           "format": "int32",
-          "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.",
           "minimum": 0
         },
         "maxNodeProvisionTimeSeconds": {
           "type": "integer",
           "format": "int32",
-          "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.",
           "minimum": 0
         },
         "podPriorityThreshold": {
           "type": "integer",
           "format": "int32",
-          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586"
+          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption"
         }
       }
     },
@@ -2975,7 +2975,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -3680,7 +3680,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2025-12-23-preview/openapi.json
@@ -1517,19 +1517,19 @@
         "maxPodGracePeriodSeconds": {
           "type": "integer",
           "format": "int32",
-          "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.",
           "minimum": 0
         },
         "maxNodeProvisionTimeSeconds": {
           "type": "integer",
           "format": "int32",
-          "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.",
           "minimum": 0
         },
         "podPriorityThreshold": {
           "type": "integer",
           "format": "int32",
-          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586"
+          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption"
         }
       }
     },
@@ -3073,7 +3073,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -3100,7 +3100,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -3844,7 +3844,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -3871,7 +3871,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-06-30-preview/openapi.json
@@ -1517,19 +1517,19 @@
         "maxPodGracePeriodSeconds": {
           "type": "integer",
           "format": "int32",
-          "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.",
           "minimum": 0
         },
         "maxNodeProvisionTimeSeconds": {
           "type": "integer",
           "format": "int32",
-          "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.",
           "minimum": 0
         },
         "podPriorityThreshold": {
           "type": "integer",
           "format": "int32",
-          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586"
+          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption"
         }
       }
     },
@@ -3262,7 +3262,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -3289,7 +3289,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -4052,7 +4052,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -4079,7 +4079,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/openapi.json
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/preview/2026-09-01-preview/openapi.json
@@ -1526,19 +1526,19 @@
         "maxPodGracePeriodSeconds": {
           "type": "integer",
           "format": "int32",
-          "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool.\nThe default is 600 seconds.",
           "minimum": 0
         },
         "maxNodeProvisionTimeSeconds": {
           "type": "integer",
           "format": "int32",
-          "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the\nprovisioning to be unsuccessful. The default is 900 seconds, or 15 minutes.",
           "minimum": 0
         },
         "podPriorityThreshold": {
           "type": "integer",
           "format": "int32",
-          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586"
+          "description": "podPriorityThreshold enables users to schedule \"best-effort\" pods, which shouldn't trigger autoscaler actions,\nbut only run when there are spare resources available. The default is -10.\nSee the following for more details:\nhttps://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption"
         }
       }
     },
@@ -3281,7 +3281,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -3308,7 +3308,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -4071,7 +4071,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",
@@ -4098,7 +4098,7 @@
         },
         "channelGroup": {
           "type": "string",
-          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.\n\nNote: The default value is not declared in the API specification because\nof a TypeSpec bug with updatable fields. The default value will be\ndeclared in a future API version once the TypeSpec bug is fixed.\nhttps://github.com/Azure/typespec-azure/issues/1586",
+          "description": "ChannelGroup is the name of the set to which this version belongs.\nEach version belongs to only a single set.\n\nIf not specified, the default value is 'stable'.",
           "x-ms-mutability": [
             "read",
             "update",

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/service.yaml
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/service.yaml
@@ -1,0 +1,13 @@
+versions:
+  - version: 2024-06-10-preview
+    source: typespec
+    swagger-files:
+      - preview/2024-06-10-preview/openapi.json
+  - version: 2025-12-23-preview
+    source: typespec
+    swagger-files:
+      - preview/2025-12-23-preview/openapi.json
+  - version: 2026-06-30-preview
+    source: typespec
+    swagger-files:
+      - preview/2026-06-30-preview/openapi.json

--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/service.yaml
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/service.yaml
@@ -11,3 +11,7 @@ versions:
     source: typespec
     swagger-files:
       - preview/2026-06-30-preview/openapi.json
+  - version: 2026-09-01-preview
+    source: typespec
+    swagger-files:
+      - preview/2026-09-01-preview/openapi.json

--- a/internal/azureapi/v20260901preview/generated/models.go
+++ b/internal/azureapi/v20260901preview/generated/models.go
@@ -33,9 +33,6 @@ type AzureResourceManagerCommonTypesManagedServiceIdentityUpdate struct {
 type ClusterAutoscalingProfile struct {
 	// maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the provisioning to be
 	// unsuccessful. The default is 900 seconds, or 15 minutes.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxNodeProvisionTimeSeconds *int32
 
 	// maxNodesTotal is the maximum allowable number of nodes for the Autoscaler scale out to be operational. The autoscaler will
@@ -45,17 +42,11 @@ type ClusterAutoscalingProfile struct {
 
 	// maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool. The default
 	// is 600 seconds.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxPodGracePeriodSeconds *int32
 
 	// podPriorityThreshold enables users to schedule "best-effort" pods, which shouldn't trigger autoscaler actions, but only
 	// run when there are spare resources available. The default is -10. See the
 	// following for more details: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	PodPriorityThreshold *int32
 }
 
@@ -830,9 +821,6 @@ type NodePoolVersionProfile struct {
 
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 }
 
@@ -840,9 +828,6 @@ type NodePoolVersionProfile struct {
 type NodePoolVersionProfileUpdate struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the unique identifier of the version.
@@ -1205,9 +1190,6 @@ type VersionProfile struct {
 
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 }
 
@@ -1215,9 +1197,6 @@ type VersionProfile struct {
 type VersionProfileUpdate struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the desired X.Y version of the cluster control plane.

--- a/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
+++ b/test/sdk/v20240610preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
@@ -52,9 +52,6 @@ type AzureResourceManagerCommonTypesTrackedResourceUpdate struct {
 type ClusterAutoscalingProfile struct {
 	// maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the provisioning to be
 	// unsuccessful. The default is 900 seconds, or 15 minutes.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxNodeProvisionTimeSeconds *int32
 
 	// maxNodesTotal is the maximum allowable number of nodes for the Autoscaler scale out to be operational. The autoscaler will
@@ -64,17 +61,11 @@ type ClusterAutoscalingProfile struct {
 
 	// maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool. The default
 	// is 600 seconds.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxPodGracePeriodSeconds *int32
 
 	// podPriorityThreshold enables users to schedule "best-effort" pods, which shouldn't trigger autoscaler actions, but only
 	// run when there are spare resources available. The default is -10. See the
 	// following for more details: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	PodPriorityThreshold *int32
 }
 
@@ -776,9 +767,6 @@ type NodePoolUpdate struct {
 type NodePoolVersionProfile struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the unique identifier of the version.
@@ -874,9 +862,7 @@ type OsDiskProfile struct {
 	// Details on how to create a Disk Encryption Set can be found here: https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-customer-managed-keys-portal#set-up-your-disk-encryption-set
 	EncryptionSetID *string
 
-	// The OS disk size in GiB. Maximum is 4095 GiB for Managed disks. For Ephemeral disks, the maximum is 2040 GiB; Azure may
-	// enforce a lower effective limit based on the selected VM size's local cache,
-	// temp, or NVMe capacity.
+	// The OS disk size in GiB
 	SizeGiB *int32
 }
 
@@ -1176,9 +1162,6 @@ type UsernameClaimProfileUpdate struct {
 type VersionProfile struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the unique identifier of the version.

--- a/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
+++ b/test/sdk/v20251223preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
@@ -52,9 +52,6 @@ type AzureResourceManagerCommonTypesTrackedResourceUpdate struct {
 type ClusterAutoscalingProfile struct {
 	// maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the provisioning to be
 	// unsuccessful. The default is 900 seconds, or 15 minutes.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxNodeProvisionTimeSeconds *int32
 
 	// maxNodesTotal is the maximum allowable number of nodes for the Autoscaler scale out to be operational. The autoscaler will
@@ -64,17 +61,11 @@ type ClusterAutoscalingProfile struct {
 
 	// maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool. The default
 	// is 600 seconds.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxPodGracePeriodSeconds *int32
 
 	// podPriorityThreshold enables users to schedule "best-effort" pods, which shouldn't trigger autoscaler actions, but only
 	// run when there are spare resources available. The default is -10. See the
 	// following for more details: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	PodPriorityThreshold *int32
 }
 
@@ -823,9 +814,6 @@ type NodePoolVersionProfile struct {
 
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 }
 
@@ -833,9 +821,6 @@ type NodePoolVersionProfile struct {
 type NodePoolVersionProfileUpdate struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the unique identifier of the version.
@@ -935,9 +920,7 @@ type OsDiskProfile struct {
 	// Details on how to create a Disk Encryption Set can be found here: https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-customer-managed-keys-portal#set-up-your-disk-encryption-set
 	EncryptionSetID *string
 
-	// The OS disk size in GiB. Maximum is 4095 GiB for Managed disks. For Ephemeral disks, the maximum is 2040 GiB; Azure may
-	// enforce a lower effective limit based on the selected VM size's local cache,
-	// temp, or NVMe capacity.
+	// The OS disk size in GiB
 	SizeGiB *int32
 }
 
@@ -1245,9 +1228,6 @@ type VersionProfile struct {
 
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 }
 
@@ -1255,9 +1235,6 @@ type VersionProfile struct {
 type VersionProfileUpdate struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the desired X.Y version of the cluster control plane.

--- a/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
+++ b/test/sdk/v20260630preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
@@ -52,9 +52,6 @@ type AzureResourceManagerCommonTypesTrackedResourceUpdate struct {
 type ClusterAutoscalingProfile struct {
 	// maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the provisioning to be
 	// unsuccessful. The default is 900 seconds, or 15 minutes.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxNodeProvisionTimeSeconds *int32
 
 	// maxNodesTotal is the maximum allowable number of nodes for the Autoscaler scale out to be operational. The autoscaler will
@@ -64,17 +61,11 @@ type ClusterAutoscalingProfile struct {
 
 	// maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool. The default
 	// is 600 seconds.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxPodGracePeriodSeconds *int32
 
 	// podPriorityThreshold enables users to schedule "best-effort" pods, which shouldn't trigger autoscaler actions, but only
 	// run when there are spare resources available. The default is -10. See the
 	// following for more details: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	PodPriorityThreshold *int32
 }
 
@@ -877,9 +868,6 @@ type NodePoolVersionProfile struct {
 
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 }
 
@@ -887,9 +875,6 @@ type NodePoolVersionProfile struct {
 type NodePoolVersionProfileUpdate struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the unique identifier of the version.
@@ -1305,9 +1290,6 @@ type VersionProfile struct {
 
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 }
 
@@ -1315,9 +1297,6 @@ type VersionProfile struct {
 type VersionProfileUpdate struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the desired X.Y version of the cluster control plane.

--- a/test/sdk/v20260901preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
+++ b/test/sdk/v20260901preview/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp/models.go
@@ -52,9 +52,6 @@ type AzureResourceManagerCommonTypesTrackedResourceUpdate struct {
 type ClusterAutoscalingProfile struct {
 	// maxNodeProvisionTimeSeconds is the maximum time to wait for node provisioning before considering the provisioning to be
 	// unsuccessful. The default is 900 seconds, or 15 minutes.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxNodeProvisionTimeSeconds *int32
 
 	// maxNodesTotal is the maximum allowable number of nodes for the Autoscaler scale out to be operational. The autoscaler will
@@ -64,17 +61,11 @@ type ClusterAutoscalingProfile struct {
 
 	// maxPodGracePeriod is the maximum seconds to wait for graceful pod termination before scaling down a NodePool. The default
 	// is 600 seconds.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	MaxPodGracePeriodSeconds *int32
 
 	// podPriorityThreshold enables users to schedule "best-effort" pods, which shouldn't trigger autoscaler actions, but only
 	// run when there are spare resources available. The default is -10. See the
 	// following for more details: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	PodPriorityThreshold *int32
 }
 
@@ -883,9 +874,6 @@ type NodePoolVersionProfile struct {
 
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 }
 
@@ -893,9 +881,6 @@ type NodePoolVersionProfile struct {
 type NodePoolVersionProfileUpdate struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the unique identifier of the version.
@@ -1311,9 +1296,6 @@ type VersionProfile struct {
 
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 }
 
@@ -1321,9 +1303,6 @@ type VersionProfile struct {
 type VersionProfileUpdate struct {
 	// ChannelGroup is the name of the set to which this version belongs. Each version belongs to only a single set.
 	// If not specified, the default value is 'stable'.
-	// Note: The default value is not declared in the API specification because of a TypeSpec bug with updatable fields. The default
-	// value will be declared in a future API version once the TypeSpec bug is
-	// fixed. https://github.com/Azure/typespec-azure/issues/1586
 	ChannelGroup *string
 
 	// ID is the desired X.Y version of the cluster control plane.


### PR DESCRIPTION
### What

Backports the TypeSpec changes from https://github.com/Azure/azure-rest-api-specs/pull/45197 that were necessary to pass all the Azure CI checks.

The `service.yaml` file is apparently a new requirement.  I've yet to find proper documentation about it, but the CI check for it pretty much dictated the content.  **It will need to be updated for every new API version.**

The `client.tsp` file currently just contains workarounds for bugs in the JavaScript SDK emitter.  Hopefully these are temporary.  More broadly, it establishes a place for any future language-specific client overrides.