### PR TITLE
observability: Frontend ARM RP SLO recording rules (ARO-28705)

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -100,7 +100,7 @@ resource arohcpFrontendSloRecordingRules 'Microsoft.AlertsManagement/prometheusR
     rules: [
       {
         record: 'sli:frontend_http:availability:rate5m'
-        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code!~"5..",route!~".*hcpoperation(results|statuses).*"}[5m]))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
+        expression: '((sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code!~"5..",route!~".*hcpoperation(results|statuses).*"}[5m]))) or 0 * sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
       }
       {
         record: 'sli:frontend_http:availability:rate_avg_30d'

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -103,8 +103,8 @@ resource arohcpFrontendSloRecordingRules 'Microsoft.AlertsManagement/prometheusR
         expression: '((sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code!~"5..",route!~".*hcpoperation(results|statuses).*"}[5m]))) or 0 * sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
       }
       {
-        record: 'sli:frontend_http:availability:rate_avg_30d'
-        expression: 'avg_over_time(sli:frontend_http:availability:rate5m[30d:5m])'
+        record: 'sli:frontend_http:good:rate5m'
+        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code!~"5..",route!~".*hcpoperation(results|statuses).*"}[5m]))) or 0 * sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m]))))'
       }
       {
         record: 'errors:frontend_http:error_rate:rate5m'
@@ -121,6 +121,10 @@ resource arohcpFrontendSloRecordingRules 'Microsoft.AlertsManagement/prometheusR
       {
         record: 'traffic:frontend_http:request_rate:rate5m'
         expression: 'sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))'
+      }
+      {
+        record: 'sli:frontend_http:availability:rate_avg_30d'
+        expression: '(avg_over_time(sli:frontend_http:good:rate5m[30d:5m]) / avg_over_time(traffic:frontend_http:request_rate:rate5m[30d:5m])) and avg_over_time(traffic:frontend_http:request_rate:rate5m[30d:5m]) > 0'
       }
       {
         record: 'sli:frontend:ready:ratio5m'

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -128,11 +128,11 @@ resource arohcpFrontendSloRecordingRules 'Microsoft.AlertsManagement/prometheusR
       }
       {
         record: 'sli:frontend:saturation_cpu:ratio5m'
-        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(container_cpu_usage_seconds_total{container="aro-hcp-frontend",namespace="aro-hcp"}[5m]))) / sum by (cluster) (max without (prometheus_replica) (kube_pod_container_resource_requests{container="aro-hcp-frontend",namespace="aro-hcp",resource="cpu"}))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (kube_pod_container_resource_requests{container="aro-hcp-frontend",namespace="aro-hcp",resource="cpu"})) > 0)'
+        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(container_cpu_usage_seconds_total{container="aro-hcp-frontend",namespace="aro-hcp"}[5m]))) / sum by (cluster) (max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{container="aro-hcp-frontend",job="kube-state-metrics",namespace="aro-hcp",resource="cpu"}))) and on (cluster) (sum by (cluster) (max by (cluster, namespace, pod, container) (kube_pod_container_resource_requests{container="aro-hcp-frontend",job="kube-state-metrics",namespace="aro-hcp",resource="cpu"})) > 0)'
       }
       {
         record: 'sli:frontend:saturation_memory:ratio5m'
-        expression: '(sum by (cluster) (max without (prometheus_replica) (container_memory_working_set_bytes{container="aro-hcp-frontend",namespace="aro-hcp"})) / sum by (cluster) (max without (prometheus_replica) (kube_pod_container_resource_limits{container="aro-hcp-frontend",namespace="aro-hcp",resource="memory"}))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (kube_pod_container_resource_limits{container="aro-hcp-frontend",namespace="aro-hcp",resource="memory"})) > 0)'
+        expression: '(sum by (cluster) (max without (prometheus_replica) (container_memory_working_set_bytes{container="aro-hcp-frontend",namespace="aro-hcp"})) / sum by (cluster) (max by (cluster, namespace, pod, container) (kube_pod_container_resource_limits{container="aro-hcp-frontend",job="kube-state-metrics",namespace="aro-hcp",resource="memory"}))) and on (cluster) (sum by (cluster) (max by (cluster, namespace, pod, container) (kube_pod_container_resource_limits{container="aro-hcp-frontend",job="kube-state-metrics",namespace="aro-hcp",resource="memory"})) > 0)'
       }
     ]
   }

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -1,3 +1,4 @@
+
 param azureMonitoring string
 
 param location string = resourceGroup().location
@@ -111,12 +112,20 @@ resource arohcpFrontendSloRecordingRules 'Microsoft.AlertsManagement/prometheusR
         expression: '((sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code=~"5..",route!~".*hcpoperation(results|statuses).*"}[5m]))) or 0 * sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
       }
       {
-        record: 'sli:frontend_http:latency:rate5m'
-        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{le=~"1(\\.0)?",route!~".*hcpoperation(results|statuses).*"}[5m]))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_count{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_count{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
+        record: 'sli:frontend_http:latency_p99:rate5m'
+        expression: 'histogram_quantile(0.99, sum by (cluster, le) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_count{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
+      }
+      {
+        record: 'sli:frontend_http:latency_p95:rate5m'
+        expression: 'histogram_quantile(0.95, sum by (cluster, le) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_count{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
       }
       {
         record: 'traffic:frontend_http:request_rate:rate5m'
         expression: 'sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))'
+      }
+      {
+        record: 'sli:frontend:ready:ratio5m'
+        expression: '(sum by (cluster) (max without (prometheus_replica) (kube_deployment_status_replicas_available{deployment="aro-hcp-frontend",namespace="aro-hcp"})) / sum by (cluster) (max without (prometheus_replica) (kube_deployment_spec_replicas{deployment="aro-hcp-frontend",namespace="aro-hcp"}))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (kube_deployment_spec_replicas{deployment="aro-hcp-frontend",namespace="aro-hcp"})) > 0)'
       }
       {
         record: 'sli:frontend:saturation_cpu:ratio5m'

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -1,4 +1,3 @@
-
 param azureMonitoring string
 
 param location string = resourceGroup().location

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -100,7 +100,7 @@ resource arohcpFrontendSloRecordingRules 'Microsoft.AlertsManagement/prometheusR
     rules: [
       {
         record: 'sli:frontend_http:availability:rate5m'
-        expression: 'sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code!~"5..",route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))'
+        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code!~"5..",route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) > 0)'
       }
       {
         record: 'sli:frontend_http:availability:rate_avg_30d'
@@ -108,11 +108,11 @@ resource arohcpFrontendSloRecordingRules 'Microsoft.AlertsManagement/prometheusR
       }
       {
         record: 'errors:frontend_http:error_rate:rate5m'
-        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code=~"5..",route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) or 0 * sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))'
+        expression: '((sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code=~"5..",route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) or 0 * sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) > 0)'
       }
       {
         record: 'sli:frontend_http:latency:rate5m'
-        expression: 'sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{le="1.0",route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_count{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))'
+        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{le=~"^1(\\.0)?$",route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_count{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_count{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) > 0)'
       }
       {
         record: 'traffic:frontend_http:request_rate:rate5m'
@@ -120,11 +120,11 @@ resource arohcpFrontendSloRecordingRules 'Microsoft.AlertsManagement/prometheusR
       }
       {
         record: 'sli:frontend:saturation_cpu:ratio5m'
-        expression: 'sum by (cluster) (max without (prometheus_replica) (rate(container_cpu_usage_seconds_total{container="aro-hcp-frontend",namespace="aro-hcp"}[5m]))) / sum by (cluster) (max without (prometheus_replica) (kube_pod_container_resource_requests{container="aro-hcp-frontend",namespace="aro-hcp",resource="cpu"}))'
+        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(container_cpu_usage_seconds_total{container="aro-hcp-frontend",namespace="aro-hcp"}[5m]))) / sum by (cluster) (max without (prometheus_replica) (kube_pod_container_resource_requests{container="aro-hcp-frontend",namespace="aro-hcp",resource="cpu"}))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (kube_pod_container_resource_requests{container="aro-hcp-frontend",namespace="aro-hcp",resource="cpu"})) > 0)'
       }
       {
         record: 'sli:frontend:saturation_memory:ratio5m'
-        expression: 'sum by (cluster) (max without (prometheus_replica) (container_memory_working_set_bytes{container="aro-hcp-frontend",namespace="aro-hcp"})) / sum by (cluster) (max without (prometheus_replica) (kube_pod_container_resource_limits{container="aro-hcp-frontend",namespace="aro-hcp",resource="memory"}))'
+        expression: '(sum by (cluster) (max without (prometheus_replica) (container_memory_working_set_bytes{container="aro-hcp-frontend",namespace="aro-hcp"})) / sum by (cluster) (max without (prometheus_replica) (kube_pod_container_resource_limits{container="aro-hcp-frontend",namespace="aro-hcp",resource="memory"}))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (kube_pod_container_resource_limits{container="aro-hcp-frontend",namespace="aro-hcp",resource="memory"})) > 0)'
       }
     ]
   }

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -100,7 +100,7 @@ resource arohcpFrontendSloRecordingRules 'Microsoft.AlertsManagement/prometheusR
     rules: [
       {
         record: 'sli:frontend_http:availability:rate5m'
-        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code!~"5..",route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) > 0)'
+        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code!~"5..",route!~".*hcpoperation(results|statuses).*"}[5m]))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
       }
       {
         record: 'sli:frontend_http:availability:rate_avg_30d'
@@ -108,15 +108,15 @@ resource arohcpFrontendSloRecordingRules 'Microsoft.AlertsManagement/prometheusR
       }
       {
         record: 'errors:frontend_http:error_rate:rate5m'
-        expression: '((sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code=~"5..",route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) or 0 * sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) > 0)'
+        expression: '((sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code=~"5..",route!~".*hcpoperation(results|statuses).*"}[5m]))) or 0 * sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
       }
       {
         record: 'sli:frontend_http:latency:rate5m'
-        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{le=~"^1(\\.0)?$",route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_count{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_count{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) > 0)'
+        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{le=~"1(\\.0)?",route!~".*hcpoperation(results|statuses).*"}[5m]))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_count{route!~".*hcpoperation(results|statuses).*"}[5m])))) and on (cluster) (sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_count{route!~".*hcpoperation(results|statuses).*"}[5m]))) > 0)'
       }
       {
         record: 'traffic:frontend_http:request_rate:rate5m'
-        expression: 'sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))'
+        expression: 'sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!~".*hcpoperation(results|statuses).*"}[5m])))'
       }
       {
         record: 'sli:frontend:saturation_cpu:ratio5m'

--- a/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep
@@ -87,3 +87,45 @@ resource arohcpUserJourneyClusterUpgradeRecordingRules 'Microsoft.AlertsManageme
     ]
   }
 }
