### PR TITLE
fix(dev-infrastructure): keep eastus2euap SVC ACR replica out of global endpoint routing

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -179,9 +179,11 @@ clouds:
             kusto:
               location: "eastus2"
             # Canary/EUAP replica: keep its regional data endpoint disabled so it
-            # doesn't serve co-located prod pulls (AROSLSRE-1592).
+            # doesn't serve co-located prod pulls (AROSLSRE-1592, AROSLSRE-1810).
             acr:
               ocp:
+                replicationState: false
+              svc:
                 replicationState: false
           switzerlandnorth:
             kusto:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -95,6 +95,10 @@ defaults:
       untaggedImagesRetention:
         enabled: true
         days: 90
+      # Same rationale as acr.ocp.replicationState below. A degraded eastus2euap
+      # replica served co-located eastus2 prod pulls and took ARO-HCP eastus2 down
+      # for 35+ hours (AROSLSRE-1810, IcM 850354110/851089087).
+      replicationState: true
     ocp:
       name: 'arohcpocp{{ .ctx.environment }}' # [globally-unique]
       zoneRedundantMode: Enabled

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -19,6 +19,7 @@ acr:
     zoneRedundantMode: Disabled
   svc:
     name: arohcpsvcdev
+    replicationState: true
     untaggedImagesRetention:
       days: 90
       enabled: true

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -19,6 +19,7 @@ acr:
     zoneRedundantMode: Disabled
   svc:
     name: arohcpsvcdev
+    replicationState: true
     untaggedImagesRetention:
       days: 90
       enabled: true

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -19,6 +19,7 @@ acr:
     zoneRedundantMode: Disabled
   svc:
     name: arohcpsvcdev
+    replicationState: true
     untaggedImagesRetention:
       days: 90
       enabled: true

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -19,6 +19,7 @@ acr:
     zoneRedundantMode: Disabled
   svc:
     name: arohcpsvcdev
+    replicationState: true
     untaggedImagesRetention:
       days: 90
       enabled: true

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -19,6 +19,7 @@ acr:
     zoneRedundantMode: Disabled
   svc:
     name: arohcpsvcdev
+    replicationState: true
     untaggedImagesRetention:
       days: 90
       enabled: true

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -19,6 +19,7 @@ acr:
     zoneRedundantMode: Disabled
   svc:
     name: arohcpsvcdev
+    replicationState: true
     untaggedImagesRetention:
       days: 90
       enabled: true

--- a/dev-infrastructure/region-pipeline.yaml
+++ b/dev-infrastructure/region-pipeline.yaml
@@ -78,6 +78,8 @@ resourceGroups:
       configRef: acr.svc.name
     - name: REPLICATION_REGION
       configRef: region
+    - name: REPLICATION_STATE
+      configRef: acr.svc.replicationState
     shellIdentity:
       input:
         resourceGroup: global


