### PR TITLE
refactor: make kube-applier desire keys parent-agnostic

### DIFF
--- a/internal/api/kubeapplierapi/registry.go
+++ b/internal/api/kubeapplierapi/registry.go
@@ -55,3 +55,14 @@ var (
 	// SystemAdminCredentialRevocationScopedReadDesireResourceType is readDesires nested under a SystemAdminCredentialRevocation under a Cluster.
 	SystemAdminCredentialRevocationScopedReadDesireResourceType = nestedResourceType(coreapi.ClusterResourceTypeName, coreapi.SystemAdminCredentialRevocationResourceTypeName, ReadDesireResourceTypeName)
 )
+
+// ApplyDesireResourceTypeForParent derives the nested ApplyDesire resource type for
+// an arbitrary parent by appending the applyDesires leaf to the parent's own type.
+func ApplyDesireResourceTypeForParent(parent *azcorearm.ResourceID) azcorearm.ResourceType {
+	return nestedResourceType(parent.ResourceType.Type, ApplyDesireResourceTypeName)
+}
+
+// ReadDesireResourceTypeForParent is the ReadDesire parallel of ApplyDesireResourceTypeForParent.
+func ReadDesireResourceTypeForParent(parent *azcorearm.ResourceID) azcorearm.ResourceType {
+	return nestedResourceType(parent.ResourceType.Type, ReadDesireResourceTypeName)
+}

--- a/internal/database/cosmosstorage/kubeappliercosmosstorage/desire_scope.go
+++ b/internal/database/cosmosstorage/kubeappliercosmosstorage/desire_scope.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubeappliercosmosstorage
+
+import (
+	"errors"
+	"fmt"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
+	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
+)
+
+// Ancestry is the broad ARM-rooting family of a desire's parent. It selects the
+// resource-ID path builder: different ancestry families build resource IDs
+// differently.
+type Ancestry string
+
+const (
+	// ClusterAncestry is subscription-rooted (…/hcpOpenShiftClusters/…).
+	// Built with ClusterNestedResourceIDBuilder.
+	ClusterAncestry Ancestry = "cluster"
+)
+
+// DesireScope is a validated parent resource that scopes a set of desires. Its
+// resourceID is unexported and only set by the constructors below or by
+// ParseDesireScope, so an invalid scope cannot be represented.
+type DesireScope struct {
+	ancestry   Ancestry
+	resourceID *azcorearm.ResourceID
+}
+
+// Ancestry reports the scope's rooting family.
+func (s DesireScope) Ancestry() Ancestry { return s.ancestry }
+
+// ResourceID returns the scope's resource ID.
+func (s DesireScope) ResourceID() *azcorearm.ResourceID { return s.resourceID }
+
+// ResourceIDBuilder returns the resource-ID path builder for this scope's ancestry.
+func (s DesireScope) ResourceIDBuilder() cosmosstorageutils.ResourceIDBuilder {
+	switch s.ancestry {
+	case ClusterAncestry:
+		return cosmosstorageutils.ClusterNestedResourceIDBuilder{}
+	default:
+		panic(fmt.Errorf("coding error: unknown kube-applier ancestry %q", s.ancestry))
+	}
+}
+
+// ClusterScope returns a DesireScope for a cluster parent.
+func ClusterScope(subscriptionID, resourceGroupName, clusterName string) (DesireScope, error) {
+	id, err := coreapi.ToClusterResourceID(subscriptionID, resourceGroupName, clusterName)
+	if err != nil {
+		return DesireScope{}, err
+	}
+	return ParseDesireScope(id)
+}
+
+// NodePoolScope returns a DesireScope for a node pool parent.
+func NodePoolScope(subscriptionID, resourceGroupName, clusterName, nodePoolName string) (DesireScope, error) {
+	id, err := coreapi.ToNodePoolResourceID(subscriptionID, resourceGroupName, clusterName, nodePoolName)
+	if err != nil {
+		return DesireScope{}, err
+	}
+	return ParseDesireScope(id)
+}
+
+// CredentialRequestScope returns a DesireScope for a SystemAdminCredentialRequest parent.
+func CredentialRequestScope(subscriptionID, resourceGroupName, clusterName, credentialRequestName string) (DesireScope, error) {
+	id, err := coreapi.ToSystemAdminCredentialRequestResourceID(subscriptionID, resourceGroupName, clusterName, credentialRequestName)
+	if err != nil {
+		return DesireScope{}, err
+	}
+	return ParseDesireScope(id)
+}
+
+// CredentialRevocationScope returns a DesireScope for a SystemAdminCredentialRevocation parent.
+func CredentialRevocationScope(subscriptionID, resourceGroupName, clusterName, revocationName string) (DesireScope, error) {
+	id, err := coreapi.ToSystemAdminCredentialRevocationResourceID(subscriptionID, resourceGroupName, clusterName, revocationName)
+	if err != nil {
+		return DesireScope{}, err
+	}
+	return ParseDesireScope(id)
+}
+
+// ParseDesireScope categorizes a raw parent resource ID into a DesireScope,
+// rejecting any resource type that is not allowed to scope desires. The
+// kube-applier controllers pass their generic key's parent through here, so an
+// unknown parent is turned into an error rather than a silently-written orphan.
+func ParseDesireScope(id *azcorearm.ResourceID) (DesireScope, error) {
+	if id == nil {
+		return DesireScope{}, errors.New("desire scope resource ID is nil")
+	}
+	ancestry, ok := ancestryForParentType(id.ResourceType)
+	if !ok {
+		return DesireScope{}, fmt.Errorf("resource type %q is not a valid desire scope", id.ResourceType)
+	}
+	return DesireScope{ancestry: ancestry, resourceID: id}, nil
+}
+
+// ancestryForParentType is the registry of resource types allowed to scope desires,
+// and the ancestry each belongs to. It is the single source of truth shared by
+// ParseDesireScope (validity) and ResourceIDBuilder (path builder).
+func ancestryForParentType(rt azcorearm.ResourceType) (Ancestry, bool) {
+	switch {
+	case armhelpers.ResourceTypeEqual(rt, coreapi.ClusterResourceType),
+		armhelpers.ResourceTypeEqual(rt, coreapi.NodePoolResourceType),
+		armhelpers.ResourceTypeEqual(rt, coreapi.SystemAdminCredentialRequestResourceType),
+		armhelpers.ResourceTypeEqual(rt, coreapi.SystemAdminCredentialRevocationResourceType):
+		return ClusterAncestry, true
+	default:
+		return "", false
+	}
+}

