### PR TITLE
observability: Frontend ARM RP SLO dashboard (ARO-28706)

### DIFF
--- a/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
@@ -26,7 +26,7 @@
       "id": 1,
       "options": {
         "code": { "language": "plaintext", "showLineNumbers": false, "showMiniMap": false },
-        "content": "### Frontend (ARM RP) SLO Dashboard\n\nUser-journey view of Frontend sync ARM SLIs. Prefer recording rules from [ARO-28705](https://redhat.atlassian.net/browse/ARO-28705) / PR [#6554](https://github.com/Azure/ARO-HCP/pull/6554).\n\n| SLI | Recording rule / source | Proposed SLO |\n|-----|-------------------------|--------------|\n| **Availability** | `sli:frontend_http:availability:rate5m` (+ `rate_avg_30d`) | ≥ 99.95% / 30d |\n| **Errors** | `errors:frontend_http:error_rate:rate5m` | &lt; 0.05% 5xx |\n| **Latency** | `sli:frontend_http:latency:rate5m` (share ≤1s) + raw p50/p95/p99 | p99 &lt; 1s |\n| **Traffic** | `traffic:frontend_http:request_rate:rate5m` | Baseline + anomaly (alerts: ARO-28707) |\n| **Saturation** | `sli:frontend:saturation_cpu:ratio5m` / `_memory:` | CPU &lt; 85% of request; memory vs limit |\n\nExcludes ARM async poll routes `hcpoperationresults` / `hcpoperationstatuses`. Cosmos RU / Istio pool saturation deferred until owned series exist.\n\n**Jira:** [ARO-28706](https://redhat.atlassian.net/browse/ARO-28706) · Epic [ARO-28703](https://redhat.atlassian.net/browse/ARO-28703)  \n**Runbook / TSG:** companion Frontend UJ runbook + [frontend-tsg](https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/frontend-tsg.html) · component panels remain on Grafana folder **Frontend** / `frontend.json`",
+        "content": "### Frontend (ARM RP) SLO Dashboard\n\nUser-journey view of Frontend sync ARM SLIs. Prefer recording rules from [ARO-28705](https://redhat.atlassian.net/browse/ARO-28705) / PR [#6554](https://github.com/Azure/ARO-HCP/pull/6554).\n\n| SLI | Recording rule / source | Proposed SLO |\n|-----|-------------------------|--------------|\n| **Availability** | `sli:frontend_http:availability:rate5m` (+ `rate_avg_30d`) | ≥ 99.95% / 30d |\n| **Errors** | `errors:frontend_http:error_rate:rate5m` | &lt; 0.05% 5xx |\n| **Latency** | `sli:frontend_http:latency_p99:rate5m` (+ `_p95:`) | p99 &lt; 1s |\n| **Traffic** | `traffic:frontend_http:request_rate:rate5m` | Baseline + anomaly (alerts: ARO-28707) |\\n| **Ready** | `sli:frontend:ready:ratio5m` | kube /healthz available/spec |\n| **Saturation** | `sli:frontend:saturation_cpu:ratio5m` / `_memory:` | CPU &lt; 85% of request; memory vs limit |\n\nExcludes ARM async poll routes `hcpoperationresults` / `hcpoperationstatuses`. Cosmos RU / Istio pool saturation deferred until owned series exist.\n\n**Jira:** [ARO-28706](https://redhat.atlassian.net/browse/ARO-28706) · Epic [ARO-28703](https://redhat.atlassian.net/browse/ARO-28703)  \n**Runbook / TSG:** companion Frontend UJ runbook + [frontend-tsg](https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/frontend-tsg.html) · component panels remain on Grafana folder **Frontend** / `frontend.json`",
         "mode": "markdown"
       },
       "pluginVersion": "11.6.9",
@@ -315,22 +315,22 @@
     },
     {
       "datasource": { "type": "datasource", "uid": "-- Mixed --" },
-      "description": "Share of requests completing within 1s (sli:frontend_http:latency:rate5m). Complements p99 < 1s SLO.",
+      "description": "Frontend HTTP p99 latency in seconds (sli:frontend_http:latency_p99:rate5m). SLO: p99 < 1s.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
           "decimals": 2,
-          "max": 100,
+          "max": 10,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red" },
-              { "color": "yellow", "value": 94 },
-              { "color": "green", "value": 99 }
+              { "color": "green" },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
             ]
           },
-          "unit": "percent"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -347,13 +347,13 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(sli:frontend_http:latency:rate5m{cluster=~\"$cluster\"}) * 100",
+          "expr": "avg(sli:frontend_http:latency_p99:rate5m{cluster=~\"$cluster\"})",
           "instant": true,
-          "legendFormat": "Share ≤1s %",
+          "legendFormat": "p99",
           "refId": "A"
         }
       ],
-      "title": "Latency SLI (share ≤ 1s)",
+      "title": "Latency p99 (SLI)",
       "type": "stat"
     },
     {
@@ -436,7 +436,7 @@
     },
     {
       "datasource": { "type": "datasource", "uid": "-- Mixed --" },
-      "description": "Share of requests ≤ 1s over time (latency SLI recording rule).",
+      "description": "Frontend HTTP p99 latency over time (histogram_quantile recording rule).",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
@@ -448,17 +448,18 @@
             "showPoints": "never",
             "thresholdsStyle": { "mode": "line" }
           },
-          "decimals": 2,
-          "max": 100,
-          "min": 90,
+          "decimals": 3,
+          "max": 10,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red" },
-              { "color": "green", "value": 99 }
+              { "color": "green" },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
             ]
           },
-          "unit": "percent"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -473,12 +474,12 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sli:frontend_http:latency:rate5m{cluster=~\"$cluster\"} * 100",
+          "expr": "sli:frontend_http:latency_p99:rate5m{cluster=~\"$cluster\"}",
           "legendFormat": "{{ cluster }}",
           "refId": "A"
         }
       ],
