### PR TITLE
feat: extend cluster mismatching controller to perform the deletion of the CS cluster if no corresponding cosmo record is found

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -639,7 +639,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		activeOperationInformer,
 	)
 
-	clusterServiceMatchingClusterController := mismatch.NewClusterServiceClusterMatchingController(b.options.ResourcesDBClient, subscriptionLister, b.options.ClustersServiceClient)
+	clusterServiceMatchingClusterController := mismatch.NewClusterServiceClusterMatchingController(b.clock, b.options.ResourcesDBClient, subscriptionLister, b.options.ClustersServiceClient)
 	alwaysSuccessClusterValidationController := clustervalidation.NewClusterValidationController(
 		validationutils.NewAlwaysSuccessValidation(),
 		b.options.ResourcesDBClient,

--- a/backend/pkg/controllers/mismatch/cluster_service_cluster_matching.go
+++ b/backend/pkg/controllers/mismatch/cluster_service_cluster_matching.go
@@ -23,19 +23,23 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
+	utilsclock "k8s.io/utils/clock"
 
 	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
 	"github.com/Azure/ARO-HCP/internal/database/listers/corelisters"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
 type clusterServiceClusterMatching struct {
-	name string
+	name  string
+	clock utilsclock.PassiveClock
 
 	subscriptionLister   corelisters.SubscriptionLister
 	resourcesDBClient    corecosmosstorage.ResourcesDBClient
@@ -47,9 +51,10 @@ type clusterServiceClusterMatching struct {
 }
 
 // NewClusterServiceClusterMatchingController periodically looks for mismatched cluster-service and cosmos clusters
-func NewClusterServiceClusterMatchingController(resourcesDBClient corecosmosstorage.ResourcesDBClient, subscriptionLister corelisters.SubscriptionLister, clusterServiceClient ocm.ClusterServiceClientSpec) controllerutils.Controller {
+func NewClusterServiceClusterMatchingController(clock utilsclock.PassiveClock, resourcesDBClient corecosmosstorage.ResourcesDBClient, subscriptionLister corelisters.SubscriptionLister, clusterServiceClient ocm.ClusterServiceClientSpec) controllerutils.Controller {
 	c := &clusterServiceClusterMatching{
 		name:                 "ClusterServiceMatchingClusters",
+		clock:                clock,
 		subscriptionLister:   subscriptionLister,
 		resourcesDBClient:    resourcesDBClient,
 		clusterServiceClient: clusterServiceClient,
@@ -81,15 +86,23 @@ func (c *clusterServiceClusterMatching) getAllCosmosObjs(ctx context.Context) (m
 
 		for _, cluster := range allHCPClusters.Items(ctx) {
 			ret = append(ret, cluster)
-			// we skip items without a clusterServiceID because they make be about to get them and shouldn't be deleted.
-			if cluster.ServiceProviderProperties.ClusterServiceID == nil {
+			// we skip items without a ClusterServiceID or PendingClusterServiceID because they may be about to get them and shouldn't be deleted.
+			if cluster.ServiceProviderProperties.ClusterServiceID == nil && cluster.ServiceProviderProperties.PendingClusterServiceID == nil {
 				continue
 			}
-			existingCluster, exists := clusterServiceIDToCluster[cluster.ServiceProviderProperties.ClusterServiceID.String()]
+
+			var clusterServiceID string
+			if cluster.ServiceProviderProperties.ClusterServiceID != nil {
+				clusterServiceID = cluster.ServiceProviderProperties.ClusterServiceID.String()
+			} else {
+				clusterServiceID = cluster.ServiceProviderProperties.PendingClusterServiceID.String()
+			}
+
+			existingCluster, exists := clusterServiceIDToCluster[clusterServiceID]
 			if exists {
 				return nil, nil, utils.TrackError(fmt.Errorf("duplicate obj found: %s, owned by %q and %q", cluster.ID.String(), existingCluster.ID.String(), cluster.ID.String()))
 			}
-			clusterServiceIDToCluster[cluster.ServiceProviderProperties.ClusterServiceID.String()] = cluster
+			clusterServiceIDToCluster[clusterServiceID] = cluster
 		}
 		if err := allHCPClusters.GetError(); err != nil {
 			return nil, nil, utils.TrackError(err)
@@ -145,11 +158,52 @@ func (c *clusterServiceClusterMatching) synchronizeAllClusters(ctx context.Conte
 
 	for _, clusterServiceCluster := range allClusterServiceClusters {
 		_, exists := clusterServiceIDToCosmosCluster[clusterServiceCluster.HREF()]
-		if !exists {
-			logger.Info("cluster service cluster doesn't have matching cosmos cluster",
+		if exists {
+			continue
+		}
+
+		clusterServiceCreationTimestamp, ok := clusterServiceCluster.GetCreationTimestamp()
+		if !ok {
+			logger.Error(
+				utils.TrackError(fmt.Errorf("cluster service cluster without creation_timestamp and a matching cosmos cluster detected")),
+				"cluster service cluster without creation_timestamp and a matching cosmos cluster detected",
+				"clusterServiceID", clusterServiceCluster.HREF())
+			continue
+		}
+
+		// if the cluster service cluster isn't older than an hour, we skip it
+		if c.clock.Since(clusterServiceCreationTimestamp) < time.Hour {
+			logger.Info("cluster service cluster doesn't have matching cosmos cluster detected but is not old enough to delete",
 				"clusterServiceID", clusterServiceCluster.HREF(),
 			)
+			continue
 		}
+
+		// before deleting, double check in the cosmos database that the cluster service cluster is still not in the cosmos database
+		_, err := c.resourcesDBClient.HCPClusters(clusterServiceCluster.Azure().SubscriptionID(), clusterServiceCluster.Azure().ResourceGroupName()).
+			Get(ctx, clusterServiceCluster.Azure().ResourceName())
+		if err == nil {
+			logger.Info("cluster service cluster exists in the cosmos database, no need to delete",
+				"clusterServiceID", clusterServiceCluster.HREF(),
+			)
+			continue
+		}
+
+		if !cosmosstorageutils.IsNotFoundError(err) {
+			logger.Error(err, "error getting cluster service cluster from cosmos database",
+				"clusterServiceID", clusterServiceCluster.HREF())
+			continue
+		}
+
+		// cluster is confirmed to not be in cosmos database, we can delete it from cluster service
+		err = c.clusterServiceClient.DeleteCluster(ctx, metadataapi.Must(metadataapi.NewInternalID(clusterServiceCluster.HREF())))
+		if err != nil {
+			logger.Error(err, "error deleting cluster service cluster",
+				"clusterServiceID", clusterServiceCluster.HREF())
+			continue
+		}
+		logger.Info("cluster service cluster without matching cosmos cluster deleted from cluster service",
+			"clusterServiceID", clusterServiceCluster.HREF())
 	}
 
 	return nil

--- a/backend/pkg/controllers/mismatch/cluster_service_cluster_matching.go
+++ b/backend/pkg/controllers/mismatch/cluster_service_cluster_matching.go
@@ -157,6 +157,7 @@ func (c *clusterServiceClusterMatching) synchronizeAllClusters(ctx context.Conte
 	}
 
 	for _, clusterServiceCluster := range allClusterServiceClusters {
+		clusterLogger := logger.WithValues("clusterServiceID", clusterServiceCluster.HREF())
 		_, exists := clusterServiceIDToCosmosCluster[clusterServiceCluster.HREF()]
 		if exists {
 			continue
@@ -164,46 +165,50 @@ func (c *clusterServiceClusterMatching) synchronizeAllClusters(ctx context.Conte
 
 		clusterServiceCreationTimestamp, ok := clusterServiceCluster.GetCreationTimestamp()
 		if !ok {
-			logger.Error(
+			clusterLogger.Error(
 				utils.TrackError(fmt.Errorf("cluster service cluster without creation_timestamp and a matching cosmos cluster detected")),
-				"cluster service cluster without creation_timestamp and a matching cosmos cluster detected",
-				"clusterServiceID", clusterServiceCluster.HREF())
+				"cluster service cluster without creation_timestamp and a matching cosmos cluster detected")
 			continue
 		}
 
 		// if the cluster service cluster isn't older than an hour, we skip it
 		if c.clock.Since(clusterServiceCreationTimestamp) < time.Hour {
-			logger.Info("cluster service cluster doesn't have matching cosmos cluster detected but is not old enough to delete",
-				"clusterServiceID", clusterServiceCluster.HREF(),
-			)
+			clusterLogger.Info("cluster service cluster doesn't have matching cosmos cluster detected but is not old enough to delete")
 			continue
 		}
 
 		// before deleting, double check in the cosmos database that the cluster service cluster is still not in the cosmos database
-		_, err := c.resourcesDBClient.HCPClusters(clusterServiceCluster.Azure().SubscriptionID(), clusterServiceCluster.Azure().ResourceGroupName()).
-			Get(ctx, clusterServiceCluster.Azure().ResourceName())
+		clusterServiceAzurePlatform, ok := clusterServiceCluster.GetAzure()
+		if !ok {
+			clusterLogger.Error(
+				utils.TrackError(fmt.Errorf("cluster service cluster without Azure properties and a matching cosmos cluster detected")),
+				"cluster service cluster without Azure properties and a matching cosmos cluster detected")
+			continue
+		}
+		_, err := c.resourcesDBClient.HCPClusters(clusterServiceAzurePlatform.SubscriptionID(), clusterServiceAzurePlatform.ResourceGroupName()).
+			Get(ctx, clusterServiceAzurePlatform.ResourceName())
 		if err == nil {
-			logger.Info("cluster service cluster exists in the cosmos database, no need to delete",
-				"clusterServiceID", clusterServiceCluster.HREF(),
-			)
+			clusterLogger.Info("cluster service cluster exists in the cosmos database, no need to delete")
 			continue
 		}
 
 		if !cosmosstorageutils.IsNotFoundError(err) {
-			logger.Error(err, "error getting cluster service cluster from cosmos database",
-				"clusterServiceID", clusterServiceCluster.HREF())
+			clusterLogger.Error(err, "error getting cluster service cluster from cosmos database")
 			continue
 		}
 
 		// cluster is confirmed to not be in cosmos database, we can delete it from cluster service
-		err = c.clusterServiceClient.DeleteCluster(ctx, metadataapi.Must(metadataapi.NewInternalID(clusterServiceCluster.HREF())))
+		clusterServiceID, err := metadataapi.NewInternalID(clusterServiceCluster.HREF())
 		if err != nil {
-			logger.Error(err, "error deleting cluster service cluster",
-				"clusterServiceID", clusterServiceCluster.HREF())
+			clusterLogger.Error(err, "error creating internal ID for cluster service cluster")
 			continue
 		}
-		logger.Info("cluster service cluster without matching cosmos cluster deleted from cluster service",
-			"clusterServiceID", clusterServiceCluster.HREF())
+		err = c.clusterServiceClient.DeleteCluster(ctx, clusterServiceID)
+		if err != nil {
+			clusterLogger.Error(err, "error deleting cluster service cluster")
+			continue
+		}
+		clusterLogger.Info("cluster service cluster without matching cosmos cluster deleted from cluster service")
 	}
 
 	return nil

--- a/backend/pkg/controllers/mismatch/cluster_service_cluster_matching_test.go
+++ b/backend/pkg/controllers/mismatch/cluster_service_cluster_matching_test.go
@@ -42,179 +42,102 @@ const (
 	testClusterServiceIDStr     = "/api/aro_hcp/v1alpha1/clusters/abc123def456"
 )
 
-func TestSynchronizeAllClusters_CSClusterMatchesCosmos(t *testing.T) {
-	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
-	ctrl := gomock.NewController(t)
-	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+func TestSynchronizeAllClusters(t *testing.T) {
+	fixedNow := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
 
-	subscription := testSubscription()
-	cosmosCluster := testCosmosCluster(t, func(c *coreapi.HCPOpenShiftCluster) {
-		clusterServiceID := metadataapi.Must(metadataapi.NewInternalID(testClusterServiceIDStr))
-		c.ServiceProviderProperties.ClusterServiceID = &clusterServiceID
-	})
-
-	mockDB, err := corecosmosstoragetesting.NewMockResourcesDBClientWithResources(ctx, []any{
-		subscription,
-		cosmosCluster,
-	})
-	require.NoError(t, err)
-
-	matchedCSCluster := testClusterServiceCluster(t, now.Add(-61*time.Minute))
-
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
-	mockCS.EXPECT().
-		ListClusters("").
-		Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{matchedCSCluster}, nil))
-
-	c := &clusterServiceClusterMatching{
-		clock: clocktesting.NewFakePassiveClock(now),
-		subscriptionLister: &corelistertesting.SliceSubscriptionLister{
-			Subscriptions: []*coreapi.Subscription{subscription},
+	tests := []struct {
+		name                            string
+		cosmosClusterBuilder            func(t *testing.T) *coreapi.HCPOpenShiftCluster
+		clusterServiceClusterCreatedAgo time.Duration
+		expectDeleteCluster             bool
+	}{
+		{
+			name: "matched cluster service cluster indexed by ClusterServiceID is not deleted",
+			cosmosClusterBuilder: func(t *testing.T) *coreapi.HCPOpenShiftCluster {
+				return testCosmosCluster(t, func(c *coreapi.HCPOpenShiftCluster) {
+					clusterServiceID := metadataapi.Must(metadataapi.NewInternalID(testClusterServiceIDStr))
+					c.ServiceProviderProperties.ClusterServiceID = &clusterServiceID
+				})
+			},
+			clusterServiceClusterCreatedAgo: 61 * time.Minute,
+			expectDeleteCluster:             false,
 		},
-		resourcesDBClient:    mockDB,
-		clusterServiceClient: mockCS,
+		{
+			name: "matched cluster service cluster indexed by PendingClusterServiceID is not deleted",
+			cosmosClusterBuilder: func(t *testing.T) *coreapi.HCPOpenShiftCluster {
+				return testCosmosCluster(t, func(c *coreapi.HCPOpenShiftCluster) {
+					pendingClusterServiceID := metadataapi.Must(metadataapi.NewInternalID(testClusterServiceIDStr))
+					c.ServiceProviderProperties.PendingClusterServiceID = &pendingClusterServiceID
+					c.ServiceProviderProperties.ClusterServiceID = nil
+				})
+			},
+			clusterServiceClusterCreatedAgo: 61 * time.Minute,
+			expectDeleteCluster:             false,
+		},
+		{
+			name:                            "unmatched young cluster service cluster is not deleted",
+			cosmosClusterBuilder:            nil,
+			clusterServiceClusterCreatedAgo: 30 * time.Minute,
+			expectDeleteCluster:             false,
+		},
+		{
+			name: "unmatched old cluster service cluster is not deleted when cosmos cluster exists",
+			cosmosClusterBuilder: func(t *testing.T) *coreapi.HCPOpenShiftCluster {
+				// No ClusterServiceID or PendingClusterServiceID, so getAllCosmosObjs does not
+				// index by CS HREF. The double-check Get by Azure coordinates must still find it.
+				return testCosmosCluster(t)
+			},
+			clusterServiceClusterCreatedAgo: 61 * time.Minute,
+			expectDeleteCluster:             false,
+		},
+		{
+			name:                            "unmatched old orphaned cluster service cluster is deleted",
+			cosmosClusterBuilder:            nil,
+			clusterServiceClusterCreatedAgo: 61 * time.Minute,
+			expectDeleteCluster:             true,
+		},
 	}
 
-	require.NoError(t, c.synchronizeAllClusters(ctx))
-}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			ctrl := gomock.NewController(t)
 
-func TestSynchronizeAllClusters_CSClusterMatchesCosmosPendingClusterServiceID(t *testing.T) {
-	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
-	ctrl := gomock.NewController(t)
-	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+			subscription := testSubscription()
+			cosmosResources := []any{subscription}
+			if testCase.cosmosClusterBuilder != nil {
+				cosmosResources = append(cosmosResources, testCase.cosmosClusterBuilder(t))
+			}
 
-	subscription := testSubscription()
-	cosmosCluster := testCosmosCluster(t, func(c *coreapi.HCPOpenShiftCluster) {
-		pendingClusterServiceID := metadataapi.Must(metadataapi.NewInternalID(testClusterServiceIDStr))
-		c.ServiceProviderProperties.PendingClusterServiceID = &pendingClusterServiceID
-		c.ServiceProviderProperties.ClusterServiceID = nil
-	})
+			resourcesDBClient, err := corecosmosstoragetesting.NewMockResourcesDBClientWithResources(ctx, cosmosResources)
+			require.NoError(t, err)
 
-	mockDB, err := corecosmosstoragetesting.NewMockResourcesDBClientWithResources(ctx, []any{
-		subscription,
-		cosmosCluster,
-	})
-	require.NoError(t, err)
+			clusterServiceClusterCreatedAt := fixedNow.Add(-testCase.clusterServiceClusterCreatedAgo)
+			clusterServiceCluster := testClusterServiceCluster(t, clusterServiceClusterCreatedAt)
 
-	// Old enough to delete if unmatched; must match via PendingClusterServiceID.
-	matchedCSCluster := testClusterServiceCluster(t, now.Add(-61*time.Minute))
+			clusterServiceClient := ocm.NewMockClusterServiceClientSpec(ctrl)
+			clusterServiceClient.EXPECT().
+				ListClusters("").
+				Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{clusterServiceCluster}, nil))
+			if testCase.expectDeleteCluster {
+				clusterServiceID := metadataapi.Must(metadataapi.NewInternalID(testClusterServiceIDStr))
+				clusterServiceClient.EXPECT().
+					DeleteCluster(gomock.Any(), clusterServiceID).
+					Return(nil)
+			}
 
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
-	mockCS.EXPECT().
-		ListClusters("").
-		Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{matchedCSCluster}, nil))
+			controller := &clusterServiceClusterMatching{
+				clock: clocktesting.NewFakePassiveClock(fixedNow),
+				subscriptionLister: &corelistertesting.SliceSubscriptionLister{
+					Subscriptions: []*coreapi.Subscription{subscription},
+				},
+				resourcesDBClient:    resourcesDBClient,
+				clusterServiceClient: clusterServiceClient,
+			}
 
-	c := &clusterServiceClusterMatching{
-		clock: clocktesting.NewFakePassiveClock(now),
-		subscriptionLister: &corelistertesting.SliceSubscriptionLister{
-			Subscriptions: []*coreapi.Subscription{subscription},
-		},
-		resourcesDBClient:    mockDB,
-		clusterServiceClient: mockCS,
+			require.NoError(t, controller.synchronizeAllClusters(ctx))
+		})
 	}
-
-	require.NoError(t, c.synchronizeAllClusters(ctx))
-}
-
-func TestSynchronizeAllClusters_CSClusterMismatchNotOldEnough(t *testing.T) {
-	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
-	ctrl := gomock.NewController(t)
-	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
-
-	subscription := testSubscription()
-
-	mockDB, err := corecosmosstoragetesting.NewMockResourcesDBClientWithResources(ctx, []any{
-		subscription,
-	})
-	require.NoError(t, err)
-
-	mismatchedYoungCSCluster := testClusterServiceCluster(t, now.Add(-30*time.Minute))
-
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
-	mockCS.EXPECT().
-		ListClusters("").
-		Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{mismatchedYoungCSCluster}, nil))
-
-	c := &clusterServiceClusterMatching{
-		clock: clocktesting.NewFakePassiveClock(now),
-		subscriptionLister: &corelistertesting.SliceSubscriptionLister{
-			Subscriptions: []*coreapi.Subscription{subscription},
-		},
-		resourcesDBClient:    mockDB,
-		clusterServiceClient: mockCS,
-	}
-
-	require.NoError(t, c.synchronizeAllClusters(ctx))
-}
-
-func TestSynchronizeAllClusters_CSClusterMismatchCosmosClusterExistsSkipsDelete(t *testing.T) {
-	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
-	ctrl := gomock.NewController(t)
-	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
-
-	subscription := testSubscription()
-	// Cluster is in Cosmos but has no ClusterServiceID yet, so getAllCosmosObjs does not
-	// index it by CS HREF. The double-check Get by Azure coordinates must still find it.
-	cosmosCluster := testCosmosCluster(t)
-
-	mockDB, err := corecosmosstoragetesting.NewMockResourcesDBClientWithResources(ctx, []any{
-		subscription,
-		cosmosCluster,
-	})
-	require.NoError(t, err)
-
-	mismatchedOlderCSClusterInCosmos := testClusterServiceCluster(t, now.Add(-61*time.Minute))
-
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
-	mockCS.EXPECT().
-		ListClusters("").
-		Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{mismatchedOlderCSClusterInCosmos}, nil))
-
-	c := &clusterServiceClusterMatching{
-		clock: clocktesting.NewFakePassiveClock(now),
-		subscriptionLister: &corelistertesting.SliceSubscriptionLister{
-			Subscriptions: []*coreapi.Subscription{subscription},
-		},
-		resourcesDBClient:    mockDB,
-		clusterServiceClient: mockCS,
-	}
-
-	require.NoError(t, c.synchronizeAllClusters(ctx))
-}
-
-func TestSynchronizeAllClusters_CSClusterMismatchOlderThanOneHourDeletes(t *testing.T) {
-	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
-	ctrl := gomock.NewController(t)
-	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
-
-	subscription := testSubscription()
-
-	mockDB, err := corecosmosstoragetesting.NewMockResourcesDBClientWithResources(ctx, []any{
-		subscription,
-	})
-	require.NoError(t, err)
-
-	mismatchedOlderOrphanedCSCluster := testClusterServiceCluster(t, now.Add(-61*time.Minute))
-	clusterServiceID := metadataapi.Must(metadataapi.NewInternalID(testClusterServiceIDStr))
-
-	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
-	mockCS.EXPECT().
-		ListClusters("").
-		Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{mismatchedOlderOrphanedCSCluster}, nil))
-	mockCS.EXPECT().
-		DeleteCluster(gomock.Any(), clusterServiceID).
-		Return(nil)
-
-	c := &clusterServiceClusterMatching{
-		clock: clocktesting.NewFakePassiveClock(now),
-		subscriptionLister: &corelistertesting.SliceSubscriptionLister{
-			Subscriptions: []*coreapi.Subscription{subscription},
-		},
-		resourcesDBClient:    mockDB,
-		clusterServiceClient: mockCS,
-	}
-
-	require.NoError(t, c.synchronizeAllClusters(ctx))
 }
 
 func testSubscription() *coreapi.Subscription {

--- a/backend/pkg/controllers/mismatch/cluster_service_cluster_matching_test.go
+++ b/backend/pkg/controllers/mismatch/cluster_service_cluster_matching_test.go
@@ -1,0 +1,268 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mismatch
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	clocktesting "k8s.io/utils/clock/testing"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/corecosmosstoragetesting"
+	"github.com/Azure/ARO-HCP/internal/database/listertesting/corelistertesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	testCSMatchingResourceGroup = "cs-matching-rg"
+	testCSMatchingClusterName   = "cs-matching-cluster"
+	testClusterServiceIDStr     = "/api/aro_hcp/v1alpha1/clusters/abc123def456"
+)
+
+func TestSynchronizeAllClusters_CSClusterMatchesCosmos(t *testing.T) {
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	subscription := testSubscription()
+	cosmosCluster := testCosmosCluster(t, func(c *coreapi.HCPOpenShiftCluster) {
+		clusterServiceID := metadataapi.Must(metadataapi.NewInternalID(testClusterServiceIDStr))
+		c.ServiceProviderProperties.ClusterServiceID = &clusterServiceID
+	})
+
+	mockDB, err := corecosmosstoragetesting.NewMockResourcesDBClientWithResources(ctx, []any{
+		subscription,
+		cosmosCluster,
+	})
+	require.NoError(t, err)
+
+	matchedCSCluster := testClusterServiceCluster(t, now.Add(-61*time.Minute))
+
+	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+	mockCS.EXPECT().
+		ListClusters("").
+		Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{matchedCSCluster}, nil))
+
+	c := &clusterServiceClusterMatching{
+		clock: clocktesting.NewFakePassiveClock(now),
+		subscriptionLister: &corelistertesting.SliceSubscriptionLister{
+			Subscriptions: []*coreapi.Subscription{subscription},
+		},
+		resourcesDBClient:    mockDB,
+		clusterServiceClient: mockCS,
+	}
+
+	require.NoError(t, c.synchronizeAllClusters(ctx))
+}
+
+func TestSynchronizeAllClusters_CSClusterMatchesCosmosPendingClusterServiceID(t *testing.T) {
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	subscription := testSubscription()
+	cosmosCluster := testCosmosCluster(t, func(c *coreapi.HCPOpenShiftCluster) {
+		pendingClusterServiceID := metadataapi.Must(metadataapi.NewInternalID(testClusterServiceIDStr))
+		c.ServiceProviderProperties.PendingClusterServiceID = &pendingClusterServiceID
+		c.ServiceProviderProperties.ClusterServiceID = nil
+	})
+
+	mockDB, err := corecosmosstoragetesting.NewMockResourcesDBClientWithResources(ctx, []any{
+		subscription,
+		cosmosCluster,
+	})
+	require.NoError(t, err)
+
+	// Old enough to delete if unmatched; must match via PendingClusterServiceID.
+	matchedCSCluster := testClusterServiceCluster(t, now.Add(-61*time.Minute))
+
+	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+	mockCS.EXPECT().
+		ListClusters("").
+		Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{matchedCSCluster}, nil))
+
+	c := &clusterServiceClusterMatching{
+		clock: clocktesting.NewFakePassiveClock(now),
+		subscriptionLister: &corelistertesting.SliceSubscriptionLister{
+			Subscriptions: []*coreapi.Subscription{subscription},
+		},
+		resourcesDBClient:    mockDB,
+		clusterServiceClient: mockCS,
+	}
+
+	require.NoError(t, c.synchronizeAllClusters(ctx))
+}
+
+func TestSynchronizeAllClusters_CSClusterMismatchNotOldEnough(t *testing.T) {
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	subscription := testSubscription()
+
+	mockDB, err := corecosmosstoragetesting.NewMockResourcesDBClientWithResources(ctx, []any{
+		subscription,
+	})
+	require.NoError(t, err)
+
+	mismatchedYoungCSCluster := testClusterServiceCluster(t, now.Add(-30*time.Minute))
+
+	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+	mockCS.EXPECT().
+		ListClusters("").
+		Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{mismatchedYoungCSCluster}, nil))
+
+	c := &clusterServiceClusterMatching{
+		clock: clocktesting.NewFakePassiveClock(now),
+		subscriptionLister: &corelistertesting.SliceSubscriptionLister{
+			Subscriptions: []*coreapi.Subscription{subscription},
+		},
+		resourcesDBClient:    mockDB,
+		clusterServiceClient: mockCS,
+	}
+
+	require.NoError(t, c.synchronizeAllClusters(ctx))
+}
+
+func TestSynchronizeAllClusters_CSClusterMismatchCosmosClusterExistsSkipsDelete(t *testing.T) {
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	subscription := testSubscription()
+	// Cluster is in Cosmos but has no ClusterServiceID yet, so getAllCosmosObjs does not
+	// index it by CS HREF. The double-check Get by Azure coordinates must still find it.
+	cosmosCluster := testCosmosCluster(t)
+
+	mockDB, err := corecosmosstoragetesting.NewMockResourcesDBClientWithResources(ctx, []any{
+		subscription,
+		cosmosCluster,
+	})
+	require.NoError(t, err)
+
+	mismatchedOlderCSClusterInCosmos := testClusterServiceCluster(t, now.Add(-61*time.Minute))
+
+	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+	mockCS.EXPECT().
+		ListClusters("").
+		Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{mismatchedOlderCSClusterInCosmos}, nil))
+
+	c := &clusterServiceClusterMatching{
+		clock: clocktesting.NewFakePassiveClock(now),
+		subscriptionLister: &corelistertesting.SliceSubscriptionLister{
+			Subscriptions: []*coreapi.Subscription{subscription},
+		},
+		resourcesDBClient:    mockDB,
+		clusterServiceClient: mockCS,
+	}
+
+	require.NoError(t, c.synchronizeAllClusters(ctx))
+}
+
+func TestSynchronizeAllClusters_CSClusterMismatchOlderThanOneHourDeletes(t *testing.T) {
+	ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+	ctrl := gomock.NewController(t)
+	now := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+
+	subscription := testSubscription()
+
+	mockDB, err := corecosmosstoragetesting.NewMockResourcesDBClientWithResources(ctx, []any{
+		subscription,
+	})
+	require.NoError(t, err)
+
+	mismatchedOlderOrphanedCSCluster := testClusterServiceCluster(t, now.Add(-61*time.Minute))
+	clusterServiceID := metadataapi.Must(metadataapi.NewInternalID(testClusterServiceIDStr))
+
+	mockCS := ocm.NewMockClusterServiceClientSpec(ctrl)
+	mockCS.EXPECT().
+		ListClusters("").
+		Return(ocm.NewSimpleClusterListIterator([]*arohcpv1alpha1.Cluster{mismatchedOlderOrphanedCSCluster}, nil))
+	mockCS.EXPECT().
+		DeleteCluster(gomock.Any(), clusterServiceID).
+		Return(nil)
+
+	c := &clusterServiceClusterMatching{
+		clock: clocktesting.NewFakePassiveClock(now),
+		subscriptionLister: &corelistertesting.SliceSubscriptionLister{
+			Subscriptions: []*coreapi.Subscription{subscription},
+		},
+		resourcesDBClient:    mockDB,
+		clusterServiceClient: mockCS,
+	}
+
+	require.NoError(t, c.synchronizeAllClusters(ctx))
+}
+
+func testSubscription() *coreapi.Subscription {
+	rid := metadataapi.Must(coreapi.ToSubscriptionResourceID(testSubscriptionID))
+	return &coreapi.Subscription{
+		CosmosMetadata: coreapi.CosmosMetadata{
+			ResourceID:   rid,
+			PartitionKey: strings.ToLower(rid.SubscriptionID),
+		},
+		ResourceID: rid,
+		State:      coreapi.SubscriptionStateRegistered,
+	}
+}
+
+func testCosmosCluster(t *testing.T, opts ...func(*coreapi.HCPOpenShiftCluster)) *coreapi.HCPOpenShiftCluster {
+	t.Helper()
+	rid := metadataapi.Must(coreapi.ToClusterResourceID(testSubscriptionID, testCSMatchingResourceGroup, testCSMatchingClusterName))
+	cluster := &coreapi.HCPOpenShiftCluster{
+		CosmosMetadata: coreapi.CosmosMetadata{
+			ResourceID:   rid,
+			PartitionKey: strings.ToLower(rid.SubscriptionID),
+		},
+		TrackedResource: coreapi.TrackedResource{
+			Resource: coreapi.Resource{
+				ID:   rid,
+				Name: testCSMatchingClusterName,
+				Type: coreapi.ClusterResourceType.String(),
+			},
+			Location: "eastus",
+		},
+	}
+	for _, opt := range opts {
+		opt(cluster)
+	}
+	return cluster
+}
+
+func testClusterServiceCluster(t *testing.T, createdAt time.Time) *arohcpv1alpha1.Cluster {
+	t.Helper()
+	cluster, err := arohcpv1alpha1.NewCluster().
+		HREF(testClusterServiceIDStr).
+		ID("abc123def456").
+		CreationTimestamp(createdAt).
+		Azure(arohcpv1alpha1.NewAzure().
+			SubscriptionID(strings.ToLower(testSubscriptionID)).
+			ResourceGroupName(strings.ToLower(testCSMatchingResourceGroup)).
+			ResourceName(strings.ToLower(testCSMatchingClusterName))).
+		Build()
+	require.NoError(t, err)
+	return cluster
+}


### PR DESCRIPTION
### What

feat: extend cluster mismatching controller to perform the deletion of the CS cluster if no corresponding cosmo record is found

### Why

Fixes https://redhat.atlassian.net/browse/ARO-27999 by

1. update the controller to consider both clusterServiceID and pendingClusterServiceID
2. not immediate trigger deletion but trigger it is 1hr has been since CS cluster creation
3. before triggering the deletion, we'll double check again in DB to be sure the cluster no longer exists

Add unit test cases for the three cases.

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- [x] Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

See this slack discussion https://redhat-external.slack.com/archives/C075PHEFZKQ/p1786627679519999?thread_ts=1786540255.264769&cid=C075PHEFZKQ

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