--- a/internal/database/cosmosstorage/kubeappliercosmosstorage/desire_scope_test.go
+++ b/internal/database/cosmosstorage/kubeappliercosmosstorage/desire_scope_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubeappliercosmosstorage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
+	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
+)
+
+func TestParseDesireScope(t *testing.T) {
+	t.Parallel()
+
+	mustParseResourceID := func(s string) *azcorearm.ResourceID {
+		id, err := azcorearm.ParseResourceID(s)
+		require.NoError(t, err)
+		return id
+	}
+
+	tests := []struct {
+		name            string
+		id              *azcorearm.ResourceID
+		wantAncestry    Ancestry
+		wantErr         string
+		wantBuilderType cosmosstorageutils.ResourceIDBuilder
+	}{
+		{
+			name:            "cluster parent",
+			id:              mustParseResourceID("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster"),
+			wantAncestry:    ClusterAncestry,
+			wantBuilderType: cosmosstorageutils.ClusterNestedResourceIDBuilder{},
+		},
+		{
+			name:            "node pool parent",
+			id:              mustParseResourceID("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/nodePools/np"),
+			wantAncestry:    ClusterAncestry,
+			wantBuilderType: cosmosstorageutils.ClusterNestedResourceIDBuilder{},
+		},
+		{
+			name:            "credential request parent",
+			id:              mustParseResourceID("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/systemAdminCredentialRequests/req"),
+			wantAncestry:    ClusterAncestry,
+			wantBuilderType: cosmosstorageutils.ClusterNestedResourceIDBuilder{},
+		},
+		{
+			name:            "credential revocation parent",
+			id:              mustParseResourceID("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/systemAdminCredentialRevocations/rev"),
+			wantAncestry:    ClusterAncestry,
+			wantBuilderType: cosmosstorageutils.ClusterNestedResourceIDBuilder{},
+		},
+		{
+			name:    "nil resource ID",
+			id:      nil,
+			wantErr: "desire scope resource ID is nil",
+		},
+		{
+			name:    "unsupported resource type",
+			id:      mustParseResourceID("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm"),
+			wantErr: "is not a valid desire scope",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			scope, err := ParseDesireScope(tt.id)
+			if len(tt.wantErr) != 0 {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAncestry, scope.Ancestry())
+			assert.Equal(t, tt.id, scope.ResourceID())
+			assert.IsType(t, tt.wantBuilderType, scope.ResourceIDBuilder())
+		})
+	}
+}
+
+func TestDesireScopeConstructors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		constructor  func() (DesireScope, error)
+		wantType     azcorearm.ResourceType
+		wantAncestry Ancestry
+	}{
+		{
+			name:         "ClusterScope",
+			constructor:  func() (DesireScope, error) { return ClusterScope("sub", "rg", "cluster") },
+			wantType:     coreapi.ClusterResourceType,
+			wantAncestry: ClusterAncestry,
+		},
+		{
+			name:         "NodePoolScope",
+			constructor:  func() (DesireScope, error) { return NodePoolScope("sub", "rg", "cluster", "np") },
+			wantType:     coreapi.NodePoolResourceType,
+			wantAncestry: ClusterAncestry,
+		},
+		{
+			name: "CredentialRequestScope",
+			constructor: func() (DesireScope, error) {
+				return CredentialRequestScope("sub", "rg", "cluster", "req")
+			},
+			wantType:     coreapi.SystemAdminCredentialRequestResourceType,
+			wantAncestry: ClusterAncestry,
+		},
+		{
+			name: "CredentialRevocationScope",
+			constructor: func() (DesireScope, error) {
+				return CredentialRevocationScope("sub", "rg", "cluster", "rev")
+			},
+			wantType:     coreapi.SystemAdminCredentialRevocationResourceType,
+			wantAncestry: ClusterAncestry,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			scope, err := tt.constructor()
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAncestry, scope.Ancestry())
+			assert.True(t, armhelpers.ResourceTypeEqual(tt.wantType, scope.ResourceID().ResourceType),
+				"resource type mismatch: want %s, got %s", tt.wantType, scope.ResourceID().ResourceType)
+		})
+	}
+}

--- a/internal/database/cosmosstorage/kubeappliercosmosstorage/kube_applier_client.go
+++ b/internal/database/cosmosstorage/kubeappliercosmosstorage/kube_applier_client.go
@@ -16,13 +16,13 @@ package kubeappliercosmosstorage
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
 
-	"github.com/Azure/ARO-HCP/internal/api/coreapi"
 	"github.com/Azure/ARO-HCP/internal/api/fleetapi"
 	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
@@ -94,6 +94,11 @@ type KubeApplierDBClient interface {
 	// ReadDesiresForSystemAdminCredentialRevocation returns a CRUD scoped to a SystemAdminCredentialRevocation parent.
 	ReadDesiresForSystemAdminCredentialRevocation(subscriptionID, resourceGroupName, clusterName, revocationName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error)
 
+	// ApplyDesiresFor returns an ApplyDesire CRUD scoped to the given parent.
+	ApplyDesiresFor(parent DesireScope) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error)
+	// ReadDesiresFor returns a ReadDesire CRUD scoped to the given parent.
+	ReadDesiresFor(parent DesireScope) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error)
+
 	// Listers lists every *Desire of each kind in this container — i.e. across the
 	// one management cluster's worth of data. Replaces the old GlobalListers /
 	// PartitionListers split, which existed only because all management clusters
@@ -115,21 +120,18 @@ type KubeApplierListers interface {
 }
 
 // KubeApplierApplyDesireCRUD is the narrow per-type peer interface that the
-// apply_desire controller takes as its database dependency. KubeApplierDBClient
-// satisfies it; tests can also provide a one-method fake.
+// apply_desire controller takes as its database dependency. The controllers key
+// off a parent resource ID, so the single parent-agnostic accessor is all they
+// call; the enumerated per-level accessors live on KubeApplierDBClient for the
+// field-driven callers. KubeApplierDBClient satisfies this; tests can also
+// provide a one-method fake.
 type KubeApplierApplyDesireCRUD interface {
-	ApplyDesiresForCluster(subscriptionID, resourceGroupName, clusterName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error)
-	ApplyDesiresForNodePool(subscriptionID, resourceGroupName, clusterName, nodePoolName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error)
-	ApplyDesiresForSystemAdminCredentialRequest(subscriptionID, resourceGroupName, clusterName, credentialRequestName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error)
-	ApplyDesiresForSystemAdminCredentialRevocation(subscriptionID, resourceGroupName, clusterName, revocationName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error)
+	ApplyDesiresFor(parent DesireScope) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error)
 }
 
 // KubeApplierReadDesireCRUD is the ReadDesire peer of KubeApplierApplyDesireCRUD.
 type KubeApplierReadDesireCRUD interface {
-	ReadDesiresForCluster(subscriptionID, resourceGroupName, clusterName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error)
-	ReadDesiresForNodePool(subscriptionID, resourceGroupName, clusterName, nodePoolName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error)
-	ReadDesiresForSystemAdminCredentialRequest(subscriptionID, resourceGroupName, clusterName, credentialRequestName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error)
-	ReadDesiresForSystemAdminCredentialRevocation(subscriptionID, resourceGroupName, clusterName, revocationName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error)
+	ReadDesiresFor(parent DesireScope) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error)
 }
 
 // kubeApplierCosmosDBClient implements KubeApplierDBClient against a Cosmos