-      "title": "Latency SLI Over Time (share ≤ 1s)",
+      "title": "Latency p99 Over Time",
       "type": "timeseries"
     },
     {

--- a/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
@@ -358,7 +358,7 @@
     },
     {
       "datasource": { "type": "datasource", "uid": "-- Mixed --" },
-      "description": "Raw histogram p99 across selected clusters (excludes operation-results). SLO target line at 1s.",
+      "description": "Raw histogram p99 for the selected cluster (excludes ARM async poll routes). SLO target line at 1s.",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
@@ -484,7 +484,7 @@
     },
     {
       "datasource": { "type": "datasource", "uid": "-- Mixed --" },
-      "description": "p50 / p95 / p99 from frontend_http_requests_duration_seconds (excludes operation-results). Red threshold line at 1s (ARM sync SLO).",
+      "description": "p50 / p95 / p99 from frontend_http_requests_duration_seconds for the selected cluster (excludes ARM async poll routes). Red threshold line at 1s (ARM sync SLO).",
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },

--- a/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
@@ -26,7 +26,7 @@
       "id": 1,
       "options": {
         "code": { "language": "plaintext", "showLineNumbers": false, "showMiniMap": false },
-        "content": "### Frontend (ARM RP) SLO Dashboard\n\nUser-journey view of Frontend sync ARM SLIs. Prefer recording rules from [ARO-28705](https://redhat.atlassian.net/browse/ARO-28705) / PR [#6554](https://github.com/Azure/ARO-HCP/pull/6554).\n\n| SLI | Recording rule / source | Proposed SLO |\n|-----|-------------------------|--------------|\n| **Availability** | `sli:frontend_http:availability:rate5m` (+ `rate_avg_30d`) | ≥ 99.95% / 30d |\n| **Errors** | `errors:frontend_http:error_rate:rate5m` | &lt; 0.05% 5xx |\n| **Latency** | `sli:frontend_http:latency_p99:rate5m` (+ `_p95:`) | p99 &lt; 1s |\n| **Traffic** | `traffic:frontend_http:request_rate:rate5m` | Baseline + anomaly (alerts: ARO-28707) |\\n| **Ready** | `sli:frontend:ready:ratio5m` | kube /healthz available/spec |\n| **Saturation** | `sli:frontend:saturation_cpu:ratio5m` / `_memory:` | CPU &lt; 85% of request; memory vs limit |\n\nExcludes ARM async poll routes `hcpoperationresults` / `hcpoperationstatuses`. Cosmos RU / Istio pool saturation deferred until owned series exist.\n\n**Jira:** [ARO-28706](https://redhat.atlassian.net/browse/ARO-28706) · Epic [ARO-28703](https://redhat.atlassian.net/browse/ARO-28703)  \n**Runbook / TSG:** companion Frontend UJ runbook + [frontend-tsg](https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/frontend-tsg.html) · component panels remain on Grafana folder **Frontend** / `frontend.json`",
+        "content": "### Frontend (ARM RP) SLO Dashboard\n\nUser-journey view of Frontend sync ARM SLIs. Prefer recording rules from [ARO-28705](https://redhat.atlassian.net/browse/ARO-28705) / PR [#6554](https://github.com/Azure/ARO-HCP/pull/6554).\n\n| SLI | Recording rule / source | Proposed SLO |\n|-----|-------------------------|--------------|\n| **Availability** | `sli:frontend_http:availability:rate5m` (+ `rate_avg_30d`) | ≥ 99.95% / 30d |\n| **Errors** | `errors:frontend_http:error_rate:rate5m` | &lt; 0.05% 5xx |\n| **Latency** | `sli:frontend_http:latency_p99:rate5m` (+ `_p95:`) | p99 &lt; 1s |\n| **Traffic** | `traffic:frontend_http:request_rate:rate5m` | Baseline + anomaly (alerts: ARO-28707) |\n| **Ready** | `sli:frontend:ready:ratio5m` | kube /healthz available/spec |\n| **Saturation** | `sli:frontend:saturation_cpu:ratio5m` / `_memory:` | CPU &lt; 85% of request; memory vs limit |\n\nExcludes ARM async poll routes `hcpoperationresults` / `hcpoperationstatuses`. Cosmos RU / Istio pool saturation deferred until owned series exist.\n\n**Jira:** [ARO-28706](https://redhat.atlassian.net/browse/ARO-28706) · Epic [ARO-28703](https://redhat.atlassian.net/browse/ARO-28703)  \n**Runbook / TSG:** companion Frontend UJ runbook + [frontend-tsg](https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/frontend-tsg.html) · component panels remain on Grafana folder **Frontend** / `frontend.json`",
         "mode": "markdown"
       },
       "pluginVersion": "11.6.9",
