### PR TITLE
fix: bump Cosmos DB request units

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1650,6 +1650,8 @@ clouds:
               deploy: true
       perf:
         defaults:
+          kubeApplier:
+            cosmosContainerMaxScale: 10000
           kusto:
             manageInstance: false
           # Service Key Vault
@@ -1658,6 +1660,9 @@ clouds:
           hypershift:
             metricsSet:
               performanceMetrics: true
+          frontend:
+            cosmosDB:
+              resourceContainerMaxScale: 10000
           dns:
             regionalSubdomain: '{{ .ctx.regionShort }}'
           maestro:
@@ -1685,6 +1690,8 @@ clouds:
                 secondaryNicCount: 7
       ci00:
         defaults:
+          kubeApplier:
+            cosmosContainerMaxScale: 10000
           customExporter:
             clusterNameFilter: "{{ .ctx.environment }}-{{ .ctx.regionShort }}"
           kusto:
@@ -1740,6 +1747,7 @@ clouds:
               connectSocket: false
             cosmosDB:
               private: false
+              resourceContainerMaxScale: 10000
               zoneRedundantMode: 'Disabled'
             tracing:
               address: "http://ingest.observability:4318"
@@ -1785,6 +1793,8 @@ clouds:
       ci01:
         # prow infra shard1 - deploys into "ARO HCP E2E Infrastructure" subscription
         defaults:
+          kubeApplier:
+            cosmosContainerMaxScale: 10000
           customExporter:
             clusterNameFilter: "{{ .ctx.environment }}-{{ .ctx.regionShort }}"
           auditLogsEventHub:
@@ -1842,6 +1852,7 @@ clouds:
               connectSocket: false
             cosmosDB:
               private: false
+              resourceContainerMaxScale: 10000
               zoneRedundantMode: 'Disabled'
             tracing:
               address: "http://ingest.observability:4318"

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -305,7 +305,7 @@ frontend:
     locksContainerMaxScale: 4000
     name: arohcpci00-rp-j7654321
     private: false
-    resourceContainerMaxScale: 8000
+    resourceContainerMaxScale: 10000
     zoneRedundantMode: Disabled
   exitOnPanic: true
   image:
@@ -487,7 +487,7 @@ imageSync:
   outboundServiceTags: ""
 keyVaultDNSSuffix: vault.azure.net
 kubeApplier:
-  cosmosContainerMaxScale: 8000
+  cosmosContainerMaxScale: 10000
   cosmosContainerName: Manifests-MC-1
   image:
     digest: sha256:bf05fa14daa56bd1275fd28da3c9348fdaa232b7f1f7cfe7e9cfa83072c63894

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -305,7 +305,7 @@ frontend:
     locksContainerMaxScale: 4000
     name: arohcpci01-rp-j7654321
     private: false
-    resourceContainerMaxScale: 8000
+    resourceContainerMaxScale: 10000
     zoneRedundantMode: Disabled
   exitOnPanic: true
   image:
@@ -487,7 +487,7 @@ imageSync:
   outboundServiceTags: ""
 keyVaultDNSSuffix: vault.azure.net
 kubeApplier:
-  cosmosContainerMaxScale: 8000
+  cosmosContainerMaxScale: 10000
   cosmosContainerName: Manifests-MC-1
   image:
     digest: sha256:bf05fa14daa56bd1275fd28da3c9348fdaa232b7f1f7cfe7e9cfa83072c63894

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -305,7 +305,7 @@ frontend:
     locksContainerMaxScale: 4000
     name: arohcpperf-rp-usw3ptest
     private: true
-    resourceContainerMaxScale: 8000
+    resourceContainerMaxScale: 10000
     zoneRedundantMode: Auto
   exitOnPanic: true
   image:
@@ -487,7 +487,7 @@ imageSync:
   outboundServiceTags: ""
 keyVaultDNSSuffix: vault.azure.net
 kubeApplier:
-  cosmosContainerMaxScale: 8000
+  cosmosContainerMaxScale: 10000
   cosmosContainerName: Manifests-MC-1
   image:
     digest: sha256:bf05fa14daa56bd1275fd28da3c9348fdaa232b7f1f7cfe7e9cfa83072c63894


### PR DESCRIPTION
https://cihealth.tools.hcpsvc.osadev.cloud/failure-patterns?q=Cosmos+DB+Normalized+RU+Consumption+High

### What

Increase the Cosmos DB autoscale maximum throughput from 8,000 to 10,000 RU/s for the Resources and kube-applier Manifests containers in the `ci00`, `ci01`, and `perf` environments only.

### Why

DEV e2e-parallel runs have intermittently fired the Cosmos DB normalized RU consumption alert since it was enabled. A targeted 25% increase provides additional headroom in CI and performance environments without increasing provisioned capacity in unrelated environments.

No tracking ticket exists; this PR follows the linked CIHealth failure pattern and the team discussion confirming the throughput bump.

### Testing

- `make verify-materialize`

No new tests are needed because this is a configuration-only capacity change; materialization validation confirms the generated environment configuration is current.

### Special notes for your reviewer

This is intentionally a draft. No reviewers have been requested.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue, or absence explained
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented or not applicable
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge
