### PR TITLE
fix: defer MI scheduler setup to run-suite/run-test only

### DIFF
--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -346,6 +346,91 @@ func miDemandPriority(spec *et.ExtensionTestSpec) int {
 	return demand
 }
 
+type miSchedulerConfig struct {
+	pooledIdentitiesEnabled bool
+	containerCount          int
+	containerCountSource    string
+}
+
+var (
+	miSchedulerSetup     miSchedulerConfig
+	miSchedulerSpecs     et.ExtensionTestSpecs
+	miSchedulerConfigure sync.Once
+)
+
+func initMIScheduler(specs et.ExtensionTestSpecs, cfg miSchedulerConfig) {
+	miSchedulerSpecs = specs
+	miSchedulerSetup = cfg
+}
+
+// configureMIScheduler walks specs to wire up per-test MI container demands for the
+// openshift-tests-extension resource-aware scheduler. Each spec's MIContainers(N) label
+// declares how many pooled identity containers it will lease. When pooled identities are
+// enabled, we set spec.Resources.ResourcePools["mi-containers"] = N so the scheduler
+// won't start the test until N slots are free in the pool.
+func configureMIScheduler(specs et.ExtensionTestSpecs, cfg miSchedulerConfig) {
+	var missingLabel []string
+	var demand0, demand1, demandN int
+	specs.Walk(func(spec *et.ExtensionTestSpec) {
+		demand, ok := parseMIContainersLabel(spec)
+		if !ok {
+			missingLabel = append(missingLabel, spec.Name)
+			return
+		}
+		switch demand {
+		case 0:
+			demand0++
+		case 1:
+			demand1++
+		default:
+			demandN++
+		}
+		if cfg.pooledIdentitiesEnabled && demand > 0 {
+			if spec.Resources.ResourcePools == nil {
+				spec.Resources.ResourcePools = make(map[string]int)
+			}
+			spec.Resources.ResourcePools["mi-containers"] = demand
+		}
+	})
+	if len(missingLabel) > 0 {
+		fmt.Fprintf(os.Stderr, "FATAL: %d tests missing MIContainers label:\n", len(missingLabel))
+		for _, name := range missingLabel {
+			fmt.Fprintf(os.Stderr, "  - %s\n", name)
+		}
+		os.Exit(1)
+	}
+	total := demand0 + demand1 + demandN
+	if cfg.pooledIdentitiesEnabled {
+		fmt.Fprintf(os.Stderr, "[scheduler] pool mi-containers=%d (source: %s), %d specs (%d×0, %d×1, %d×2+)\n",
+			cfg.containerCount, cfg.containerCountSource, total, demand0, demand1, demandN)
+	} else {
+		fmt.Fprintf(os.Stderr, "[scheduler] pooled identities disabled (%s!=true), skipping mi-containers pool demands; %d specs (%d×0, %d×1, %d×2+)\n",
+			framework.UsePooledIdentitiesEnvvar, total, demand0, demand1, demandN)
+	}
+
+	if os.Getenv("ARO_HCP_DISABLE_MI_SORT") != "true" {
+		sort.SliceStable(specs, func(i, j int) bool {
+			return miDemandPriority(specs[i]) > miDemandPriority(specs[j])
+		})
+	}
+}
+
+func ensureMISchedulerConfigured() {
+	miSchedulerConfigure.Do(func() {
+		configureMIScheduler(miSchedulerSpecs, miSchedulerSetup)
+	})
+}
+
+func wrapMISchedulerPreRun(cmd *cobra.Command) {
+	existingPreRun := cmd.PersistentPreRun
+	cmd.PersistentPreRun = func(c *cobra.Command, args []string) {
+		ensureMISchedulerConfigured()
+		if existingPreRun != nil {
+			existingPreRun(c, args)
+		}
+	}
+}
+
 // isRunSuiteProcess returns true when this is the long-lived parent run-suite
 // process (os.Args[1] == "run-suite"), not a per-spec run-test worker subprocess.
 // The openshift-tests-extension framework spawns each spec as a separate