@@ -164,90 +166,88 @@ func NewKubeApplierDBClientFromDatabase(database *azcosmos.DatabaseClient, conta
 }
 
 func (c *kubeApplierCosmosDBClient) ApplyDesiresForCluster(subscriptionID, resourceGroupName, clusterName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
-	parentID, err := coreapi.ToClusterResourceID(subscriptionID, resourceGroupName, clusterName)
+	parent, err := ClusterScope(subscriptionID, resourceGroupName, clusterName)
 	if err != nil {
 		return nil, err
 	}
-	return cosmosstorageutils.NewCosmosResourceCRUDWithStrategies[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ApplyDesire]](
-		c.kubeApplier, parentID, kubeapplierapi.ClusterScopedApplyDesireResourceType,
-		cosmosstorageutils.KubeApplierPartitionKeyDeriver{ManagementClusterResourceID: c.managementClusterResourceID}, cosmosstorageutils.ClusterNestedResourceIDBuilder{},
-	), nil
+	return c.ApplyDesiresFor(parent)
 }
 
 func (c *kubeApplierCosmosDBClient) ApplyDesiresForNodePool(subscriptionID, resourceGroupName, clusterName, nodePoolName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
-	parentID, err := coreapi.ToNodePoolResourceID(subscriptionID, resourceGroupName, clusterName, nodePoolName)
+	parent, err := NodePoolScope(subscriptionID, resourceGroupName, clusterName, nodePoolName)
 	if err != nil {
 		return nil, err
 	}
-	return cosmosstorageutils.NewCosmosResourceCRUDWithStrategies[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ApplyDesire]](
-		c.kubeApplier, parentID, kubeapplierapi.NodePoolScopedApplyDesireResourceType,
-		cosmosstorageutils.KubeApplierPartitionKeyDeriver{ManagementClusterResourceID: c.managementClusterResourceID}, cosmosstorageutils.ClusterNestedResourceIDBuilder{},
-	), nil
+	return c.ApplyDesiresFor(parent)
 }
 
 func (c *kubeApplierCosmosDBClient) ApplyDesiresForSystemAdminCredentialRequest(subscriptionID, resourceGroupName, clusterName, credentialRequestName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
-	parentID, err := coreapi.ToSystemAdminCredentialRequestResourceID(subscriptionID, resourceGroupName, clusterName, credentialRequestName)
+	parent, err := CredentialRequestScope(subscriptionID, resourceGroupName, clusterName, credentialRequestName)
 	if err != nil {
 		return nil, err
 	}
-	return cosmosstorageutils.NewCosmosResourceCRUDWithStrategies[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ApplyDesire]](
-		c.kubeApplier, parentID, kubeapplierapi.SystemAdminCredentialRequestScopedApplyDesireResourceType,
-		cosmosstorageutils.KubeApplierPartitionKeyDeriver{ManagementClusterResourceID: c.managementClusterResourceID}, cosmosstorageutils.ClusterNestedResourceIDBuilder{},
-	), nil
+	return c.ApplyDesiresFor(parent)
 }
 
 func (c *kubeApplierCosmosDBClient) ApplyDesiresForSystemAdminCredentialRevocation(subscriptionID, resourceGroupName, clusterName, revocationName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
-	parentID, err := coreapi.ToSystemAdminCredentialRevocationResourceID(subscriptionID, resourceGroupName, clusterName, revocationName)
+	parent, err := CredentialRevocationScope(subscriptionID, resourceGroupName, clusterName, revocationName)
 	if err != nil {
 		return nil, err
 	}
-	return cosmosstorageutils.NewCosmosResourceCRUDWithStrategies[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ApplyDesire]](
-		c.kubeApplier, parentID, kubeapplierapi.SystemAdminCredentialRevocationScopedApplyDesireResourceType,
-		cosmosstorageutils.KubeApplierPartitionKeyDeriver{ManagementClusterResourceID: c.managementClusterResourceID}, cosmosstorageutils.ClusterNestedResourceIDBuilder{},
-	), nil
+	return c.ApplyDesiresFor(parent)
 }
 
 func (c *kubeApplierCosmosDBClient) ReadDesiresForCluster(subscriptionID, resourceGroupName, clusterName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error) {
-	parentID, err := coreapi.ToClusterResourceID(subscriptionID, resourceGroupName, clusterName)
+	parent, err := ClusterScope(subscriptionID, resourceGroupName, clusterName)
 	if err != nil {
 		return nil, err
 	}
-	return cosmosstorageutils.NewCosmosResourceCRUDWithStrategies[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ReadDesire]](
-		c.kubeApplier, parentID, kubeapplierapi.ClusterScopedReadDesireResourceType,
-		cosmosstorageutils.KubeApplierPartitionKeyDeriver{ManagementClusterResourceID: c.managementClusterResourceID}, cosmosstorageutils.ClusterNestedResourceIDBuilder{},
-	), nil
+	return c.ReadDesiresFor(parent)
 }
 
 func (c *kubeApplierCosmosDBClient) ReadDesiresForNodePool(subscriptionID, resourceGroupName, clusterName, nodePoolName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error) {
-	parentID, err := coreapi.ToNodePoolResourceID(subscriptionID, resourceGroupName, clusterName, nodePoolName)
+	parent, err := NodePoolScope(subscriptionID, resourceGroupName, clusterName, nodePoolName)
 	if err != nil {
 		return nil, err
 	}
-	return cosmosstorageutils.NewCosmosResourceCRUDWithStrategies[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ReadDesire]](
-		c.kubeApplier, parentID, kubeapplierapi.NodePoolScopedReadDesireResourceType,
-		cosmosstorageutils.KubeApplierPartitionKeyDeriver{ManagementClusterResourceID: c.managementClusterResourceID}, cosmosstorageutils.ClusterNestedResourceIDBuilder{},
-	), nil
+	return c.ReadDesiresFor(parent)
 }
 
 func (c *kubeApplierCosmosDBClient) ReadDesiresForSystemAdminCredentialRequest(subscriptionID, resourceGroupName, clusterName, credentialRequestName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error) {
-	parentID, err := coreapi.ToSystemAdminCredentialRequestResourceID(subscriptionID, resourceGroupName, clusterName, credentialRequestName)
+	parent, err := CredentialRequestScope(subscriptionID, resourceGroupName, clusterName, credentialRequestName)
 	if err != nil {
 		return nil, err
 	}
-	return cosmosstorageutils.NewCosmosResourceCRUDWithStrategies[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ReadDesire]](
-		c.kubeApplier, parentID, kubeapplierapi.SystemAdminCredentialRequestScopedReadDesireResourceType,
-		cosmosstorageutils.KubeApplierPartitionKeyDeriver{ManagementClusterResourceID: c.managementClusterResourceID}, cosmosstorageutils.ClusterNestedResourceIDBuilder{},
-	), nil
+	return c.ReadDesiresFor(parent)
 }
 
 func (c *kubeApplierCosmosDBClient) ReadDesiresForSystemAdminCredentialRevocation(subscriptionID, resourceGroupName, clusterName, revocationName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error) {
-	parentID, err := coreapi.ToSystemAdminCredentialRevocationResourceID(subscriptionID, resourceGroupName, clusterName, revocationName)
+	parent, err := CredentialRevocationScope(subscriptionID, resourceGroupName, clusterName, revocationName)
 	if err != nil {
 		return nil, err
 	}
+	return c.ReadDesiresFor(parent)
+}
+
+// ApplyDesiresFor returns an ApplyDesire CRUD scoped to the given parent.
+func (c *kubeApplierCosmosDBClient) ApplyDesiresFor(parent DesireScope) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
+	if parent.resourceID == nil {
+		return nil, errors.New("desire scope is not initialized")
+	}
+	return cosmosstorageutils.NewCosmosResourceCRUDWithStrategies[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ApplyDesire]](
+		c.kubeApplier, parent.resourceID, kubeapplierapi.ApplyDesireResourceTypeForParent(parent.resourceID),
+		cosmosstorageutils.KubeApplierPartitionKeyDeriver{ManagementClusterResourceID: c.managementClusterResourceID}, parent.ResourceIDBuilder(),
+	), nil
+}
+
+// ReadDesiresFor returns a ReadDesire CRUD scoped to the given parent.
+func (c *kubeApplierCosmosDBClient) ReadDesiresFor(parent DesireScope) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error) {
+	if parent.resourceID == nil {
+		return nil, errors.New("desire scope is not initialized")
+	}
 	return cosmosstorageutils.NewCosmosResourceCRUDWithStrategies[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ReadDesire]](
-		c.kubeApplier, parentID, kubeapplierapi.SystemAdminCredentialRevocationScopedReadDesireResourceType,
-		cosmosstorageutils.KubeApplierPartitionKeyDeriver{ManagementClusterResourceID: c.managementClusterResourceID}, cosmosstorageutils.ClusterNestedResourceIDBuilder{},
+		c.kubeApplier, parent.resourceID, kubeapplierapi.ReadDesireResourceTypeForParent(parent.resourceID),
+		cosmosstorageutils.KubeApplierPartitionKeyDeriver{ManagementClusterResourceID: c.managementClusterResourceID}, parent.ResourceIDBuilder(),
 	), nil
 }
 