+
+resource arohcpFrontendSloRecordingRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_frontend_slo_recording_rules'
+  location: location
+  properties: {
+    scopes: [
+      azureMonitoring
+    ]
+    enabled: true
+    interval: 'PT1M'
+    rules: [
+      {
+        record: 'sli:frontend_http:availability:rate5m'
+        expression: 'sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code!~"5..",route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))'
+      }
+      {
+        record: 'sli:frontend_http:availability:rate_avg_30d'
+        expression: 'avg_over_time(sli:frontend_http:availability:rate5m[30d:5m])'
+      }
+      {
+        record: 'errors:frontend_http:error_rate:rate5m'
+        expression: '(sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{code=~"5..",route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) or 0 * sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))'
+      }
+      {
+        record: 'sli:frontend_http:latency:rate5m'
+        expression: 'sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_bucket{le="1.0",route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m]))) / sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_duration_seconds_count{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))'
+      }
+      {
+        record: 'traffic:frontend_http:request_rate:rate5m'
+        expression: 'sum by (cluster) (max without (prometheus_replica) (rate(frontend_http_requests_total{route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"}[5m])))'
+      }
+      {
+        record: 'sli:frontend:saturation_cpu:ratio5m'
+        expression: 'sum by (cluster) (max without (prometheus_replica) (rate(container_cpu_usage_seconds_total{container="aro-hcp-frontend",namespace="aro-hcp"}[5m]))) / sum by (cluster) (max without (prometheus_replica) (kube_pod_container_resource_requests{container="aro-hcp-frontend",namespace="aro-hcp",resource="cpu"}))'
+      }
+      {
+        record: 'sli:frontend:saturation_memory:ratio5m'
+        expression: 'sum by (cluster) (max without (prometheus_replica) (container_memory_working_set_bytes{container="aro-hcp-frontend",namespace="aro-hcp"})) / sum by (cluster) (max without (prometheus_replica) (kube_pod_container_resource_limits{container="aro-hcp-frontend",namespace="aro-hcp",resource="memory"}))'
+      }
+    ]
+  }
+}

--- a/observability/recording-rules-services.yaml
+++ b/observability/recording-rules-services.yaml
@@ -3,5 +3,6 @@ prometheusRules:
   - recording-rules/access-cluster-slo-recordingRule.yaml
   - recording-rules/cluster-provision-slo-recordingRule.yaml
   - recording-rules/userJourneyClusterUpgrade-recordingRule.yaml
+  - recording-rules/frontend-slo-recordingRule.yaml
   untestedRules: []
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedRecordingRules.bicep

--- a/observability/recording-rules/frontend-slo-recordingRule.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule.yaml
@@ -84,7 +84,6 @@ spec:
       # Errors: 5xx / total (Access-style error_rate for future MWMBR alerts).
 
       # `or 0 * total` keeps error_rate=0 when there is traffic but no 5xx series.
-
       expr: |
         (
           (
@@ -129,7 +128,6 @@ spec:
       # Latency SLI: requests completing within 1s / total.
 
       # Atomic single expression; le matches "1" or "1.0".
-
       expr: |
         (
           sum by (cluster) (

--- a/observability/recording-rules/frontend-slo-recordingRule.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule.yaml
@@ -233,6 +233,9 @@ spec:
         )
     - record: sli:frontend:saturation_cpu:ratio5m
       # Saturation — CPU: usage cores / requested cores (ratio). SLO target < 0.85.
+      # kube-state-metrics requests/limits: max by (cluster, namespace, pod, container)
+      # so multi-target scrapes are not double-counted (same pattern as
+      # serviceMemoryResources).
 
       expr: |
         (
@@ -246,11 +249,12 @@ spec:
           )
           /
           sum by (cluster) (
-            max without (prometheus_replica) (
+            max by (cluster, namespace, pod, container) (
               kube_pod_container_resource_requests{
                 namespace="aro-hcp",
                 container="aro-hcp-frontend",
-                resource="cpu"
+                resource="cpu",
+                job="kube-state-metrics"
               }
             )
           )
@@ -258,11 +262,12 @@ spec:
         and on (cluster)
         (
           sum by (cluster) (
-            max without (prometheus_replica) (
+            max by (cluster, namespace, pod, container) (
               kube_pod_container_resource_requests{
                 namespace="aro-hcp",
                 container="aro-hcp-frontend",
-                resource="cpu"
+                resource="cpu",
+                job="kube-state-metrics"
               }
             )
           )
@@ -283,11 +288,12 @@ spec:
           )
           /
           sum by (cluster) (
-            max without (prometheus_replica) (
+            max by (cluster, namespace, pod, container) (
               kube_pod_container_resource_limits{
                 namespace="aro-hcp",
                 container="aro-hcp-frontend",
-                resource="memory"
+                resource="memory",
+                job="kube-state-metrics"
               }
             )
           )
@@ -295,11 +301,12 @@ spec:
         and on (cluster)
         (
           sum by (cluster) (
-            max without (prometheus_replica) (
+            max by (cluster, namespace, pod, container) (
               kube_pod_container_resource_limits{
                 namespace="aro-hcp",
                 container="aro-hcp-frontend",
-                resource="memory"
+                resource="memory",
+                job="kube-state-metrics"
               }
             )
           )

--- a/observability/recording-rules/frontend-slo-recordingRule.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule.yaml
@@ -14,7 +14,9 @@ spec:
   # Frontend (ARM RP) User Journey SLO Recording Rules
   # ========================================
   # Baseline SLIs per ARO HCP Alerting Recommendation ADR.
-  # Availability and errors are good/total (or 5xx/total) ratios.
+  # Availability and errors are good/total (or 5xx/total) ratios at 5m.
+  # 30d availability is request-weighted: avg(good RPS)/avg(total RPS), not
+  # avg_over_time of the 5m ratio (that ignores per-window request volume).
   # Latency is histogram_quantile p99/p95 in seconds (not a ≤1s share).
   # Traffic is absolute RPS. Ready is kube available/spec.
   # ARO-28705. Proposed SLOs (formal burn-rate alerts: ARO-28707):
@@ -84,10 +86,28 @@ spec:
           )
           > 0
         )
-    - record: sli:frontend_http:availability:rate_avg_30d
-      # 30-day smoothed availability for SLO status panels (not for fast burn alerts).
-
-      expr: avg_over_time(sli:frontend_http:availability:rate5m[30d:5m])
+    - record: sli:frontend_http:good:rate5m
+      # Non-5xx request rate (RPS). Numerator for request-weighted long-window
+      # availability. `or 0 * total` keeps good=0 when traffic is all 5xx.
+      expr: |
+        (
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              rate(frontend_http_requests_total{
+                code!~"5..",
+                route!~".*hcpoperation(results|statuses).*"
+              }[5m])
+            )
+          )
+          or
+          0 * sum by (cluster) (
+            max without (prometheus_replica) (
+              rate(frontend_http_requests_total{
+                route!~".*hcpoperation(results|statuses).*"
+              }[5m])
+            )
+          )
+        )
     - record: errors:frontend_http:error_rate:rate5m
       # Errors: 5xx / total (Access-style error_rate for future MWMBR alerts).
 
@@ -194,6 +214,20 @@ spec:
             }[5m])
           )
         )