@@ -666,68 +751,33 @@ func setupCli() *cobra.Command {
 	//	}
 	// })
 
-	// Walk specs to wire up per-test MI container demands for the
-	// openshift-tests-extension resource-aware scheduler. Each spec's
-	// MIContainers(N) label declares how many pooled identity containers
-	// it will lease. When pooled identities are enabled, we set
-	// spec.Resources.ResourcePools["mi-containers"] = N so the scheduler
-	// won't start the test until N slots are free in the pool.
-	// demand0/demand1/demandN bucket counts are for the log summary only.
-	var missingLabel []string
-	var demand0, demand1, demandN int
-	specs.Walk(func(spec *et.ExtensionTestSpec) {
-		demand, ok := parseMIContainersLabel(spec)
-		if !ok {
-			missingLabel = append(missingLabel, spec.Name)
-			return
-		}
-		switch demand {
-		case 0:
-			demand0++
-		case 1:
-			demand1++
-		default:
-			demandN++
-		}
-		if pooledIdentitiesEnabled && demand > 0 {
-			if spec.Resources.ResourcePools == nil {
-				spec.Resources.ResourcePools = make(map[string]int)
-			}
-			spec.Resources.ResourcePools["mi-containers"] = demand
-		}
-	})
-	if len(missingLabel) > 0 {
-		fmt.Fprintf(os.Stderr, "FATAL: %d tests missing MIContainers label:\n", len(missingLabel))
-		for _, name := range missingLabel {
-			fmt.Fprintf(os.Stderr, "  - %s\n", name)
-		}
-		os.Exit(1)
-	}
-	total := demand0 + demand1 + demandN
-	if pooledIdentitiesEnabled {
-		fmt.Fprintf(os.Stderr, "[scheduler] pool mi-containers=%d (source: %s), %d specs (%d×0, %d×1, %d×2+)\n",
-			containerCount, containerCountSource, total, demand0, demand1, demandN)
-	} else {
-		fmt.Fprintf(os.Stderr, "[scheduler] pooled identities disabled (%s!=true), skipping mi-containers pool demands; %d specs (%d×0, %d×1, %d×2+)\n",
-			framework.UsePooledIdentitiesEnvvar, total, demand0, demand1, demandN)
-	}
-
-	if os.Getenv("ARO_HCP_DISABLE_MI_SORT") != "true" {
-		sort.SliceStable(specs, func(i, j int) bool {
-			return miDemandPriority(specs[i]) > miDemandPriority(specs[j])
-		})
-	}
-
 	registerEV2RetryCatcher(specs)
 
 	ext.AddSpecs(specs)
 	registry.Register(ext)
 
+	// AddSpecs copies specs into a new backing array (ext.specs), so the
+	// scheduler must be wired against ext.GetSpecs() rather than the local
+	// specs slice above — otherwise the demand-based sort in
+	// configureMIScheduler reorders a slice run-suite/run-test never reads.
+	initMIScheduler(ext.GetSpecs(), miSchedulerConfig{
+		pooledIdentitiesEnabled: pooledIdentitiesEnabled,
+		containerCount:          containerCount,
+		containerCountSource:    containerCountSource,
+	})
+
 	root := &cobra.Command{
 		Long: "ARO-HCP E2E Tests",
 	}
 
-	root.AddCommand(cmd.DefaultExtensionCommands(registry)...)
+	extensionCmds := cmd.DefaultExtensionCommands(registry)
+	for _, c := range extensionCmds {
+		switch c.Name() {
+		case "run-suite", "run-test":
+			wrapMISchedulerPreRun(c)
+		}
+	}
+	root.AddCommand(extensionCmds...)
 	root.AddCommand(cleanup.NewCommand())
 	root.AddCommand(metadataapi.Must(visualize.NewCommand()))
 	root.AddCommand(metadataapi.Must(customlinktools.NewCommand()))

--- a/test/cmd/aro-hcp-tests/main_test.go
+++ b/test/cmd/aro-hcp-tests/main_test.go
@@ -15,13 +15,272 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
+
+	e "github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+	et "github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
 
 	"github.com/Azure/ARO-HCP/test/util/testutil"
 )