@@ -75,7 +75,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(sli:frontend_http:availability:rate5m{cluster=~\"$cluster\"}) * 100",
+          "expr": "avg(sli:frontend_http:availability:rate5m{cluster=\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "Availability %",
           "refId": "A"
@@ -118,7 +118,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(sli:frontend_http:availability:rate_avg_30d{cluster=~\"$cluster\"}) * 100",
+          "expr": "avg(sli:frontend_http:availability:rate_avg_30d{cluster=\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "Availability 30d %",
           "refId": "A"
@@ -160,7 +160,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(errors:frontend_http:error_rate:rate5m{cluster=~\"$cluster\"}) * 100",
+          "expr": "avg(errors:frontend_http:error_rate:rate5m{cluster=\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "Error rate %",
           "refId": "A"
@@ -203,7 +203,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "clamp_min(\n  (\n    avg(sli:frontend_http:availability:rate_avg_30d{cluster=~\"$cluster\"}) - 0.9995\n  ) / (1 - 0.9995) * 100,\n  0\n)",
+          "expr": "clamp_min(\n  (\n    avg(sli:frontend_http:availability:rate_avg_30d{cluster=\"$cluster\"}) - 0.9995\n  ) / (1 - 0.9995) * 100,\n  0\n)",
           "instant": true,
           "legendFormat": "Budget remaining %",
           "refId": "A"
@@ -251,7 +251,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sli:frontend_http:availability:rate5m{cluster=~\"$cluster\"} * 100",
+          "expr": "sli:frontend_http:availability:rate5m{cluster=\"$cluster\"} * 100",
           "legendFormat": "{{ cluster }}",
           "refId": "A"
         }
@@ -297,7 +297,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "errors:frontend_http:error_rate:rate5m{cluster=~\"$cluster\"} * 100",
+          "expr": "errors:frontend_http:error_rate:rate5m{cluster=\"$cluster\"} * 100",
           "legendFormat": "{{ cluster }}",
           "refId": "A"
         }
@@ -347,7 +347,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(sli:frontend_http:latency_p99:rate5m{cluster=~\"$cluster\"})",
+          "expr": "avg(sli:frontend_http:latency_p99:rate5m{cluster=\"$cluster\"})",
           "instant": true,
           "legendFormat": "p99",
           "refId": "A"
@@ -388,7 +388,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!~\".*hcpoperation(results|statuses).*\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(0.99,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=\"$cluster\",\n        route!~\".*hcpoperation(results|statuses).*\"\n      }[$__rate_interval])\n    )\n  )\n)",
           "instant": true,
           "legendFormat": "p99",
           "refId": "A"
@@ -425,7 +425,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sum(traffic:frontend_http:request_rate:rate5m{cluster=~\"$cluster\"})",
+          "expr": "sum(traffic:frontend_http:request_rate:rate5m{cluster=\"$cluster\"})",
           "instant": true,
           "legendFormat": "RPS",
           "refId": "A"
@@ -474,7 +474,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sli:frontend_http:latency_p99:rate5m{cluster=~\"$cluster\"}",
+          "expr": "sli:frontend_http:latency_p99:rate5m{cluster=\"$cluster\"}",
           "legendFormat": "{{ cluster }}",
           "refId": "A"
         }
@@ -519,21 +519,21 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!~\".*hcpoperation(results|statuses).*\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(0.50,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=\"$cluster\",\n        route!~\".*hcpoperation(results|statuses).*\"\n      }[$__rate_interval])\n    )\n  )\n)",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!~\".*hcpoperation(results|statuses).*\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(0.95,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=\"$cluster\",\n        route!~\".*hcpoperation(results|statuses).*\"\n      }[$__rate_interval])\n    )\n  )\n)",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!~\".*hcpoperation(results|statuses).*\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(0.99,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=\"$cluster\",\n        route!~\".*hcpoperation(results|statuses).*\"\n      }[$__rate_interval])\n    )\n  )\n)",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -577,7 +577,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "traffic:frontend_http:request_rate:rate5m{cluster=~\"$cluster\"}",
+          "expr": "traffic:frontend_http:request_rate:rate5m{cluster=\"$cluster\"}",
           "legendFormat": "{{ cluster }}",
           "refId": "A"
         }
@@ -624,14 +624,14 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sli:frontend:saturation_cpu:ratio5m{cluster=~\"$cluster\"} * 100",
+          "expr": "sli:frontend:saturation_cpu:ratio5m{cluster=\"$cluster\"} * 100",
           "legendFormat": "CPU {{ cluster }}",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sli:frontend:saturation_memory:ratio5m{cluster=~\"$cluster\"} * 100",
+          "expr": "sli:frontend:saturation_memory:ratio5m{cluster=\"$cluster\"} * 100",
           "legendFormat": "Memory {{ cluster }}",
           "refId": "B"
         }
@@ -673,7 +673,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(sli:frontend:saturation_cpu:ratio5m{cluster=~\"$cluster\"}) * 100",
+          "expr": "avg(sli:frontend:saturation_cpu:ratio5m{cluster=\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "CPU %",
           "refId": "A"
@@ -716,7 +716,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(sli:frontend:saturation_memory:ratio5m{cluster=~\"$cluster\"}) * 100",
+          "expr": "avg(sli:frontend:saturation_memory:ratio5m{cluster=\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "Memory %",
           "refId": "A"

--- a/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
@@ -326,8 +326,8 @@
             "mode": "absolute",
             "steps": [
               { "color": "red" },
-              { "color": "yellow", "value": 99 },
-              { "color": "green", "value": 99.9 }
+              { "color": "yellow", "value": 94 },
+              { "color": "green", "value": 99 }
             ]
           },
           "unit": "percent"
@@ -388,7 +388,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(0.99,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!~\".*hcpoperation(results|statuses).*\"\n      }[$__rate_interval])\n    )\n  )\n)",
           "instant": true,
           "legendFormat": "p99",
           "refId": "A"
@@ -518,21 +518,21 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(0.50,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!~\".*hcpoperation(results|statuses).*\"\n      }[$__rate_interval])\n    )\n  )\n)",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(0.95,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!~\".*hcpoperation(results|statuses).*\"\n      }[$__rate_interval])\n    )\n  )\n)",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(0.99,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!~\".*hcpoperation(results|statuses).*\"\n      }[$__rate_interval])\n    )\n  )\n)",
           "legendFormat": "p99",
           "refId": "C"
         }

--- a/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
@@ -26,7 +26,7 @@
       "id": 1,
       "options": {
         "code": { "language": "plaintext", "showLineNumbers": false, "showMiniMap": false },
-        "content": "### Frontend (ARM RP) SLO Dashboard\n\nUser-journey view of Frontend sync ARM SLIs. Prefer recording rules from [ARO-28705](https://redhat.atlassian.net/browse/ARO-28705) / PR [#6554](https://github.com/Azure/ARO-HCP/pull/6554).\n\n| SLI | Recording rule / source | Proposed SLO |\n|-----|-------------------------|--------------|\n| **Availability** | `sli:frontend_http:availability:rate5m` (+ `rate_avg_30d`) | ≥ 99.95% / 30d |\n| **Errors** | `errors:frontend_http:error_rate:rate5m` | &lt; 0.05% 5xx |\n| **Latency** | `sli:frontend_http:latency:rate5m` (share ≤1s) + raw p50/p95/p99 | p99 &lt; 1s |\n| **Traffic** | `traffic:frontend_http:request_rate:rate5m` | Baseline + anomaly (alerts: ARO-28707) |\n| **Saturation** | `sli:frontend:saturation_cpu:ratio5m` / `_memory:` | CPU &lt; 85% of request; memory vs limit |\n\nExcludes `hcpoperationresults` poll route (same as `FrontendLatency`). Cosmos RU / Istio pool saturation deferred until owned series exist.\n\n**Jira:** [ARO-28706](https://redhat.atlassian.net/browse/ARO-28706) · Epic [ARO-28703](https://redhat.atlassian.net/browse/ARO-28703)  \n**Runbook / TSG:** companion Frontend UJ runbook + [frontend-tsg](https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/frontend-tsg.html) · component panels remain on Grafana folder **Frontend** / `frontend.json`",
+        "content": "### Frontend (ARM RP) SLO Dashboard\n\nUser-journey view of Frontend sync ARM SLIs. Prefer recording rules from [ARO-28705](https://redhat.atlassian.net/browse/ARO-28705) / PR [#6554](https://github.com/Azure/ARO-HCP/pull/6554).\n\n| SLI | Recording rule / source | Proposed SLO |\n|-----|-------------------------|--------------|\n| **Availability** | `sli:frontend_http:availability:rate5m` (+ `rate_avg_30d`) | ≥ 99.95% / 30d |\n| **Errors** | `errors:frontend_http:error_rate:rate5m` | &lt; 0.05% 5xx |\n| **Latency** | `sli:frontend_http:latency:rate5m` (share ≤1s) + raw p50/p95/p99 | p99 &lt; 1s |\n| **Traffic** | `traffic:frontend_http:request_rate:rate5m` | Baseline + anomaly (alerts: ARO-28707) |\n| **Saturation** | `sli:frontend:saturation_cpu:ratio5m` / `_memory:` | CPU &lt; 85% of request; memory vs limit |\n\nExcludes ARM async poll routes `hcpoperationresults` / `hcpoperationstatuses`. Cosmos RU / Istio pool saturation deferred until owned series exist.\n\n**Jira:** [ARO-28706](https://redhat.atlassian.net/browse/ARO-28706) · Epic [ARO-28703](https://redhat.atlassian.net/browse/ARO-28703)  \n**Runbook / TSG:** companion Frontend UJ runbook + [frontend-tsg](https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/frontend-tsg.html) · component panels remain on Grafana folder **Frontend** / `frontend.json`",
         "mode": "markdown"
       },
       "pluginVersion": "11.6.9",
@@ -42,7 +42,7 @@
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
       "description": "Current availability (non-5xx / total) from sli:frontend_http:availability:rate5m. SLO target ≥ 99.95%.",
       "fieldConfig": {
         "defaults": {
@@ -75,7 +75,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(sli:frontend_http:availability:rate5m{cluster=\"$cluster\"}) * 100",
+          "expr": "avg(sli:frontend_http:availability:rate5m{cluster=~\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "Availability %",
           "refId": "A"
@@ -85,7 +85,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
       "description": "30-day smoothed availability from sli:frontend_http:availability:rate_avg_30d. Primary SLO status gauge (≥ 99.95%).",
       "fieldConfig": {
         "defaults": {
@@ -118,7 +118,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(sli:frontend_http:availability:rate_avg_30d{cluster=\"$cluster\"}) * 100",
+          "expr": "avg(sli:frontend_http:availability:rate_avg_30d{cluster=~\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "Availability 30d %",
           "refId": "A"
@@ -128,7 +128,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
       "description": "5xx / total from errors:frontend_http:error_rate:rate5m. SLO target < 0.05%.",
       "fieldConfig": {
         "defaults": {
@@ -160,7 +160,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(errors:frontend_http:error_rate:rate5m{cluster=\"$cluster\"}) * 100",
+          "expr": "avg(errors:frontend_http:error_rate:rate5m{cluster=~\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "Error rate %",
           "refId": "A"
@@ -170,7 +170,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
       "description": "Error budget remaining for 99.95% availability SLO using 30d availability: (avail - 0.9995) / (1 - 0.9995). 100% = full budget left; 0% = budget exhausted.",
       "fieldConfig": {
         "defaults": {
@@ -203,7 +203,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "clamp_min(\n  (\n    avg(sli:frontend_http:availability:rate_avg_30d{cluster=\"$cluster\"}) - 0.9995\n  ) / (1 - 0.9995) * 100,\n  0\n)",
+          "expr": "clamp_min(\n  (\n    avg(sli:frontend_http:availability:rate_avg_30d{cluster=~\"$cluster\"}) - 0.9995\n  ) / (1 - 0.9995) * 100,\n  0\n)",
           "instant": true,
           "legendFormat": "Budget remaining %",
           "refId": "A"
@@ -213,7 +213,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
       "description": "Availability over time with 99.95% SLO target line.",
       "fieldConfig": {
         "defaults": {
@@ -251,7 +251,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sli:frontend_http:availability:rate5m{cluster=\"$cluster\"} * 100",
+          "expr": "sli:frontend_http:availability:rate5m{cluster=~\"$cluster\"} * 100",
           "legendFormat": "{{ cluster }}",
           "refId": "A"
         }
@@ -260,7 +260,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
       "description": "5xx error rate over time with 0.05% SLO threshold line.",
       "fieldConfig": {
         "defaults": {
@@ -297,7 +297,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "errors:frontend_http:error_rate:rate5m{cluster=\"$cluster\"} * 100",
+          "expr": "errors:frontend_http:error_rate:rate5m{cluster=~\"$cluster\"} * 100",
           "legendFormat": "{{ cluster }}",
           "refId": "A"
         }
@@ -314,7 +314,7 @@
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
       "description": "Share of requests completing within 1s (sli:frontend_http:latency:rate5m). Complements p99 < 1s SLO.",
       "fieldConfig": {
         "defaults": {
@@ -347,7 +347,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(sli:frontend_http:latency:rate5m{cluster=\"$cluster\"}) * 100",
+          "expr": "avg(sli:frontend_http:latency:rate5m{cluster=~\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "Share ≤1s %",
           "refId": "A"
@@ -357,7 +357,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
       "description": "Raw histogram p99 across selected clusters (excludes operation-results). SLO target line at 1s.",
       "fieldConfig": {
         "defaults": {
@@ -388,7 +388,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n  sum by (cluster, le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(0.99,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
           "instant": true,
           "legendFormat": "p99",
           "refId": "A"
@@ -398,7 +398,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
       "description": "Request rate from traffic:frontend_http:request_rate:rate5m.",
       "fieldConfig": {
         "defaults": {
@@ -425,7 +425,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sum(traffic:frontend_http:request_rate:rate5m{cluster=\"$cluster\"})",
+          "expr": "sum(traffic:frontend_http:request_rate:rate5m{cluster=~\"$cluster\"})",
           "instant": true,
           "legendFormat": "RPS",
           "refId": "A"
@@ -435,7 +435,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
       "description": "Share of requests ≤ 1s over time (latency SLI recording rule).",
       "fieldConfig": {
         "defaults": {
@@ -473,7 +473,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sli:frontend_http:latency:rate5m{cluster=\"$cluster\"} * 100",
+          "expr": "sli:frontend_http:latency:rate5m{cluster=~\"$cluster\"} * 100",
           "legendFormat": "{{ cluster }}",
           "refId": "A"
         }
@@ -482,7 +482,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
       "description": "p50 / p95 / p99 from frontend_http_requests_duration_seconds (excludes operation-results). Red threshold line at 1s (ARM sync SLO).",
       "fieldConfig": {
         "defaults": {
@@ -518,21 +518,21 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50,\n  sum by (cluster, le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(0.50,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95,\n  sum by (cluster, le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(0.95,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n  sum by (cluster, le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(0.99,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -549,7 +549,7 @@
       "type": "row"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
       "description": "Request rate (RPS) over time from traffic:frontend_http:request_rate:rate5m. Anomaly thresholds deferred to ARO-28707.",
       "fieldConfig": {
         "defaults": {
@@ -576,7 +576,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "traffic:frontend_http:request_rate:rate5m{cluster=\"$cluster\"}",
+          "expr": "traffic:frontend_http:request_rate:rate5m{cluster=~\"$cluster\"}",
           "legendFormat": "{{ cluster }}",
           "refId": "A"
         }
@@ -585,7 +585,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
       "description": "Frontend pod CPU (usage / request) and memory (working set / limit). CPU SLO line at 85%. Cosmos RU / Istio connection pool not wired yet.",
       "fieldConfig": {
         "defaults": {
@@ -623,14 +623,14 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sli:frontend:saturation_cpu:ratio5m{cluster=\"$cluster\"} * 100",
+          "expr": "sli:frontend:saturation_cpu:ratio5m{cluster=~\"$cluster\"} * 100",
           "legendFormat": "CPU {{ cluster }}",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sli:frontend:saturation_memory:ratio5m{cluster=\"$cluster\"} * 100",
+          "expr": "sli:frontend:saturation_memory:ratio5m{cluster=~\"$cluster\"} * 100",
           "legendFormat": "Memory {{ cluster }}",
           "refId": "B"
         }
@@ -639,7 +639,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
       "description": "Current Frontend CPU usage vs request (sli:frontend:saturation_cpu:ratio5m). Target < 85%.",
       "fieldConfig": {
         "defaults": {
@@ -672,7 +672,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(sli:frontend:saturation_cpu:ratio5m{cluster=\"$cluster\"}) * 100",
+          "expr": "avg(sli:frontend:saturation_cpu:ratio5m{cluster=~\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "CPU %",
           "refId": "A"
@@ -682,7 +682,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
       "description": "Current Frontend memory working set vs limit (sli:frontend:saturation_memory:ratio5m).",
       "fieldConfig": {
         "defaults": {
@@ -715,7 +715,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(sli:frontend:saturation_memory:ratio5m{cluster=\"$cluster\"}) * 100",
+          "expr": "avg(sli:frontend:saturation_memory:ratio5m{cluster=~\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "Memory %",
           "refId": "A"

--- a/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
@@ -42,7 +42,7 @@
       "type": "row"
     },
     {
-      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Current availability (non-5xx / total) from sli:frontend_http:availability:rate5m. SLO target ≥ 99.95%.",
       "fieldConfig": {
         "defaults": {
@@ -75,7 +75,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(sli:frontend_http:availability:rate5m{cluster=~\"$cluster\"}) * 100",
+          "expr": "avg(sli:frontend_http:availability:rate5m{cluster=\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "Availability %",
           "refId": "A"
@@ -85,7 +85,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "30-day smoothed availability from sli:frontend_http:availability:rate_avg_30d. Primary SLO status gauge (≥ 99.95%).",
       "fieldConfig": {
         "defaults": {
@@ -118,7 +118,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(sli:frontend_http:availability:rate_avg_30d{cluster=~\"$cluster\"}) * 100",
+          "expr": "avg(sli:frontend_http:availability:rate_avg_30d{cluster=\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "Availability 30d %",
           "refId": "A"
@@ -128,7 +128,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "5xx / total from errors:frontend_http:error_rate:rate5m. SLO target < 0.05%.",
       "fieldConfig": {
         "defaults": {
@@ -160,7 +160,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(errors:frontend_http:error_rate:rate5m{cluster=~\"$cluster\"}) * 100",
+          "expr": "avg(errors:frontend_http:error_rate:rate5m{cluster=\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "Error rate %",
           "refId": "A"
@@ -170,7 +170,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Error budget remaining for 99.95% availability SLO using 30d availability: (avail - 0.9995) / (1 - 0.9995). 100% = full budget left; 0% = budget exhausted.",
       "fieldConfig": {
         "defaults": {
@@ -203,7 +203,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "clamp_min(\n  (\n    avg(sli:frontend_http:availability:rate_avg_30d{cluster=~\"$cluster\"}) - 0.9995\n  ) / (1 - 0.9995) * 100,\n  0\n)",
+          "expr": "clamp_min(\n  (\n    avg(sli:frontend_http:availability:rate_avg_30d{cluster=\"$cluster\"}) - 0.9995\n  ) / (1 - 0.9995) * 100,\n  0\n)",
           "instant": true,
           "legendFormat": "Budget remaining %",
           "refId": "A"
@@ -213,7 +213,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Availability over time with 99.95% SLO target line.",
       "fieldConfig": {
         "defaults": {
@@ -251,7 +251,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sli:frontend_http:availability:rate5m{cluster=~\"$cluster\"} * 100",
+          "expr": "sli:frontend_http:availability:rate5m{cluster=\"$cluster\"} * 100",
           "legendFormat": "{{ cluster }}",
           "refId": "A"
         }
@@ -260,7 +260,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "5xx error rate over time with 0.05% SLO threshold line.",
       "fieldConfig": {
         "defaults": {
@@ -297,7 +297,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "errors:frontend_http:error_rate:rate5m{cluster=~\"$cluster\"} * 100",
+          "expr": "errors:frontend_http:error_rate:rate5m{cluster=\"$cluster\"} * 100",
           "legendFormat": "{{ cluster }}",
           "refId": "A"
         }
@@ -314,7 +314,7 @@
       "type": "row"
     },
     {
-      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Share of requests completing within 1s (sli:frontend_http:latency:rate5m). Complements p99 < 1s SLO.",
       "fieldConfig": {
         "defaults": {
@@ -347,7 +347,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(sli:frontend_http:latency:rate5m{cluster=~\"$cluster\"}) * 100",
+          "expr": "avg(sli:frontend_http:latency:rate5m{cluster=\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "Share ≤1s %",
           "refId": "A"
@@ -357,7 +357,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Raw histogram p99 across selected clusters (excludes operation-results). SLO target line at 1s.",
       "fieldConfig": {
         "defaults": {
@@ -388,7 +388,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(0.99,\n  sum by (cluster, le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
           "instant": true,
           "legendFormat": "p99",
           "refId": "A"
@@ -398,7 +398,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Request rate from traffic:frontend_http:request_rate:rate5m.",
       "fieldConfig": {
         "defaults": {
@@ -425,7 +425,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sum(traffic:frontend_http:request_rate:rate5m{cluster=~\"$cluster\"})",
+          "expr": "sum(traffic:frontend_http:request_rate:rate5m{cluster=\"$cluster\"})",
           "instant": true,
           "legendFormat": "RPS",
           "refId": "A"
@@ -435,7 +435,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Share of requests ≤ 1s over time (latency SLI recording rule).",
       "fieldConfig": {
         "defaults": {
@@ -473,7 +473,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sli:frontend_http:latency:rate5m{cluster=~\"$cluster\"} * 100",
+          "expr": "sli:frontend_http:latency:rate5m{cluster=\"$cluster\"} * 100",
           "legendFormat": "{{ cluster }}",
           "refId": "A"
         }
@@ -482,7 +482,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "p50 / p95 / p99 from frontend_http_requests_duration_seconds (excludes operation-results). Red threshold line at 1s (ARM sync SLO).",
       "fieldConfig": {
         "defaults": {
@@ -518,21 +518,21 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(0.50,\n  sum by (cluster, le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
           "legendFormat": "p50",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(0.95,\n  sum by (cluster, le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
           "legendFormat": "p95",
           "refId": "B"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "expr": "histogram_quantile(0.99,\n  sum by (cluster, le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
           "legendFormat": "p99",
           "refId": "C"
         }
@@ -549,7 +549,7 @@
       "type": "row"
     },
     {
-      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Request rate (RPS) over time from traffic:frontend_http:request_rate:rate5m. Anomaly thresholds deferred to ARO-28707.",
       "fieldConfig": {
         "defaults": {
@@ -576,7 +576,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "traffic:frontend_http:request_rate:rate5m{cluster=~\"$cluster\"}",
+          "expr": "traffic:frontend_http:request_rate:rate5m{cluster=\"$cluster\"}",
           "legendFormat": "{{ cluster }}",
           "refId": "A"
         }
@@ -585,7 +585,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Frontend pod CPU (usage / request) and memory (working set / limit). CPU SLO line at 85%. Cosmos RU / Istio connection pool not wired yet.",
       "fieldConfig": {
         "defaults": {
@@ -623,14 +623,14 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sli:frontend:saturation_cpu:ratio5m{cluster=~\"$cluster\"} * 100",
+          "expr": "sli:frontend:saturation_cpu:ratio5m{cluster=\"$cluster\"} * 100",
           "legendFormat": "CPU {{ cluster }}",
           "refId": "A"
         },
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "sli:frontend:saturation_memory:ratio5m{cluster=~\"$cluster\"} * 100",
+          "expr": "sli:frontend:saturation_memory:ratio5m{cluster=\"$cluster\"} * 100",
           "legendFormat": "Memory {{ cluster }}",
           "refId": "B"
         }
@@ -639,7 +639,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Current Frontend CPU usage vs request (sli:frontend:saturation_cpu:ratio5m). Target < 85%.",
       "fieldConfig": {
         "defaults": {
@@ -672,7 +672,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(sli:frontend:saturation_cpu:ratio5m{cluster=~\"$cluster\"}) * 100",
+          "expr": "avg(sli:frontend:saturation_cpu:ratio5m{cluster=\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "CPU %",
           "refId": "A"
@@ -682,7 +682,7 @@
       "type": "stat"
     },
     {
-      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
       "description": "Current Frontend memory working set vs limit (sli:frontend:saturation_memory:ratio5m).",
       "fieldConfig": {
         "defaults": {
@@ -715,7 +715,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "$datasource" },
           "editorMode": "code",
-          "expr": "avg(sli:frontend:saturation_memory:ratio5m{cluster=~\"$cluster\"}) * 100",
+          "expr": "avg(sli:frontend:saturation_memory:ratio5m{cluster=\"$cluster\"}) * 100",
           "instant": true,
           "legendFormat": "Memory %",
           "refId": "A"

--- a/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
@@ -1,0 +1,765 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "code": { "language": "plaintext", "showLineNumbers": false, "showMiniMap": false },
+        "content": "### Frontend (ARM RP) SLO Dashboard\n\nUser-journey view of Frontend sync ARM SLIs. Prefer recording rules from [ARO-28705](https://redhat.atlassian.net/browse/ARO-28705) / PR [#6554](https://github.com/Azure/ARO-HCP/pull/6554).\n\n| SLI | Recording rule / source | Proposed SLO |\n|-----|-------------------------|--------------|\n| **Availability** | `sli:frontend_http:availability:rate5m` (+ `rate_avg_30d`) | ≥ 99.95% / 30d |\n| **Errors** | `errors:frontend_http:error_rate:rate5m` | &lt; 0.05% 5xx |\n| **Latency** | `sli:frontend_http:latency:rate5m` (share ≤1s) + raw p50/p95/p99 | p99 &lt; 1s |\n| **Traffic** | `traffic:frontend_http:request_rate:rate5m` | Baseline + anomaly (alerts: ARO-28707) |\n| **Saturation** | `sli:frontend:saturation_cpu:ratio5m` / `_memory:` | CPU &lt; 85% of request; memory vs limit |\n\nExcludes `hcpoperationresults` poll route (same as `FrontendLatency`). Cosmos RU / Istio pool saturation deferred until owned series exist.\n\n**Jira:** [ARO-28706](https://redhat.atlassian.net/browse/ARO-28706) · Epic [ARO-28703](https://redhat.atlassian.net/browse/ARO-28703)  \n**Runbook / TSG:** companion Frontend UJ runbook + [frontend-tsg](https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/troubleshooting/frontend-tsg.html) · component panels remain on Grafana folder **Frontend** / `frontend.json`",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.6.9",
+      "title": "Dashboard Info",
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 10,
+      "panels": [],
+      "title": "Availability & Errors",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Current availability (non-5xx / total) from sli:frontend_http:availability:rate5m. SLO target ≥ 99.95%.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 3,
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red" },
+              { "color": "yellow", "value": 99.9 },
+              { "color": "green", "value": 99.95 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 6 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "avg(sli:frontend_http:availability:rate5m{cluster=~\"$cluster\"}) * 100",
+          "instant": true,
+          "legendFormat": "Availability %",
+          "refId": "A"
+        }
+      ],
+      "title": "Availability (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "30-day smoothed availability from sli:frontend_http:availability:rate_avg_30d. Primary SLO status gauge (≥ 99.95%).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 3,
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red" },
+              { "color": "yellow", "value": 99.9 },
+              { "color": "green", "value": 99.95 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 6 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "avg(sli:frontend_http:availability:rate_avg_30d{cluster=~\"$cluster\"}) * 100",
+          "instant": true,
+          "legendFormat": "Availability 30d %",
+          "refId": "A"
+        }
+      ],
+      "title": "Availability (30d avg)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "5xx / total from errors:frontend_http:error_rate:rate5m. SLO target < 0.05%.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 3,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "yellow", "value": 0.05 },
+              { "color": "red", "value": 0.5 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 6 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "avg(errors:frontend_http:error_rate:rate5m{cluster=~\"$cluster\"}) * 100",
+          "instant": true,
+          "legendFormat": "Error rate %",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate (5xx %)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Error budget remaining for 99.95% availability SLO using 30d availability: (avail - 0.9995) / (1 - 0.9995). 100% = full budget left; 0% = budget exhausted.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 1,
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red" },
+              { "color": "yellow", "value": 25 },
+              { "color": "green", "value": 50 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 6 },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "clamp_min(\n  (\n    avg(sli:frontend_http:availability:rate_avg_30d{cluster=~\"$cluster\"}) - 0.9995\n  ) / (1 - 0.9995) * 100,\n  0\n)",
+          "instant": true,
+          "legendFormat": "Budget remaining %",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Budget Remaining (30d)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Availability over time with 99.95% SLO target line.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "decimals": 3,
+          "max": 100,
+          "min": 99,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red" },
+              { "color": "green", "value": 99.95 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 11 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "sli:frontend_http:availability:rate5m{cluster=~\"$cluster\"} * 100",
+          "legendFormat": "{{ cluster }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Availability Over Time (SLO 99.95%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "5xx error rate over time with 0.05% SLO threshold line.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "decimals": 3,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "red", "value": 0.05 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 11 },
+      "id": 7,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "errors:frontend_http:error_rate:rate5m{cluster=~\"$cluster\"} * 100",
+          "legendFormat": "{{ cluster }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate Over Time (SLO 0.05%)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 19 },
+      "id": 11,
+      "panels": [],
+      "title": "Latency",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Share of requests completing within 1s (sli:frontend_http:latency:rate5m). Complements p99 < 1s SLO.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 2,
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red" },
+              { "color": "yellow", "value": 99 },
+              { "color": "green", "value": 99.9 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 20 },
+      "id": 8,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "avg(sli:frontend_http:latency:rate5m{cluster=~\"$cluster\"}) * 100",
+          "instant": true,
+          "legendFormat": "Share ≤1s %",
+          "refId": "A"
+        }
+      ],
+      "title": "Latency SLI (share ≤ 1s)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Raw histogram p99 across selected clusters (excludes operation-results). SLO target line at 1s.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "yellow", "value": 0.8 },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 8, "x": 8, "y": 20 },
+      "id": 9,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "instant": true,
+          "legendFormat": "p99",
+          "refId": "A"
+        }
+      ],
+      "title": "Latency p99 (raw)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Request rate from traffic:frontend_http:request_rate:rate5m.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue" }]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 8, "x": 16, "y": 20 },
+      "id": 12,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "sum(traffic:frontend_http:request_rate:rate5m{cluster=~\"$cluster\"})",
+          "instant": true,
+          "legendFormat": "RPS",
+          "refId": "A"
+        }
+      ],
+      "title": "Traffic (RPS)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Share of requests ≤ 1s over time (latency SLI recording rule).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "decimals": 2,
+          "max": 100,
+          "min": 90,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red" },
+              { "color": "green", "value": 99 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
+      "id": 13,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "sli:frontend_http:latency:rate5m{cluster=~\"$cluster\"} * 100",
+          "legendFormat": "{{ cluster }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Latency SLI Over Time (share ≤ 1s)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "p50 / p95 / p99 from frontend_http_requests_duration_seconds (excludes operation-results). Red threshold line at 1s (ARM sync SLO).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
+      "id": 14,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99,\n  sum by (le) (\n    max without (prometheus_replica) (\n      rate(frontend_http_requests_duration_seconds_bucket{\n        cluster=~\"$cluster\",\n        route!=\"/subscriptions/{subscriptionid}/providers/microsoft.redhatopenshift/locations/{location}/hcpoperationresults/{operationid}\"\n      }[$__rate_interval])\n    )\n  )\n)",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Latency p50 / p95 / p99 (SLO 1s)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 33 },
+      "id": 15,
+      "panels": [],
+      "title": "Traffic & Saturation",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Request rate (RPS) over time from traffic:frontend_http:request_rate:rate5m. Anomaly thresholds deferred to ARO-28707.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 34 },
+      "id": 16,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "traffic:frontend_http:request_rate:rate5m{cluster=~\"$cluster\"}",
+          "legendFormat": "{{ cluster }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Traffic Over Time (RPS)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Frontend pod CPU (usage / request) and memory (working set / limit). CPU SLO line at 85%. Cosmos RU / Istio connection pool not wired yet.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "thresholdsStyle": { "mode": "line" }
+          },
+          "decimals": 1,
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "red", "value": 85 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 34 },
+      "id": 17,
+      "options": {
+        "legend": { "calcs": ["mean", "lastNotNull", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "sli:frontend:saturation_cpu:ratio5m{cluster=~\"$cluster\"} * 100",
+          "legendFormat": "CPU {{ cluster }}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "sli:frontend:saturation_memory:ratio5m{cluster=~\"$cluster\"} * 100",
+          "legendFormat": "Memory {{ cluster }}",
+          "refId": "B"
+        }
+      ],
+      "title": "Saturation CPU / Memory (SLO CPU 85%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Current Frontend CPU usage vs request (sli:frontend:saturation_cpu:ratio5m). Target < 85%.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 1,
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "yellow", "value": 70 },
+              { "color": "red", "value": 85 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 12, "x": 0, "y": 42 },
+      "id": 18,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "avg(sli:frontend:saturation_cpu:ratio5m{cluster=~\"$cluster\"}) * 100",
+          "instant": true,
+          "legendFormat": "CPU %",
+          "refId": "A"
+        }
+      ],
+      "title": "Saturation — CPU",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "datasource", "uid": "-- Mixed --" },
+      "description": "Current Frontend memory working set vs limit (sli:frontend:saturation_memory:ratio5m).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "decimals": 1,
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "color": "yellow", "value": 70 },
+              { "color": "red", "value": 85 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 12, "x": 12, "y": 42 },
+      "id": 19,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "editorMode": "code",
+          "expr": "avg(sli:frontend:saturation_memory:ratio5m{cluster=~\"$cluster\"}) * 100",
+          "instant": true,
+          "legendFormat": "Memory %",
+          "refId": "A"
+        }
+      ],
+      "title": "Saturation — Memory",
+      "type": "stat"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["aro-hcp", "frontend", "slo", "user-journey"],
+  "templating": {
+    "list": [
+      {
+        "allowCustomValue": false,
+        "current": { "text": "All", "value": "$__all" },
+        "includeAll": true,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "^Managed_Prometheus_services-.*$",
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": { "text": "All", "value": "$__all" },
+        "datasource": { "type": "prometheus", "uid": "$datasource" },
+        "definition": "label_values(frontend_http_requests_total, cluster)",
+        "includeAll": true,
+        "label": "Service Cluster",
+        "multi": true,
+        "name": "cluster",
+        "query": "label_values(frontend_http_requests_total, cluster)",
+        "refresh": 2,
+        "regex": "^.*-svc(-[0-9]+)?$",
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-7d", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Frontend SLO",
+  "uid": "frontend-slo",
+  "version": 1
+}

--- a/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
@@ -731,8 +731,10 @@
     "list": [
       {
         "allowCustomValue": false,
-        "current": { "text": "All", "value": "$__all" },
-        "includeAll": true,
+        "current": {},
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
@@ -741,17 +743,16 @@
         "type": "datasource"
       },
       {
-        "allValue": ".*",
-        "current": { "text": "All", "value": "$__all" },
+        "current": {},
         "datasource": { "type": "prometheus", "uid": "$datasource" },
         "definition": "label_values(frontend_http_requests_total, cluster)",
-        "includeAll": true,
-        "label": "Service Cluster",
-        "multi": true,
+        "includeAll": false,
+        "label": "cluster",
+        "multi": false,
         "name": "cluster",
         "query": "label_values(frontend_http_requests_total, cluster)",
         "refresh": 2,
-        "regex": "^.*-svc(-[0-9]+)?$",
+        "regex": "^.*-svc-\\d+$",
         "type": "query"
       }
     ]


### PR DESCRIPTION
## Summary
- Adds Frontend (ARM RP) user-journey SLO Grafana dashboard for [ARO-28706](https://redhat.atlassian.net/browse/ARO-28706) under **SRE User Journey**.
- Panels: Availability (5m + 30d), Errors, Latency SLI + raw p50/p95/p99 with 1s SLO line, Traffic RPS, Saturation CPU/memory, and 30d error-budget remaining.
- Uses Managed Prometheus `services` datasource + single-select svc `cluster` variable (`^.*-svc-\d+$`), matching Access / `frontend.json`.
- Leaves component `frontend.json` unchanged; this is the journey SLO view.
- **Depends on** recording rules from [#6554](https://github.com/Azure/ARO-HCP/pull/6554) ([ARO-28705](https://redhat.atlassian.net/browse/ARO-28705)) for SLI series; raw latency/traffic still work from existing metrics.

## Test plan
- [x] `go run tooling/grafanactl verify dashboards`
- [x] Spot-check recording-rule / Explore panels on prod (australiaeast `prod-australiaeast-svc-1`):

<img width="1024" height="458" alt="image" src="https://github.com/user-attachments/assets/4e476097-b106-4233-895f-9d5eaa8d831c" />

- [x] Spot-check p50/p95/p99 vs Frontend Control Plane Latency dashboard
- [ ] Merge after [#6554](https://github.com/Azure/ARO-HCP/pull/6554)

## Related
- Epic: [ARO-28703](https://redhat.atlassian.net/browse/ARO-28703) · Story: [ARO-28706](https://redhat.atlassian.net/browse/ARO-28706)
- SLIs: [#6554](https://github.com/Azure/ARO-HCP/pull/6554)