+    - record: sli:frontend_http:availability:rate_avg_30d
+      # Request-weighted 30-day availability for SLO status panels (not fast burn).
+      # avg(good RPS) / avg(total RPS) over equal 5m steps equals
+      # sum(good requests) / sum(total requests). Averaging the rate5m *ratio*
+      # would treat a 1-request window the same as a 10k-request window.
+      # Extra rate1h/rate6h ratio windows do not fix that (same avg-of-ratios).
+      expr: |
+        (
+          avg_over_time(sli:frontend_http:good:rate5m[30d:5m])
+          /
+          avg_over_time(traffic:frontend_http:request_rate:rate5m[30d:5m])
+        )
+        and
+        avg_over_time(traffic:frontend_http:request_rate:rate5m[30d:5m]) > 0
     - record: sli:frontend:ready:ratio5m
       # Process health: available / desired replicas. Kube readiness probes
 

--- a/observability/recording-rules/frontend-slo-recordingRule.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule.yaml
@@ -80,9 +80,10 @@ spec:
       # 30-day smoothed availability for SLO status panels (not for fast burn alerts).
 
       expr: avg_over_time(sli:frontend_http:availability:rate5m[30d:5m])
-    # `or 0 * total` keeps error_rate=0 when there is traffic but no 5xx series.
     - record: errors:frontend_http:error_rate:rate5m
       # Errors: 5xx / total (Access-style error_rate for future MWMBR alerts).
+
+      # `or 0 * total` keeps error_rate=0 when there is traffic but no 5xx series.
 
       expr: |
         (
@@ -124,9 +125,10 @@ spec:
           )
           > 0
         )
-    # Atomic single expression; le matches "1" or "1.0".
     - record: sli:frontend_http:latency:rate5m
       # Latency SLI: requests completing within 1s / total.
+
+      # Atomic single expression; le matches "1" or "1.0".
 
       expr: |
         (

--- a/observability/recording-rules/frontend-slo-recordingRule.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule.yaml
@@ -17,19 +17,24 @@ spec:
   # and ARO-28705. Proposed SLOs (formal burn-rate alerts: ARO-28707):
   #   Availability: >= 99.95% over 30d (non-5xx / total)
   #   Errors:       < 0.05% 5xx share (same budget as availability)
-  #   Latency:      p99 < 1s ARM sync — recorded as share of requests <= 1s
+  #   Latency:      p99 < 1s ARM sync — histogram_quantile (p99 / p95 seconds)
   #   Traffic:      request rate (anomaly detection is alert-side)
+  #   Ready:        kube Deployment available/spec (kube /healthz probes)
   #   Saturation:   Frontend pod CPU vs request, memory vs limit (Istio /
   #                 Cosmos RU saturation deferred until owned series are wired)
   #
   # Scope: synchronous Frontend HTTP on svc clusters. Excludes ARM async poll
   # routes hcpoperationresults and hcpoperationstatuses (status polls dilute SLIs).
   #
+  # HTTP availability/errors/latency emit no sample when there is zero ARM
+  # traffic (avoid NaN). That makes a complete Frontend outage look like a
+  # quiet cluster. Distinguish with sli:frontend:ready:ratio5m — kube
+  # readiness probes hit Frontend /healthz (see frontend deployment). There is
+  # no ARM-path blackbox of /healthz (MISE/POP); kube ready is the probe we have.
+  #
   # Metrics: frontend_http_requests_total / _duration_seconds (histogram has a
-  # 1s bucket — see frontend/pkg/frontend/metrics.go). Match le as "1" or "1.0"
-  # (client_golang may emit either; same pattern as frontend latency dashboards).
-  # HA scrapes are deduped with max without (prometheus_replica).
-  # Zero traffic / zero requests / zero resource request → no sample (avoid NaN).
+  # 1s bucket — see frontend/pkg/frontend/metrics.go). HA scrapes are deduped
+  # with max without (prometheus_replica).
   - name: arohcp_frontend_slo_recording_rules
     interval: 1m
     rules:
@@ -124,24 +129,41 @@ spec:
           )
           > 0
         )
-    - record: sli:frontend_http:latency:rate5m
-      # Latency SLI: requests completing within 1s / total.
+    - record: sli:frontend_http:latency_p99:rate5m
+      # Latency p99 in seconds (ADR LatencyP99). SLO: p99 < 1s.
 
-      # Atomic single expression; le matches "1" or "1.0".
+      # histogram_quantile distinguishes 1.01s vs 50s; a 1s-bucket share cannot.
       expr: |
-        (
-          sum by (cluster) (
+        histogram_quantile(
+          0.99,
+          sum by (cluster, le) (
             max without (prometheus_replica) (
               rate(frontend_http_requests_duration_seconds_bucket{
-                le=~"1(\\.0)?",
                 route!~".*hcpoperation(results|statuses).*"
               }[5m])
             )
           )
-          /
+        )
+        and on (cluster)
+        (
           sum by (cluster) (
             max without (prometheus_replica) (
               rate(frontend_http_requests_duration_seconds_count{
+                route!~".*hcpoperation(results|statuses).*"
+              }[5m])
+            )
+          )
+          > 0
+        )
+    - record: sli:frontend_http:latency_p95:rate5m
+      # Latency p95 in seconds (ADR LatencyP95). Same histogram / route filter as p99.
+
+      expr: |
+        histogram_quantile(
+          0.95,
+          sum by (cluster, le) (
+            max without (prometheus_replica) (
+              rate(frontend_http_requests_duration_seconds_bucket{
                 route!~".*hcpoperation(results|statuses).*"
               }[5m])
             )
@@ -168,6 +190,43 @@ spec:
               route!~".*hcpoperation(results|statuses).*"
             }[5m])
           )
+        )
+    - record: sli:frontend:ready:ratio5m
+      # Process health: available / desired replicas. Kube readiness probes
+
+      # GET /healthz on the frontend container. Emits 0 on a full outage
+      # (unlike HTTP SLIs, which go absent with no ARM traffic).
+      expr: |
+        (
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              kube_deployment_status_replicas_available{
+                namespace="aro-hcp",
+                deployment="aro-hcp-frontend"
+              }
+            )
+          )
+          /
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              kube_deployment_spec_replicas{
+                namespace="aro-hcp",
+                deployment="aro-hcp-frontend"
+              }
+            )
+          )
+        )
+        and on (cluster)
+        (
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              kube_deployment_spec_replicas{
+                namespace="aro-hcp",
+                deployment="aro-hcp-frontend"
+              }
+            )
+          )
+          > 0
         )
     - record: sli:frontend:saturation_cpu:ratio5m
       # Saturation — CPU: usage cores / requested cores (ratio). SLO target < 0.85.

--- a/observability/recording-rules/frontend-slo-recordingRule.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule.yaml
@@ -13,8 +13,11 @@ spec:
   # ========================================
   # Frontend (ARM RP) User Journey SLO Recording Rules
   # ========================================
-  # Baseline SLIs per ARO HCP Alerting Recommendation ADR (good / total ratios)
-  # and ARO-28705. Proposed SLOs (formal burn-rate alerts: ARO-28707):
+  # Baseline SLIs per ARO HCP Alerting Recommendation ADR.
+  # Availability and errors are good/total (or 5xx/total) ratios.
+  # Latency is histogram_quantile p99/p95 in seconds (not a ≤1s share).
+  # Traffic is absolute RPS. Ready is kube available/spec.
+  # ARO-28705. Proposed SLOs (formal burn-rate alerts: ARO-28707):
   #   Availability: >= 99.95% over 30d (non-5xx / total)
   #   Errors:       < 0.05% 5xx share (same budget as availability)
   #   Latency:      p99 < 1s ARM sync — histogram_quantile (p99 / p95 seconds)

--- a/observability/recording-rules/frontend-slo-recordingRule.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule.yaml
@@ -34,15 +34,26 @@ spec:
     interval: 1m
     rules:
     # Availability SLI: non-5xx / total (ratio in [0,1]).