--- a/internal/database/cosmosstoragetesting/kubeappliercosmosstoragetesting/mock_kube_applier_client.go
+++ b/internal/database/cosmosstoragetesting/kubeappliercosmosstoragetesting/mock_kube_applier_client.go
@@ -17,6 +17,7 @@ package kubeappliercosmosstoragetesting
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -30,7 +31,6 @@ import (
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/kubeappliercosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/corecosmosstoragetesting"
-	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
 )
 
 // MockKubeApplierDBClient is the in-memory test double for kubeappliercosmosstorage.KubeApplierDBClient.
@@ -140,96 +140,102 @@ var _ corecosmosstoragetesting.MockDocumentStore = &MockKubeApplierDBClient{}
 func (m *MockKubeApplierDBClient) ApplyDesiresForCluster(
 	subscriptionID, resourceGroupName, clusterName string,
 ) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
-	parentID, err := coreapi.ToClusterResourceID(subscriptionID, resourceGroupName, clusterName)
+	parent, err := kubeappliercosmosstorage.ClusterScope(subscriptionID, resourceGroupName, clusterName)
 	if err != nil {
 		return nil, err
 	}
-	return corecosmosstoragetesting.NewMockResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ApplyDesire]](
-		m, parentID, kubeapplierapi.ClusterScopedApplyDesireResourceType,
-	), nil
+	return m.ApplyDesiresFor(parent)
 }
 
 func (m *MockKubeApplierDBClient) ApplyDesiresForNodePool(
 	subscriptionID, resourceGroupName, clusterName, nodePoolName string,
 ) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
-	parentID, err := coreapi.ToNodePoolResourceID(subscriptionID, resourceGroupName, clusterName, nodePoolName)
+	parent, err := kubeappliercosmosstorage.NodePoolScope(subscriptionID, resourceGroupName, clusterName, nodePoolName)
 	if err != nil {
 		return nil, err
 	}
-	return corecosmosstoragetesting.NewMockResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ApplyDesire]](
-		m, parentID, kubeapplierapi.NodePoolScopedApplyDesireResourceType,
-	), nil
+	return m.ApplyDesiresFor(parent)
 }
 
 func (m *MockKubeApplierDBClient) ApplyDesiresForSystemAdminCredentialRequest(
 	subscriptionID, resourceGroupName, clusterName, credentialRequestName string,
 ) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
-	parentID, err := coreapi.ToSystemAdminCredentialRequestResourceID(subscriptionID, resourceGroupName, clusterName, credentialRequestName)
+	parent, err := kubeappliercosmosstorage.CredentialRequestScope(subscriptionID, resourceGroupName, clusterName, credentialRequestName)
 	if err != nil {
 		return nil, err
 	}
-	return corecosmosstoragetesting.NewMockResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ApplyDesire]](
-		m, parentID, kubeapplierapi.SystemAdminCredentialRequestScopedApplyDesireResourceType,
-	), nil
+	return m.ApplyDesiresFor(parent)
 }
 
 func (m *MockKubeApplierDBClient) ApplyDesiresForSystemAdminCredentialRevocation(
 	subscriptionID, resourceGroupName, clusterName, revocationName string,
 ) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
-	parentID, err := coreapi.ToSystemAdminCredentialRevocationResourceID(subscriptionID, resourceGroupName, clusterName, revocationName)
+	parent, err := kubeappliercosmosstorage.CredentialRevocationScope(subscriptionID, resourceGroupName, clusterName, revocationName)
 	if err != nil {
 		return nil, err
 	}
-	return corecosmosstoragetesting.NewMockResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ApplyDesire]](
-		m, parentID, kubeapplierapi.SystemAdminCredentialRevocationScopedApplyDesireResourceType,
-	), nil
+	return m.ApplyDesiresFor(parent)
 }
 
 func (m *MockKubeApplierDBClient) ReadDesiresForCluster(
 	subscriptionID, resourceGroupName, clusterName string,
 ) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error) {
-	parentID, err := coreapi.ToClusterResourceID(subscriptionID, resourceGroupName, clusterName)
+	parent, err := kubeappliercosmosstorage.ClusterScope(subscriptionID, resourceGroupName, clusterName)
 	if err != nil {
 		return nil, err
 	}
-	return corecosmosstoragetesting.NewMockResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ReadDesire]](
-		m, parentID, kubeapplierapi.ClusterScopedReadDesireResourceType,
-	), nil
+	return m.ReadDesiresFor(parent)
 }
 
 func (m *MockKubeApplierDBClient) ReadDesiresForNodePool(
 	subscriptionID, resourceGroupName, clusterName, nodePoolName string,
 ) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error) {
-	parentID, err := coreapi.ToNodePoolResourceID(subscriptionID, resourceGroupName, clusterName, nodePoolName)
+	parent, err := kubeappliercosmosstorage.NodePoolScope(subscriptionID, resourceGroupName, clusterName, nodePoolName)
 	if err != nil {
 		return nil, err
 	}
-	return corecosmosstoragetesting.NewMockResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ReadDesire]](
-		m, parentID, kubeapplierapi.NodePoolScopedReadDesireResourceType,
-	), nil
+	return m.ReadDesiresFor(parent)
 }
 
 func (m *MockKubeApplierDBClient) ReadDesiresForSystemAdminCredentialRequest(
 	subscriptionID, resourceGroupName, clusterName, credentialRequestName string,
 ) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error) {
-	parentID, err := coreapi.ToSystemAdminCredentialRequestResourceID(subscriptionID, resourceGroupName, clusterName, credentialRequestName)
+	parent, err := kubeappliercosmosstorage.CredentialRequestScope(subscriptionID, resourceGroupName, clusterName, credentialRequestName)
 	if err != nil {
 		return nil, err
 	}
-	return corecosmosstoragetesting.NewMockResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ReadDesire]](
-		m, parentID, kubeapplierapi.SystemAdminCredentialRequestScopedReadDesireResourceType,
-	), nil
+	return m.ReadDesiresFor(parent)
 }
 
 func (m *MockKubeApplierDBClient) ReadDesiresForSystemAdminCredentialRevocation(
 	subscriptionID, resourceGroupName, clusterName, revocationName string,
 ) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error) {
-	parentID, err := coreapi.ToSystemAdminCredentialRevocationResourceID(subscriptionID, resourceGroupName, clusterName, revocationName)
+	parent, err := kubeappliercosmosstorage.CredentialRevocationScope(subscriptionID, resourceGroupName, clusterName, revocationName)
 	if err != nil {
 		return nil, err
 	}
+	return m.ReadDesiresFor(parent)
+}
+
+func (m *MockKubeApplierDBClient) ApplyDesiresFor(
+	parent kubeappliercosmosstorage.DesireScope,
+) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
+	if parent.ResourceID() == nil {
+		return nil, errors.New("desire scope is not initialized")
+	}
+	return corecosmosstoragetesting.NewMockResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ApplyDesire]](
+		m, parent.ResourceID(), kubeapplierapi.ApplyDesireResourceTypeForParent(parent.ResourceID()),
+	), nil
+}
+
+func (m *MockKubeApplierDBClient) ReadDesiresFor(
+	parent kubeappliercosmosstorage.DesireScope,
+) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error) {
+	if parent.ResourceID() == nil {
+		return nil, errors.New("desire scope is not initialized")
+	}
 	return corecosmosstoragetesting.NewMockResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ReadDesire]](
-		m, parentID, kubeapplierapi.SystemAdminCredentialRevocationScopedReadDesireResourceType,
+		m, parent.ResourceID(), kubeapplierapi.ReadDesireResourceTypeForParent(parent.ResourceID()),
 	), nil
 }
 
