### PR TITLE
chore: bump imageSync image

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1111,7 +1111,7 @@ defaults:
       image:
         registry: arohcpsvcdev.azurecr.io
         repository: image-sync/oc-mirror
-        digest: sha256:c1028d5847587c43206a1342e13da9fe70ca61bd325e39eb0e2cd9b1c6829bde # 5aa543a (2026-08-13 04:43)
+        digest: sha256:2e25b5eed1bd3212a0514fdeffdc5d3f401aec6a33304b4f237d4a8fa114edb1 # 021b9b9 (2026-08-14 11:48)
       pullSecretName: ocmirror-pull-secret
       operatorVersionsToMirror: "4.18,4.19,4.20,4.21,4.22"
   # Automation Account

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -476,7 +476,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:c1028d5847587c43206a1342e13da9fe70ca61bd325e39eb0e2cd9b1c6829bde
+      digest: sha256:2e25b5eed1bd3212a0514fdeffdc5d3f401aec6a33304b4f237d4a8fa114edb1
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -476,7 +476,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:c1028d5847587c43206a1342e13da9fe70ca61bd325e39eb0e2cd9b1c6829bde
+      digest: sha256:2e25b5eed1bd3212a0514fdeffdc5d3f401aec6a33304b4f237d4a8fa114edb1
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -476,7 +476,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:c1028d5847587c43206a1342e13da9fe70ca61bd325e39eb0e2cd9b1c6829bde
+      digest: sha256:2e25b5eed1bd3212a0514fdeffdc5d3f401aec6a33304b4f237d4a8fa114edb1
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -476,7 +476,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:c1028d5847587c43206a1342e13da9fe70ca61bd325e39eb0e2cd9b1c6829bde
+      digest: sha256:2e25b5eed1bd3212a0514fdeffdc5d3f401aec6a33304b4f237d4a8fa114edb1
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -476,7 +476,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:c1028d5847587c43206a1342e13da9fe70ca61bd325e39eb0e2cd9b1c6829bde
+      digest: sha256:2e25b5eed1bd3212a0514fdeffdc5d3f401aec6a33304b4f237d4a8fa114edb1
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -476,7 +476,7 @@ imageSync:
   ocMirror:
     enabled: true
     image:
-      digest: sha256:c1028d5847587c43206a1342e13da9fe70ca61bd325e39eb0e2cd9b1c6829bde
+      digest: sha256:2e25b5eed1bd3212a0514fdeffdc5d3f401aec6a33304b4f237d4a8fa114edb1
       registry: arohcpsvcdev.azurecr.io
       repository: image-sync/oc-mirror
     jobNamePrefix: ""


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1813

### What

Bump only the `imageSync` image from `sha256:c1028d...` to `sha256:2e25b5...` (`021b9b9`, built 2026-08-14 11:48 UTC) and regenerate the rendered configuration.

| Name | Old Digest | New Digest | Tag | Date | Status |
| --- | --- | --- | --- | --- | --- |
| imageSync | c1028d584758… | 2e25b5eed1bd… | 021b9b9 | 2026-08-14 11:48 | updated |

### Why

The STG rollout containing #6540 still referenced the pre-fix image digest, so the hourly mirror continued using the Azure CLI-incompatible credential helper. Stage e2e [2088245669562159104](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-e2e-stage-e2e-parallel/2088245669562159104) consequently failed 49 tests with the same four unavailable operator catalogs.

The automated digest PR #6539 contains this update alongside unrelated component bumps and may be delayed by its broader e2e scope. This focused PR provides a fallback deployment path for the image-sync fix.

### Testing

- `make -C config materialize`
- `make verify-materialize`

### Special notes for your reviewer

This PR should be closed if #6539 merges first. @galchammat @weherdh

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots not applicable
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR not needed; the change is complete
- [x] Commit history is clean
- [x] No tricky code blocks introduced
- [x] Specific reviewers tagged
- [x] No open comment threads