+    # `or 0 * total` keeps availability=0 when traffic is all 5xx (non-5xx series gone).
     - record: sli:frontend_http:availability:rate5m
       expr: |
         (
-          sum by (cluster) (
-            max without (prometheus_replica) (
-              rate(frontend_http_requests_total{
-                code!~"5..",
-                route!~".*hcpoperation(results|statuses).*"
-              }[5m])
+          (
+            sum by (cluster) (
+              max without (prometheus_replica) (
+                rate(frontend_http_requests_total{
+                  code!~"5..",
+                  route!~".*hcpoperation(results|statuses).*"
+                }[5m])
+              )
+            )
+            or
+            0 * sum by (cluster) (
+              max without (prometheus_replica) (
+                rate(frontend_http_requests_total{
+                  route!~".*hcpoperation(results|statuses).*"
+                }[5m])
+              )
             )
           )
           /

--- a/observability/recording-rules/frontend-slo-recordingRule.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule.yaml
@@ -25,30 +25,45 @@ spec:
   # Scope: synchronous Frontend HTTP on svc clusters. Excludes the known-slow
   # operation-results poll route (same filter as FrontendLatency alerts).
   #
-  # Metrics: frontend_http_requests_total / _duration_seconds (histogram le=1.0
-  # bucket exists — see frontend/pkg/frontend/metrics.go). HA scrapes are
-  # deduped with max without (prometheus_replica) like Frontend component alerts.
+  # Metrics: frontend_http_requests_total / _duration_seconds (histogram has a
+  # 1s bucket — see frontend/pkg/frontend/metrics.go). Match le as "1" or "1.0"
+  # (client_golang may emit either; same pattern as frontend latency dashboards).
+  # HA scrapes are deduped with max without (prometheus_replica).
+  # Zero traffic / zero requests / zero resource request → no sample (avoid NaN).
   - name: arohcp_frontend_slo_recording_rules
     interval: 1m
     rules:
-    # Availability SLI: non-5xx / total (ratio in [0,1]). No traffic → no sample.
+    # Availability SLI: non-5xx / total (ratio in [0,1]).
     - record: sli:frontend_http:availability:rate5m
       expr: |
-        sum by (cluster) (
-          max without (prometheus_replica) (
-            rate(frontend_http_requests_total{
-              code!~"5..",
-              route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
-            }[5m])
+        (
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              rate(frontend_http_requests_total{
+                code!~"5..",
+                route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+              }[5m])
+            )
+          )
+          /
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              rate(frontend_http_requests_total{
+                route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+              }[5m])
+            )
           )
         )
-        /
-        sum by (cluster) (
-          max without (prometheus_replica) (
-            rate(frontend_http_requests_total{
-              route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
-            }[5m])
+        and on (cluster)
+        (
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              rate(frontend_http_requests_total{
+                route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+              }[5m])
+            )
           )
+          > 0
         )
     # 30-day smoothed availability for SLO status panels (not for fast burn alerts).
     - record: sli:frontend_http:availability:rate_avg_30d
@@ -58,50 +73,76 @@ spec:
     - record: errors:frontend_http:error_rate:rate5m
       expr: |
         (
+          (
+            sum by (cluster) (
+              max without (prometheus_replica) (
+                rate(frontend_http_requests_total{
+                  code=~"5..",
+                  route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+                }[5m])
+              )
+            )
+            or
+            0 * sum by (cluster) (
+              max without (prometheus_replica) (
+                rate(frontend_http_requests_total{
+                  route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+                }[5m])
+              )
+            )
+          )
+          /
           sum by (cluster) (
             max without (prometheus_replica) (
               rate(frontend_http_requests_total{
-                code=~"5..",
                 route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
               }[5m])
             )
           )
-          or
-          0 * sum by (cluster) (
+        )
+        and on (cluster)
+        (
+          sum by (cluster) (
             max without (prometheus_replica) (
               rate(frontend_http_requests_total{
                 route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
               }[5m])
             )
           )
+          > 0
         )
-        /
-        sum by (cluster) (
-          max without (prometheus_replica) (
-            rate(frontend_http_requests_total{
-              route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
-            }[5m])
-          )
-        )
-    # Latency SLI: requests completing within 1s / total (histogram le="1.0").
-    # Atomic single expression so numerator and denominator share scrape timing.
+    # Latency SLI: requests completing within 1s / total.
+    # Atomic single expression; le matches "1" or "1.0".
     - record: sli:frontend_http:latency:rate5m
       expr: |
-        sum by (cluster) (
-          max without (prometheus_replica) (
-            rate(frontend_http_requests_duration_seconds_bucket{
-              le="1.0",
-              route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
-            }[5m])
+        (
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              rate(frontend_http_requests_duration_seconds_bucket{
+                le=~"^1(\\.0)?$",
+                route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+              }[5m])
+            )
+          )
+          /
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              rate(frontend_http_requests_duration_seconds_count{
+                route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+              }[5m])
+            )
           )
         )
-        /
-        sum by (cluster) (
-          max without (prometheus_replica) (
-            rate(frontend_http_requests_duration_seconds_count{
-              route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
-            }[5m])
+        and on (cluster)
+        (
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              rate(frontend_http_requests_duration_seconds_count{
+                route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+              }[5m])
+            )
           )
+          > 0
         )
     # Traffic: absolute request rate (RPS). Anomaly thresholds belong in ARO-28707.
     - record: traffic:frontend_http:request_rate:rate5m
@@ -116,42 +157,72 @@ spec:
     # Saturation — CPU: usage cores / requested cores (ratio). SLO target < 0.85.
     - record: sli:frontend:saturation_cpu:ratio5m
       expr: |
-        sum by (cluster) (
-          max without (prometheus_replica) (
-            rate(container_cpu_usage_seconds_total{
-              namespace="aro-hcp",
-              container="aro-hcp-frontend"
-            }[5m])
+        (
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              rate(container_cpu_usage_seconds_total{
+                namespace="aro-hcp",
+                container="aro-hcp-frontend"
+              }[5m])
+            )
+          )
+          /
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              kube_pod_container_resource_requests{
+                namespace="aro-hcp",
+                container="aro-hcp-frontend",
+                resource="cpu"
+              }
+            )
           )
         )
-        /
-        sum by (cluster) (
-          max without (prometheus_replica) (
-            kube_pod_container_resource_requests{
-              namespace="aro-hcp",
-              container="aro-hcp-frontend",
-              resource="cpu"
-            }
+        and on (cluster)
+        (
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              kube_pod_container_resource_requests{
+                namespace="aro-hcp",
+                container="aro-hcp-frontend",
+                resource="cpu"
+              }
+            )
           )
+          > 0
         )
     # Saturation — memory: working set / limit (ratio). Frontend sets a memory limit.
     - record: sli:frontend:saturation_memory:ratio5m
       expr: |
-        sum by (cluster) (
-          max without (prometheus_replica) (
-            container_memory_working_set_bytes{
-              namespace="aro-hcp",
-              container="aro-hcp-frontend"
-            }
+        (
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              container_memory_working_set_bytes{
+                namespace="aro-hcp",
+                container="aro-hcp-frontend"
+              }
+            )
+          )
+          /
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              kube_pod_container_resource_limits{
+                namespace="aro-hcp",
+                container="aro-hcp-frontend",
+                resource="memory"
+              }
+            )
           )
         )
-        /
-        sum by (cluster) (
-          max without (prometheus_replica) (
-            kube_pod_container_resource_limits{
-              namespace="aro-hcp",
-              container="aro-hcp-frontend",
-              resource="memory"
-            }
+        and on (cluster)
+        (
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              kube_pod_container_resource_limits{
+                namespace="aro-hcp",
+                container="aro-hcp-frontend",
+                resource="memory"
+              }
+            )
           )
+          > 0
         )

--- a/observability/recording-rules/frontend-slo-recordingRule.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule.yaml
@@ -22,8 +22,8 @@ spec:
   #   Saturation:   Frontend pod CPU vs request, memory vs limit (Istio /
   #                 Cosmos RU saturation deferred until owned series are wired)
   #
-  # Scope: synchronous Frontend HTTP on svc clusters. Excludes the known-slow
-  # operation-results poll route (same filter as FrontendLatency alerts).
+  # Scope: synchronous Frontend HTTP on svc clusters. Excludes ARM async poll
+  # routes hcpoperationresults and hcpoperationstatuses (status polls dilute SLIs).
   #
   # Metrics: frontend_http_requests_total / _duration_seconds (histogram has a
   # 1s bucket — see frontend/pkg/frontend/metrics.go). Match le as "1" or "1.0"
@@ -41,7 +41,7 @@ spec:
             max without (prometheus_replica) (
               rate(frontend_http_requests_total{
                 code!~"5..",
-                route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+                route!~".*hcpoperation(results|statuses).*"
               }[5m])
             )
           )
