### PR TITLE
fix: repair oc-mirror ACR credential helper for Azure CLI 2.88.0

### DIFF
--- a/image-sync/oc-mirror/docker-login.sh
+++ b/image-sync/oc-mirror/docker-login.sh
@@ -24,7 +24,10 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --password-stdin)
+            # Command substitution already strips trailing newlines; also drop a
+            # trailing CR so a CRLF-terminated token does not corrupt the value.
             PASSWORD="$(cat)"
+            PASSWORD="${PASSWORD%$'\r'}"
             shift
             ;;
         *)
@@ -45,4 +48,10 @@ AUTH_FILE="${XDG_RUNTIME_DIR}/containers/auth.json"
 TMP_AUTH_FILE="${XDG_RUNTIME_DIR}/containers/tmp-auth.json"
 
 jq --arg registry "$REGISTRY_URL" --arg auth "$AUTH" '.auths[$registry] = { "auth": $auth }' "${AUTH_FILE}" > "${TMP_AUTH_FILE}"
-cp "${TMP_AUTH_FILE}" "${AUTH_FILE}"
+# Prefer mv: within a directory it is atomic, so a reader never sees a partial
+# file. The dry-run make targets bind-mount auth.json itself, and rename() over
+# a mount point fails with EBUSY, so fall back to a copy in that case.
+if ! mv "${TMP_AUTH_FILE}" "${AUTH_FILE}" 2>/dev/null; then
+    cp "${TMP_AUTH_FILE}" "${AUTH_FILE}"
+    rm -f "${TMP_AUTH_FILE}"
+fi

--- a/image-sync/oc-mirror/docker-login.sh
+++ b/image-sync/oc-mirror/docker-login.sh
@@ -1,10 +1,48 @@
 #!/bin/bash
 
-USERNAME=$3
-PASSWORD=$5
+set -euo pipefail
 
-PLAIN_CREDS="$USERNAME:$PASSWORD"
-AUTH=$(echo -n $PLAIN_CREDS | base64)
+# Credential helper invoked by `az acr login` via DOCKER_COMMAND. It receives a
+# `docker login` invocation and writes the resulting credential into auth.json
+# for oc-mirror to consume.
+#
+# The credential is passed differently depending on the Azure CLI version:
+#   < 2.88.0  ->  login --username <user> --password <token> <registry>
+#   >= 2.88.0 ->  login --username <user> --password-stdin <registry>, token on stdin
+# Parse the flags rather than relying on positional arguments so both forms work.
+USERNAME=""
+PASSWORD=""
 
-jq --arg registry "$REGISTRY_URL" --arg auth "$AUTH" '.auths[$registry] = { "auth": $auth }' ${XDG_RUNTIME_DIR}/containers/auth.json > ${XDG_RUNTIME_DIR}/containers/tmp-auth.json
-cp ${XDG_RUNTIME_DIR}/containers/tmp-auth.json ${XDG_RUNTIME_DIR}/containers/auth.json
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --username|-u)
+            USERNAME="$2"
+            shift 2
+            ;;
+        --password|-p)
+            PASSWORD="$2"
+            shift 2
+            ;;
+        --password-stdin)
+            PASSWORD="$(cat)"
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "${USERNAME}" || -z "${PASSWORD}" ]]; then
+    echo "docker-login.sh: could not determine registry credentials from 'docker login' arguments" >&2
+    exit 1
+fi
+
+# -w0 keeps the value on a single line; auth.json consumers expect an unwrapped string.
+AUTH=$(printf '%s:%s' "${USERNAME}" "${PASSWORD}" | base64 -w0)
+
+AUTH_FILE="${XDG_RUNTIME_DIR}/containers/auth.json"
+TMP_AUTH_FILE="${XDG_RUNTIME_DIR}/containers/tmp-auth.json"
+
+jq --arg registry "$REGISTRY_URL" --arg auth "$AUTH" '.auths[$registry] = { "auth": $auth }' "${AUTH_FILE}" > "${TMP_AUTH_FILE}"
+cp "${TMP_AUTH_FILE}" "${AUTH_FILE}"

--- a/image-sync/oc-mirror/mirror.sh
+++ b/image-sync/oc-mirror/mirror.sh
@@ -12,6 +12,7 @@ DOCKER_COMMAND=/usr/local/bin/docker-login.sh az acr login -n "${REGISTRY}"
 IMAGE_SET_CONFIG_FILE="/config/imageset-config.yaml"
 echo "${IMAGE_SET_CONFIG}" | base64 -d | yq eval -P > ${IMAGE_SET_CONFIG_FILE}
 API_VERSION=$(yq eval '.apiVersion' ${IMAGE_SET_CONFIG_FILE})
+ADDITIONAL_FLAGS=""
 if echo "$API_VERSION" | grep -q "^mirror.openshift.io/v2"; then
     ADDITIONAL_FLAGS="--workspace file:///oc-mirror-workspace --v2"
 fi
@@ -33,6 +34,7 @@ dig "${REGISTRY_URL}"
 
 echo "Start mirroring"
 MIRROR_LOG=$(mktemp)