+
+func TestNonTestCommandsSkipMISchedulerBanner(t *testing.T) {
+	root := setupCli()
+	root.SetArgs([]string{"list", "suites", "--output", "names"})
+
+	stderrReader, stderrWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stderr pipe: %v", err)
+	}
+	defer stderrReader.Close()
+	originalStderr := os.Stderr
+	os.Stderr = stderrWriter
+	defer func() {
+		os.Stderr = originalStderr
+		stderrWriter.Close()
+	}()
+
+	stdout, err := os.CreateTemp("", "test-output-*.txt")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(stdout.Name())
+	defer stdout.Close()
+
+	originalStdout := os.Stdout
+	os.Stdout = stdout
+	defer func() {
+		os.Stdout = originalStdout
+	}()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- root.Execute()
+		stderrWriter.Close()
+	}()
+
+	var stderrBuf bytes.Buffer
+	if _, err := io.Copy(&stderrBuf, stderrReader); err != nil {
+		t.Fatalf("failed to read stderr: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("failed to execute list suites: %v", err)
+	}
+	if strings.Contains(stderrBuf.String(), "[scheduler]") {
+		t.Fatalf("expected no scheduler banner for list command, got stderr: %s", stderrBuf.String())
+	}
+}
+
+// captureStderr redirects os.Stderr to a temp file for the duration of fn and returns
+// everything written to it. Unlike the os.Pipe pattern above, fn here runs synchronously
+// with no concurrent writer, so a plain temp file avoids needing a reader goroutine.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	tmp, err := os.CreateTemp("", "stderr-capture-*.txt")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+	defer tmp.Close()
+
+	original := os.Stderr
+	os.Stderr = tmp
+	defer func() { os.Stderr = original }()
+	fn()
+
+	data, err := os.ReadFile(tmp.Name())
+	if err != nil {
+		t.Fatalf("failed to read captured stderr: %v", err)
+	}
+	return string(data)
+}
+
+func specNames(specs et.ExtensionTestSpecs) []string {
+	names := make([]string, len(specs))
+	for i, s := range specs {
+		names[i] = s.Name
+	}
+	return names
+}
+
+func assertSpecOrder(t *testing.T, specs et.ExtensionTestSpecs, want []string) {
+	t.Helper()
+	got := specNames(specs)
+	if len(got) != len(want) {
+		t.Fatalf("expected specs %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected specs sorted as %v, got %v", want, got)
+		}
+	}
+}
+
+func TestParseMIContainersLabel(t *testing.T) {
+	tests := []struct {
+		name       string
+		labels     []string
+		wantDemand int
+		wantFound  bool
+	}{
+		{name: "no MIContainers label", labels: nil, wantDemand: 0, wantFound: false},
+		{name: "zero demand", labels: []string{"MIContainers:0"}, wantDemand: 0, wantFound: true},
+		{name: "positive demand", labels: []string{"MIContainers:3"}, wantDemand: 3, wantFound: true},
+		{name: "unrelated labels are ignored", labels: []string{"SLOW", "MIContainers:1"}, wantDemand: 1, wantFound: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := &et.ExtensionTestSpec{Name: tt.name, Labels: sets.New(tt.labels...)}
+			demand, found := parseMIContainersLabel(spec)
+			if demand != tt.wantDemand || found != tt.wantFound {
+				t.Fatalf("parseMIContainersLabel() = (%d, %v), want (%d, %v)", demand, found, tt.wantDemand, tt.wantFound)
+			}
+		})
+	}
+}
+
+func TestMIDemandPriority(t *testing.T) {
+	labeled := &et.ExtensionTestSpec{Name: "labeled", Labels: sets.New("MIContainers:4")}
+	if got := miDemandPriority(labeled); got != 4 {
+		t.Fatalf("miDemandPriority() = %d, want 4", got)
+	}
+	unlabeled := &et.ExtensionTestSpec{Name: "unlabeled", Labels: sets.New[string]()}
+	if got := miDemandPriority(unlabeled); got != 0 {
+		t.Fatalf("miDemandPriority() for a spec missing the label = %d, want 0", got)
+	}
+}
+
+func TestConfigureMISchedulerWiresResourcePoolsAndSortsByDemand(t *testing.T) {
+	t.Setenv("ARO_HCP_DISABLE_MI_SORT", "")
+
+	newSpecs := func() et.ExtensionTestSpecs {
+		return et.ExtensionTestSpecs{
+			{Name: "zero-demand", Labels: sets.New("MIContainers:0")},
+			{Name: "high-demand", Labels: sets.New("MIContainers:2")},
+			{Name: "low-demand", Labels: sets.New("MIContainers:1")},
+		}
+	}
+	wantOrder := []string{"high-demand", "low-demand", "zero-demand"}
+
+	t.Run("pooled identities enabled", func(t *testing.T) {
+		specs := newSpecs()
+		stderr := captureStderr(t, func() {
+			configureMIScheduler(specs, miSchedulerConfig{pooledIdentitiesEnabled: true, containerCount: 5, containerCountSource: "test"})
+		})
+
+		assertSpecOrder(t, specs, wantOrder)
+		for _, spec := range specs {
+			demand, _ := parseMIContainersLabel(spec)
+			if got := spec.Resources.ResourcePools["mi-containers"]; got != demand {
+				t.Fatalf("expected spec %q mi-containers pool demand %d, got %d", spec.Name, demand, got)
+			}
+		}
+		if !strings.Contains(stderr, "[scheduler] pool mi-containers=5") {
+			t.Fatalf("expected scheduler banner reporting the pool size, got: %s", stderr)
+		}
+	})
+
+	t.Run("pooled identities disabled", func(t *testing.T) {
+		specs := newSpecs()
+		stderr := captureStderr(t, func() {
+			configureMIScheduler(specs, miSchedulerConfig{pooledIdentitiesEnabled: false, containerCount: 5, containerCountSource: "test"})
+		})
+
+		assertSpecOrder(t, specs, wantOrder)
+		for _, spec := range specs {
+			if len(spec.Resources.ResourcePools) != 0 {
+				t.Fatalf("expected no ResourcePools wiring when pooled identities are disabled, got %v on %q", spec.Resources.ResourcePools, spec.Name)
+			}
+		}
+		if !strings.Contains(stderr, "pooled identities disabled") {
+			t.Fatalf("expected scheduler banner noting pooled identities are disabled, got: %s", stderr)
+		}
+	})
+}
+
+// TestMISchedulerSortReflectedInExtensionSpecs guards against the bug fixed in
+// ARO-29044: initMIScheduler must be wired to ext.GetSpecs(), not the local specs
+// slice from before ext.AddSpecs(specs). AddSpecs does e.specs = append(e.specs,
+// specs...), which allocates a new backing array -- wiring the pre-AddSpecs slice
+// would make the demand-priority sort reorder a slice run-suite/run-test never reads.
+func TestMISchedulerSortReflectedInExtensionSpecs(t *testing.T) {
+	origSpecs, origSetup := miSchedulerSpecs, miSchedulerSetup
+	defer func() {
+		miSchedulerSpecs, miSchedulerSetup = origSpecs, origSetup
+		miSchedulerConfigure = sync.Once{}
+	}()
+	t.Setenv("ARO_HCP_DISABLE_MI_SORT", "")
+
+	specs := et.ExtensionTestSpecs{
+		{Name: "low-demand", Labels: sets.New("MIContainers:0")},
+		{Name: "high-demand", Labels: sets.New("MIContainers:2")},
+	}
+
+	ext := e.NewExtension("test", "payload", "mi-scheduler-regression")
+	ext.AddSpecs(specs)
+
+	initMIScheduler(ext.GetSpecs(), miSchedulerConfig{pooledIdentitiesEnabled: false, containerCount: 1, containerCountSource: "test"})
+	miSchedulerConfigure = sync.Once{}
+	captureStderr(t, ensureMISchedulerConfigured)
+
+	assertSpecOrder(t, ext.GetSpecs(), []string{"high-demand", "low-demand"})
+}
+
+func TestEnsureMISchedulerConfiguredRunsOnce(t *testing.T) {
+	origSpecs, origSetup := miSchedulerSpecs, miSchedulerSetup
+	defer func() {
+		miSchedulerSpecs, miSchedulerSetup = origSpecs, origSetup
+		miSchedulerConfigure = sync.Once{}
+	}()
+
+	miSchedulerSpecs = et.ExtensionTestSpecs{{Name: "once-test", Labels: sets.New("MIContainers:1")}}
+	miSchedulerSetup = miSchedulerConfig{pooledIdentitiesEnabled: false, containerCount: 1, containerCountSource: "test"}
+	miSchedulerConfigure = sync.Once{}
+
+	stderr := captureStderr(t, func() {
+		ensureMISchedulerConfigured()
+		ensureMISchedulerConfigured()
+		ensureMISchedulerConfigured()
+	})
+
+	if got := strings.Count(stderr, "[scheduler]"); got != 1 {
+		t.Fatalf("expected configureMIScheduler to run exactly once across repeated PreRun invocations, got %d banners in stderr: %s", got, stderr)
+	}
+}
+
+// TestConfigureMISchedulerFatalOnMissingLabel exercises the FATAL/os.Exit(1) path
+// configureMIScheduler takes for a spec missing the MIContainers label -- the failure
+// mode this PR's PreRun deferral is meant to preserve for run-suite/run-test while no
+// longer triggering it for every other subcommand.
+func TestConfigureMISchedulerFatalOnMissingLabel(t *testing.T) {
+	if os.Getenv("ARO_HCP_TESTS_CRASH_TEST") == "1" {
+		spec := &et.ExtensionTestSpec{Name: "unlabeled-test", Labels: sets.New[string]()}
+		configureMIScheduler(et.ExtensionTestSpecs{spec}, miSchedulerConfig{pooledIdentitiesEnabled: true, containerCount: 1, containerCountSource: "test"})
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestConfigureMISchedulerFatalOnMissingLabel$")
+	cmd.Env = append(os.Environ(), "ARO_HCP_TESTS_CRASH_TEST=1")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok || exitErr.ExitCode() != 1 {
+		t.Fatalf("expected configureMIScheduler to exit(1) for a spec missing the MIContainers label, got err=%v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "FATAL") || !strings.Contains(stderr.String(), "unlabeled-test") {
+		t.Fatalf("expected a FATAL message naming the offending spec, got: %s", stderr.String())
+	}
+}
 
 func TestMainListSuitesForEachSuite(t *testing.T) {
 	type testCase struct {
@@ -54,6 +313,7 @@ func TestMainListSuitesForEachSuite(t *testing.T) {
 				t.Fatalf("failed to create temp file: %v", err)
 			}
 			defer os.Remove(mktempfile.Name())
+			defer mktempfile.Close()
 
 			// Capture stdout to verify the command executes successfully
 			originalStdout := os.Stdout

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -1,4 +1,4 @@
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
+Customer should be able to list available HCP OpenShift versions and validate response content
 SRE should be able to log into a cluster via a breakglass session
 SRE should be able to retrieve serial console logs for a VM
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
@@ -19,6 +19,7 @@ FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mo
 Customer should be able to create an HCP cluster and manage pull secrets
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
 Customer should be able to create an HCP cluster with back-level version 4.19
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -57,8 +58,10 @@ Customer should be able to successfully upgrade control plane minor version from
 Customer should be able to successfully upgrade control plane minor version from 5.9 minor to 5.10 minor
 Customer should be able to successfully upgrade control plane minor version from 5.10 minor to 5.11 minor
 Customer should be able to successfully upgrade control plane minor version from 5.11 minor to 5.12 minor
+Engineering should be able to retrieve expected metrics from the /metrics endpoint
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster
+Fleet should have registered stamps with ready management clusters
 SRE can pause schedules to stop backup execution for an HCP cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
@@ -76,6 +79,3 @@ Customer should upgrade a nodepool skipping one minor version (+2) from 4.20.z t
 Customer should downgrade a nodepool version z-stream downgrade from 4.21.zLatest to 4.21.zPrevious
 Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest to 4.19.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL
-Customer should be able to list available HCP OpenShift versions and validate response content
-Engineering should be able to retrieve expected metrics from the /metrics endpoint
-Fleet should have registered stamps with ready management clusters

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -1,5 +1,4 @@
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
-Customer should not be able to reuse subnets and NSGs between clusters
+Customer should be able to list available HCP OpenShift versions and validate response content
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
@@ -15,11 +14,13 @@ Customer should create a cluster using v20260901preview API and verify cluster h
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
+Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to create an HCP cluster and manage pull secrets
 Customer should create an HCP cluster and validate TLS certificates
 Update HCPOpenShiftCluster Negative creates a cluster and fails to update its name with a PATCH request
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
 Customer should be able to create an HCP cluster with back-level version 4.19
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -76,4 +77,3 @@ Customer should downgrade a nodepool version z-stream downgrade from 4.21.zLates
 Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest to 4.19.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources
-Customer should be able to list available HCP OpenShift versions and validate response content

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -1,5 +1,4 @@
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
-Customer should not be able to reuse subnets and NSGs between clusters
+Customer should be able to list available HCP OpenShift versions and validate response content
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
@@ -15,11 +14,13 @@ Customer should create a cluster using v20260901preview API and verify cluster h
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
+Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to create an HCP cluster and manage pull secrets
 Customer should create an HCP cluster and validate TLS certificates
 Update HCPOpenShiftCluster Negative creates a cluster and fails to update its name with a PATCH request
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
 Customer should be able to create an HCP cluster with back-level version 4.19
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -76,4 +77,3 @@ Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest 
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings
 Customer should not be able to perform various invalid operations on cluster resources
-Customer should be able to list available HCP OpenShift versions and validate response content

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -1,5 +1,4 @@
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
-Customer should not be able to reuse subnets and NSGs between clusters
+Customer should be able to list available HCP OpenShift versions and validate response content
 SRE should be able to log into a cluster via a breakglass session
 SRE should be able to retrieve serial console logs for a VM
 SRE should return 409 when boot diagnostics is disabled on a VM
@@ -18,9 +17,11 @@ Create HCPOpenShiftCluster with Private KeyVault should create a cluster with pr
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
+Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to create an HCP cluster and manage pull secrets
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
 Customer should be able to create an HCP cluster with back-level version 4.19
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -59,11 +60,15 @@ Customer should be able to successfully upgrade control plane minor version from
 Customer should be able to successfully upgrade control plane minor version from 5.9 minor to 5.10 minor
 Customer should be able to successfully upgrade control plane minor version from 5.10 minor to 5.11 minor
 Customer should be able to successfully upgrade control plane minor version from 5.11 minor to 5.12 minor
+Engineering should be able to retrieve expected metrics from the /metrics endpoint
 Customer should be able to create a cluster with an external auth config and get the external auth config
 Customer should be able to lifecycle and confirm external auth on a cluster
+Fleet should have registered stamps with ready management clusters
 SRE can pause schedules to stop backup execution for an HCP cluster
 Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
+Image Registry Policy should deny pods with images from disallowed registries
+Image Registry Policy should allow pods with images from allowed registries and have a valid allowlist
 Customer should be able to rotate KMS key for a cluster with version >= 4.22
 Engineering should be able to retrieve kusto logs for a cluster and services
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
@@ -80,8 +85,3 @@ Customer should downgrade a nodepool version z-stream downgrade from 4.21.zLates
 Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest to 4.19.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources
-Customer should be able to list available HCP OpenShift versions and validate response content
-Engineering should be able to retrieve expected metrics from the /metrics endpoint
-Fleet should have registered stamps with ready management clusters
-Image Registry Policy should deny pods with images from disallowed registries
-Image Registry Policy should allow pods with images from allowed registries and have a valid allowlist

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -1,5 +1,4 @@
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
-Customer should not be able to reuse subnets and NSGs between clusters
+Customer should be able to list available HCP OpenShift versions and validate response content
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
@@ -15,9 +14,11 @@ Create HCPOpenShiftCluster with Private KeyVault should create a cluster with pr
 Customer should create a cluster using v20260901preview API and verify cluster health
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
+Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to create an HCP cluster and manage pull secrets
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
 Customer should be able to create an HCP cluster with back-level version 4.19
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -73,4 +74,3 @@ Customer should downgrade a nodepool version z-stream downgrade from 4.21.zLates
 Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest to 4.19.zLatest
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should not be able to perform various invalid operations on cluster resources
-Customer should be able to list available HCP OpenShift versions and validate response content

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -1,5 +1,4 @@
-Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
-Customer should not be able to reuse subnets and NSGs between clusters
+Customer should be able to list available HCP OpenShift versions and validate response content
 Customer should be able to test admin credentials before cluster ready, then full admin credential lifecycle
 Customer should be able to create node pools with ARM64-based VMs
 Authorized CIDRs Connectivity should allow API access only from authorized VM IP
@@ -15,11 +14,13 @@ Customer should create a cluster using v20260901preview API and verify cluster h
 ARO HCP Service should successfully provision cluster when MI role assignments are added after cluster creation
 Customer should be able to create an HCP cluster then delete it by deleting the customer resource group
 FIPS Mode Support with v2026-06-30 API should create an HCP cluster with FIPS mode enabled via cryptoRestrictions property
+Customer should not be able to reuse subnets and NSGs between clusters
 Customer should be able to create an HCP cluster and manage pull secrets
 Customer should create an HCP cluster and validate TLS certificates
 Update HCPOpenShiftCluster Negative creates a cluster and fails to update its name with a PATCH request
 Update HCPOpenShiftCluster Positive creates a cluster and updates tags with a PATCH request
 Customer should be able to create an HCP cluster with back-level version 4.19
+Customer should be able to create several HCP clusters in their customer resource group, but not in the same managed resource group
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.20
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.21
 ARO-HCP should be able to perform a control plane and node pool install with OCP candidate channel for 4.22
@@ -76,4 +77,3 @@ Customer should downgrade a nodepool to a lower minor version from 4.21.zLatest 
 Customer should be able to use workload identity via the cluster OIDC issuer URL
 Customer should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings
 Customer should not be able to perform various invalid operations on cluster resources
-Customer should be able to list available HCP OpenShift versions and validate response content


### PR DESCRIPTION

https://redhat.atlassian.net/browse/ARO-29044

### What

Avoid walking all E2E specs and validating MIContainers labels on every aro-hcp-tests subcommand invocation, so slot-manager and other helpers never pay the cost or hit a fatal exit from missing labels.


### Why

Prevent misleading log messages about scheduler usage when there are no tests to run, also prevent an improperly configured e2e test from breaking every aro-hcp-tests subcommand. 

### Testing

e2e tests should catch any introduced regression, also added a unit test to make sure we don't do MI scheduling work on subcommands that do not run tests.

### Special notes for your reviewer

None

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