@@ -49,7 +49,7 @@ spec:
           sum by (cluster) (
             max without (prometheus_replica) (
               rate(frontend_http_requests_total{
-                route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+                route!~".*hcpoperation(results|statuses).*"
               }[5m])
             )
           )
@@ -59,18 +59,20 @@ spec:
           sum by (cluster) (
             max without (prometheus_replica) (
               rate(frontend_http_requests_total{
-                route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+                route!~".*hcpoperation(results|statuses).*"
               }[5m])
             )
           )
           > 0
         )
-    # 30-day smoothed availability for SLO status panels (not for fast burn alerts).
     - record: sli:frontend_http:availability:rate_avg_30d
+      # 30-day smoothed availability for SLO status panels (not for fast burn alerts).
+
       expr: avg_over_time(sli:frontend_http:availability:rate5m[30d:5m])
-    # Errors: 5xx / total (Access-style error_rate for future MWMBR alerts).
     # `or 0 * total` keeps error_rate=0 when there is traffic but no 5xx series.
     - record: errors:frontend_http:error_rate:rate5m
+      # Errors: 5xx / total (Access-style error_rate for future MWMBR alerts).
+
       expr: |
         (
           (
@@ -78,7 +80,7 @@ spec:
               max without (prometheus_replica) (
                 rate(frontend_http_requests_total{
                   code=~"5..",
-                  route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+                  route!~".*hcpoperation(results|statuses).*"
                 }[5m])
               )
             )
@@ -86,7 +88,7 @@ spec:
             0 * sum by (cluster) (
               max without (prometheus_replica) (
                 rate(frontend_http_requests_total{
-                  route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+                  route!~".*hcpoperation(results|statuses).*"
                 }[5m])
               )
             )
@@ -95,7 +97,7 @@ spec:
           sum by (cluster) (
             max without (prometheus_replica) (
               rate(frontend_http_requests_total{
-                route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+                route!~".*hcpoperation(results|statuses).*"
               }[5m])
             )
           )
@@ -105,22 +107,23 @@ spec:
           sum by (cluster) (
             max without (prometheus_replica) (
               rate(frontend_http_requests_total{
-                route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+                route!~".*hcpoperation(results|statuses).*"
               }[5m])
             )
           )
           > 0
         )
-    # Latency SLI: requests completing within 1s / total.
     # Atomic single expression; le matches "1" or "1.0".
     - record: sli:frontend_http:latency:rate5m
+      # Latency SLI: requests completing within 1s / total.
+
       expr: |
         (
           sum by (cluster) (
             max without (prometheus_replica) (
               rate(frontend_http_requests_duration_seconds_bucket{
-                le=~"^1(\\.0)?$",
-                route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+                le=~"1(\\.0)?",
+                route!~".*hcpoperation(results|statuses).*"
               }[5m])
             )
           )
@@ -128,7 +131,7 @@ spec:
           sum by (cluster) (
             max without (prometheus_replica) (
               rate(frontend_http_requests_duration_seconds_count{
-                route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+                route!~".*hcpoperation(results|statuses).*"
               }[5m])
             )
           )
@@ -138,24 +141,26 @@ spec:
           sum by (cluster) (
             max without (prometheus_replica) (
               rate(frontend_http_requests_duration_seconds_count{
-                route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+                route!~".*hcpoperation(results|statuses).*"
               }[5m])
             )
           )
           > 0
         )
-    # Traffic: absolute request rate (RPS). Anomaly thresholds belong in ARO-28707.
     - record: traffic:frontend_http:request_rate:rate5m
+      # Traffic: absolute request rate (RPS). Anomaly thresholds belong in ARO-28707.
+
       expr: |
         sum by (cluster) (
           max without (prometheus_replica) (
             rate(frontend_http_requests_total{
-              route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+              route!~".*hcpoperation(results|statuses).*"
             }[5m])
           )
         )
-    # Saturation — CPU: usage cores / requested cores (ratio). SLO target < 0.85.
     - record: sli:frontend:saturation_cpu:ratio5m
+      # Saturation — CPU: usage cores / requested cores (ratio). SLO target < 0.85.
+
       expr: |
         (
           sum by (cluster) (
@@ -190,8 +195,9 @@ spec:
           )
           > 0
         )
-    # Saturation — memory: working set / limit (ratio). Frontend sets a memory limit.
     - record: sli:frontend:saturation_memory:ratio5m
