### PR TITLE
fix: extend v20260630preview timebomb deadline by 1 week to 2026-08-21

### DIFF
--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -47,7 +47,7 @@ const (
 )
 
 // API version deployment deadlines (timebombs)
-var V20260630PreviewDeploymentDeadline = Must(time.Parse(time.RFC3339, "2026-08-14T00:00:00Z"))
+var V20260630PreviewDeploymentDeadline = Must(time.Parse(time.RFC3339, "2026-08-21T00:00:00Z"))
 
 // Backup timeouts
 const (


### PR DESCRIPTION
## Summary

Follows up on #6469 and #6271, which extended the `v20260630preview` API deployment timebomb deadline to 2026-08-14.

Extends `framework.V20260630PreviewDeploymentDeadline` from 2026-08-14 to 2026-08-21 to allow additional time for the API rollout before the affected E2E tests fail instead of skip:

- `cluster_create_private_ingress`
- `kms_key_rotation`
- `cluster_fips_mode`

This is a test-only change and does not affect deployed product code.

## Current status

The 2026-08-14 deadline has now passed, but the first post-deadline E2E run is not yet available. This PR is prepared in case the next run confirms that `v20260630preview` is still unavailable.

## Evidence

The previous deadline extension was required after:

[branch-ci-Azure-ARO-HCP-main-e2e-integration-e2e-parallel #2085552497933422592](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-e2e-integration-e2e-parallel/2085552497933422592)

That run reported hard failures instead of skips:

- `cluster_create_private_ingress.go:91`: `v20260630preview API still not deployed as of 2026-08-07T00:00:00Z deadline`
- `cluster_fips_mode.go:120`: same failure for the FIPS mode test

## Test plan

- Wait for the first post-deadline integrated E2E run.
- Merge only if the affected tests fail because the API remains unavailable.
- Verify the updated deadline restores skip behavior.