@@ -395,21 +401,15 @@ func (m *MockKubeApplierDBClient) addResource(ctx context.Context, resource any)
 }
 
 func (m *MockKubeApplierDBClient) addApplyDesire(ctx context.Context, d *kubeapplierapi.ApplyDesire) error {
-	scope, err := parentForKubeApplierDesire(d.GetResourceID())
+	resourceID := d.GetResourceID()
+	if resourceID == nil || resourceID.Parent == nil {
+		return fmt.Errorf("desire %v has no parent in its resource ID", resourceID)
+	}
+	parent, err := kubeappliercosmosstorage.ParseDesireScope(resourceID.Parent)
 	if err != nil {
 		return err
 	}
-	var crud cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire]
-	switch {
-	case len(scope.nodePoolName) != 0:
-		crud, err = m.ApplyDesiresForNodePool(scope.subscriptionID, scope.resourceGroupName, scope.clusterName, scope.nodePoolName)
-	case len(scope.credentialRequestName) != 0:
-		crud, err = m.ApplyDesiresForSystemAdminCredentialRequest(scope.subscriptionID, scope.resourceGroupName, scope.clusterName, scope.credentialRequestName)
-	case len(scope.revocationName) != 0:
-		crud, err = m.ApplyDesiresForSystemAdminCredentialRevocation(scope.subscriptionID, scope.resourceGroupName, scope.clusterName, scope.revocationName)
-	default:
-		crud, err = m.ApplyDesiresForCluster(scope.subscriptionID, scope.resourceGroupName, scope.clusterName)
-	}
+	crud, err := m.ApplyDesiresFor(parent)
 	if err != nil {
 		return err
 	}
@@ -418,98 +418,20 @@ func (m *MockKubeApplierDBClient) addApplyDesire(ctx context.Context, d *kubeapp
 }
 
 func (m *MockKubeApplierDBClient) addReadDesire(ctx context.Context, d *kubeapplierapi.ReadDesire) error {
-	scope, err := parentForKubeApplierDesire(d.GetResourceID())
+	resourceID := d.GetResourceID()
+	if resourceID == nil || resourceID.Parent == nil {
+		return fmt.Errorf("desire %v has no parent in its resource ID", resourceID)
+	}
+	parent, err := kubeappliercosmosstorage.ParseDesireScope(resourceID.Parent)
 	if err != nil {
 		return err
 	}
-	var crud cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire]
-	switch {
-	case len(scope.nodePoolName) != 0:
-		crud, err = m.ReadDesiresForNodePool(scope.subscriptionID, scope.resourceGroupName, scope.clusterName, scope.nodePoolName)
-	case len(scope.credentialRequestName) != 0:
-		crud, err = m.ReadDesiresForSystemAdminCredentialRequest(scope.subscriptionID, scope.resourceGroupName, scope.clusterName, scope.credentialRequestName)
-	case len(scope.revocationName) != 0:
-		crud, err = m.ReadDesiresForSystemAdminCredentialRevocation(scope.subscriptionID, scope.resourceGroupName, scope.clusterName, scope.revocationName)
-	default:
-		crud, err = m.ReadDesiresForCluster(scope.subscriptionID, scope.resourceGroupName, scope.clusterName)
-	}
+	crud, err := m.ReadDesiresFor(parent)
 	if err != nil {
 		return err
 	}
 	_, err = crud.Create(ctx, d, nil)
 	return err
-}
-
-// kubeApplierDesireScope holds the parent field names parsed out of a *Desire's
-// resource ID. Exactly one of nodePoolName / credentialRequestName /
-// revocationName is set for a nested desire; all three are empty for a
-// cluster-scoped desire.
-type kubeApplierDesireScope struct {
-	subscriptionID        string
-	resourceGroupName     string
-	clusterName           string
-	nodePoolName          string
-	credentialRequestName string
-	revocationName        string
-}
-
-// parentForKubeApplierDesire splits a *Desire's resource ID into the parent
-// field names that identify which CRUD scope owns it.
-func parentForKubeApplierDesire(resourceID *azcorearm.ResourceID) (kubeApplierDesireScope, error) {
-	if resourceID == nil {
-		return kubeApplierDesireScope{}, fmt.Errorf("resource ID is nil")
-	}
-	if resourceID.Parent == nil {
-		return kubeApplierDesireScope{}, fmt.Errorf("desire %q has no parent in its resource ID", resourceID.String())
-	}
-	parentType := resourceID.Parent.ResourceType
-	switch {
-	case armhelpers.ResourceTypeEqual(parentType, coreapi.ClusterResourceType):
-		return kubeApplierDesireScope{
-			subscriptionID:    resourceID.SubscriptionID,
-			resourceGroupName: resourceID.ResourceGroupName,
-			clusterName:       resourceID.Parent.Name,
-		}, nil
-	case armhelpers.ResourceTypeEqual(parentType, coreapi.NodePoolResourceType):
-		if resourceID.Parent.Parent == nil {
-			return kubeApplierDesireScope{}, fmt.Errorf(
-				"nodepool-scoped desire %q has no grandparent cluster", resourceID.String(),
-			)
-		}
-		return kubeApplierDesireScope{
-			subscriptionID:    resourceID.SubscriptionID,
-			resourceGroupName: resourceID.ResourceGroupName,
-			clusterName:       resourceID.Parent.Parent.Name,
-			nodePoolName:      resourceID.Parent.Name,
-		}, nil
-	case armhelpers.ResourceTypeEqual(parentType, coreapi.SystemAdminCredentialRequestResourceType):
-		if resourceID.Parent.Parent == nil {
-			return kubeApplierDesireScope{}, fmt.Errorf(
-				"credential-request-scoped desire %q has no grandparent cluster", resourceID.String(),
-			)
-		}
-		return kubeApplierDesireScope{
-			subscriptionID:        resourceID.SubscriptionID,
-			resourceGroupName:     resourceID.ResourceGroupName,
-			clusterName:           resourceID.Parent.Parent.Name,
-			credentialRequestName: resourceID.Parent.Name,
-		}, nil
-	case armhelpers.ResourceTypeEqual(parentType, coreapi.SystemAdminCredentialRevocationResourceType):
-		if resourceID.Parent.Parent == nil {
-			return kubeApplierDesireScope{}, fmt.Errorf(
-				"revocation-scoped desire %q has no grandparent cluster", resourceID.String(),
-			)
-		}
-		return kubeApplierDesireScope{
-			subscriptionID:    resourceID.SubscriptionID,
-			resourceGroupName: resourceID.ResourceGroupName,
-			clusterName:       resourceID.Parent.Parent.Name,
-			revocationName:    resourceID.Parent.Name,
-		}, nil
-	}
-	return kubeApplierDesireScope{}, fmt.Errorf(
-		"unsupported parent resource type for kube-applier desire: %s", parentType,
-	)
 }
 
 // MockKubeApplierDBClients is the in-memory test double for

--- a/kube-applier/docs/02-api-types.md
+++ b/kube-applier/docs/02-api-types.md
@@ -182,15 +182,20 @@ These produce resource IDs of the form:
   applyDesires/{name}
 ```
 
-**Cosmos CRUD** (in `internal/database/kube_applier_client.go`): the
-`KubeApplierDBClient` interface exposes per-parent CRUD accessors alongside the
-existing cluster/node-pool ones:
+**Cosmos CRUD** (in `internal/database/kubeappliercosmosstorage/kube_applier_client.go`):
+`KubeApplierDBClient` exposes both per-level convenience accessors and
+parent-agnostic accessors:
 
 ```go