+      # Saturation — memory: working set / limit (ratio). Frontend sets a memory limit.
+
       expr: |
         (
           sum by (cluster) (

--- a/observability/recording-rules/frontend-slo-recordingRule.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule.yaml
@@ -1,0 +1,157 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: k8s
+    role: recording-rules
+  name: frontend-slo-recording-rules
+  namespace: monitoring
+spec:
+  groups:
+  # ========================================
+  # Frontend (ARM RP) User Journey SLO Recording Rules
+  # ========================================
+  # Baseline SLIs per ARO HCP Alerting Recommendation ADR (good / total ratios)
+  # and ARO-28705. Proposed SLOs (formal burn-rate alerts: ARO-28707):
+  #   Availability: >= 99.95% over 30d (non-5xx / total)
+  #   Errors:       < 0.05% 5xx share (same budget as availability)
+  #   Latency:      p99 < 1s ARM sync — recorded as share of requests <= 1s
+  #   Traffic:      request rate (anomaly detection is alert-side)
+  #   Saturation:   Frontend pod CPU vs request, memory vs limit (Istio /
+  #                 Cosmos RU saturation deferred until owned series are wired)
+  #
+  # Scope: synchronous Frontend HTTP on svc clusters. Excludes the known-slow
+  # operation-results poll route (same filter as FrontendLatency alerts).
+  #
+  # Metrics: frontend_http_requests_total / _duration_seconds (histogram le=1.0
+  # bucket exists — see frontend/pkg/frontend/metrics.go). HA scrapes are
+  # deduped with max without (prometheus_replica) like Frontend component alerts.
+  - name: arohcp_frontend_slo_recording_rules
+    interval: 1m
+    rules:
+    # Availability SLI: non-5xx / total (ratio in [0,1]). No traffic → no sample.
+    - record: sli:frontend_http:availability:rate5m
+      expr: |
+        sum by (cluster) (
+          max without (prometheus_replica) (
+            rate(frontend_http_requests_total{
+              code!~"5..",
+              route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+            }[5m])
+          )
+        )
+        /
+        sum by (cluster) (
+          max without (prometheus_replica) (
+            rate(frontend_http_requests_total{
+              route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+            }[5m])
+          )
+        )
+    # 30-day smoothed availability for SLO status panels (not for fast burn alerts).
+    - record: sli:frontend_http:availability:rate_avg_30d
+      expr: avg_over_time(sli:frontend_http:availability:rate5m[30d:5m])
+    # Errors: 5xx / total (Access-style error_rate for future MWMBR alerts).
+    # `or 0 * total` keeps error_rate=0 when there is traffic but no 5xx series.
+    - record: errors:frontend_http:error_rate:rate5m
+      expr: |
+        (
+          sum by (cluster) (
+            max without (prometheus_replica) (
+              rate(frontend_http_requests_total{
+                code=~"5..",
+                route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+              }[5m])
+            )
+          )
+          or
+          0 * sum by (cluster) (
+            max without (prometheus_replica) (
+              rate(frontend_http_requests_total{
+                route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+              }[5m])
+            )
+          )
+        )
+        /
+        sum by (cluster) (
+          max without (prometheus_replica) (
+            rate(frontend_http_requests_total{
+              route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+            }[5m])
+          )
+        )
+    # Latency SLI: requests completing within 1s / total (histogram le="1.0").
+    # Atomic single expression so numerator and denominator share scrape timing.
+    - record: sli:frontend_http:latency:rate5m
+      expr: |
+        sum by (cluster) (
+          max without (prometheus_replica) (
+            rate(frontend_http_requests_duration_seconds_bucket{
+              le="1.0",
+              route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+            }[5m])
+          )
+        )
+        /
+        sum by (cluster) (
+          max without (prometheus_replica) (
+            rate(frontend_http_requests_duration_seconds_count{
+              route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+            }[5m])
+          )
+        )
+    # Traffic: absolute request rate (RPS). Anomaly thresholds belong in ARO-28707.
+    - record: traffic:frontend_http:request_rate:rate5m
+      expr: |
+        sum by (cluster) (
+          max without (prometheus_replica) (
+            rate(frontend_http_requests_total{
+              route!="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}"
+            }[5m])
+          )
+        )
+    # Saturation — CPU: usage cores / requested cores (ratio). SLO target < 0.85.
+    - record: sli:frontend:saturation_cpu:ratio5m
+      expr: |
+        sum by (cluster) (
+          max without (prometheus_replica) (
+            rate(container_cpu_usage_seconds_total{
+              namespace="aro-hcp",
+              container="aro-hcp-frontend"
+            }[5m])
+          )
+        )
+        /
+        sum by (cluster) (
+          max without (prometheus_replica) (
+            kube_pod_container_resource_requests{
+              namespace="aro-hcp",
+              container="aro-hcp-frontend",
+              resource="cpu"
+            }
+          )
+        )
+    # Saturation — memory: working set / limit (ratio). Frontend sets a memory limit.
+    - record: sli:frontend:saturation_memory:ratio5m
+      expr: |
+        sum by (cluster) (
+          max without (prometheus_replica) (
+            container_memory_working_set_bytes{
+              namespace="aro-hcp",
+              container="aro-hcp-frontend"
+            }
+          )
+        )
+        /
+        sum by (cluster) (
+          max without (prometheus_replica) (
+            kube_pod_container_resource_limits{
+              namespace="aro-hcp",
+              container="aro-hcp-frontend",
+              resource="memory"
+            }
+          )
+        )

--- a/observability/recording-rules/frontend-slo-recordingRule_test.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule_test.yaml
@@ -24,16 +24,22 @@ tests:
   - series: 'frontend_http_requests_total{cluster="svc-1", code="200", method="GET", route="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationstatuses/{operationid}", prometheus_replica="a"}'
     values: "0+1000x15"
   - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-1", le="0.8", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
-    # Latency histogram: 45/min within 1s (le="1"), 60/min total → 0.75
+    # Latency histogram: 60/min, 50 within 0.8s, all within 1s → p99 < 1s.
 
-    # Production client_golang typically emits le="1" for the 1.0 bucket.
-    values: "0+40x15"
+    # Finite le="15" is required so histogram_quantile can interpolate (not +Inf).
+    values: "0+50x15"
   - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-1", le="1", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
-    values: "0+45x15"
+    values: "0+60x15"
+  - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-1", le="15", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+    values: "0+60x15"
   - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-1", le="+Inf", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
     values: "0+60x15"
   - series: 'frontend_http_requests_duration_seconds_count{cluster="svc-1", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
     values: "0+60x15"
+  - series: 'kube_deployment_status_replicas_available{cluster="svc-1", namespace="aro-hcp", deployment="aro-hcp-frontend", prometheus_replica="a"}'
+    values: "2+0x15"
+  - series: 'kube_deployment_spec_replicas{cluster="svc-1", namespace="aro-hcp", deployment="aro-hcp-frontend", prometheus_replica="a"}'
+    values: "2+0x15"
   - series: 'container_cpu_usage_seconds_total{cluster="svc-1", namespace="aro-hcp", container="aro-hcp-frontend", pod="aro-hcp-frontend-0", prometheus_replica="a"}'
     # Saturation: 0.5 CPU cores used / 1.0 requested; 512Mi / 1024Mi memory
 
@@ -55,11 +61,21 @@ tests:
     exp_samples:
     - labels: '{__name__="errors:frontend_http:error_rate:rate5m", cluster="svc-1"}'
       value: 0.25
-  - expr: sli:frontend_http:latency:rate5m{cluster="svc-1"}
+  - expr: sli:frontend_http:latency_p99:rate5m{cluster="svc-1"}
     eval_time: 5m
     exp_samples:
-    - labels: '{__name__="sli:frontend_http:latency:rate5m", cluster="svc-1"}'
-      value: 0.75
+    - labels: '{__name__="sli:frontend_http:latency_p99:rate5m", cluster="svc-1"}'
+      value: 0.988
+  - expr: sli:frontend_http:latency_p95:rate5m{cluster="svc-1"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="sli:frontend_http:latency_p95:rate5m", cluster="svc-1"}'
+      value: 0.94
+  - expr: sli:frontend:ready:ratio5m{cluster="svc-1"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="sli:frontend:ready:ratio5m", cluster="svc-1"}'
+      value: 1
   - expr: traffic:frontend_http:request_rate:rate5m{cluster="svc-1"}
     eval_time: 5m
     exp_samples:
@@ -109,3 +125,35 @@ tests:
     exp_samples:
     - labels: '{__name__="errors:frontend_http:error_rate:rate5m", cluster="svc-3"}'
       value: 1
+- interval: 1m
+  # Slow p99: 45/min in the 1s bucket, 15/min in (1s, 15s] → p99 interpolates near 15s.
+
+  input_series:
+  - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-slow", le="1", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+    values: "0+45x15"
+  - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-slow", le="15", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+    values: "0+60x15"
+  - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-slow", le="+Inf", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+    values: "0+60x15"
+  - series: 'frontend_http_requests_duration_seconds_count{cluster="svc-slow", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+    values: "0+60x15"
+  promql_expr_test:
+  - expr: sli:frontend_http:latency_p99:rate5m{cluster="svc-slow"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="sli:frontend_http:latency_p99:rate5m", cluster="svc-slow"}'
+      value: 14.44
+- interval: 1m
+  # Full replica outage — ready emits 0 (not absent).
+
+  input_series:
+  - series: 'kube_deployment_status_replicas_available{cluster="svc-down", namespace="aro-hcp", deployment="aro-hcp-frontend", prometheus_replica="a"}'
+    values: "0+0x15"
+  - series: 'kube_deployment_spec_replicas{cluster="svc-down", namespace="aro-hcp", deployment="aro-hcp-frontend", prometheus_replica="a"}'
+    values: "2+0x15"
+  promql_expr_test:
+  - expr: sli:frontend:ready:ratio5m{cluster="svc-down"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="sli:frontend:ready:ratio5m", cluster="svc-down"}'
+      value: 0

--- a/observability/recording-rules/frontend-slo-recordingRule_test.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule_test.yaml
@@ -27,7 +27,6 @@ tests:
     # Latency histogram: 45/min within 1s (le="1"), 60/min total → 0.75
 
     # Production client_golang typically emits le="1" for the 1.0 bucket.
-
     values: "0+40x15"
   - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-1", le="1", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
     values: "0+45x15"

--- a/observability/recording-rules/frontend-slo-recordingRule_test.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule_test.yaml
@@ -157,3 +157,32 @@ tests:
     exp_samples:
     - labels: '{__name__="sli:frontend:ready:ratio5m", cluster="svc-down"}'
       value: 0
+- interval: 1m
+  # Idle but healthy: ready=1, no ARM HTTP series → HTTP SLIs/traffic/latency
+  # emit no sample (not 0/NaN). Protects long-window aggregates.
+  input_series:
+  - series: 'kube_deployment_status_replicas_available{cluster="svc-idle", namespace="aro-hcp", deployment="aro-hcp-frontend", prometheus_replica="a"}'
+    values: "2+0x15"
+  - series: 'kube_deployment_spec_replicas{cluster="svc-idle", namespace="aro-hcp", deployment="aro-hcp-frontend", prometheus_replica="a"}'
+    values: "2+0x15"
+  promql_expr_test:
+  - expr: sli:frontend_http:availability:rate5m{cluster="svc-idle"}
+    eval_time: 5m
+    exp_samples: []
+  - expr: errors:frontend_http:error_rate:rate5m{cluster="svc-idle"}
+    eval_time: 5m
+    exp_samples: []
+  - expr: sli:frontend_http:latency_p99:rate5m{cluster="svc-idle"}
+    eval_time: 5m
+    exp_samples: []
+  - expr: sli:frontend_http:latency_p95:rate5m{cluster="svc-idle"}
+    eval_time: 5m
+    exp_samples: []
+  - expr: traffic:frontend_http:request_rate:rate5m{cluster="svc-idle"}
+    eval_time: 5m
+    exp_samples: []
+  - expr: sli:frontend:ready:ratio5m{cluster="svc-idle"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="sli:frontend:ready:ratio5m", cluster="svc-idle"}'
+      value: 1

--- a/observability/recording-rules/frontend-slo-recordingRule_test.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule_test.yaml
@@ -23,9 +23,10 @@ tests:
     values: "0+1000x15"
   - series: 'frontend_http_requests_total{cluster="svc-1", code="200", method="GET", route="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationstatuses/{operationid}", prometheus_replica="a"}'
     values: "0+1000x15"
-  # Production client_golang typically emits le="1" for the 1.0 bucket.
   - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-1", le="0.8", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
     # Latency histogram: 45/min within 1s (le="1"), 60/min total → 0.75
+
+    # Production client_golang typically emits le="1" for the 1.0 bucket.
 
     values: "0+40x15"
   - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-1", le="1", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
@@ -92,8 +93,9 @@ tests:
     exp_samples:
     - labels: '{__name__="errors:frontend_http:error_rate:rate5m", cluster="svc-2"}'
       value: 0
-# All-5xx traffic — availability must emit 0 (not drop), errors 1
 - interval: 1m
+  # All-5xx traffic — availability must emit 0 (not drop), errors 1
+
   input_series:
   - series: 'frontend_http_requests_total{cluster="svc-3", code="500", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
     values: "0+60x15"

--- a/observability/recording-rules/frontend-slo-recordingRule_test.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule_test.yaml
@@ -44,11 +44,11 @@ tests:
     # Saturation: 0.5 CPU cores used / 1.0 requested; 512Mi / 1024Mi memory
 
     values: "0+30x15"
-  - series: 'kube_pod_container_resource_requests{cluster="svc-1", namespace="aro-hcp", container="aro-hcp-frontend", pod="aro-hcp-frontend-0", resource="cpu", unit="core", prometheus_replica="a"}'
+  - series: 'kube_pod_container_resource_requests{cluster="svc-1", namespace="aro-hcp", container="aro-hcp-frontend", pod="aro-hcp-frontend-0", resource="cpu", unit="core", job="kube-state-metrics", prometheus_replica="a"}'
     values: "1+0x15"
   - series: 'container_memory_working_set_bytes{cluster="svc-1", namespace="aro-hcp", container="aro-hcp-frontend", pod="aro-hcp-frontend-0", prometheus_replica="a"}'
     values: "536870912+0x15"
-  - series: 'kube_pod_container_resource_limits{cluster="svc-1", namespace="aro-hcp", container="aro-hcp-frontend", pod="aro-hcp-frontend-0", resource="memory", unit="byte", prometheus_replica="a"}'
+  - series: 'kube_pod_container_resource_limits{cluster="svc-1", namespace="aro-hcp", container="aro-hcp-frontend", pod="aro-hcp-frontend-0", resource="memory", unit="byte", job="kube-state-metrics", prometheus_replica="a"}'
     values: "1073741824+0x15"
   promql_expr_test:
   - expr: sli:frontend_http:availability:rate5m{cluster="svc-1"}

--- a/observability/recording-rules/frontend-slo-recordingRule_test.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule_test.yaml
@@ -56,6 +56,16 @@ tests:
     exp_samples:
     - labels: '{__name__="sli:frontend_http:availability:rate5m", cluster="svc-1"}'
       value: 0.75
+  - expr: sli:frontend_http:good:rate5m{cluster="svc-1"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="sli:frontend_http:good:rate5m", cluster="svc-1"}'
+      value: 0.75
+  - expr: sli:frontend_http:availability:rate_avg_30d{cluster="svc-1"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="sli:frontend_http:availability:rate_avg_30d", cluster="svc-1"}'
+      value: 0.75
   - expr: errors:frontend_http:error_rate:rate5m{cluster="svc-1"}
     eval_time: 5m
     exp_samples:
@@ -120,6 +130,11 @@ tests:
     exp_samples:
     - labels: '{__name__="sli:frontend_http:availability:rate5m", cluster="svc-3"}'
       value: 0
+  - expr: sli:frontend_http:good:rate5m{cluster="svc-3"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="sli:frontend_http:good:rate5m", cluster="svc-3"}'
+      value: 0
   - expr: errors:frontend_http:error_rate:rate5m{cluster="svc-3"}
     eval_time: 5m
     exp_samples:
@@ -169,6 +184,12 @@ tests:
   - expr: sli:frontend_http:availability:rate5m{cluster="svc-idle"}
     eval_time: 5m
     exp_samples: []
+  - expr: sli:frontend_http:good:rate5m{cluster="svc-idle"}
+    eval_time: 5m
+    exp_samples: []
+  - expr: sli:frontend_http:availability:rate_avg_30d{cluster="svc-idle"}
+    eval_time: 5m
+    exp_samples: []
   - expr: errors:frontend_http:error_rate:rate5m{cluster="svc-idle"}
     eval_time: 5m
     exp_samples: []
@@ -186,3 +207,34 @@ tests:
     exp_samples:
     - labels: '{__name__="sli:frontend:ready:ratio5m", cluster="svc-idle"}'
       value: 1
+- interval: 1m
+  # Request-weighted 30d vs avg-of-ratios. Two 5m windows:
+  #   t=0-5m: 10,000 good requests; t=7m: 1 failed request (inside the
+  #   second 5m rate window so rate() observes the increase).
+  # avg_over_time of the 5m *ratio* is 50%. Weighted 30d is 10000/10001.
+  input_series:
+  - series: 'frontend_http_requests_total{cluster="svc-skew", code="200", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+    values: "0+2000x5 10000+0x12"
+  - series: 'frontend_http_requests_total{cluster="svc-skew", code="500", method="PUT", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+    values: "0+0x6 1+0x11"
+  promql_expr_test:
+  - expr: sli:frontend_http:availability:rate5m{cluster="svc-skew"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="sli:frontend_http:availability:rate5m", cluster="svc-skew"}'
+      value: 1
+  - expr: sli:frontend_http:availability:rate5m{cluster="svc-skew"}
+    eval_time: 10m
+    exp_samples:
+    - labels: '{__name__="sli:frontend_http:availability:rate5m", cluster="svc-skew"}'
+      value: 0
+  - expr: avg_over_time(sli:frontend_http:availability:rate5m{cluster="svc-skew"}[30d:5m])
+    eval_time: 10m
+    exp_samples:
+    - labels: '{cluster="svc-skew"}'
+      value: 0.5
+  - expr: sli:frontend_http:availability:rate_avg_30d{cluster="svc-skew"}
+    eval_time: 10m
+    exp_samples:
+    - labels: '{__name__="sli:frontend_http:availability:rate_avg_30d", cluster="svc-skew"}'
+      value: 0.9999000099990002

--- a/observability/recording-rules/frontend-slo-recordingRule_test.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule_test.yaml
@@ -92,3 +92,19 @@ tests:
     exp_samples:
     - labels: '{__name__="errors:frontend_http:error_rate:rate5m", cluster="svc-2"}'
       value: 0
+# All-5xx traffic — availability must emit 0 (not drop), errors 1
+- interval: 1m
+  input_series:
+  - series: 'frontend_http_requests_total{cluster="svc-3", code="500", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+    values: "0+60x15"
+  promql_expr_test:
+  - expr: sli:frontend_http:availability:rate5m{cluster="svc-3"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="sli:frontend_http:availability:rate5m", cluster="svc-3"}'
+      value: 0
+  - expr: errors:frontend_http:error_rate:rate5m{cluster="svc-3"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="errors:frontend_http:error_rate:rate5m", cluster="svc-3"}'
+      value: 1

--- a/observability/recording-rules/frontend-slo-recordingRule_test.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule_test.yaml
@@ -19,10 +19,11 @@ tests:
   # Operation-results poll traffic must be excluded from SLIs
   - series: 'frontend_http_requests_total{cluster="svc-1", code="200", method="GET", route="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}", prometheus_replica="a"}'
     values: "0+1000x15"
-  # Latency histogram: 45/min within 1s, 60/min total → 0.75
+  # Latency histogram: 45/min within 1s (le="1"), 60/min total → 0.75
+  # Production client_golang typically emits le="1" for the 1.0 bucket.
   - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-1", le="0.8", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
     values: "0+40x15"
-  - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-1", le="1.0", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+  - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-1", le="1", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
     values: "0+45x15"
   - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-1", le="+Inf", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
     values: "0+60x15"

--- a/observability/recording-rules/frontend-slo-recordingRule_test.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule_test.yaml
@@ -1,0 +1,86 @@
+rule_files:
+- frontend-slo-recordingRule.yaml
+evaluation_interval: 1m
+tests:
+# Availability 0.75 / Errors 0.25 / Traffic 1 RPS / Latency 0.75
+# Rates use exact binary fractions (see HCPkas latency tests) to avoid float drift.
+- interval: 1m
+  input_series:
+  # 45 non-5xx/min + 15 5xx/min = 60/min = 1 RPS; availability 0.75
+  - series: 'frontend_http_requests_total{cluster="svc-1", code="200", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+    values: "0+45x15"
+  - series: 'frontend_http_requests_total{cluster="svc-1", code="500", method="PUT", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+    values: "0+15x15"
+  # Duplicate replica must be collapsed by max without (prometheus_replica)
+  - series: 'frontend_http_requests_total{cluster="svc-1", code="200", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="b"}'
+    values: "0+45x15"
+  - series: 'frontend_http_requests_total{cluster="svc-1", code="500", method="PUT", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="b"}'
+    values: "0+15x15"
+  # Operation-results poll traffic must be excluded from SLIs
+  - series: 'frontend_http_requests_total{cluster="svc-1", code="200", method="GET", route="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}", prometheus_replica="a"}'
+    values: "0+1000x15"
+  # Latency histogram: 45/min within 1s, 60/min total → 0.75
+  - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-1", le="0.8", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+    values: "0+40x15"
+  - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-1", le="1.0", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+    values: "0+45x15"
+  - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-1", le="+Inf", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+    values: "0+60x15"
+  - series: 'frontend_http_requests_duration_seconds_count{cluster="svc-1", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+    values: "0+60x15"
+  # Saturation: 0.5 CPU cores used / 1.0 requested; 512Mi / 1024Mi memory
+  - series: 'container_cpu_usage_seconds_total{cluster="svc-1", namespace="aro-hcp", container="aro-hcp-frontend", pod="aro-hcp-frontend-0", prometheus_replica="a"}'
+    values: "0+30x15"
+  - series: 'kube_pod_container_resource_requests{cluster="svc-1", namespace="aro-hcp", container="aro-hcp-frontend", pod="aro-hcp-frontend-0", resource="cpu", unit="core", prometheus_replica="a"}'
+    values: "1+0x15"
+  - series: 'container_memory_working_set_bytes{cluster="svc-1", namespace="aro-hcp", container="aro-hcp-frontend", pod="aro-hcp-frontend-0", prometheus_replica="a"}'
+    values: "536870912+0x15"
+  - series: 'kube_pod_container_resource_limits{cluster="svc-1", namespace="aro-hcp", container="aro-hcp-frontend", pod="aro-hcp-frontend-0", resource="memory", unit="byte", prometheus_replica="a"}'
+    values: "1073741824+0x15"
+  promql_expr_test:
+  - expr: sli:frontend_http:availability:rate5m{cluster="svc-1"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="sli:frontend_http:availability:rate5m", cluster="svc-1"}'
+      value: 0.75
+  - expr: errors:frontend_http:error_rate:rate5m{cluster="svc-1"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="errors:frontend_http:error_rate:rate5m", cluster="svc-1"}'
+      value: 0.25
+  - expr: sli:frontend_http:latency:rate5m{cluster="svc-1"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="sli:frontend_http:latency:rate5m", cluster="svc-1"}'
+      value: 0.75
+  - expr: traffic:frontend_http:request_rate:rate5m{cluster="svc-1"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="traffic:frontend_http:request_rate:rate5m", cluster="svc-1"}'
+      value: 1
+  - expr: sli:frontend:saturation_cpu:ratio5m{cluster="svc-1"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="sli:frontend:saturation_cpu:ratio5m", cluster="svc-1"}'
+      value: 0.5
+  - expr: sli:frontend:saturation_memory:ratio5m{cluster="svc-1"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="sli:frontend:saturation_memory:ratio5m", cluster="svc-1"}'
+      value: 0.5
+# Perfect availability (all 2xx)
+- interval: 1m
+  input_series:
+  - series: 'frontend_http_requests_total{cluster="svc-2", code="200", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+    values: "0+60x15"
+  promql_expr_test:
+  - expr: sli:frontend_http:availability:rate5m{cluster="svc-2"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="sli:frontend_http:availability:rate5m", cluster="svc-2"}'
+      value: 1
+  - expr: errors:frontend_http:error_rate:rate5m{cluster="svc-2"}
+    eval_time: 5m
+    exp_samples:
+    - labels: '{__name__="errors:frontend_http:error_rate:rate5m", cluster="svc-2"}'
+      value: 0

--- a/observability/recording-rules/frontend-slo-recordingRule_test.yaml
+++ b/observability/recording-rules/frontend-slo-recordingRule_test.yaml
@@ -11,17 +11,22 @@ tests:
     values: "0+45x15"
   - series: 'frontend_http_requests_total{cluster="svc-1", code="500", method="PUT", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
     values: "0+15x15"
-  # Duplicate replica must be collapsed by max without (prometheus_replica)
   - series: 'frontend_http_requests_total{cluster="svc-1", code="200", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="b"}'
+    # Duplicate replica must be collapsed by max without (prometheus_replica)
+
     values: "0+45x15"
   - series: 'frontend_http_requests_total{cluster="svc-1", code="500", method="PUT", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="b"}'
     values: "0+15x15"
-  # Operation-results poll traffic must be excluded from SLIs
   - series: 'frontend_http_requests_total{cluster="svc-1", code="200", method="GET", route="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}", prometheus_replica="a"}'
+    # ARM async poll traffic must be excluded from SLIs (results + statuses)
+
     values: "0+1000x15"
-  # Latency histogram: 45/min within 1s (le="1"), 60/min total → 0.75
+  - series: 'frontend_http_requests_total{cluster="svc-1", code="200", method="GET", route="/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationstatuses/{operationid}", prometheus_replica="a"}'
+    values: "0+1000x15"
   # Production client_golang typically emits le="1" for the 1.0 bucket.
   - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-1", le="0.8", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
+    # Latency histogram: 45/min within 1s (le="1"), 60/min total → 0.75
+
     values: "0+40x15"
   - series: 'frontend_http_requests_duration_seconds_bucket{cluster="svc-1", le="1", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
     values: "0+45x15"
@@ -29,8 +34,9 @@ tests:
     values: "0+60x15"
   - series: 'frontend_http_requests_duration_seconds_count{cluster="svc-1", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
     values: "0+60x15"
-  # Saturation: 0.5 CPU cores used / 1.0 requested; 512Mi / 1024Mi memory
   - series: 'container_cpu_usage_seconds_total{cluster="svc-1", namespace="aro-hcp", container="aro-hcp-frontend", pod="aro-hcp-frontend-0", prometheus_replica="a"}'
+    # Saturation: 0.5 CPU cores used / 1.0 requested; 512Mi / 1024Mi memory
+
     values: "0+30x15"
   - series: 'kube_pod_container_resource_requests{cluster="svc-1", namespace="aro-hcp", container="aro-hcp-frontend", pod="aro-hcp-frontend-0", resource="cpu", unit="core", prometheus_replica="a"}'
     values: "1+0x15"
@@ -69,8 +75,9 @@ tests:
     exp_samples:
     - labels: '{__name__="sli:frontend:saturation_memory:ratio5m", cluster="svc-1"}'
       value: 0.5
-# Perfect availability (all 2xx)
 - interval: 1m
+  # Perfect availability (all 2xx)
+
   input_series:
   - series: 'frontend_http_requests_total{cluster="svc-2", code="200", method="GET", route="/subscriptions/{subscriptionid}/resourcegroups/{resourcegroupname}/providers/microsoft.redhatopenshift/hcpopenshiftclusters/{resourcename}", prometheus_replica="a"}'
     values: "0+60x15"


### PR DESCRIPTION
## Summary
- Adds Frontend (ARM RP) user-journey SLO recording rules for [ARO-28705](https://redhat.atlassian.net/browse/ARO-28705).
- Covers ADR baseline SLIs:
  - Availability: good/total ratio (non-5xx / total)
  - Errors: 5xx / total
  - Latency: `histogram_quantile` p99 / p95 **in seconds** (`sli:frontend_http:latency_p99:rate5m`, `_p95:`) — not a ≤1s bucket share
  - Traffic: request rate (RPS)
  - Ready: kube Deployment available/spec (`sli:frontend:ready:ratio5m`; probes hit `/healthz`)
  - Saturation: Frontend pod CPU vs request, memory vs limit (kube-state-metrics requests/limits deduped with `max by (cluster, namespace, pod, container)`)
- Excludes ARM async poll routes `hcpoperationresults` and `hcpoperationstatuses` (`route!~".*hcpoperation(results|statuses).*"`). Dedups HA scrapes with `max without (prometheus_replica)`.
- Zero ARM traffic: HTTP availability/errors/latency/traffic emit **no sample** (avoid NaN). Idle-cluster promtool case covers that. Distinguish a Frontend outage with the ready ratio (0 vs absent).
- Regenerates `generatedRecordingRules.bicep`. Istio/Cosmos saturation deferred until owned series are confirmed.
- Alerts ([ARO-28707](https://redhat.atlassian.net/browse/ARO-28707) / #6557) and dashboards ([ARO-28706](https://redhat.atlassian.net/browse/ARO-28706) / #6555) are out of scope for this PR.

## Test plan
- [ ] `prometheus-rules` + `promtool test rules` for `frontend-slo-recordingRule_test.yaml` (including idle-but-healthy cluster)
- [x] `az bicep format` on `generatedRecordingRules.bicep` (CI `observability-prometheus` / `bicep-lint` green)
- [ ] Confirm recorded series appear after deploy on INT svc Prometheus
- [ ] Spot-check against Grafana Frontend SLO dashboard (#6555)

## Related
- Epic: [ARO-28703](https://redhat.atlassian.net/browse/ARO-28703) · Story: [ARO-28705](https://redhat.atlassian.net/browse/ARO-28705)
- Companion docs: Frontend UJ runbook / TSG (Azure-Documents-Common)
- Merge order: **#6554 → #6555 → #6557**