### PR DESCRIPTION
[AROSLSRE-1821](https://redhat.atlassian.net/browse/AROSLSRE-1821)

### What

Threads a per-region `acr.svc.replicationState` through `region-pipeline.yaml` into the existing `svc-acr-replication` step, and pins `eastus2euap` to `false` so the canary replica of `arohcpsvcprod` stays out of global endpoint routing.

This is the same mechanism #6400 introduced for the **OCP** ACR after [AROSLSRE-1592](https://redhat.atlassian.net/browse/AROSLSRE-1592), applied to the **SVC** ACR.

Three substantive lines:

| File | Change |
| --- | --- |
| `config/config.yaml` | `acr.svc.replicationState: true` default — no behaviour change for any region |
| `config/config.msft.clouds-overlay.yaml` | `acr.svc.replicationState: false` for `eastus2euap`, next to the existing `acr.ocp` override |
| `dev-infrastructure/region-pipeline.yaml` | pass `REPLICATION_STATE` (`configRef: acr.svc.replicationState`) to `svc-acr-replication` |

Plus 6 regenerated `config/rendered/dev/*` files from `make -C config/ materialize`.

**No schema change is required** — `acr.svc` and `acr.ocp` both `$ref: "#/definitions/acr"`, and that shared definition already declares `replicationState`.

### Why

`arohcpsvcprod` is geo-replicated, and the global endpoint `arohcpsvcprod.azurecr.io` routes each client to its nearest replica. eastus2euap is physically co-located with eastus2, so **prod eastus2 nodes are routed to the canary replica**.

When that replica's SLB VIP `20.39.15.142` lost its forwarding rule (`NoForwardingDip` with all 3 DIPs healthy — host/VFP programming gap), every ACR pull from `prod-eastus2-svc-1`, `prod-eastus2-mgmt-1` and `prod-eastus2euap-svc-1` failed with `dial tcp 20.39.15.142:443: i/o timeout`. ARO-HCP prod eastus2 was 100% down for 35+ hours — AROSLSRE-1810, IcM 850354110 (IcM 851089087 closed as duplicate; prior occurrence 849062918).

A broken *canary* replica took down *prod*. [AROSLSRE-1592](https://redhat.atlassian.net/browse/AROSLSRE-1592) was the identical failure via the OCP ACR.

**Why the manual mitigation isn't enough.** The immediate fix is `az acr replication update --registry arohcpsvcprod --name eastus2euap --global-endpoint-routing false`. With `REPLICATION_STATE` unset (`desiredEnabled = true`) that survives a normal rollout, because `reconcile()` only forces the endpoint when the desired state is `false`. But there are two silent-revert paths in `dev-infrastructure/scripts/acr-replication/main.go`:

| Replica state at rollout | Code path | Effect on the manual `false` |
| --- | --- | --- |
| `Succeeded`, currently disabled | guard `if !desiredEnabled && ...` not entered | survives |
| `Failed` | delete, then `createReplication(..., desiredEnabled=true)` | **silently re-enabled** |
| Missing / not yet created | `createReplication(..., desiredEnabled=true)` | **silently re-enabled** |
| `Creating`/`Updating`/`Deleting` | `default:` branch | survives |

A replica is most likely to enter `Failed` during exactly this kind of regional degradation, so the recovery path re-arms the outage with no alert. The setting also lives only in live Azure state — nothing in the repo records the intent.

With `desiredEnabled = false` the behaviour inverts for eastus2euap: drift back to enabled is **forced back to disabled**, and a `Failed`/missing replica is **recreated already disabled**. Every other region keeps `true`, and because the guard is `if !desiredEnabled && ...`, a `true` value never re-enables anything — so no other region's manually-disabled replica can be clobbered.

### Testing

No Go code changed, so no new unit tests. `REPLICATION_STATE` parsing already has three subtests in `main_test.go` (`false` / `true` / invalid).

**Existing gates — all passing**

- `make -C config/ materialize` — clean, helm fixtures unchanged, idempotent
- `make verify-schema` — pass
- `make yamlfmt` — idempotent, zero changes beyond this diff
- `go test ./...` in `dev-infrastructure/scripts/acr-replication` — pass
- `make validate-config-pipelines` — pass (this is the gate that resolves every `configRef`)

**Negative test — proves the configRef gate is meaningful.** Temporarily typo'd the ref to `acr.svc.replicationStateTYPO`; validation failed as expected, then reverted:

```
Microsoft.Azure.ARO.HCP.Region: resourceGroups[0].steps[2].variables[4]:
configRef "acr.svc.replicationStateTYPO" not present in configuration:
configuration[acr][svc]: key replicationStateTYPO not found
```

**Prod render — not covered by CI.** `config/validate` only renders dev environments, but the override targets `public/prod`. Rendered directly through the msft overlay:

```
eastus2euap  -> svc.replicationState=false   ocp.replicationState=false
eastus2      -> svc.replicationState=true    ocp.replicationState=true
uksouth      -> svc.replicationState=true    ocp.replicationState=true
```

**Dry run against a live registry** (`arohcpsvcdev`, `DRY_RUN=1`, read-only — verified afterwards that nothing was mutated). All three paths behave as designed:

1. `REPLICATION_STATE=false` — new behaviour, drift forced back:
```
desired regional endpoint state   region=eastus2  enabled=false
found existing replication        state=Succeeded  endpointEnabled=true
[DRY_RUN] would reconcile replication regional endpoint  desiredEnabled=false
```
2. `REPLICATION_STATE` unset — today's SVC behaviour, passive:
```
desired regional endpoint state   region=eastus2  enabled=true
endpoint reconciliation not requested or already satisfied; leaving existing state unchanged
```
3. Home region (`westus3`) — clean early exit, no ARM writes:
```
registry is homed in the target region; replication is only needed for different regions
```

`arohcpsvcprod` was not reachable from my account (prod Global subscription needs JIT), so the prod dry run is pending.

### Special notes for your reviewer

- **This does not mitigate the live incident.** The config applies on the next eastus2euap Region pipeline run, after this merges and sdp-pipelines does `make -C hcp/ bump REVISION=<sha>` + `make -C hcp/ update`. The `az` command above is still required now.
- **This does not fix eastus2euap.** The broken SLB forwarding rule is Cloudnet's, tracked on IcM 850354110.
- **Re-enabling is not automatic.** Flipping the value back to `true` will not re-enable a disabled replica — that's the documented, intentional behaviour of the tool. When eastus2euap recovers, run `--global-endpoint-routing true` manually.
- Per the [ACR geo-replication docs](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-geo-replication), data continues syncing **bidirectionally** while a replica is excluded, so re-enabling has no catch-up window. Also worth knowing when validating the mitigation: clients with a long-lived DNS cache for the global endpoint keep resolving to the disabled replica until their cache expires, which makes the change look like it didn't take effect.
- Separately worth pursuing with the ACR team: ACR's **health-aware failover** is documented to reroute global endpoint traffic away from unhealthy replicas within minutes, with no customer action. It never fired here across 35+ hours — consistent with the DRI finding that requests died in the SLB datapath and never reached ACR, leaving its health signal clean. Not addressed by this PR.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) — n/a
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable) — n/a
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
