### PR TITLE
feat(kube-applier): split ApplyDesire success into SuccessfullyApplie…

### DIFF
--- a/backend/pkg/kubeapplierhelpers/desire_deletion.go
+++ b/backend/pkg/kubeapplierhelpers/desire_deletion.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
+	"github.com/Azure/ARO-HCP/internal/apihelpers/kubeapplierapihelpers"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/kubeappliercosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -126,8 +127,9 @@ func removeApplyDesireForDeletion(
 	if applyDesire.Spec.Type != kubeapplierapi.ApplyDesireTypeDelete {
 		applyDesire.Spec.Type = kubeapplierapi.ApplyDesireTypeDelete
 		applyDesire.Spec.ServerSideApply = nil
-		// clearing conditions so that we can be certain that a success means we deleted.
-		// TODO, different conditions.
+		// Clear conditions so a later SuccessfullyDeleted (or, for an older
+		// kube-applier, Successful) unambiguously reflects the delete rather than a
+		// stale server-side-apply result.
 		applyDesire.Status.Conditions = nil
 		if _, err := applyCRUD.Replace(ctx, applyDesire, nil); err != nil && !cosmosstorageutils.IsNotFoundError(err) {
 			return false, utils.TrackError(fmt.Errorf("convert ApplyDesire %s to Delete: %w", desireName, err))
@@ -136,13 +138,13 @@ func removeApplyDesireForDeletion(
 	}
 
 	// The desire is a Delete — remove the document once the delete has succeeded.
-	for _, cond := range applyDesire.Status.Conditions {
-		if cond.Type == kubeapplierapi.ConditionTypeSuccessful && cond.Status == "True" {
-			if err := applyCRUD.Delete(ctx, strings.ToLower(desireName)); err != nil && !cosmosstorageutils.IsNotFoundError(err) {
-				return false, utils.TrackError(fmt.Errorf("delete ApplyDesire %s: %w", desireName, err))
-			}
-			return true, nil
+	// Prefer the operation-specific SuccessfullyDeleted condition, falling back to
+	// the legacy Successful for documents last written by an older kube-applier.
+	if kubeapplierapihelpers.IsConditionTruePreferring(applyDesire.Status.Conditions, kubeapplierapi.ConditionTypeSuccessfullyDeleted, kubeapplierapi.ConditionTypeSuccessful) {
+		if err := applyCRUD.Delete(ctx, strings.ToLower(desireName)); err != nil && !cosmosstorageutils.IsNotFoundError(err) {
+			return false, utils.TrackError(fmt.Errorf("delete ApplyDesire %s: %w", desireName, err))
 		}
+		return true, nil
 	}
 	// Delete not yet successful; wait.
 	return false, nil

--- a/internal/api/kubeapplierapi/conditions.go
+++ b/internal/api/kubeapplierapi/conditions.go
@@ -18,7 +18,27 @@ package kubeapplierapi
 const (
 	// ConditionTypeSuccessful is true when the controller most-recently observed the
 	// desired effect of the *Desire achieved against the kube-apiserver.
+	//
+	// For an ApplyDesire it is retained for backwards compatibility and mirrors
+	// whichever operation-specific condition applies — ConditionTypeSuccessfullyApplied
+	// for Type=ServerSideApply, ConditionTypeSuccessfullyDeleted for Type=Delete.
+	// Readers should prefer the operation-specific condition (see
+	// kubeapplierapihelpers.IsConditionTruePreferring) and fall back to this one
+	// only when the operation-specific condition is absent (e.g. a document last
+	// written by an older kube-applier). It remains the primary condition for a
+	// ReadDesire, which has a single observe operation.
 	ConditionTypeSuccessful = "Successful"
+
+	// ConditionTypeSuccessfullyApplied is true when the controller most-recently
+	// observed that an ApplyDesire with Type=ServerSideApply achieved its desired
+	// effect (the server-side apply succeeded).
+	ConditionTypeSuccessfullyApplied = "SuccessfullyApplied"
+
+	// ConditionTypeSuccessfullyDeleted is true when the controller most-recently
+	// observed that an ApplyDesire with Type=Delete achieved its desired effect
+	// (the target is gone). While finalizers are running it stays False with reason
+	// ConditionReasonWaitingForDeletion.
+	ConditionTypeSuccessfullyDeleted = "SuccessfullyDeleted"
 
 	// ConditionTypeDegraded reports controller-level health for the *Desire.
 	// True means the controller failed in a way unrelated to the kube-apiserver
@@ -31,8 +51,10 @@ const (
 	// ConditionReasonKubeAPIError is set when the kube-apiserver returned an error for our request.
 	ConditionReasonKubeAPIError = "KubeAPIError"
 
-	// ConditionReasonPreCheckFailed is set when we could not issue the kube-apiserver request
-	// (e.g. malformed kubeContent, GVR not present in the RESTMapper, etc.).
+	// ConditionReasonPreCheckFailed is set when we could not even issue the kube-apiserver request
+	// (e.g. malformed kubeContent, or missing required spec.targetItem fields). An unresolvable GVR
+	// is not a pre-check failure: the controller passes the GVR straight to the dynamic client
+	// without consulting a RESTMapper, so the kube-apiserver rejects it as a ConditionReasonKubeAPIError.
 	ConditionReasonPreCheckFailed = "PreCheckFailed"
 
 	// ConditionReasonWaitingForDeletion is set on an ApplyDesire with Type=Delete when the

--- a/internal/api/kubeapplierapi/types_apply_desire.go
+++ b/internal/api/kubeapplierapi/types_apply_desire.go
@@ -126,9 +126,17 @@ type ServerSideApplyConfig struct {
 
 type ApplyDesireStatus struct {
 	// Conditions reports per-desire reconciliation status. Well-known types:
-	//   - "Successful": the operation succeeded (SSA applied, or target deleted).
-	//     For Delete, Successful=True means the target is gone. While finalizers
-	//     are running, Successful stays False with reason "WaitingForDeletion".
+	//   - "SuccessfullyApplied": set for Type=ServerSideApply. True means the SSA
+	//                   succeeded.
+	//   - "SuccessfullyDeleted": set for Type=Delete. True means the target is
+	//                   gone. While finalizers are running it stays False with
+	//                   reason "WaitingForDeletion".
+	//   - "Successful": retained for backwards compatibility. It mirrors whichever
+	//                   operation-specific condition applies (SuccessfullyApplied
+	//                   for ServerSideApply, SuccessfullyDeleted for Delete) with
+	//                   the same status/reason/message. Prefer the
+	//                   operation-specific condition; see
+	//                   kubeapplierapihelpers.IsConditionTruePreferring.
 	//   - "Degraded":   the controller is not making progress for an
 	//                   out-of-band reason.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`

--- a/internal/apihelpers/kubeapplierapihelpers/conditions.go
+++ b/internal/apihelpers/kubeapplierapihelpers/conditions.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubeapplierapihelpers
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// IsConditionTruePreferring reports whether the first of preferTypes present on conds is True.
+// preferTypes are tried in order — most specific first — so callers pass the operation-specific
+// condition (e.g. kubeapplierapi.ConditionTypeSuccessfullyDeleted) followed by the legacy
+// kubeapplierapi.ConditionTypeSuccessful as the backwards-compatible fallback for documents last
+// written by an older kube-applier. When none of preferTypes is present it returns false.
+func IsConditionTruePreferring(conds []metav1.Condition, preferTypes ...string) bool {
+	for _, conditionType := range preferTypes {
+		if c := meta.FindStatusCondition(conds, conditionType); c != nil {
+			return c.Status == metav1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/internal/apihelpers/kubeapplierapihelpers/conditions_test.go
+++ b/internal/apihelpers/kubeapplierapihelpers/conditions_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubeapplierapihelpers
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
+)
+
+func TestIsConditionTruePreferring(t *testing.T) {
+	cond := func(condType string, status metav1.ConditionStatus) metav1.Condition {
+		return metav1.Condition{Type: condType, Status: status}
+	}
+
+	for _, tc := range []struct {
+		name        string
+		conds       []metav1.Condition
+		preferTypes []string
+		want        bool
+	}{
+		{
+			name:        "prefers first condition when present and True",
+			conds:       []metav1.Condition{cond(kubeapplierapi.ConditionTypeSuccessfullyDeleted, metav1.ConditionTrue), cond(kubeapplierapi.ConditionTypeSuccessful, metav1.ConditionFalse)},
+			preferTypes: []string{kubeapplierapi.ConditionTypeSuccessfullyDeleted, kubeapplierapi.ConditionTypeSuccessful},
+			want:        true,
+		},
+		{
+			name:        "prefers first condition when present and False (ignores later True)",
+			conds:       []metav1.Condition{cond(kubeapplierapi.ConditionTypeSuccessfullyDeleted, metav1.ConditionFalse), cond(kubeapplierapi.ConditionTypeSuccessful, metav1.ConditionTrue)},
+			preferTypes: []string{kubeapplierapi.ConditionTypeSuccessfullyDeleted, kubeapplierapi.ConditionTypeSuccessful},
+			want:        false,
+		},
+		{
+			name:        "falls back to legacy Successful=True when preferred absent",
+			conds:       []metav1.Condition{cond(kubeapplierapi.ConditionTypeSuccessful, metav1.ConditionTrue)},
+			preferTypes: []string{kubeapplierapi.ConditionTypeSuccessfullyDeleted, kubeapplierapi.ConditionTypeSuccessful},
+			want:        true,
+		},
+		{
+			name:        "falls back to legacy Successful=False when preferred absent",
+			conds:       []metav1.Condition{cond(kubeapplierapi.ConditionTypeSuccessful, metav1.ConditionFalse)},
+			preferTypes: []string{kubeapplierapi.ConditionTypeSuccessfullyApplied, kubeapplierapi.ConditionTypeSuccessful},
+			want:        false,
+		},
+		{
+			name:        "no listed conditions present is false",
+			conds:       []metav1.Condition{cond(kubeapplierapi.ConditionTypeDegraded, metav1.ConditionFalse)},
+			preferTypes: []string{kubeapplierapi.ConditionTypeSuccessfullyApplied, kubeapplierapi.ConditionTypeSuccessful},
+			want:        false,
+		},
+		{
+			name:        "nil conditions is false",
+			conds:       nil,
+			preferTypes: []string{kubeapplierapi.ConditionTypeSuccessfullyDeleted, kubeapplierapi.ConditionTypeSuccessful},
+			want:        false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsConditionTruePreferring(tc.conds, tc.preferTypes...); got != tc.want {
+				t.Errorf("IsConditionTruePreferring = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/kube-applier/docs/01-overview.md
+++ b/kube-applier/docs/01-overview.md
@@ -76,8 +76,15 @@ We reuse that idiom on each `*Desire.Status.Conditions`.
 
 The well-known condition types per the readme:
 
-- `Successful` &mdash; was the desired effect achieved (with reasons
-  `KubeAPIError` or `PreCheckFailed` when not).
+- `SuccessfullyApplied` &mdash; for an ApplyDesire with `Type=ServerSideApply`,
+  was the desired effect achieved (with reasons `KubeAPIError` or
+  `PreCheckFailed` when not).
+- `SuccessfullyDeleted` &mdash; for an ApplyDesire with `Type=Delete`, is the
+  target gone (`WaitingForDeletion` while finalizers run).
+- `Successful` &mdash; retained for backwards compatibility. For an ApplyDesire
+  it mirrors whichever operation-specific condition applies; it is the primary
+  condition for a ReadDesire. Readers prefer the operation-specific condition and
+  fall back to `Successful` (`kubeapplierapi.IsConditionTruePreferring`).
 - `Degraded` &mdash; controller-level health (replaces the existing
   `Controller` resource's `Degraded`).
 

--- a/kube-applier/docs/02-api-types.md
+++ b/kube-applier/docs/02-api-types.md
@@ -103,8 +103,17 @@ Add a small `conditions.go` next to the types:
 
 ```go
 const (
+    // ApplyDesire operation-specific success conditions.
+    ConditionSuccessfullyApplied = "SuccessfullyApplied" // Type=ServerSideApply
+    ConditionSuccessfullyDeleted = "SuccessfullyDeleted" // Type=Delete
+
+    // Successful is retained for backwards compatibility. For an ApplyDesire it
+    // mirrors whichever operation-specific condition applies; it is the primary
+    // condition for a ReadDesire. Readers prefer the operation-specific condition
+    // and fall back to Successful (see IsConditionTruePreferring).
     ConditionSuccessful = "Successful"
-    ConditionDegraded   = "Degraded"
+
+    ConditionDegraded = "Degraded"
 )
 
 const (

--- a/kube-applier/docs/05-controllers.md
+++ b/kube-applier/docs/05-controllers.md
@@ -39,10 +39,19 @@ The existing controllerutils path writes `Degraded` to a Cosmos
 Add a small helper, `kube-applier/pkg/controllers/conditions/conditions.go`:
 
 ```go
+// ApplyDesire Type=ServerSideApply: sets SuccessfullyApplied (+ legacy Successful).
+func SetSuccessfullyApplied(conds *[]metav1.Condition, err error)
+// ApplyDesire Type=Delete: sets SuccessfullyDeleted (+ legacy Successful).
+func SetSuccessfullyDeleted(conds *[]metav1.Condition, err error)
+func SetWaitingForDeletion(conds *[]metav1.Condition, deletionTime metav1.Time, uid types.UID)
+// ReadDesire (single observe operation): sets the legacy Successful.
 func SetSuccessful(conds *[]metav1.Condition, err error)
-func SetSuccessfulWaitingForDeletion(conds *[]metav1.Condition, deletionTime metav1.Time, uid types.UID)
 func SetDegraded(conds *[]metav1.Condition, err error)
 ```
+
+The `SetSuccessfully*` / `SetWaitingForDeletion` helpers dual-write the
+operation-specific condition **and** the legacy `Successful` condition (same
+status/reason/message) so readers written against `Successful` keep working.
 
 Each helper:
 
@@ -104,10 +113,10 @@ Sync logic dispatches on `spec.type`:
 3. Server-side-apply with Force=true and FieldManager="kube-applier" via
    the dynamic client:
        dyn.Resource(gvr).Namespace(ns).Apply(ctx, name, obj, applyOpts)
-4. On success: SetSuccessful(conds, nil); SetDegraded(conds, nil).
-   On error:   SetSuccessful(conds, err); SetDegraded(conds, classifyAsDegraded(err)).
+4. On success: SetSuccessfullyApplied(conds, nil); SetDegraded(conds, nil).
+   On error:   SetSuccessfullyApplied(conds, err); SetDegraded(conds, classifyAsDegraded(err)).
    On a pre-check failure (malformed targetItem, malformed
-   kubeContent): SetSuccessful(conds, err with PreCheckFailed reason); SetDegraded(conds, nil).
+   kubeContent): SetSuccessfullyApplied(conds, err with PreCheckFailed reason); SetDegraded(conds, nil).
 5. Write status via statuswriter.
 ```
 
@@ -116,13 +125,13 @@ Sync logic dispatches on `spec.type`:
 ```
 1. Resolve the target resource from the ApplyDesire spec.
 2. Get the target object from the cluster:
-     not found             -> SetSuccessful(true)
-     has deletion timestamp -> SetSuccessfulWaitingForDeletion(
+     not found             -> SetSuccessfullyDeleted(true)
+     has deletion timestamp -> SetWaitingForDeletion(
                                deletionTimestamp, uid)
      no deletion timestamp -> issue Delete; if delete fails -> KubeAPIError
                                re-issue get:
-                                 still not found -> SetSuccessful(true)
-                                 has deletion timestamp -> SetSuccessfulWaitingForDeletion(
+                                 still not found -> SetSuccessfullyDeleted(true)
+                                 has deletion timestamp -> SetWaitingForDeletion(
                                                            deletionTimestamp, uid)
 3. Write status via statuswriter.
 ```

--- a/kube-applier/docs/07-testing.md
+++ b/kube-applier/docs/07-testing.md
@@ -36,24 +36,30 @@ dyn, _ := dynamic.NewForConfig(cfg)
 
 ### ApplyDesireController
 
+Conditions below name `SuccessfullyApplied`; the controller also dual-writes the
+legacy `Successful` with the same status/reason (assert it mirrors).
+
 | Case | Expected condition |
 | --- | --- |
-| valid Deployment payload, apply succeeds | `Successful=True` |
-| invalid YAML in `kubeContent` | `Successful=False`, reason `PreCheckFailed` |
-| GVK has no RESTMapper match | `Successful=False`, reason `PreCheckFailed` |
-| kube-apiserver returns 403 | `Successful=False`, reason `KubeAPIError`, msg contains the upstream error |
-| existing object owned by another field manager (force=true) | `Successful=True`; verify the diff was applied |
+| valid Deployment payload, apply succeeds | `SuccessfullyApplied=True` |
+| invalid YAML in `kubeContent` | `SuccessfullyApplied=False`, reason `PreCheckFailed` |
+| GVR in `targetItem` does not resolve on the cluster | `SuccessfullyApplied=False`, reason `KubeAPIError` (the controller passes the GVR straight to the dynamic client; it does not consult a RESTMapper) |
+| kube-apiserver returns 403 | `SuccessfullyApplied=False`, reason `KubeAPIError`, msg contains the upstream error |
+| existing object owned by another field manager (force=true) | `SuccessfullyApplied=True`; verify the diff was applied |
 | no-op resync (status already correct) | no Cosmos write (verify via mock) |
 
 ### ApplyDesireController (Type=Delete)
 
+Conditions below name `SuccessfullyDeleted`; the controller also dual-writes the
+legacy `Successful` with the same status/reason (assert it mirrors).
+
 | Case | Expected condition |
 | --- | --- |
-| target absent | `Successful=True` |
-| target present, no deletionTimestamp, delete returns 404 (race) | `Successful=True` |
-| target present, no deletionTimestamp, delete succeeds | `Successful=False`, reason `WaitingForDeletion`, message includes UID + DT |
-| target present, deletionTimestamp already set | `Successful=False`, reason `WaitingForDeletion` |
-| delete returns 500 | `Successful=False`, reason `KubeAPIError` |
+| target absent | `SuccessfullyDeleted=True` |
+| target present, no deletionTimestamp, delete returns 404 (race) | `SuccessfullyDeleted=True` |
+| target present, no deletionTimestamp, delete succeeds | `SuccessfullyDeleted=False`, reason `WaitingForDeletion`, message includes UID + DT |
+| target present, deletionTimestamp already set | `SuccessfullyDeleted=False`, reason `WaitingForDeletion` |
+| delete returns 500 | `SuccessfullyDeleted=False`, reason `KubeAPIError` |
 
 ### ReadDesireInformerManagingController
 
@@ -107,7 +113,7 @@ Smoke scenarios at minimum:
   verify the ConfigMap is updated; delete the ApplyDesire (mock-side),
   verify the ConfigMap is left in place (we are not cascading deletes).
 - Create an ApplyDesire with `Type=Delete` targeting the ConfigMap, verify
-  it is deleted and the desire reports `Successful=True`.
+  it is deleted and the desire reports `SuccessfullyDeleted=True`.
 - Create a ReadDesire on the ConfigMap; verify `.status.kubeContent`
   becomes the live ConfigMap; mutate the live ConfigMap directly via the
   KIND client; verify `.status.kubeContent` updates within one resync.

--- a/kube-applier/docs/08-rollout.md
+++ b/kube-applier/docs/08-rollout.md
@@ -116,8 +116,10 @@ Single PR.
       including delete-type ApplyDesires.
 
 Exit criteria: in cspr, a hand-inserted ApplyDesire with `Type=ServerSideApply`
-produces the expected kube object and `.status.conditions["Successful"]=True`;
-an ApplyDesire with `Type=Delete` removes the target object.
+produces the expected kube object and `.status.conditions["SuccessfullyApplied"]=True`
+(with `["Successful"]=True` mirrored for backwards compatibility); an ApplyDesire
+with `Type=Delete` removes the target object and reports
+`.status.conditions["SuccessfullyDeleted"]=True`.
 
 ## Phase 8 &mdash; ReadDesire controllers (Doc 05.3 + 5.4)
 

--- a/kube-applier/pkg/app/desire_metrics.go
+++ b/kube-applier/pkg/app/desire_metrics.go
@@ -85,14 +85,28 @@ func (c *desireCollector) collect() {
 	}
 }
 
-// initCounts pre-seeds all label combinations to 0 so gauges go to zero when desires disappear.
+// initCounts pre-seeds all label combinations to 0 so gauges go to zero when
+// desires disappear. Condition types are per desire type: ApplyDesires report the
+// operation-specific SuccessfullyApplied / SuccessfullyDeleted conditions (plus
+// the legacy Successful) while ReadDesires only report Successful.
 func initCounts() map[string]map[string]float64 {
-	condTypes := []string{kubeapplierapi.ConditionTypeSuccessful, kubeapplierapi.ConditionTypeDegraded}
+	condTypesByDesireType := map[string][]string{
+		"apply": {
+			kubeapplierapi.ConditionTypeSuccessful,
+			kubeapplierapi.ConditionTypeSuccessfullyApplied,
+			kubeapplierapi.ConditionTypeSuccessfullyDeleted,
+			kubeapplierapi.ConditionTypeDegraded,
+		},
+		"read": {
+			kubeapplierapi.ConditionTypeSuccessful,
+			kubeapplierapi.ConditionTypeDegraded,
+		},
+	}
 	counts := map[string]map[string]float64{}
-	for _, t := range []string{"apply", "read"} {
-		counts[t] = map[string]float64{}
+	for desireType, condTypes := range condTypesByDesireType {
+		counts[desireType] = map[string]float64{}
 		for _, cond := range condTypes {
-			counts[t][cond] = 0
+			counts[desireType][cond] = 0
 		}
 	}
 	return counts

--- a/kube-applier/pkg/controllers/apply_desire/controller.go
+++ b/kube-applier/pkg/controllers/apply_desire/controller.go
@@ -24,8 +24,10 @@
 //     reports WaitingForDeletion until the target disappears (finalizers
 //     complete).
 //
-// The outcome is recorded on .status.conditions["Successful"] / ["Degraded"]
-// and persisted via the StatusWriter.
+// The outcome is recorded on .status.conditions: ["SuccessfullyApplied"] for
+// ServerSideApply or ["SuccessfullyDeleted"] for Delete, the legacy
+// ["Successful"] (retained for backwards compatibility), and ["Degraded"]; it is
+// persisted via the StatusWriter.
 package apply_desire
 
 import (
@@ -260,7 +262,7 @@ func (c *ApplyDesireController) SyncOnce(ctx context.Context, key keys.ApplyDesi
 		}
 
 		return c.writer.UpdateStatus(ctx, key, func(d *kubeapplierapi.ApplyDesire) {
-			conditions.SetSuccessful(&d.Status.Conditions, syncErr)
+			conditions.SetSuccessfullyApplied(&d.Status.Conditions, syncErr)
 			conditions.SetDegraded(&d.Status.Conditions, classifyAsDegraded(syncErr))
 			d.Status.AppliedKubeGeneration = appliedKubeGeneration
 		})
@@ -279,7 +281,7 @@ func (c *ApplyDesireController) SyncOnce(ctx context.Context, key keys.ApplyDesi
 // applyDesired performs the kubeContent decode and SSA call. The GVR comes
 // straight from spec.targetItem; we don't consult a RESTMapper or guess. The
 // dynamic client surfaces a kube error if the GVR doesn't resolve, and that
-// lands in SetSuccessful as KubeAPIError.
+// lands in SetSuccessfullyApplied as KubeAPIError.
 //
 // PreCheckError is returned for pre-flight failures (parse, missing fields)
 // so they classify as PreCheckFailed; everything else is treated as a
@@ -309,8 +311,9 @@ func (c *ApplyDesireController) applyDesired(ctx context.Context, d *kubeapplier
 		Force:        true,
 	})
 	if applyErr != nil {
-		// Wrap with a contextual prefix; keep the original kind so SetSuccessful
-		// classifies it as a kube-apiserver error (NOT a *PreCheckError).
+		// Wrap with a contextual prefix; keep the original kind so
+		// SetSuccessfullyApplied classifies it as a kube-apiserver error (NOT a
+		// *PreCheckError).
 		return nil, fmt.Errorf("server-side apply: %w", applyErr)
 	}
 	return result, nil
@@ -322,18 +325,18 @@ func (c *ApplyDesireController) applyDesired(ctx context.Context, d *kubeapplier
 // State machine:
 //
 //	get target
-//	  not found             -> Successful=True
+//	  not found             -> SuccessfullyDeleted=True
 //	  has deletion timestamp -> WaitingForDeletion
 //	  no deletion timestamp -> issue Delete; on error -> KubeAPIError
 //	                           re-issue get
-//	                             not found              -> Successful=True
+//	                             not found              -> SuccessfullyDeleted=True
 //	                             has deletion timestamp  -> WaitingForDeletion
 func (c *ApplyDesireController) evaluateDelete(ctx context.Context, d *kubeapplierapi.ApplyDesire) desirestatuswriter.MutateFunc[kubeapplierapi.ApplyDesire] {
 	target := d.Spec.TargetItem
 	if len(target.Resource) == 0 || len(target.Version) == 0 || len(target.Name) == 0 {
 		err := conditions.NewPreCheckError(errors.New("spec.targetItem requires version, resource, and name"))
 		return func(d *kubeapplierapi.ApplyDesire) {
-			conditions.SetSuccessful(&d.Status.Conditions, err)
+			conditions.SetSuccessfullyDeleted(&d.Status.Conditions, err)
 			conditions.SetDegraded(&d.Status.Conditions, classifyAsDegraded(err))
 		}
 	}
@@ -348,14 +351,14 @@ func (c *ApplyDesireController) evaluateDelete(ctx context.Context, d *kubeappli
 	got, getErr := kubeResourceAccessor.Get(ctx, target.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(getErr) {
 		return func(d *kubeapplierapi.ApplyDesire) {
-			conditions.SetSuccessful(&d.Status.Conditions, nil)
+			conditions.SetSuccessfullyDeleted(&d.Status.Conditions, nil)
 			conditions.SetDegraded(&d.Status.Conditions, nil)
 		}
 	}
 	if getErr != nil {
 		err := fmt.Errorf("get target: %w", getErr)
 		return func(d *kubeapplierapi.ApplyDesire) {
-			conditions.SetSuccessful(&d.Status.Conditions, err)
+			conditions.SetSuccessfullyDeleted(&d.Status.Conditions, err)
 			conditions.SetDegraded(&d.Status.Conditions, classifyAsDegraded(err))
 		}
 	}
@@ -363,7 +366,7 @@ func (c *ApplyDesireController) evaluateDelete(ctx context.Context, d *kubeappli
 	if dt := got.GetDeletionTimestamp(); dt != nil {
 		uid := got.GetUID()
 		return func(d *kubeapplierapi.ApplyDesire) {
-			conditions.SetSuccessfulWaitingForDeletion(&d.Status.Conditions, *dt, uid)
+			conditions.SetWaitingForDeletion(&d.Status.Conditions, *dt, uid)
 			conditions.SetDegraded(&d.Status.Conditions, nil)
 		}
 	}
@@ -371,13 +374,13 @@ func (c *ApplyDesireController) evaluateDelete(ctx context.Context, d *kubeappli
 	if delErr := kubeResourceAccessor.Delete(ctx, target.Name, metav1.DeleteOptions{}); delErr != nil {
 		if apierrors.IsNotFound(delErr) {
 			return func(d *kubeapplierapi.ApplyDesire) {
-				conditions.SetSuccessful(&d.Status.Conditions, nil)
+				conditions.SetSuccessfullyDeleted(&d.Status.Conditions, nil)
 				conditions.SetDegraded(&d.Status.Conditions, nil)
 			}
 		}
 		err := fmt.Errorf("delete target: %w", delErr)
 		return func(d *kubeapplierapi.ApplyDesire) {
-			conditions.SetSuccessful(&d.Status.Conditions, err)
+			conditions.SetSuccessfullyDeleted(&d.Status.Conditions, err)
 			conditions.SetDegraded(&d.Status.Conditions, classifyAsDegraded(err))
 		}
 	}
@@ -387,14 +390,14 @@ func (c *ApplyDesireController) evaluateDelete(ctx context.Context, d *kubeappli
 	post, postErr := kubeResourceAccessor.Get(ctx, target.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(postErr) {
 		return func(d *kubeapplierapi.ApplyDesire) {
-			conditions.SetSuccessful(&d.Status.Conditions, nil)
+			conditions.SetSuccessfullyDeleted(&d.Status.Conditions, nil)
 			conditions.SetDegraded(&d.Status.Conditions, nil)
 		}
 	}
 	if postErr != nil {
 		err := fmt.Errorf("post-delete get: %w", postErr)
 		return func(d *kubeapplierapi.ApplyDesire) {
-			conditions.SetSuccessful(&d.Status.Conditions, err)
+			conditions.SetSuccessfullyDeleted(&d.Status.Conditions, err)
 			conditions.SetDegraded(&d.Status.Conditions, classifyAsDegraded(err))
 		}
 	}
@@ -405,7 +408,7 @@ func (c *ApplyDesireController) evaluateDelete(ctx context.Context, d *kubeappli
 		dt = &now
 	}
 	return func(d *kubeapplierapi.ApplyDesire) {
-		conditions.SetSuccessfulWaitingForDeletion(&d.Status.Conditions, *dt, uid)
+		conditions.SetWaitingForDeletion(&d.Status.Conditions, *dt, uid)
 		conditions.SetDegraded(&d.Status.Conditions, nil)
 	}
 }

--- a/kube-applier/pkg/controllers/apply_desire/controller_test.go
+++ b/kube-applier/pkg/controllers/apply_desire/controller_test.go
@@ -393,6 +393,16 @@ func TestSyncOnce_AppliedKubeGenerationSetOnSuccess(t *testing.T) {
 	if got := *replacer.last.Status.AppliedKubeGeneration; got != 3 {
 		t.Errorf("AppliedKubeGeneration = %d, want 3 (metadata.generation from SSA response)", got)
 	}
+	// A ServerSideApply success sets the operation-specific SuccessfullyApplied
+	// condition and mirrors it onto the legacy Successful condition.
+	for _, condType := range []string{kubeapplierapi.ConditionTypeSuccessfullyApplied, kubeapplierapi.ConditionTypeSuccessful} {
+		if got := findCond(replacer.last.Status.Conditions, condType); got == nil || got.Status != metav1.ConditionTrue {
+			t.Errorf("%s=%v, want True after successful apply", condType, got)
+		}
+	}
+	if got := findCond(replacer.last.Status.Conditions, kubeapplierapi.ConditionTypeSuccessfullyDeleted); got != nil {
+		t.Errorf("SuccessfullyDeleted should not be set on a ServerSideApply, got %v", got)
+	}
 }
 
 // TestSyncOnce_AppliedKubeGenerationNilOnFailure verifies that after a failed
@@ -483,6 +493,20 @@ func findCond(conds []metav1.Condition, condType string) *metav1.Condition {
 	return nil
 }
 
+// assertLegacyMirrors verifies the legacy Successful condition mirrors the
+// operation-specific primary condition (same status/reason/message), which the
+// controller dual-writes for backwards compatibility.
+func assertLegacyMirrors(t *testing.T, conds []metav1.Condition, primary *metav1.Condition) {
+	t.Helper()
+	legacy := findCond(conds, kubeapplierapi.ConditionTypeSuccessful)
+	if legacy == nil {
+		t.Fatalf("legacy Successful condition not set (want mirror of %s)", primary.Type)
+	}
+	if legacy.Status != primary.Status || legacy.Reason != primary.Reason || legacy.Message != primary.Message {
+		t.Errorf("legacy Successful=%+v does not mirror %s=%+v", legacy, primary.Type, primary)
+	}
+}
+
 func TestEvaluateDelete_TargetGoneIsSuccessful(t *testing.T) {
 	dyn := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
 		{Version: "v1", Resource: "configmaps"}: "ConfigMapList",
@@ -494,10 +518,11 @@ func TestEvaluateDelete_TargetGoneIsSuccessful(t *testing.T) {
 	})
 	mutate := c.evaluateDelete(context.Background(), desire)
 	mutate(desire)
-	if got := findCond(desire.Status.Conditions, kubeapplierapi.ConditionTypeSuccessful); got == nil ||
-		got.Status != metav1.ConditionTrue {
-		t.Errorf("Successful=%v, want True (target absent)", got)
+	got := findCond(desire.Status.Conditions, kubeapplierapi.ConditionTypeSuccessfullyDeleted)
+	if got == nil || got.Status != metav1.ConditionTrue {
+		t.Errorf("SuccessfullyDeleted=%v, want True (target absent)", got)
 	}
+	assertLegacyMirrors(t, desire.Status.Conditions, got)
 }
 
 func TestEvaluateDelete_TargetWithDeletionTimestampWaits(t *testing.T) {
@@ -513,9 +538,9 @@ func TestEvaluateDelete_TargetWithDeletionTimestampWaits(t *testing.T) {
 	})
 	mutate := c.evaluateDelete(context.Background(), desire)
 	mutate(desire)
-	got := findCond(desire.Status.Conditions, kubeapplierapi.ConditionTypeSuccessful)
+	got := findCond(desire.Status.Conditions, kubeapplierapi.ConditionTypeSuccessfullyDeleted)
 	if got == nil || got.Status != metav1.ConditionFalse {
-		t.Fatalf("Successful=%v, want False (waiting)", got)
+		t.Fatalf("SuccessfullyDeleted=%v, want False (waiting)", got)
 	}
 	if got.Reason != kubeapplierapi.ConditionReasonWaitingForDeletion {
 		t.Errorf("Reason = %q, want %q", got.Reason, kubeapplierapi.ConditionReasonWaitingForDeletion)
@@ -523,6 +548,7 @@ func TestEvaluateDelete_TargetWithDeletionTimestampWaits(t *testing.T) {
 	if !strings.Contains(got.Message, "doomed-uid") {
 		t.Errorf("Message %q does not contain UID", got.Message)
 	}
+	assertLegacyMirrors(t, desire.Status.Conditions, got)
 }
 
 func TestEvaluateDelete_PresentNoTSIssuesDelete_ThenWaitsForFinalizers(t *testing.T) {
@@ -565,10 +591,11 @@ func TestEvaluateDelete_PresentNoTSIssuesDelete_ThenWaitsForFinalizers(t *testin
 	})
 	mutate := c.evaluateDelete(context.Background(), desire)
 	mutate(desire)
-	got := findCond(desire.Status.Conditions, kubeapplierapi.ConditionTypeSuccessful)
+	got := findCond(desire.Status.Conditions, kubeapplierapi.ConditionTypeSuccessfullyDeleted)
 	if got == nil || got.Status != metav1.ConditionFalse || got.Reason != kubeapplierapi.ConditionReasonWaitingForDeletion {
-		t.Errorf("Successful=%v, want False/WaitingForDeletion", got)
+		t.Errorf("SuccessfullyDeleted=%v, want False/WaitingForDeletion", got)
 	}
+	assertLegacyMirrors(t, desire.Status.Conditions, got)
 }
 
 func TestEvaluateDelete_DeleteAPIErrorClassifiesAsKubeAPIError(t *testing.T) {
@@ -587,10 +614,11 @@ func TestEvaluateDelete_DeleteAPIErrorClassifiesAsKubeAPIError(t *testing.T) {
 	})
 	mutate := c.evaluateDelete(context.Background(), desire)
 	mutate(desire)
-	got := findCond(desire.Status.Conditions, kubeapplierapi.ConditionTypeSuccessful)
+	got := findCond(desire.Status.Conditions, kubeapplierapi.ConditionTypeSuccessfullyDeleted)
 	if got == nil || got.Status != metav1.ConditionFalse || got.Reason != kubeapplierapi.ConditionReasonKubeAPIError {
-		t.Errorf("Successful=%v, want False/KubeAPIError", got)
+		t.Errorf("SuccessfullyDeleted=%v, want False/KubeAPIError", got)
 	}
+	assertLegacyMirrors(t, desire.Status.Conditions, got)
 }
 
 func TestEvaluateDelete_BadTargetIsPreCheckFailed(t *testing.T) {
@@ -601,8 +629,9 @@ func TestEvaluateDelete_BadTargetIsPreCheckFailed(t *testing.T) {
 	})
 	mutate := c.evaluateDelete(context.Background(), desire)
 	mutate(desire)
-	got := findCond(desire.Status.Conditions, kubeapplierapi.ConditionTypeSuccessful)
+	got := findCond(desire.Status.Conditions, kubeapplierapi.ConditionTypeSuccessfullyDeleted)
 	if got == nil || got.Reason != kubeapplierapi.ConditionReasonPreCheckFailed {
-		t.Errorf("Successful=%v, want PreCheckFailed", got)
+		t.Errorf("SuccessfullyDeleted=%v, want PreCheckFailed", got)
 	}
+	assertLegacyMirrors(t, desire.Status.Conditions, got)
 }

--- a/kube-applier/pkg/controllers/conditions/conditions.go
+++ b/kube-applier/pkg/controllers/conditions/conditions.go
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 // Package conditions provides typed setters for the well-known
-// kube-applier *Desire conditions (Successful, Degraded).
+// kube-applier *Desire conditions (SuccessfullyApplied, SuccessfullyDeleted,
+// the legacy Successful, and Degraded).
 //
 // All setters go through meta.SetStatusCondition, which preserves
 // LastTransitionTime when the condition's Status, Reason, and Message are
@@ -46,15 +47,15 @@ func (e *PreCheckError) Unwrap() error { return e.Err }
 // pre-check failure rather than a kube-apiserver call failure.
 func NewPreCheckError(err error) error { return &PreCheckError{Err: err} }
 
-// SetSuccessful records the result of a single sync attempt on the desire's
-// Conditions slice. err == nil means the desired effect was achieved.
-//   - nil err          -> Successful=True, reason=NoErrors
-//   - *PreCheckError   -> Successful=False, reason=PreCheckFailed
-//   - any other err    -> Successful=False, reason=KubeAPIError
-func SetSuccessful(conds *[]metav1.Condition, err error) {
+// setResult records the result of a single sync attempt under condType.
+// err == nil means the desired effect was achieved.
+//   - nil err          -> condType=True, reason=NoErrors
+//   - *PreCheckError   -> condType=False, reason=PreCheckFailed
+//   - any other err    -> condType=False, reason=KubeAPIError
+func setResult(conds *[]metav1.Condition, condType string, err error) {
 	if err == nil {
 		meta.SetStatusCondition(conds, metav1.Condition{
-			Type:    kubeapplierapi.ConditionTypeSuccessful,
+			Type:    condType,
 			Status:  metav1.ConditionTrue,
 			Reason:  kubeapplierapi.ConditionReasonNoErrors,
 			Message: "As expected.",
@@ -66,25 +67,59 @@ func SetSuccessful(conds *[]metav1.Condition, err error) {
 		reason = kubeapplierapi.ConditionReasonPreCheckFailed
 	}
 	meta.SetStatusCondition(conds, metav1.Condition{
-		Type:    kubeapplierapi.ConditionTypeSuccessful,
+		Type:    condType,
 		Status:  metav1.ConditionFalse,
 		Reason:  reason,
 		Message: err.Error(),
 	})
 }
 
-// SetSuccessfulWaitingForDeletion records the "deletion is in flight"
-// state for an ApplyDesire with Type=Delete whose target still exists in the cluster.
-// The deletion timestamp and UID are surfaced verbatim in the message
-// so consumers can correlate without an extra cluster read.
-func SetSuccessfulWaitingForDeletion(conds *[]metav1.Condition, deletionTime metav1.Time, uid types.UID) {
-	meta.SetStatusCondition(conds, metav1.Condition{
-		Type:   kubeapplierapi.ConditionTypeSuccessful,
-		Status: metav1.ConditionFalse,
-		Reason: kubeapplierapi.ConditionReasonWaitingForDeletion,
-		Message: fmt.Sprintf("waiting for deletion: deletionTimestamp=%s uid=%s",
-			deletionTime.UTC().Format(time.RFC3339), uid),
-	})
+// SetSuccessful records the result of a single sync attempt under the legacy
+// ConditionTypeSuccessful. It is used for ReadDesire, whose single observe
+// operation has no operation-specific condition. ApplyDesire controllers use
+// SetSuccessfullyApplied / SetSuccessfullyDeleted instead.
+func SetSuccessful(conds *[]metav1.Condition, err error) {
+	setResult(conds, kubeapplierapi.ConditionTypeSuccessful, err)
+}
+
+// SetSuccessfullyApplied records the result of an ApplyDesire Type=ServerSideApply
+// sync attempt. It writes both the operation-specific ConditionTypeSuccessfullyApplied
+// and the legacy ConditionTypeSuccessful (retained for backwards compatibility)
+// with the same status/reason/message.
+func SetSuccessfullyApplied(conds *[]metav1.Condition, err error) {
+	setResult(conds, kubeapplierapi.ConditionTypeSuccessfullyApplied, err)
+	setResult(conds, kubeapplierapi.ConditionTypeSuccessful, err)
+}
+
+// SetSuccessfullyDeleted records the result of an ApplyDesire Type=Delete sync
+// attempt. It writes both the operation-specific ConditionTypeSuccessfullyDeleted
+// and the legacy ConditionTypeSuccessful (retained for backwards compatibility)
+// with the same status/reason/message.
+func SetSuccessfullyDeleted(conds *[]metav1.Condition, err error) {
+	setResult(conds, kubeapplierapi.ConditionTypeSuccessfullyDeleted, err)
+	setResult(conds, kubeapplierapi.ConditionTypeSuccessful, err)
+}
+
+// SetWaitingForDeletion records the "deletion is in flight" state for an
+// ApplyDesire with Type=Delete whose target still exists in the cluster. The
+// deletion timestamp and UID are surfaced verbatim in the message so consumers
+// can correlate without an extra cluster read. It writes both the
+// operation-specific ConditionTypeSuccessfullyDeleted and the legacy
+// ConditionTypeSuccessful (retained for backwards compatibility).
+func SetWaitingForDeletion(conds *[]metav1.Condition, deletionTime metav1.Time, uid types.UID) {
+	message := fmt.Sprintf("waiting for deletion: deletionTimestamp=%s uid=%s",
+		deletionTime.UTC().Format(time.RFC3339), uid)
+	for _, condType := range []string{
+		kubeapplierapi.ConditionTypeSuccessfullyDeleted,
+		kubeapplierapi.ConditionTypeSuccessful,
+	} {
+		meta.SetStatusCondition(conds, metav1.Condition{
+			Type:    condType,
+			Status:  metav1.ConditionFalse,
+			Reason:  kubeapplierapi.ConditionReasonWaitingForDeletion,
+			Message: message,
+		})
+	}
 }
 
 // SetDegraded records controller-level health. Convention matches the

--- a/kube-applier/pkg/controllers/conditions/conditions_test.go
+++ b/kube-applier/pkg/controllers/conditions/conditions_test.go
@@ -79,26 +79,82 @@ func TestSetSuccessful_RegularErrorIsKubeAPIError(t *testing.T) {
 	}
 }
 
-func TestSetSuccessfulWaitingForDeletion(t *testing.T) {
+// SetSuccessfullyApplied writes both the operation-specific SuccessfullyApplied
+// condition and the legacy Successful condition with identical status/reason.
+func TestSetSuccessfullyApplied_WritesBothConditions(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		err        error
+		wantStatus metav1.ConditionStatus
+		wantReason string
+	}{
+		{"success", nil, metav1.ConditionTrue, kubeapplierapi.ConditionReasonNoErrors},
+		{"precheck", NewPreCheckError(errors.New("bad")), metav1.ConditionFalse, kubeapplierapi.ConditionReasonPreCheckFailed},
+		{"kubeapi", errors.New("503"), metav1.ConditionFalse, kubeapplierapi.ConditionReasonKubeAPIError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var conds []metav1.Condition
+			SetSuccessfullyApplied(&conds, tc.err)
+			for _, condType := range []string{kubeapplierapi.ConditionTypeSuccessfullyApplied, kubeapplierapi.ConditionTypeSuccessful} {
+				c := findCondition(conds, condType)
+				if c == nil {
+					t.Fatalf("%s condition not set", condType)
+				}
+				if c.Status != tc.wantStatus {
+					t.Errorf("%s Status = %v, want %v", condType, c.Status, tc.wantStatus)
+				}
+				if c.Reason != tc.wantReason {
+					t.Errorf("%s Reason = %q, want %q", condType, c.Reason, tc.wantReason)
+				}
+			}
+			if findCondition(conds, kubeapplierapi.ConditionTypeSuccessfullyDeleted) != nil {
+				t.Error("SuccessfullyDeleted should not be set by SetSuccessfullyApplied")
+			}
+		})
+	}
+}
+
+// SetSuccessfullyDeleted writes both the operation-specific SuccessfullyDeleted
+// condition and the legacy Successful condition.
+func TestSetSuccessfullyDeleted_WritesBothConditions(t *testing.T) {
+	var conds []metav1.Condition
+	SetSuccessfullyDeleted(&conds, nil)
+	for _, condType := range []string{kubeapplierapi.ConditionTypeSuccessfullyDeleted, kubeapplierapi.ConditionTypeSuccessful} {
+		c := findCondition(conds, condType)
+		if c == nil {
+			t.Fatalf("%s condition not set", condType)
+		}
+		if c.Status != metav1.ConditionTrue {
+			t.Errorf("%s Status = %v, want True", condType, c.Status)
+		}
+	}
+	if findCondition(conds, kubeapplierapi.ConditionTypeSuccessfullyApplied) != nil {
+		t.Error("SuccessfullyApplied should not be set by SetSuccessfullyDeleted")
+	}
+}
+
+func TestSetWaitingForDeletion_WritesBothConditions(t *testing.T) {
 	var conds []metav1.Condition
 	dt := metav1.NewTime(time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC))
 	uid := types.UID("abc-123")
-	SetSuccessfulWaitingForDeletion(&conds, dt, uid)
-	c := findCondition(conds, kubeapplierapi.ConditionTypeSuccessful)
-	if c == nil {
-		t.Fatal("Successful condition not set")
-	}
-	if c.Status != metav1.ConditionFalse {
-		t.Errorf("Status = %v, want False", c.Status)
-	}
-	if c.Reason != kubeapplierapi.ConditionReasonWaitingForDeletion {
-		t.Errorf("Reason = %q, want %q", c.Reason, kubeapplierapi.ConditionReasonWaitingForDeletion)
-	}
-	if !contains(c.Message, "abc-123") {
-		t.Errorf("Message = %q does not contain UID", c.Message)
-	}
-	if !contains(c.Message, "2026-05-01T12:00:00Z") {
-		t.Errorf("Message = %q does not contain RFC3339 deletionTimestamp", c.Message)
+	SetWaitingForDeletion(&conds, dt, uid)
+	for _, condType := range []string{kubeapplierapi.ConditionTypeSuccessfullyDeleted, kubeapplierapi.ConditionTypeSuccessful} {
+		c := findCondition(conds, condType)
+		if c == nil {
+			t.Fatalf("%s condition not set", condType)
+		}
+		if c.Status != metav1.ConditionFalse {
+			t.Errorf("%s Status = %v, want False", condType, c.Status)
+		}
+		if c.Reason != kubeapplierapi.ConditionReasonWaitingForDeletion {
+			t.Errorf("%s Reason = %q, want %q", condType, c.Reason, kubeapplierapi.ConditionReasonWaitingForDeletion)
+		}
+		if !contains(c.Message, "abc-123") {
+			t.Errorf("%s Message = %q does not contain UID", condType, c.Message)
+		}
+		if !contains(c.Message, "2026-05-01T12:00:00Z") {
+			t.Errorf("%s Message = %q does not contain RFC3339 deletionTimestamp", condType, c.Message)
+		}
 	}
 }
 

--- a/test-integration/kube-applier/artifacts/apply_creates_configmap/03-desireEventually-status-successful/expected.json
+++ b/test-integration/kube-applier/artifacts/apply_creates_configmap/03-desireEventually-status-successful/expected.json
@@ -3,6 +3,10 @@
 		"conditions": [
 			{
 				"status": "True",
+				"type": "SuccessfullyApplied"
+			},
+			{
+				"status": "True",
 				"type": "Successful"
 			}
 		]

--- a/test-integration/kube-applier/artifacts/delete_removes_configmap/04-desireEventually-status-successful/expected.json
+++ b/test-integration/kube-applier/artifacts/delete_removes_configmap/04-desireEventually-status-successful/expected.json
@@ -3,6 +3,10 @@
 		"conditions": [
 			{
 				"status": "True",
+				"type": "SuccessfullyDeleted"
+			},
+			{
+				"status": "True",
 				"type": "Successful"
 			}
 		]


### PR DESCRIPTION
…d/SuccessfullyDeleted

An ApplyDesire is a discriminated union (spec.type ServerSideApply or Delete), but the controller reported a single "Successful" condition for both operations, so a consumer had to also inspect spec.type to know whether success meant "applied" or "deleted". Make the outcome self-describing.

Add two operation-specific conditions — SuccessfullyApplied (ServerSideApply) and SuccessfullyDeleted (Delete) — while retaining the legacy Successful for backwards compatibility. The controller dual-writes the operation-specific condition and Successful with identical status/reason/message. Readers prefer the operation-specific condition and fall back to Successful when it is absent, which keeps them working against in-flight Cosmos documents written by an older kube-applier during rollout.

Scope is ApplyDesire only; ReadDesire's Successful (informer synced) is unchanged.

- internal/api/kubeapplierapi: add ConditionTypeSuccessfullyApplied/Deleted and IsConditionTruePreferring(conds, preferredType); document the ApplyDesire status.
- kube-applier conditions: SetSuccessfullyApplied/SetSuccessfullyDeleted and SetWaitingForDeletion (dual-write); SetSuccessful retained for ReadDesire.
- apply_desire controller: SSA -> SetSuccessfullyApplied, Delete ->
  SetSuccessfullyDeleted/SetWaitingForDeletion; metrics pre-seed the new per-desire-type conditions.
- backend desire_deletion: read the delete outcome via IsConditionTruePreferring (SuccessfullyDeleted, falling back to Successful).
- tests, integration expected.json fixtures, and kube-applier/docs updated.


/hold  AI generated, I need to review first.