+trap 'rm -f "${MIRROR_LOG}"' EXIT
 /usr/local/bin/oc-mirror-${OC_MIRROR_VERSION} --config ${IMAGE_SET_CONFIG_FILE} ${ADDITIONAL_FLAGS} docker://${REGISTRY_URL} "$@" 2>&1 | tee "${MIRROR_LOG}"
 
 # oc-mirror v2 exits 0 even when every image fails to mirror, so a broken job

--- a/image-sync/oc-mirror/mirror.sh
+++ b/image-sync/oc-mirror/mirror.sh
@@ -32,4 +32,15 @@ echo "Inspecting DNS for target registry"
 dig "${REGISTRY_URL}"
 
 echo "Start mirroring"
-/usr/local/bin/oc-mirror-${OC_MIRROR_VERSION} --config ${IMAGE_SET_CONFIG_FILE} ${ADDITIONAL_FLAGS} docker://${REGISTRY_URL} @$
+MIRROR_LOG=$(mktemp)
+/usr/local/bin/oc-mirror-${OC_MIRROR_VERSION} --config ${IMAGE_SET_CONFIG_FILE} ${ADDITIONAL_FLAGS} docker://${REGISTRY_URL} "$@" 2>&1 | tee "${MIRROR_LOG}"
+
+# oc-mirror v2 exits 0 even when every image fails to mirror, so a broken job
+# reports success. Inspect its summary line and fail when nothing was mirrored.
+# The summary is prefixed with a timestamp and log level, e.g.
+#   2026/08/12 23:00:35  [INFO]   :    0 / 4 additional images mirrored: ...
+# Requiring whitespace before the 0 avoids matching counts such as "10 / 20".
+if grep -qE '[[:space:]]0 / [1-9][0-9]* (additional|release|operator) images mirrored' "${MIRROR_LOG}"; then
+    echo "ERROR: oc-mirror reported 0 mirrored images" >&2
+    exit 1
+fi


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1813

### What

Fixes the `oc-mirror` ACR credential helper so it works with Azure CLI 2.88.0+, and makes the job fail loudly when nothing is mirrored.

- `docker-login.sh` — parse the `docker login` flags and read the token from stdin instead of reading positional `$3`/`$5`. Works on both pre- and post-2.88.0 CLIs. Exits non-zero rather than writing a broken credential.
- `mirror.sh` — fail when oc-mirror reports `0 / N images mirrored`, and forward `"$@"` (was a literal `@$`).

### Why

**The catalog mirroring has been broken since Jul 7, in every environment.**

Azure CLI 2.88.0 changed `az acr login` to pass the registry token via `--password-stdin` instead of `--password` ([Azure/azure-cli#33373](https://github.com/Azure/azure-cli/commit/28d6a5f)). Our helper read the token positionally from `$5`, which after that change is the **registry hostname**. It wrote `base64("00000000-0000-0000-0000-000000000000:arohcpocpstg.azurecr.io")` into `auth.json`, so ACR received a hostname where a JWT belongs and rejected every destination request with `IDX12729` / `401`.

`azure-cli` ships in the `ms-oss` repo, so the `tdnf update -y` in the Dockerfile pulled it in despite the pinned base-image digest:

| Event | UTC |
| --- | --- |
| `azure-cli 2.88.0-1.azl3` published to ms-oss | Jul 7, 04:55:34 |
| oc-mirror image `ba5c4733` built | Jul 7, 05:41 (+46 min) |
| Prior image `4cd6b733` built | Jul 6, 14:09 → shipped 2.87.0 |

**This is not an ACR issue.** `arohcpocpint` was never deleted or recreated, is in `LegacyRegistryPermissions` mode, and fails identically every hour — which rules out both the ABAC and registry-recreation theories. The STG ACR recreation didn't cause this; it removed the stale catalogs that had been masking it since Jul 7.

**Why nobody noticed for five weeks:** the jobs report `Succeeded` — 100/100 in INT — while mirroring `0 / 4`. oc-mirror v2 exits 0 after `[WARN] some errors occurred during the mirroring`, so `set -euo pipefail` never trips. Hence the fail-on-zero check here.

The `@$` typo is unrelated and predates this ([#762](https://github.com/Azure/ARO-HCP/pull/762), Nov 2024). It silently dropped `--dry-run`, so `make ocp-dry-run` / `make acm-dry-run` have been performing **real mirrors**. Included because it is a one-line fix in a file this PR already touches.

### Testing

No automated tests exist for these scripts. Verified manually:

**`docker-login.sh`** — driven with both CLI argument forms against a stub `auth.json`:

| Invocation | Result |
| --- | --- |
| `--username U --password <token> <registry>` (≤2.87) | correct credential |
| `--username U --password-stdin <registry>` + stdin (≥2.88) | identical credential |
| no credential flags | exits 1, writes nothing |
| 1600-char token | single-line base64, no wrapping |

Existing upstream entries (`registry.redhat.io`) are preserved. Confirmed `set -x` in `mirror.sh` does not propagate into the helper, so the token is not echoed.

**`mirror.sh`** — the fail-on-zero regex was checked against **real** log lines pulled from the INT Log Analytics workspace, not hand-written samples:

```
[INFO] :    0 / 4 additional images mirrored: ...   → matches (fails job)
[INFO] :    4 / 4 additional images mirrored        → no match
[INFO] :   10 / 20 additional images mirrored       → no match
[INFO] :  Nothing mirrored. Skipping IDMS ...       → no match
```