-ApplyDesiresForCredentialRequest(sub, rg, cluster, credReq string) (ResourceCRUD[...], error)
-ReadDesiresForCredentialRequest(sub, rg, cluster, credReq string) (ResourceCRUD[...], error)
-ApplyDesiresForRevocation(sub, rg, cluster, revocation string) (ResourceCRUD[...], error)
-ReadDesiresForRevocation(sub, rg, cluster, revocation string) (ResourceCRUD[...], error)
+// Per-level (used by backend controllers that know the parent type):
+ApplyDesiresForSystemAdminCredentialRequest(sub, rg, cluster, credReq string) (ResourceCRUD[...], error)
+ReadDesiresForSystemAdminCredentialRequest(sub, rg, cluster, credReq string) (ResourceCRUD[...], error)
+ApplyDesiresForSystemAdminCredentialRevocation(sub, rg, cluster, revocation string) (ResourceCRUD[...], error)
+ReadDesiresForSystemAdminCredentialRevocation(sub, rg, cluster, revocation string) (ResourceCRUD[...], error)
+
+// Parent-agnostic (used by kube-applier controllers that key off a resource ID):
+ApplyDesiresFor(parent DesireScope) (ResourceCRUD[...], error)
+ReadDesiresFor(parent DesireScope) (ResourceCRUD[...], error)
 ```
 
 The per-management-cluster listers and change-feed informers list all four

--- a/kube-applier/docs/03-database.md
+++ b/kube-applier/docs/03-database.md
@@ -24,7 +24,9 @@
 Reference files:
 
 - `internal/database/kube_applier_client.go` &mdash; `KubeApplierDBClient`,
-  `KubeApplierListers`, `KubeApplierDBClients`, `ResourceParent`, constructors.
+  `KubeApplierListers`, `KubeApplierDBClients`, constructors.
+- `internal/database/kubeappliercosmosstorage/desire_scope.go` &mdash;
+  `DesireScope`, `Ancestry`, scope constructors, `ParseDesireScope`.
 - `internal/database/crud_kube_applier.go` &mdash; per-MC `ResourceCRUD`
   implementation; partition key is the management cluster's name.
 - `internal/database/crud_untyped_kube_applier.go` &mdash; cross-partition
@@ -88,14 +90,17 @@ type ManagementClusterLister interface {
     List(ctx context.Context) ([]*fleet.ManagementCluster, error)
 }
 
-// ResourceParent identifies what the *Desires are nested under.
-// Either a cluster (NodePoolName == "") or a nodepool under a cluster.
-type ResourceParent struct {
-    SubscriptionID    string
-    ResourceGroupName string
-    ClusterName       string
-    NodePoolName      string // optional
-}
+// DesireScope is a validated parent resource that scopes a set of desires.
+// Constructed via ClusterScope, NodePoolScope, CredentialRequestScope,
+// CredentialRevocationScope, or ParseDesireScope. An invalid scope cannot be
+// represented (the constructors reject unknown parent types).
+type DesireScope struct { /* unexported fields: ancestry Ancestry, resourceID *azcorearm.ResourceID */ }
+
+func ClusterScope(sub, rg, cluster string) (DesireScope, error)
+func NodePoolScope(sub, rg, cluster, np string) (DesireScope, error)
+func CredentialRequestScope(sub, rg, cluster, credReq string) (DesireScope, error)
+func CredentialRevocationScope(sub, rg, cluster, revocation string) (DesireScope, error)
+func ParseDesireScope(id *azcorearm.ResourceID) (DesireScope, error)
 
 // Constructors.
 func NewKubeApplierDBClient(container *azcosmos.ContainerClient, managementClusterPartitionKey string) KubeApplierDBClient

--- a/kube-applier/pkg/controllers/keys/keys.go
+++ b/kube-applier/pkg/controllers/keys/keys.go
@@ -27,7 +27,6 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
-	"github.com/Azure/ARO-HCP/internal/api/coreapi"
 	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
 	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
@@ -35,25 +34,25 @@ import (
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
 
-// ApplyDesireKey identifies a single ApplyDesire by the parts of its resource ID
-// that map to the lister's CRUD helpers.
+// ApplyDesireKey identifies a single ApplyDesire by its parent resource ID and name.
 type ApplyDesireKey struct {
-	SubscriptionID    string
-	ResourceGroupName string
-	ClusterName       string
-	SubResourceType   string // lowercased leaf type name of the intermediate parent (empty for cluster-scoped)
-	SubResourceName   string // name of the intermediate parent (empty for cluster-scoped)
-	Name              string
+	// ParentResourceID is the canonical lowercased resource ID string of the desire's parent.
+	ParentResourceID string
+	Name             string
 }
 
 // CRUD returns the right per-scope CRUD for this key's parent.
 func (k ApplyDesireKey) CRUD(client kubeappliercosmosstorage.KubeApplierApplyDesireCRUD) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
-	return applyDesireCRUD(k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.SubResourceType, k.SubResourceName, client)
+	parent, err := parseDesireScope(k.ParentResourceID)
+	if err != nil {
+		return nil, err
+	}
+	return client.ApplyDesiresFor(parent)
 }
 
 // GetResourceID returns the desire's full resource ID.
 func (k ApplyDesireKey) GetResourceID() *azcorearm.ResourceID {
-	s := desireResourceIDString(k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.SubResourceType, k.SubResourceName, kubeapplierapi.ApplyDesireResourceTypeName, k.Name)
+	s := strings.ToLower(path.Join(k.ParentResourceID, kubeapplierapi.ApplyDesireResourceTypeName, k.Name))
 	return metadataapi.Must(azcorearm.ParseResourceID(s))
 }
 
@@ -67,22 +66,23 @@ func (k ApplyDesireKey) AddLoggerValues(logger logr.Logger) logr.Logger {
 
 // ReadDesireKey identifies a single ReadDesire.
 type ReadDesireKey struct {
-	SubscriptionID    string
-	ResourceGroupName string
-	ClusterName       string
-	SubResourceType   string
-	SubResourceName   string
-	Name              string
+	// ParentResourceID is the canonical lowercased resource ID string of the desire's parent
+	ParentResourceID string
+	Name             string
 }
 
-// CRUD returns the right per-scope CRUD for this key's parent.
+// CRUD returns a parent-scoped CRUD for this key.
 func (k ReadDesireKey) CRUD(client kubeappliercosmosstorage.KubeApplierReadDesireCRUD) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error) {
-	return readDesireCRUD(k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.SubResourceType, k.SubResourceName, client)
+	parent, err := parseDesireScope(k.ParentResourceID)
+	if err != nil {
+		return nil, err
+	}
+	return client.ReadDesiresFor(parent)
 }
 
 // GetResourceID returns the desire's full resource ID.
 func (k ReadDesireKey) GetResourceID() *azcorearm.ResourceID {
-	s := desireResourceIDString(k.SubscriptionID, k.ResourceGroupName, k.ClusterName, k.SubResourceType, k.SubResourceName, kubeapplierapi.ReadDesireResourceTypeName, k.Name)
+	s := strings.ToLower(path.Join(k.ParentResourceID, kubeapplierapi.ReadDesireResourceTypeName, k.Name))
 	return metadataapi.Must(azcorearm.ParseResourceID(s))
 }
 
@@ -92,14 +92,8 @@ func (k ReadDesireKey) AddLoggerValues(logger logr.Logger) logr.Logger {
 	return logger.WithValues(utils.LogValues{}.AddLogValuesForResourceID(k.GetResourceID())...)
 }
 
-// FromResourceID parses an ApplyDesireKey out of a *Desire's resource ID. The
-// caller is expected to have a desire whose resource ID follows one of these
-// patterns (or analogous patterns for other cluster sub-resource types):
-//
-//	.../hcpOpenShiftClusters/<c>/applyDesires/<n>
-//	.../hcpOpenShiftClusters/<c>/nodePools/<np>/applyDesires/<n>
-//	.../hcpOpenShiftClusters/<c>/systemAdminCredentialRequests/<cr>/applyDesires/<n>
-//	.../hcpOpenShiftClusters/<c>/systemAdminCredentialRevocations/<rev>/applyDesires/<n>
+// ApplyDesireKeyFromResourceID parses an ApplyDesireKey out of a *Desire's
+// resource ID. The desire is the leaf; everything above it is the parent.
 func ApplyDesireKeyFromResourceID(id *azcorearm.ResourceID) (ApplyDesireKey, error) {
 	parts, err := parseDesireParts(id)
 	if err != nil {
@@ -121,102 +115,30 @@ func ReadDesireKeyFromResourceID(id *azcorearm.ResourceID) (ReadDesireKey, error
 // type lets us do clean conversions to the kind-specific exported keys without
 // reflection.
 type desireParts struct {
-	SubscriptionID    string
-	ResourceGroupName string
-	ClusterName       string
-	SubResourceType   string
-	SubResourceName   string
-	Name              string
+	ParentResourceID string
+	Name             string
 }
 
 func parseDesireParts(id *azcorearm.ResourceID) (desireParts, error) {
 	if id == nil {
 		return desireParts{}, fmt.Errorf("resource ID is nil")
 	}
-	out := desireParts{
-		SubscriptionID:    id.SubscriptionID,
-		ResourceGroupName: id.ResourceGroupName,
-		Name:              id.Name,
-	}
-	// Walk the parent chain to find the containing cluster. The desire itself
-	// is the leaf; its parent is either the cluster (cluster-scoped) or an
-	// intermediate sub-resource type (e.g. nodePool, credentialRequest).
-	parent := id.Parent
-	if parent == nil {
+	if id.Parent == nil {
 		return desireParts{}, fmt.Errorf("desire %q has no parent in its resource ID", id.String())
 	}
-
-	if matchesType(parent.ResourceType, coreapi.ClusterResourceType) {
-		out.ClusterName = parent.Name
-		return out, nil
-	}
-
-	// The immediate parent is an intermediate sub-resource. Record it and
-	// look one more level up for the cluster.
-	out.SubResourceType = strings.ToLower(leafTypeName(parent.ResourceType))
-	out.SubResourceName = parent.Name
-
-	grandparent := parent.Parent
-	if grandparent == nil {
-		return desireParts{}, fmt.Errorf(
-			"desire %q has intermediate parent %s but no grandparent cluster", id.String(), parent.ResourceType,
-		)
-	}
-	if !matchesType(grandparent.ResourceType, coreapi.ClusterResourceType) {
-		return desireParts{}, fmt.Errorf(
-			"desire %q grandparent is %s, not a cluster", id.String(), grandparent.ResourceType,
-		)
-	}
-	out.ClusterName = grandparent.Name
-	return out, nil
+	return desireParts{
+		ParentResourceID: strings.ToLower(id.Parent.String()),
+		Name:             id.Name,
+	}, nil
 }
 
-func matchesType(got, want azcorearm.ResourceType) bool {
-	return strings.EqualFold(got.Namespace, want.Namespace) &&
-		strings.EqualFold(got.Type, want.Type)
-}
-
-// leafTypeName returns the trailing segment of an ARM ResourceType.
-func leafTypeName(rt azcorearm.ResourceType) string {
-	return rt.Types[len(rt.Types)-1]
-}
-
-// desireResourceIDString builds the lowercased resource ID string for a desire
-// from its decomposed parts.
-func desireResourceIDString(subscriptionID, resourceGroupName, clusterName, subResourceType, subResourceName, desireTypeName, desireName string) string {
-	clusterPath := coreapi.ToClusterResourceIDString(subscriptionID, resourceGroupName, clusterName)
-	if len(subResourceType) == 0 {
-		return strings.ToLower(path.Join(clusterPath, desireTypeName, desireName))
+// parseDesireScope parses the stored parent resource ID string and categorizes
+// it into a known-valid DesireScope, rejecting any parent that is not allowed
+// to own desires.
+func parseDesireScope(parentResourceID string) (kubeappliercosmosstorage.DesireScope, error) {
+	id, err := azcorearm.ParseResourceID(parentResourceID)
+	if err != nil {
+		return kubeappliercosmosstorage.DesireScope{}, err
 	}
-	return strings.ToLower(path.Join(clusterPath, subResourceType, subResourceName, desireTypeName, desireName))
-}
-
-func applyDesireCRUD(subscriptionID, resourceGroupName, clusterName, subResourceType, subResourceName string, client kubeappliercosmosstorage.KubeApplierApplyDesireCRUD) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
-	switch strings.ToLower(subResourceType) {
-	case "":
-		return client.ApplyDesiresForCluster(subscriptionID, resourceGroupName, clusterName)
-	case strings.ToLower(coreapi.NodePoolResourceTypeName):
-		return client.ApplyDesiresForNodePool(subscriptionID, resourceGroupName, clusterName, subResourceName)
-	case strings.ToLower(coreapi.SystemAdminCredentialRequestResourceTypeName):
-		return client.ApplyDesiresForSystemAdminCredentialRequest(subscriptionID, resourceGroupName, clusterName, subResourceName)
-	case strings.ToLower(coreapi.SystemAdminCredentialRevocationResourceTypeName):
-		return client.ApplyDesiresForSystemAdminCredentialRevocation(subscriptionID, resourceGroupName, clusterName, subResourceName)
-	default:
-		return nil, fmt.Errorf("unsupported sub-resource type %q for apply desire CRUD dispatch", subResourceType)
-	}
-}
-
-func readDesireCRUD(subscriptionID, resourceGroupName, clusterName, subResourceType, subResourceName string, client kubeappliercosmosstorage.KubeApplierReadDesireCRUD) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error) {
-	switch strings.ToLower(subResourceType) {
-	case "":
-		return client.ReadDesiresForCluster(subscriptionID, resourceGroupName, clusterName)
-	case strings.ToLower(coreapi.NodePoolResourceTypeName):
-		return client.ReadDesiresForNodePool(subscriptionID, resourceGroupName, clusterName, subResourceName)
-	case strings.ToLower(coreapi.SystemAdminCredentialRequestResourceTypeName):
-		return client.ReadDesiresForSystemAdminCredentialRequest(subscriptionID, resourceGroupName, clusterName, subResourceName)
-	case strings.ToLower(coreapi.SystemAdminCredentialRevocationResourceTypeName):
-		return client.ReadDesiresForSystemAdminCredentialRevocation(subscriptionID, resourceGroupName, clusterName, subResourceName)
-	default:
-		return nil, fmt.Errorf("unsupported sub-resource type %q for read desire CRUD dispatch", subResourceType)
-	}
+	return kubeappliercosmosstorage.ParseDesireScope(id)
 }

--- a/kube-applier/pkg/controllers/keys/keys_test.go
+++ b/kube-applier/pkg/controllers/keys/keys_test.go
@@ -23,6 +23,7 @@ import (
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
+	"github.com/Azure/ARO-HCP/internal/api/coreapi"
 	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
 	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/kubeappliercosmosstoragetesting"
@@ -38,76 +39,63 @@ const (
 	testDesireName   = "my-desire"
 )
 
-func TestParseDesireParts_ClusterScoped(t *testing.T) {
+func TestApplyDesireKeyFromResourceID_ClusterScoped(t *testing.T) {
 	idStr := kubeapplierapi.ToClusterScopedApplyDesireResourceIDString(testSubscription, testRG, testCluster, testDesireName)
 	id := metadataapi.Must(azcorearm.ParseResourceID(idStr))
 
 	key, err := ApplyDesireKeyFromResourceID(id)
 	require.NoError(t, err)
-	require.Equal(t, testSubscription, key.SubscriptionID)
-	require.Equal(t, testRG, key.ResourceGroupName)
-	require.Equal(t, testCluster, key.ClusterName)
-	require.Empty(t, key.SubResourceType)
-	require.Empty(t, key.SubResourceName)
+	require.Equal(t, strings.ToLower(coreapi.ToClusterResourceIDString(testSubscription, testRG, testCluster)), key.ParentResourceID)
 	require.Equal(t, testDesireName, key.Name)
 }
 
-func TestParseDesireParts_NodePoolScoped(t *testing.T) {
+func TestApplyDesireKeyFromResourceID_NodePoolScoped(t *testing.T) {
 	idStr := kubeapplierapi.ToNodePoolScopedApplyDesireResourceIDString(testSubscription, testRG, testCluster, testNodePool, testDesireName)
 	id := metadataapi.Must(azcorearm.ParseResourceID(idStr))
 
 	key, err := ApplyDesireKeyFromResourceID(id)
 	require.NoError(t, err)
-	require.Equal(t, testCluster, key.ClusterName)
-	require.Equal(t, "nodepools", key.SubResourceType)
-	require.Equal(t, testNodePool, key.SubResourceName)
+	require.Equal(t, strings.ToLower(coreapi.ToNodePoolResourceIDString(testSubscription, testRG, testCluster, testNodePool)), key.ParentResourceID)
 	require.Equal(t, testDesireName, key.Name)
 }
 
-func TestParseDesireParts_SystemAdminCredentialRequestScoped(t *testing.T) {
+func TestApplyDesireKeyFromResourceID_SystemAdminCredentialRequestScoped(t *testing.T) {
 	idStr := kubeapplierapi.ToSystemAdminCredentialRequestScopedApplyDesireResourceIDString(testSubscription, testRG, testCluster, testCredReq, testDesireName)
 	id := metadataapi.Must(azcorearm.ParseResourceID(idStr))
 
 	key, err := ApplyDesireKeyFromResourceID(id)
 	require.NoError(t, err)
-	require.Equal(t, testCluster, key.ClusterName)
-	require.Equal(t, "systemadmincredentialrequests", key.SubResourceType)
-	require.Equal(t, testCredReq, key.SubResourceName)
+	require.Equal(t, strings.ToLower(coreapi.ToSystemAdminCredentialRequestResourceIDString(testSubscription, testRG, testCluster, testCredReq)), key.ParentResourceID)
 	require.Equal(t, testDesireName, key.Name)
 }
 
-func TestParseDesireParts_SystemAdminCredentialRevocationScoped(t *testing.T) {
+func TestApplyDesireKeyFromResourceID_SystemAdminCredentialRevocationScoped(t *testing.T) {
 	idStr := kubeapplierapi.ToSystemAdminCredentialRevocationScopedApplyDesireResourceIDString(testSubscription, testRG, testCluster, testRevocation, testDesireName)
 	id := metadataapi.Must(azcorearm.ParseResourceID(idStr))
 
 	key, err := ApplyDesireKeyFromResourceID(id)
 	require.NoError(t, err)
-	require.Equal(t, testCluster, key.ClusterName)
-	require.Equal(t, "systemadmincredentialrevocations", key.SubResourceType)
-	require.Equal(t, testRevocation, key.SubResourceName)
+	require.Equal(t, strings.ToLower(coreapi.ToSystemAdminCredentialRevocationResourceIDString(testSubscription, testRG, testCluster, testRevocation)), key.ParentResourceID)
 	require.Equal(t, testDesireName, key.Name)
 }
 
-func TestParseDesireParts_ReadDesire(t *testing.T) {
+func TestReadDesireKeyFromResourceID_SystemAdminCredentialRequestScoped(t *testing.T) {
 	idStr := kubeapplierapi.ToSystemAdminCredentialRequestScopedReadDesireResourceIDString(testSubscription, testRG, testCluster, testCredReq, testDesireName)
 	id := metadataapi.Must(azcorearm.ParseResourceID(idStr))
 
 	key, err := ReadDesireKeyFromResourceID(id)
 	require.NoError(t, err)
-	require.Equal(t, testCluster, key.ClusterName)
-	require.Equal(t, "systemadmincredentialrequests", key.SubResourceType)
-	require.Equal(t, testCredReq, key.SubResourceName)
+	require.Equal(t, strings.ToLower(coreapi.ToSystemAdminCredentialRequestResourceIDString(testSubscription, testRG, testCluster, testCredReq)), key.ParentResourceID)
 	require.Equal(t, testDesireName, key.Name)
 }
 
-func TestParseDesireParts_ErrorCases(t *testing.T) {
+func TestDesireKeyFromResourceID_ErrorCases(t *testing.T) {
 	t.Run("nil resource ID", func(t *testing.T) {
 		_, err := ApplyDesireKeyFromResourceID(nil)
 		require.Error(t, err)
 	})
-
-	t.Run("no parent", func(t *testing.T) {
-		id := metadataapi.Must(azcorearm.ParseResourceID("/subscriptions/" + testSubscription))
+	t.Run("resource ID with no parent", func(t *testing.T) {
+		id := &azcorearm.ResourceID{Name: "orphan"}
 		_, err := ApplyDesireKeyFromResourceID(id)
 		require.Error(t, err)
 	})

--- a/kube-applier/pkg/controllers/read_desire_kubernetes/controller.go
+++ b/kube-applier/pkg/controllers/read_desire_kubernetes/controller.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -124,7 +125,7 @@ func NewReadDesireKubernetesController(
 			workqueue.TypedRateLimitingQueueConfig[keys.ReadDesireKey]{
 				// Underscores rather than slashes: this name surfaces as a
 				// Prometheus label and slashes complicate downstream tooling.
-				Name: fmt.Sprintf("%s_%s_%s_%s_%s", ReadDesireKubernetesControllerName, key.ClusterName, key.SubResourceType, key.SubResourceName, key.Name),
+				Name: ReadDesireKubernetesControllerName + strings.ReplaceAll(key.GetResourceID().String(), "/", "_"),
 			},
 		),
 		writer: desirestatuswriter.New[kubeapplierapi.ReadDesire, keys.ReadDesireKey, *kubeapplierapi.ReadDesire](


### PR DESCRIPTION
### What

Collapse the desire workqueue keys from individual fields (SubscriptionID, ResourceGroupName, ClusterName, SubResourceType, SubResourceName) into {ParentResourceID, Name}. Controllers no longer need to know which kind of parent they are reconciling.

Introduce DesireScope (validated parent + Ancestry classification) so the CRUD accessor picks the correct resource-type and path builder without a per-parent-type switch. New parent types only need an entry in ancestryForParentType.

Narrow the controller-facing interfaces (KubeApplierApplyDesireCRUD, KubeApplierReadDesireCRUD) to the single parent-agnostic ApplyDesiresFor/ReadDesiresFor method. The enumerated per-level accessors remain on KubeApplierDBClient for field-driven callers in the backend.

### Why

Prepwork for introducing management-cluster-scoped desires.

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
