### PR TITLE
observability: Frontend ARM RP SLO burn-rate alerts (ARO-28707)

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -17,13 +17,15 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyAccessClusterErrors1h5m'
         enabled: true
         labels: {
@@ -46,13 +48,15 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyAccessClusterErrors6h30m'
         enabled: true
         labels: {
@@ -75,13 +79,15 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyAccessClusterErrors3d'
         enabled: true
         labels: {
@@ -103,13 +109,15 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyAccessClusterErrorsDegradation'
         enabled: true
         labels: {
@@ -130,13 +138,15 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyAccessClusterStuckOperation'
         enabled: true
         labels: {
@@ -169,13 +179,15 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyAccessClusterSaturationQueueDepth'
         enabled: true
         labels: {
@@ -195,13 +207,15 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyAccessClusterSaturationRetryHotLoop'
         enabled: true
         labels: {
@@ -234,13 +248,15 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJClusterProvisionErrors1h5m'
         enabled: true
         labels: {
@@ -263,13 +279,15 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJClusterProvisionErrors6h30m'
         enabled: true
         labels: {
@@ -292,13 +310,15 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJClusterProvisionErrors3d'
         enabled: true
         labels: {
@@ -320,13 +340,15 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJClusterProvisionErrorsDegradation'
         enabled: true
         labels: {
@@ -360,13 +382,15 @@ resource rpUserJourneyClusterUpgradeMonitorRules 'Microsoft.AlertsManagement/pro
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyClusterUpgradeStuckInDesired'
         enabled: true
         labels: {
@@ -391,13 +415,15 @@ Service Cluster: {{ $labels.cluster }}
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyClusterUpgradeStuckInProgress'
         enabled: true
         labels: {
@@ -435,13 +461,15 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolErrors1h5m'
         enabled: true
         labels: {
@@ -464,13 +492,15 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolErrors6h30m'
         enabled: true
         labels: {
@@ -493,13 +523,15 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolErrors3d'
         enabled: true
         labels: {
@@ -521,13 +553,15 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolErrorsDegradation'
         enabled: true
         labels: {
@@ -548,13 +582,15 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolStuckOperation'
         enabled: true
         labels: {
@@ -587,13 +623,15 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolSaturationQueueDepth'
         enabled: true
         labels: {
@@ -626,13 +664,15 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendErrors1h5m'
         enabled: true
         labels: {
@@ -646,7 +686,7 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
           correlationId: 'userJourneyFrontendErrors1h5m/{{ $labels.cluster }}'
           description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h).'
           info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h).'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)'
           title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)'
         }
@@ -655,13 +695,15 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendErrors6h30m'
         enabled: true
         labels: {
@@ -675,7 +717,7 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
           correlationId: 'userJourneyFrontendErrors6h30m/{{ $labels.cluster }}'
           description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget).'
           info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget).'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%)'
           title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%)'
         }
@@ -684,13 +726,15 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendErrors3d6h'
         enabled: true
         labels: {
@@ -704,7 +748,7 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
           correlationId: 'userJourneyFrontendErrors3d6h/{{ $labels.cluster }}'
           description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn).'
           info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn).'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)'
           title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)'
         }
@@ -726,13 +770,15 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendAvailability1h5m'
         enabled: true
         labels: {
@@ -746,7 +792,7 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
           correlationId: 'userJourneyFrontendAvailability1h5m/{{ $labels.cluster }}'
           description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
           info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)'
           title: '{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)'
         }
@@ -755,13 +801,15 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendAvailability6h30m'
         enabled: true
         labels: {
@@ -775,7 +823,7 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
           correlationId: 'userJourneyFrontendAvailability6h30m/{{ $labels.cluster }}'
           description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
           info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%)'
           title: '{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%)'
         }
@@ -784,13 +832,15 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendAvailability3d6h'
         enabled: true
         labels: {
@@ -804,7 +854,7 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
           correlationId: 'userJourneyFrontendAvailability3d6h/{{ $labels.cluster }}'
           description: 'Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO on both the 3d and 6h windows (1x burn).'
           info: 'Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO on both the 3d and 6h windows (1x burn).'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%)'
           title: '{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%)'
         }
@@ -826,13 +876,15 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendLatency1h5m'
         enabled: true
         labels: {
@@ -846,7 +898,7 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
           correlationId: 'userJourneyFrontendLatency1h5m/{{ $labels.cluster }}'
           description: 'Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO).'
           info: 'Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO).'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI critically low (share <=1s <85.6%)'
           title: '{{ $labels.cluster }}: Frontend HTTP latency SLI critically low (share <=1s <85.6%)'
         }
@@ -855,13 +907,15 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendLatency6h30m'
         enabled: true
         labels: {
@@ -875,7 +929,7 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
           correlationId: 'userJourneyFrontendLatency6h30m/{{ $labels.cluster }}'
           description: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% on both the 6h and 30m windows (6x burn).'
           info: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% on both the 6h and 30m windows (6x burn).'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%)'
           title: '{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%)'
         }
@@ -884,13 +938,15 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendLatency3d6h'
         enabled: true
         labels: {
@@ -904,7 +960,7 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
           correlationId: 'userJourneyFrontendLatency3d6h/{{ $labels.cluster }}'
           description: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% on both the 3d and 6h windows (1x burn of the p99 < 1s latency budget).'
           info: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% on both the 3d and 6h windows (1x burn of the p99 < 1s latency budget).'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%)'
           title: '{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%)'
         }
@@ -926,13 +982,15 @@ resource arohcpFrontendSloTrafficAlerts 'Microsoft.AlertsManagement/prometheusRu
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendTrafficDrop'
         enabled: true
         labels: {
@@ -944,7 +1002,7 @@ resource arohcpFrontendSloTrafficAlerts 'Microsoft.AlertsManagement/prometheusRu
           correlationId: 'userJourneyFrontendTrafficDrop/{{ $labels.cluster }}'
           description: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS.'
           info: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS.'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline'
           title: '{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline'
         }
@@ -966,13 +1024,15 @@ resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheu
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendSaturationCPU'
         enabled: true
         labels: {
@@ -984,7 +1044,7 @@ resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheu
           correlationId: 'userJourneyFrontendSaturationCPU/{{ $labels.cluster }}'
           description: 'Frontend container CPU (usage/request) on cluster {{ $labels.cluster }} is above 85% for 15m.'
           info: 'Frontend container CPU (usage/request) on cluster {{ $labels.cluster }} is above 85% for 15m.'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend pod CPU above 85% of request for 15+ minutes'
           title: '{{ $labels.cluster }}: Frontend pod CPU above 85% of request for 15+ minutes'
         }
@@ -993,13 +1053,15 @@ resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendSaturationMemory'
         enabled: true
         labels: {
@@ -1011,7 +1073,7 @@ resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheu
           correlationId: 'userJourneyFrontendSaturationMemory/{{ $labels.cluster }}'
           description: 'Frontend container memory (working set/limit) on cluster {{ $labels.cluster }} is above 85% for 15m.'
           info: 'Frontend container memory (working set/limit) on cluster {{ $labels.cluster }} is above 85% for 15m.'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend pod memory above 85% of limit for 15+ minutes'
           title: '{{ $labels.cluster }}: Frontend pod memory above 85% of limit for 15+ minutes'
         }

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -17,13 +17,15 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyAccessClusterErrors1h5m'
         enabled: true
         labels: {
@@ -46,13 +48,15 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyAccessClusterErrors6h30m'
         enabled: true
         labels: {
@@ -75,13 +79,15 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyAccessClusterErrors3d'
         enabled: true
         labels: {
@@ -103,13 +109,15 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyAccessClusterErrorsDegradation'
         enabled: true
         labels: {
@@ -130,13 +138,15 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyAccessClusterStuckOperation'
         enabled: true
         labels: {
@@ -169,13 +179,15 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyAccessClusterSaturationQueueDepth'
         enabled: true
         labels: {
@@ -195,13 +207,15 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyAccessClusterSaturationRetryHotLoop'
         enabled: true
         labels: {
@@ -234,13 +248,15 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJClusterProvisionErrors1h5m'
         enabled: true
         labels: {
@@ -263,13 +279,15 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJClusterProvisionErrors6h30m'
         enabled: true
         labels: {
@@ -292,13 +310,15 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJClusterProvisionErrors3d'
         enabled: true
         labels: {
@@ -320,13 +340,15 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJClusterProvisionErrorsDegradation'
         enabled: true
         labels: {
@@ -360,13 +382,15 @@ resource rpUserJourneyClusterUpgradeMonitorRules 'Microsoft.AlertsManagement/pro
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyClusterUpgradeStuckInDesired'
         enabled: true
         labels: {
@@ -391,13 +415,15 @@ Service Cluster: {{ $labels.cluster }}
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyClusterUpgradeStuckInProgress'
         enabled: true
         labels: {
@@ -435,13 +461,15 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolErrors1h5m'
         enabled: true
         labels: {
@@ -464,13 +492,15 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolErrors6h30m'
         enabled: true
         labels: {
@@ -493,13 +523,15 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolErrors3d'
         enabled: true
         labels: {
@@ -521,13 +553,15 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolErrorsDegradation'
         enabled: true
         labels: {
@@ -548,13 +582,15 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolStuckOperation'
         enabled: true
         labels: {
@@ -587,13 +623,15 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'UJNodePoolSaturationQueueDepth'
         enabled: true
         labels: {
@@ -626,13 +664,15 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendErrors1h5m'
         enabled: true
         labels: {
@@ -655,13 +695,15 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendErrors6h30m'
         enabled: true
         labels: {
@@ -684,13 +726,15 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendErrors3d6h'
         enabled: true
         labels: {
@@ -726,13 +770,15 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendAvailability1h5m'
         enabled: true
         labels: {
@@ -755,13 +801,15 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendAvailability6h30m'
         enabled: true
         labels: {
@@ -784,13 +832,15 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendAvailability3d6h'
         enabled: true
         labels: {
@@ -826,13 +876,15 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendLatencyP991h5m'
         enabled: true
         labels: {
@@ -855,13 +907,15 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendLatencyP996h30m'
         enabled: true
         labels: {
@@ -884,13 +938,15 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendLatencyP993d6h'
         enabled: true
         labels: {
@@ -926,13 +982,15 @@ resource arohcpFrontendSloReadyAlerts 'Microsoft.AlertsManagement/prometheusRule
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendReady'
         enabled: true
         labels: {
@@ -966,13 +1024,15 @@ resource arohcpFrontendSloTrafficAlerts 'Microsoft.AlertsManagement/prometheusRu
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendTrafficDrop'
         enabled: true
         labels: {
@@ -1006,13 +1066,15 @@ resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheu
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendSaturationCPU'
         enabled: true
         labels: {
@@ -1033,13 +1095,15 @@ resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyFrontendSaturationMemory'
         enabled: true
         labels: {

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -684,14 +684,14 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         }
         annotations: {
           correlationId: 'userJourneyFrontendErrors1h5m/{{ $labels.cluster }}'
-          description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% for 5m (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~12h.'
-          info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% for 5m (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~12h.'
+          description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~12h.'
+          info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~12h.'
           runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)'
           title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)'
         }
-        expression: 'errors:frontend_http:error_rate:rate5m > 0.0072'
-        for: 'PT5M'
+        expression: '(avg_over_time(errors:frontend_http:error_rate:rate5m[1h]) > 0.0072 and avg_over_time(errors:frontend_http:error_rate:rate5m[5m]) > 0.0072)'
+        for: 'PT2M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
@@ -715,14 +715,14 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         }
         annotations: {
           correlationId: 'userJourneyFrontendErrors6h30m/{{ $labels.cluster }}'
-          description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% for 30m (6x burn of the 0.05% error budget).'
-          info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% for 30m (6x burn of the 0.05% error budget).'
+          description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget).'
+          info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget).'
           runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
-          summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%) for 30+ minutes'
-          title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%) for 30+ minutes'
+          summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%)'
+          title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%)'
         }
-        expression: 'errors:frontend_http:error_rate:rate5m > 0.003'
-        for: 'PT30M'
+        expression: '(avg_over_time(errors:frontend_http:error_rate:rate5m[6h]) > 0.003 and avg_over_time(errors:frontend_http:error_rate:rate5m[30m]) > 0.003)'
+        for: 'PT15M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
@@ -735,53 +735,25 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
             }
           }
         ]
-        alert: 'userJourneyFrontendErrors3d'
+        alert: 'userJourneyFrontendErrors3d6h'
         enabled: true
         labels: {
           component: 'slo'
           long_window: '3d'
           severity: '4'
+          short_window: '6h'
           slo: 'frontend-errors'
         }
         annotations: {
-          correlationId: 'userJourneyFrontendErrors3d/{{ $labels.cluster }}'
-          description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary for 6h (1x burn).'
-          info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary for 6h (1x burn).'
+          correlationId: 'userJourneyFrontendErrors3d6h/{{ $labels.cluster }}'
+          description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn).'
+          info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn).'
           runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
-          summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%) for 6+ hours'
-          title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%) for 6+ hours'
+          summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)'
+          title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)'
         }
-        expression: 'errors:frontend_http:error_rate:rate5m > 0.0005'
-        for: 'PT6H'
-        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyFrontendErrorsDegradation'
-        enabled: true
-        labels: {
-          component: 'slo'
-          severity: '4'
-          slo: 'frontend-errors'
-        }
-        annotations: {
-          correlationId: 'userJourneyFrontendErrorsDegradation/{{ $labels.cluster }}'
-          description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.15% (3x budget) for 30m - precursor before medium/fast burn pages.'
-          info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.15% (3x budget) for 30m - precursor before medium/fast burn pages.'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
-          summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds 0.15% for 30 minutes'
-          title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds 0.15% for 30 minutes'
-        }
-        expression: 'errors:frontend_http:error_rate:rate5m > 0.0015'
-        for: 'PT30M'
+        expression: '(avg_over_time(errors:frontend_http:error_rate:rate5m[3d]) > 0.0005 and avg_over_time(errors:frontend_http:error_rate:rate5m[6h]) > 0.0005)'
+        for: 'PT1H'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
     ]
@@ -818,14 +790,14 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
         }
         annotations: {
           correlationId: 'userJourneyFrontendAvailability1h5m/{{ $labels.cluster }}'
-          description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket — Errors family pages on the complementary 5xx burn.'
-          info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket — Errors family pages on the complementary 5xx burn.'
+          description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
+          info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
           runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)'
           title: '{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)'
         }
-        expression: 'sli:frontend_http:availability:rate5m < 0.9928'
-        for: 'PT5M'
+        expression: '(avg_over_time(sli:frontend_http:availability:rate5m[1h]) < 0.9928 and avg_over_time(sli:frontend_http:availability:rate5m[5m]) < 0.9928)'
+        for: 'PT2M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
@@ -849,14 +821,14 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
         }
         annotations: {
           correlationId: 'userJourneyFrontendAvailability6h30m/{{ $labels.cluster }}'
-          description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% for 30m (6x burn). Sev4 ticket — Errors family pages on the complementary 5xx burn.'
-          info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% for 30m (6x burn). Sev4 ticket — Errors family pages on the complementary 5xx burn.'
+          description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
+          info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
           runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
-          summary: '{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%) for 30+ minutes'
-          title: '{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%) for 30+ minutes'
+          summary: '{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%)'
+          title: '{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%)'
         }
-        expression: 'sli:frontend_http:availability:rate5m < 0.997'
-        for: 'PT30M'
+        expression: '(avg_over_time(sli:frontend_http:availability:rate5m[6h]) < 0.997 and avg_over_time(sli:frontend_http:availability:rate5m[30m]) < 0.997)'
+        for: 'PT15M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
@@ -869,24 +841,25 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
             }
           }
         ]
-        alert: 'userJourneyFrontendAvailability3d'
+        alert: 'userJourneyFrontendAvailability3d6h'
         enabled: true
         labels: {
           component: 'slo'
           long_window: '3d'
           severity: '4'
+          short_window: '6h'
           slo: 'frontend-availability'
         }
         annotations: {
-          correlationId: 'userJourneyFrontendAvailability3d/{{ $labels.cluster }}'
-          description: 'Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO for 6h (1x burn).'
-          info: 'Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO for 6h (1x burn).'
+          correlationId: 'userJourneyFrontendAvailability3d6h/{{ $labels.cluster }}'
+          description: 'Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO on both the 3d and 6h windows (1x burn).'
+          info: 'Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO on both the 3d and 6h windows (1x burn).'
           runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
-          summary: '{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%) for 6+ hours'
-          title: '{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%) for 6+ hours'
+          summary: '{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%)'
+          title: '{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%)'
         }
-        expression: 'sli:frontend_http:availability:rate5m < 0.9995'
-        for: 'PT6H'
+        expression: '(avg_over_time(sli:frontend_http:availability:rate5m[3d]) < 0.9995 and avg_over_time(sli:frontend_http:availability:rate5m[6h]) < 0.9995)'
+        for: 'PT1H'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
     ]
@@ -923,14 +896,14 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
         }
         annotations: {
           correlationId: 'userJourneyFrontendLatency1h5m/{{ $labels.cluster }}'
-          description: 'Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% for 5m (14.4x burn of the 1% latency budget for the p99 < 1s SLO).'
-          info: 'Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% for 5m (14.4x burn of the 1% latency budget for the p99 < 1s SLO).'
+          description: 'Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO).'
+          info: 'Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO).'
           runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI critically low (share <=1s <85.6%)'
           title: '{{ $labels.cluster }}: Frontend HTTP latency SLI critically low (share <=1s <85.6%)'
         }
-        expression: 'sli:frontend_http:latency:rate5m < 0.856'
-        for: 'PT5M'
+        expression: '(avg_over_time(sli:frontend_http:latency:rate5m[1h]) < 0.856 and avg_over_time(sli:frontend_http:latency:rate5m[5m]) < 0.856)'
+        for: 'PT2M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
@@ -954,14 +927,14 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
         }
         annotations: {
           correlationId: 'userJourneyFrontendLatency6h30m/{{ $labels.cluster }}'
-          description: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% for 30m (6x burn).'
-          info: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% for 30m (6x burn).'
+          description: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% on both the 6h and 30m windows (6x burn).'
+          info: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% on both the 6h and 30m windows (6x burn).'
           runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
-          summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%) for 30+ minutes'
-          title: '{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%) for 30+ minutes'
+          summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%)'
+          title: '{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%)'
         }
-        expression: 'sli:frontend_http:latency:rate5m < 0.94'
-        for: 'PT30M'
+        expression: '(avg_over_time(sli:frontend_http:latency:rate5m[6h]) < 0.94 and avg_over_time(sli:frontend_http:latency:rate5m[30m]) < 0.94)'
+        for: 'PT15M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
@@ -974,24 +947,25 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
             }
           }
         ]
-        alert: 'userJourneyFrontendLatency3d'
+        alert: 'userJourneyFrontendLatency3d6h'
         enabled: true
         labels: {
           component: 'slo'
           long_window: '3d'
           severity: '4'
+          short_window: '6h'
           slo: 'frontend-latency'
         }
         annotations: {
-          correlationId: 'userJourneyFrontendLatency3d/{{ $labels.cluster }}'
-          description: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% for 6h (1x burn of the p99 < 1s latency budget).'
-          info: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% for 6h (1x burn of the p99 < 1s latency budget).'
+          correlationId: 'userJourneyFrontendLatency3d6h/{{ $labels.cluster }}'
+          description: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% on both the 3d and 6h windows (1x burn of the p99 < 1s latency budget).'
+          info: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% on both the 3d and 6h windows (1x burn of the p99 < 1s latency budget).'
           runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
-          summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%) for 6+ hours'
-          title: '{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%) for 6+ hours'
+          summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%)'
+          title: '{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%)'
         }
-        expression: 'sli:frontend_http:latency:rate5m < 0.99'
-        for: 'PT6H'
+        expression: '(avg_over_time(sli:frontend_http:latency:rate5m[3d]) < 0.99 and avg_over_time(sli:frontend_http:latency:rate5m[6h]) < 0.99)'
+        for: 'PT1H'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
     ]

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -17,15 +17,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterErrors1h5m'
         enabled: true
         labels: {
@@ -48,15 +46,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterErrors6h30m'
         enabled: true
         labels: {
@@ -79,15 +75,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterErrors3d'
         enabled: true
         labels: {
@@ -109,15 +103,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterErrorsDegradation'
         enabled: true
         labels: {
@@ -138,15 +130,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterStuckOperation'
         enabled: true
         labels: {
@@ -179,15 +169,13 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterSaturationQueueDepth'
         enabled: true
         labels: {
@@ -207,15 +195,13 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterSaturationRetryHotLoop'
         enabled: true
         labels: {
@@ -248,15 +234,13 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJClusterProvisionErrors1h5m'
         enabled: true
         labels: {
@@ -279,15 +263,13 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJClusterProvisionErrors6h30m'
         enabled: true
         labels: {
@@ -310,15 +292,13 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJClusterProvisionErrors3d'
         enabled: true
         labels: {
@@ -340,15 +320,13 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJClusterProvisionErrorsDegradation'
         enabled: true
         labels: {
@@ -382,15 +360,13 @@ resource rpUserJourneyClusterUpgradeMonitorRules 'Microsoft.AlertsManagement/pro
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyClusterUpgradeStuckInDesired'
         enabled: true
         labels: {
@@ -415,15 +391,13 @@ Service Cluster: {{ $labels.cluster }}
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyClusterUpgradeStuckInProgress'
         enabled: true
         labels: {
@@ -461,15 +435,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolErrors1h5m'
         enabled: true
         labels: {
@@ -492,15 +464,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolErrors6h30m'
         enabled: true
         labels: {
@@ -523,15 +493,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolErrors3d'
         enabled: true
         labels: {
@@ -553,15 +521,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolErrorsDegradation'
         enabled: true
         labels: {
@@ -582,15 +548,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolStuckOperation'
         enabled: true
         labels: {
@@ -623,15 +587,13 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolSaturationQueueDepth'
         enabled: true
         labels: {
@@ -664,15 +626,13 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendErrors1h5m'
         enabled: true
         labels: {
@@ -695,15 +655,13 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendErrors6h30m'
         enabled: true
         labels: {
@@ -726,15 +684,13 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendErrors3d6h'
         enabled: true
         labels: {
@@ -770,15 +726,13 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendAvailability1h5m'
         enabled: true
         labels: {
@@ -801,15 +755,13 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendAvailability6h30m'
         enabled: true
         labels: {
@@ -832,15 +784,13 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendAvailability3d6h'
         enabled: true
         labels: {
@@ -876,16 +826,14 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
-        alert: 'userJourneyFrontendLatency1h5m'
+        }]
+        alert: 'userJourneyFrontendLatencyP991h5m'
         enabled: true
         labels: {
           component: 'slo'
@@ -895,28 +843,26 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
           slo: 'frontend-latency'
         }
         annotations: {
-          correlationId: 'userJourneyFrontendLatency1h5m/{{ $labels.cluster }}'
-          description: 'Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO).'
-          info: 'Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO).'
+          correlationId: 'userJourneyFrontendLatencyP991h5m/{{ $labels.cluster }}'
+          description: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 5s on both the 1h and 5m windows (severe miss of the p99 < 1s ARM sync SLO).'
+          info: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 5s on both the 1h and 5m windows (severe miss of the p99 < 1s ARM sync SLO).'
           runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
-          summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI critically low (share <=1s <85.6%)'
-          title: '{{ $labels.cluster }}: Frontend HTTP latency SLI critically low (share <=1s <85.6%)'
+          summary: '{{ $labels.cluster }}: Frontend HTTP p99 latency critically high (>5s)'
+          title: '{{ $labels.cluster }}: Frontend HTTP p99 latency critically high (>5s)'
         }
-        expression: '(avg_over_time(sli:frontend_http:latency:rate5m[1h]) < 0.856 and avg_over_time(sli:frontend_http:latency:rate5m[5m]) < 0.856)'
+        expression: '(avg_over_time(sli:frontend_http:latency_p99:rate5m[1h]) > 5 and avg_over_time(sli:frontend_http:latency_p99:rate5m[5m]) > 5)'
         for: 'PT2M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
-        alert: 'userJourneyFrontendLatency6h30m'
+        }]
+        alert: 'userJourneyFrontendLatencyP996h30m'
         enabled: true
         labels: {
           component: 'slo'
@@ -926,28 +872,26 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
           slo: 'frontend-latency'
         }
         annotations: {
-          correlationId: 'userJourneyFrontendLatency6h30m/{{ $labels.cluster }}'
-          description: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% on both the 6h and 30m windows (6x burn).'
-          info: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% on both the 6h and 30m windows (6x burn).'
+          correlationId: 'userJourneyFrontendLatencyP996h30m/{{ $labels.cluster }}'
+          description: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 6h and 30m windows (p99 < 1s ARM sync SLO miss).'
+          info: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 6h and 30m windows (p99 < 1s ARM sync SLO miss).'
           runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
-          summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%)'
-          title: '{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%)'
+          summary: '{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)'
+          title: '{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)'
         }
-        expression: '(avg_over_time(sli:frontend_http:latency:rate5m[6h]) < 0.94 and avg_over_time(sli:frontend_http:latency:rate5m[30m]) < 0.94)'
+        expression: '(avg_over_time(sli:frontend_http:latency_p99:rate5m[6h]) > 1 and avg_over_time(sli:frontend_http:latency_p99:rate5m[30m]) > 1)'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
-        alert: 'userJourneyFrontendLatency3d6h'
+        }]
+        alert: 'userJourneyFrontendLatencyP993d6h'
         enabled: true
         labels: {
           component: 'slo'
@@ -957,16 +901,56 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
           slo: 'frontend-latency'
         }
         annotations: {
-          correlationId: 'userJourneyFrontendLatency3d6h/{{ $labels.cluster }}'
-          description: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% on both the 3d and 6h windows (1x burn of the p99 < 1s latency budget).'
-          info: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% on both the 3d and 6h windows (1x burn of the p99 < 1s latency budget).'
+          correlationId: 'userJourneyFrontendLatencyP993d6h/{{ $labels.cluster }}'
+          description: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 3d and 6h windows (1x burn of the p99 < 1s SLO).'
+          info: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 3d and 6h windows (1x burn of the p99 < 1s SLO).'
           runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
-          summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%)'
-          title: '{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%)'
+          summary: '{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)'
+          title: '{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)'
         }
-        expression: '(avg_over_time(sli:frontend_http:latency:rate5m[3d]) < 0.99 and avg_over_time(sli:frontend_http:latency:rate5m[6h]) < 0.99)'
+        expression: '(avg_over_time(sli:frontend_http:latency_p99:rate5m[3d]) > 1 and avg_over_time(sli:frontend_http:latency_p99:rate5m[6h]) > 1)'
         for: 'PT1H'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
+resource arohcpFrontendSloReadyAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_frontend_slo_ready_alerts'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
+          }
+        }]
+        alert: 'userJourneyFrontendReady'
+        enabled: true
+        labels: {
+          component: 'slo'
+          severity: '3'
+          slo: 'frontend-ready'
+        }
+        annotations: {
+          correlationId: 'userJourneyFrontendReady/{{ $labels.cluster }}'
+          description: 'aro-hcp-frontend on cluster {{ $labels.cluster }} has 0 available replicas (kube readiness probes hit /healthz). This is a process outage, not an ARM traffic drought.'
+          info: 'aro-hcp-frontend on cluster {{ $labels.cluster }} has 0 available replicas (kube readiness probes hit /healthz). This is a process outage, not an ARM traffic drought.'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          summary: '{{ $labels.cluster }}: Frontend has no Ready replicas (kube /healthz)'
+          title: '{{ $labels.cluster }}: Frontend has no Ready replicas (kube /healthz)'
+        }
+        expression: 'sli:frontend:ready:ratio5m == 0'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
     ]
     scopes: [
@@ -982,15 +966,13 @@ resource arohcpFrontendSloTrafficAlerts 'Microsoft.AlertsManagement/prometheusRu
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendTrafficDrop'
         enabled: true
         labels: {
@@ -1000,13 +982,13 @@ resource arohcpFrontendSloTrafficAlerts 'Microsoft.AlertsManagement/prometheusRu
         }
         annotations: {
           correlationId: 'userJourneyFrontendTrafficDrop/{{ $labels.cluster }}'
-          description: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS.'
-          info: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS.'
+          description: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS and pods are still Ready (traffic drought, not a replica outage).'
+          info: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS and pods are still Ready (traffic drought, not a replica outage).'
           runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline'
           title: '{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline'
         }
-        expression: '(avg_over_time(traffic:frontend_http:request_rate:rate5m[15m]) < 0.1 * avg_over_time(traffic:frontend_http:request_rate:rate5m[1d])) and avg_over_time(traffic:frontend_http:request_rate:rate5m[1d]) > 0.5'
+        expression: '(avg_over_time(traffic:frontend_http:request_rate:rate5m[15m]) < 0.1 * avg_over_time(traffic:frontend_http:request_rate:rate5m[1d])) and avg_over_time(traffic:frontend_http:request_rate:rate5m[1d]) > 0.5 and sli:frontend:ready:ratio5m > 0'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
@@ -1024,15 +1006,13 @@ resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheu
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendSaturationCPU'
         enabled: true
         labels: {
@@ -1053,15 +1033,13 @@ resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendSaturationMemory'
         enabled: true
         labels: {

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -17,15 +17,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterErrors1h5m'
         enabled: true
         labels: {
@@ -48,15 +46,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterErrors6h30m'
         enabled: true
         labels: {
@@ -79,15 +75,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterErrors3d'
         enabled: true
         labels: {
@@ -109,15 +103,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterErrorsDegradation'
         enabled: true
         labels: {
@@ -138,15 +130,13 @@ resource arohcpAccessClusterSloErrorAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterStuckOperation'
         enabled: true
         labels: {
@@ -179,15 +169,13 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterSaturationQueueDepth'
         enabled: true
         labels: {
@@ -207,15 +195,13 @@ resource arohcpAccessClusterSaturationAlerts 'Microsoft.AlertsManagement/prometh
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyAccessClusterSaturationRetryHotLoop'
         enabled: true
         labels: {
@@ -248,15 +234,13 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJClusterProvisionErrors1h5m'
         enabled: true
         labels: {
@@ -279,15 +263,13 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJClusterProvisionErrors6h30m'
         enabled: true
         labels: {
@@ -310,15 +292,13 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJClusterProvisionErrors3d'
         enabled: true
         labels: {
@@ -340,15 +320,13 @@ resource arohcpClusterProvisionSloErrorAlerts 'Microsoft.AlertsManagement/promet
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJClusterProvisionErrorsDegradation'
         enabled: true
         labels: {
@@ -382,15 +360,13 @@ resource rpUserJourneyClusterUpgradeMonitorRules 'Microsoft.AlertsManagement/pro
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyClusterUpgradeStuckInDesired'
         enabled: true
         labels: {
@@ -415,15 +391,13 @@ Service Cluster: {{ $labels.cluster }}
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyClusterUpgradeStuckInProgress'
         enabled: true
         labels: {
@@ -461,15 +435,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolErrors1h5m'
         enabled: true
         labels: {
@@ -492,15 +464,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolErrors6h30m'
         enabled: true
         labels: {
@@ -523,15 +493,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolErrors3d'
         enabled: true
         labels: {
@@ -553,15 +521,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolErrorsDegradation'
         enabled: true
         labels: {
@@ -582,15 +548,13 @@ resource arohcpNodepoolSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolStuckOperation'
         enabled: true
         labels: {
@@ -623,15 +587,13 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'UJNodePoolSaturationQueueDepth'
         enabled: true
         labels: {
@@ -664,15 +626,13 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendErrors1h5m'
         enabled: true
         labels: {
@@ -684,8 +644,8 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         }
         annotations: {
           correlationId: 'userJourneyFrontendErrors1h5m/{{ $labels.cluster }}'
-          description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~12h.'
-          info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~12h.'
+          description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h).'
+          info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h).'
           runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)'
           title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)'
@@ -695,15 +655,13 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendErrors6h30m'
         enabled: true
         labels: {
@@ -726,15 +684,13 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendErrors3d6h'
         enabled: true
         labels: {
@@ -770,15 +726,13 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendAvailability1h5m'
         enabled: true
         labels: {
@@ -801,15 +755,13 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendAvailability6h30m'
         enabled: true
         labels: {
@@ -832,15 +784,13 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendAvailability3d6h'
         enabled: true
         labels: {
@@ -876,15 +826,13 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendLatency1h5m'
         enabled: true
         labels: {
@@ -907,15 +855,13 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendLatency6h30m'
         enabled: true
         labels: {
@@ -938,15 +884,13 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendLatency3d6h'
         enabled: true
         labels: {
@@ -982,15 +926,13 @@ resource arohcpFrontendSloTrafficAlerts 'Microsoft.AlertsManagement/prometheusRu
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendTrafficDrop'
         enabled: true
         labels: {
@@ -1024,15 +966,13 @@ resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheu
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendSaturationCPU'
         enabled: true
         labels: {
@@ -1053,15 +993,13 @@ resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheu
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyFrontendSaturationMemory'
         enabled: true
         labels: {

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -1042,8 +1042,8 @@ resource arohcpFrontendSloTrafficAlerts 'Microsoft.AlertsManagement/prometheusRu
         }
         annotations: {
           correlationId: 'userJourneyFrontendTrafficDrop/{{ $labels.cluster }}'
-          description: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS and pods are still Ready (traffic drought, not a replica outage).'
-          info: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS and pods are still Ready (traffic drought, not a replica outage).'
+          description: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the 1d baseline exceeded 0.5 RPS (fleet-wide noise floor) and pods are still Ready (traffic drought, not a replica outage).'
+          info: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the 1d baseline exceeded 0.5 RPS (fleet-wide noise floor) and pods are still Ready (traffic drought, not a replica outage).'
           runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline'
           title: '{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline'

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -646,7 +646,7 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
           correlationId: 'userJourneyFrontendErrors1h5m/{{ $labels.cluster }}'
           description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h).'
           info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)'
           title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)'
         }
@@ -675,7 +675,7 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
           correlationId: 'userJourneyFrontendErrors6h30m/{{ $labels.cluster }}'
           description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget).'
           info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%)'
           title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%)'
         }
@@ -704,7 +704,7 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
           correlationId: 'userJourneyFrontendErrors3d6h/{{ $labels.cluster }}'
           description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn).'
           info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)'
           title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)'
         }
@@ -746,7 +746,7 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
           correlationId: 'userJourneyFrontendAvailability1h5m/{{ $labels.cluster }}'
           description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
           info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)'
           title: '{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)'
         }
@@ -775,7 +775,7 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
           correlationId: 'userJourneyFrontendAvailability6h30m/{{ $labels.cluster }}'
           description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
           info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%)'
           title: '{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%)'
         }
@@ -804,7 +804,7 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
           correlationId: 'userJourneyFrontendAvailability3d6h/{{ $labels.cluster }}'
           description: 'Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO on both the 3d and 6h windows (1x burn).'
           info: 'Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO on both the 3d and 6h windows (1x burn).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%)'
           title: '{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%)'
         }
@@ -846,7 +846,7 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
           correlationId: 'userJourneyFrontendLatency1h5m/{{ $labels.cluster }}'
           description: 'Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO).'
           info: 'Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI critically low (share <=1s <85.6%)'
           title: '{{ $labels.cluster }}: Frontend HTTP latency SLI critically low (share <=1s <85.6%)'
         }
@@ -875,7 +875,7 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
           correlationId: 'userJourneyFrontendLatency6h30m/{{ $labels.cluster }}'
           description: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% on both the 6h and 30m windows (6x burn).'
           info: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% on both the 6h and 30m windows (6x burn).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%)'
           title: '{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%)'
         }
@@ -904,7 +904,7 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
           correlationId: 'userJourneyFrontendLatency3d6h/{{ $labels.cluster }}'
           description: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% on both the 3d and 6h windows (1x burn of the p99 < 1s latency budget).'
           info: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% on both the 3d and 6h windows (1x burn of the p99 < 1s latency budget).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%)'
           title: '{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%)'
         }
@@ -944,7 +944,7 @@ resource arohcpFrontendSloTrafficAlerts 'Microsoft.AlertsManagement/prometheusRu
           correlationId: 'userJourneyFrontendTrafficDrop/{{ $labels.cluster }}'
           description: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS.'
           info: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS.'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline'
           title: '{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline'
         }
@@ -984,7 +984,7 @@ resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheu
           correlationId: 'userJourneyFrontendSaturationCPU/{{ $labels.cluster }}'
           description: 'Frontend container CPU (usage/request) on cluster {{ $labels.cluster }} is above 85% for 15m.'
           info: 'Frontend container CPU (usage/request) on cluster {{ $labels.cluster }} is above 85% for 15m.'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend pod CPU above 85% of request for 15+ minutes'
           title: '{{ $labels.cluster }}: Frontend pod CPU above 85% of request for 15+ minutes'
         }
@@ -1011,7 +1011,7 @@ resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheu
           correlationId: 'userJourneyFrontendSaturationMemory/{{ $labels.cluster }}'
           description: 'Frontend container memory (working set/limit) on cluster {{ $labels.cluster }} is above 85% for 15m.'
           info: 'Frontend container memory (working set/limit) on cluster {{ $labels.cluster }} is above 85% for 15m.'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend pod memory above 85% of limit for 15+ minutes'
           title: '{{ $labels.cluster }}: Frontend pod memory above 85% of limit for 15+ minutes'
         }

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -686,7 +686,7 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
           correlationId: 'userJourneyFrontendErrors1h5m/{{ $labels.cluster }}'
           description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h).'
           info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)'
           title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)'
         }
@@ -717,7 +717,7 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
           correlationId: 'userJourneyFrontendErrors6h30m/{{ $labels.cluster }}'
           description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget).'
           info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%)'
           title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%)'
         }
@@ -748,7 +748,7 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
           correlationId: 'userJourneyFrontendErrors3d6h/{{ $labels.cluster }}'
           description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn).'
           info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)'
           title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)'
         }
@@ -792,7 +792,7 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
           correlationId: 'userJourneyFrontendAvailability1h5m/{{ $labels.cluster }}'
           description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
           info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)'
           title: '{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)'
         }
@@ -823,7 +823,7 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
           correlationId: 'userJourneyFrontendAvailability6h30m/{{ $labels.cluster }}'
           description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
           info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%)'
           title: '{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%)'
         }
@@ -854,7 +854,7 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
           correlationId: 'userJourneyFrontendAvailability3d6h/{{ $labels.cluster }}'
           description: 'Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO on both the 3d and 6h windows (1x burn).'
           info: 'Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO on both the 3d and 6h windows (1x burn).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%)'
           title: '{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%)'
         }
@@ -898,7 +898,7 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
           correlationId: 'userJourneyFrontendLatencyP991h5m/{{ $labels.cluster }}'
           description: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 5s on both the 1h and 5m windows (severe miss of the p99 < 1s ARM sync SLO).'
           info: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 5s on both the 1h and 5m windows (severe miss of the p99 < 1s ARM sync SLO).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP p99 latency critically high (>5s)'
           title: '{{ $labels.cluster }}: Frontend HTTP p99 latency critically high (>5s)'
         }
@@ -929,7 +929,7 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
           correlationId: 'userJourneyFrontendLatencyP996h30m/{{ $labels.cluster }}'
           description: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 6h and 30m windows (p99 < 1s ARM sync SLO miss).'
           info: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 6h and 30m windows (p99 < 1s ARM sync SLO miss).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)'
           title: '{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)'
         }
@@ -960,7 +960,7 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
           correlationId: 'userJourneyFrontendLatencyP993d6h/{{ $labels.cluster }}'
           description: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 3d and 6h windows (1x burn of the p99 < 1s SLO).'
           info: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 3d and 6h windows (1x burn of the p99 < 1s SLO).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)'
           title: '{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)'
         }
@@ -1002,7 +1002,7 @@ resource arohcpFrontendSloReadyAlerts 'Microsoft.AlertsManagement/prometheusRule
           correlationId: 'userJourneyFrontendReady/{{ $labels.cluster }}'
           description: 'aro-hcp-frontend on cluster {{ $labels.cluster }} has 0 available replicas (kube readiness probes hit /healthz). This is a process outage, not an ARM traffic drought.'
           info: 'aro-hcp-frontend on cluster {{ $labels.cluster }} has 0 available replicas (kube readiness probes hit /healthz). This is a process outage, not an ARM traffic drought.'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend has no Ready replicas (kube /healthz)'
           title: '{{ $labels.cluster }}: Frontend has no Ready replicas (kube /healthz)'
         }
@@ -1044,7 +1044,7 @@ resource arohcpFrontendSloTrafficAlerts 'Microsoft.AlertsManagement/prometheusRu
           correlationId: 'userJourneyFrontendTrafficDrop/{{ $labels.cluster }}'
           description: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS and pods are still Ready (traffic drought, not a replica outage).'
           info: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS and pods are still Ready (traffic drought, not a replica outage).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline'
           title: '{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline'
         }
@@ -1086,7 +1086,7 @@ resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheu
           correlationId: 'userJourneyFrontendSaturationCPU/{{ $labels.cluster }}'
           description: 'Frontend container CPU (usage/request) on cluster {{ $labels.cluster }} is above 85% for 15m.'
           info: 'Frontend container CPU (usage/request) on cluster {{ $labels.cluster }} is above 85% for 15m.'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend pod CPU above 85% of request for 15+ minutes'
           title: '{{ $labels.cluster }}: Frontend pod CPU above 85% of request for 15+ minutes'
         }
@@ -1115,7 +1115,7 @@ resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheu
           correlationId: 'userJourneyFrontendSaturationMemory/{{ $labels.cluster }}'
           description: 'Frontend container memory (working set/limit) on cluster {{ $labels.cluster }} is above 85% for 15m.'
           info: 'Frontend container memory (working set/limit) on cluster {{ $labels.cluster }} is above 85% for 15m.'
-          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
           summary: '{{ $labels.cluster }}: Frontend pod memory above 85% of limit for 15+ minutes'
           title: '{{ $labels.cluster }}: Frontend pod memory above 85% of limit for 15+ minutes'
         }

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -812,21 +812,21 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
         labels: {
           component: 'slo'
           long_window: '1h'
-          severity: '3'
+          severity: '4'
           short_window: '5m'
           slo: 'frontend-availability'
         }
         annotations: {
           correlationId: 'userJourneyFrontendAvailability1h5m/{{ $labels.cluster }}'
-          description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget).'
-          info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget).'
+          description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket — Errors family pages on the complementary 5xx burn.'
+          info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket — Errors family pages on the complementary 5xx burn.'
           runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)'
           title: '{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)'
         }
         expression: 'sli:frontend_http:availability:rate5m < 0.9928'
         for: 'PT5M'
-        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
         actions: [
@@ -843,21 +843,21 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
         labels: {
           component: 'slo'
           long_window: '6h'
-          severity: '3'
+          severity: '4'
           short_window: '30m'
           slo: 'frontend-availability'
         }
         annotations: {
           correlationId: 'userJourneyFrontendAvailability6h30m/{{ $labels.cluster }}'
-          description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% for 30m (6x burn).'
-          info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% for 30m (6x burn).'
+          description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% for 30m (6x burn). Sev4 ticket — Errors family pages on the complementary 5xx burn.'
+          info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% for 30m (6x burn). Sev4 ticket — Errors family pages on the complementary 5xx burn.'
           runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%) for 30+ minutes'
           title: '{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%) for 30+ minutes'
         }
         expression: 'sli:frontend_http:availability:rate5m < 0.997'
         for: 'PT30M'
-        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
         actions: [

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -656,3 +656,460 @@ resource arohcpNodepoolSaturationAlerts 'Microsoft.AlertsManagement/prometheusRu
     ]
   }
 }
+
+resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_frontend_slo_error_alerts'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyFrontendErrors1h5m'
+        enabled: true
+        labels: {
+          component: 'slo'
+          long_window: '1h'
+          severity: '3'
+          short_window: '5m'
+          slo: 'frontend-errors'
+        }
+        annotations: {
+          correlationId: 'userJourneyFrontendErrors1h5m/{{ $labels.cluster }}'
+          description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% for 5m (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~12h.'
+          info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% for 5m (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~12h.'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)'
+          title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)'
+        }
+        expression: 'errors:frontend_http:error_rate:rate5m > 0.0072'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyFrontendErrors6h30m'
+        enabled: true
+        labels: {
+          component: 'slo'
+          long_window: '6h'
+          severity: '3'
+          short_window: '30m'
+          slo: 'frontend-errors'
+        }
+        annotations: {
+          correlationId: 'userJourneyFrontendErrors6h30m/{{ $labels.cluster }}'
+          description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% for 30m (6x burn of the 0.05% error budget).'
+          info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% for 30m (6x burn of the 0.05% error budget).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%) for 30+ minutes'
+          title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%) for 30+ minutes'
+        }
+        expression: 'errors:frontend_http:error_rate:rate5m > 0.003'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyFrontendErrors3d'
+        enabled: true
+        labels: {
+          component: 'slo'
+          long_window: '3d'
+          severity: '4'
+          slo: 'frontend-errors'
+        }
+        annotations: {
+          correlationId: 'userJourneyFrontendErrors3d/{{ $labels.cluster }}'
+          description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary for 6h (1x burn).'
+          info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary for 6h (1x burn).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%) for 6+ hours'
+          title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%) for 6+ hours'
+        }
+        expression: 'errors:frontend_http:error_rate:rate5m > 0.0005'
+        for: 'PT6H'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyFrontendErrorsDegradation'
+        enabled: true
+        labels: {
+          component: 'slo'
+          severity: '4'
+          slo: 'frontend-errors'
+        }
+        annotations: {
+          correlationId: 'userJourneyFrontendErrorsDegradation/{{ $labels.cluster }}'
+          description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.15% (3x budget) for 30m - precursor before medium/fast burn pages.'
+          info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.15% (3x budget) for 30m - precursor before medium/fast burn pages.'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds 0.15% for 30 minutes'
+          title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds 0.15% for 30 minutes'
+        }
+        expression: 'errors:frontend_http:error_rate:rate5m > 0.0015'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
+resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_frontend_slo_availability_alerts'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyFrontendAvailability1h5m'
+        enabled: true
+        labels: {
+          component: 'slo'
+          long_window: '1h'
+          severity: '3'
+          short_window: '5m'
+          slo: 'frontend-availability'
+        }
+        annotations: {
+          correlationId: 'userJourneyFrontendAvailability1h5m/{{ $labels.cluster }}'
+          description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget).'
+          info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          summary: '{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)'
+          title: '{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)'
+        }
+        expression: 'sli:frontend_http:availability:rate5m < 0.9928'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyFrontendAvailability6h30m'
+        enabled: true
+        labels: {
+          component: 'slo'
+          long_window: '6h'
+          severity: '3'
+          short_window: '30m'
+          slo: 'frontend-availability'
+        }
+        annotations: {
+          correlationId: 'userJourneyFrontendAvailability6h30m/{{ $labels.cluster }}'
+          description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% for 30m (6x burn).'
+          info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% for 30m (6x burn).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          summary: '{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%) for 30+ minutes'
+          title: '{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%) for 30+ minutes'
+        }
+        expression: 'sli:frontend_http:availability:rate5m < 0.997'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyFrontendAvailability3d'
+        enabled: true
+        labels: {
+          component: 'slo'
+          long_window: '3d'
+          severity: '4'
+          slo: 'frontend-availability'
+        }
+        annotations: {
+          correlationId: 'userJourneyFrontendAvailability3d/{{ $labels.cluster }}'
+          description: 'Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO for 6h (1x burn).'
+          info: 'Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO for 6h (1x burn).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          summary: '{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%) for 6+ hours'
+          title: '{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%) for 6+ hours'
+        }
+        expression: 'sli:frontend_http:availability:rate5m < 0.9995'
+        for: 'PT6H'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
+resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_frontend_slo_latency_alerts'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyFrontendLatency1h5m'
+        enabled: true
+        labels: {
+          component: 'slo'
+          long_window: '1h'
+          severity: '3'
+          short_window: '5m'
+          slo: 'frontend-latency'
+        }
+        annotations: {
+          correlationId: 'userJourneyFrontendLatency1h5m/{{ $labels.cluster }}'
+          description: 'Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% for 5m (14.4x burn of the 1% latency budget for the p99 < 1s SLO).'
+          info: 'Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% for 5m (14.4x burn of the 1% latency budget for the p99 < 1s SLO).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI critically low (share <=1s <85.6%)'
+          title: '{{ $labels.cluster }}: Frontend HTTP latency SLI critically low (share <=1s <85.6%)'
+        }
+        expression: 'sli:frontend_http:latency:rate5m < 0.856'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyFrontendLatency6h30m'
+        enabled: true
+        labels: {
+          component: 'slo'
+          long_window: '6h'
+          severity: '3'
+          short_window: '30m'
+          slo: 'frontend-latency'
+        }
+        annotations: {
+          correlationId: 'userJourneyFrontendLatency6h30m/{{ $labels.cluster }}'
+          description: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% for 30m (6x burn).'
+          info: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% for 30m (6x burn).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%) for 30+ minutes'
+          title: '{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%) for 30+ minutes'
+        }
+        expression: 'sli:frontend_http:latency:rate5m < 0.94'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyFrontendLatency3d'
+        enabled: true
+        labels: {
+          component: 'slo'
+          long_window: '3d'
+          severity: '4'
+          slo: 'frontend-latency'
+        }
+        annotations: {
+          correlationId: 'userJourneyFrontendLatency3d/{{ $labels.cluster }}'
+          description: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% for 6h (1x burn of the p99 < 1s latency budget).'
+          info: 'Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% for 6h (1x burn of the p99 < 1s latency budget).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          summary: '{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%) for 6+ hours'
+          title: '{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%) for 6+ hours'
+        }
+        expression: 'sli:frontend_http:latency:rate5m < 0.99'
+        for: 'PT6H'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
+resource arohcpFrontendSloTrafficAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_frontend_slo_traffic_alerts'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyFrontendTrafficDrop'
+        enabled: true
+        labels: {
+          component: 'slo'
+          severity: '4'
+          slo: 'frontend-traffic'
+        }
+        annotations: {
+          correlationId: 'userJourneyFrontendTrafficDrop/{{ $labels.cluster }}'
+          description: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS.'
+          info: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS.'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          summary: '{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline'
+          title: '{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline'
+        }
+        expression: '(avg_over_time(traffic:frontend_http:request_rate:rate5m[15m]) < 0.1 * avg_over_time(traffic:frontend_http:request_rate:rate5m[1d])) and avg_over_time(traffic:frontend_http:request_rate:rate5m[1d]) > 0.5'
+        for: 'PT15M'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
+resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'arohcp_frontend_slo_saturation_alerts'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyFrontendSaturationCPU'
+        enabled: true
+        labels: {
+          component: 'slo'
+          severity: '4'
+          slo: 'frontend-saturation'
+        }
+        annotations: {
+          correlationId: 'userJourneyFrontendSaturationCPU/{{ $labels.cluster }}'
+          description: 'Frontend container CPU (usage/request) on cluster {{ $labels.cluster }} is above 85% for 15m.'
+          info: 'Frontend container CPU (usage/request) on cluster {{ $labels.cluster }} is above 85% for 15m.'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          summary: '{{ $labels.cluster }}: Frontend pod CPU above 85% of request for 15+ minutes'
+          title: '{{ $labels.cluster }}: Frontend pod CPU above 85% of request for 15+ minutes'
+        }
+        expression: 'sli:frontend:saturation_cpu:ratio5m > 0.85'
+        for: 'PT15M'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyFrontendSaturationMemory'
+        enabled: true
+        labels: {
+          component: 'slo'
+          severity: '4'
+          slo: 'frontend-saturation'
+        }
+        annotations: {
+          correlationId: 'userJourneyFrontendSaturationMemory/{{ $labels.cluster }}'
+          description: 'Frontend container memory (working set/limit) on cluster {{ $labels.cluster }} is above 85% for 15m.'
+          info: 'Frontend container memory (working set/limit) on cluster {{ $labels.cluster }} is above 85% for 15m.'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
+          summary: '{{ $labels.cluster }}: Frontend pod memory above 85% of limit for 15+ minutes'
+          title: '{{ $labels.cluster }}: Frontend pod memory above 85% of limit for 15+ minutes'
+        }
+        expression: 'sli:frontend:saturation_memory:ratio5m > 0.85'
+        for: 'PT15M'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}

--- a/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPPrometheusAlertingRules.bicep
@@ -686,7 +686,7 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
           correlationId: 'userJourneyFrontendErrors1h5m/{{ $labels.cluster }}'
           description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h).'
           info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h).'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)'
           title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)'
         }
@@ -717,7 +717,7 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
           correlationId: 'userJourneyFrontendErrors6h30m/{{ $labels.cluster }}'
           description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget).'
           info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget).'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%)'
           title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%)'
         }
@@ -748,7 +748,7 @@ resource arohcpFrontendSloErrorAlerts 'Microsoft.AlertsManagement/prometheusRule
           correlationId: 'userJourneyFrontendErrors3d6h/{{ $labels.cluster }}'
           description: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn).'
           info: 'Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn).'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)'
           title: '{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)'
         }
@@ -792,7 +792,7 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
           correlationId: 'userJourneyFrontendAvailability1h5m/{{ $labels.cluster }}'
           description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
           info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)'
           title: '{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)'
         }
@@ -823,7 +823,7 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
           correlationId: 'userJourneyFrontendAvailability6h30m/{{ $labels.cluster }}'
           description: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
           info: 'Frontend availability on cluster {{ $labels.cluster }} is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn.'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%)'
           title: '{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%)'
         }
@@ -854,7 +854,7 @@ resource arohcpFrontendSloAvailabilityAlerts 'Microsoft.AlertsManagement/prometh
           correlationId: 'userJourneyFrontendAvailability3d6h/{{ $labels.cluster }}'
           description: 'Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO on both the 3d and 6h windows (1x burn).'
           info: 'Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO on both the 3d and 6h windows (1x burn).'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%)'
           title: '{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%)'
         }
@@ -898,7 +898,7 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
           correlationId: 'userJourneyFrontendLatencyP991h5m/{{ $labels.cluster }}'
           description: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 5s on both the 1h and 5m windows (severe miss of the p99 < 1s ARM sync SLO).'
           info: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 5s on both the 1h and 5m windows (severe miss of the p99 < 1s ARM sync SLO).'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP p99 latency critically high (>5s)'
           title: '{{ $labels.cluster }}: Frontend HTTP p99 latency critically high (>5s)'
         }
@@ -929,7 +929,7 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
           correlationId: 'userJourneyFrontendLatencyP996h30m/{{ $labels.cluster }}'
           description: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 6h and 30m windows (p99 < 1s ARM sync SLO miss).'
           info: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 6h and 30m windows (p99 < 1s ARM sync SLO miss).'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)'
           title: '{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)'
         }
@@ -960,7 +960,7 @@ resource arohcpFrontendSloLatencyAlerts 'Microsoft.AlertsManagement/prometheusRu
           correlationId: 'userJourneyFrontendLatencyP993d6h/{{ $labels.cluster }}'
           description: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 3d and 6h windows (1x burn of the p99 < 1s SLO).'
           info: 'Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 3d and 6h windows (1x burn of the p99 < 1s SLO).'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)'
           title: '{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)'
         }
@@ -1002,7 +1002,7 @@ resource arohcpFrontendSloReadyAlerts 'Microsoft.AlertsManagement/prometheusRule
           correlationId: 'userJourneyFrontendReady/{{ $labels.cluster }}'
           description: 'aro-hcp-frontend on cluster {{ $labels.cluster }} has 0 available replicas (kube readiness probes hit /healthz). This is a process outage, not an ARM traffic drought.'
           info: 'aro-hcp-frontend on cluster {{ $labels.cluster }} has 0 available replicas (kube readiness probes hit /healthz). This is a process outage, not an ARM traffic drought.'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend has no Ready replicas (kube /healthz)'
           title: '{{ $labels.cluster }}: Frontend has no Ready replicas (kube /healthz)'
         }
@@ -1044,7 +1044,7 @@ resource arohcpFrontendSloTrafficAlerts 'Microsoft.AlertsManagement/prometheusRu
           correlationId: 'userJourneyFrontendTrafficDrop/{{ $labels.cluster }}'
           description: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the 1d baseline exceeded 0.5 RPS (fleet-wide noise floor) and pods are still Ready (traffic drought, not a replica outage).'
           info: 'Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the 1d baseline exceeded 0.5 RPS (fleet-wide noise floor) and pods are still Ready (traffic drought, not a replica outage).'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline'
           title: '{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline'
         }
@@ -1086,7 +1086,7 @@ resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheu
           correlationId: 'userJourneyFrontendSaturationCPU/{{ $labels.cluster }}'
           description: 'Frontend container CPU (usage/request) on cluster {{ $labels.cluster }} is above 85% for 15m.'
           info: 'Frontend container CPU (usage/request) on cluster {{ $labels.cluster }} is above 85% for 15m.'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend pod CPU above 85% of request for 15+ minutes'
           title: '{{ $labels.cluster }}: Frontend pod CPU above 85% of request for 15+ minutes'
         }
@@ -1115,7 +1115,7 @@ resource arohcpFrontendSloSaturationAlerts 'Microsoft.AlertsManagement/prometheu
           correlationId: 'userJourneyFrontendSaturationMemory/{{ $labels.cluster }}'
           description: 'Frontend container memory (working set/limit) on cluster {{ $labels.cluster }} is above 85% for 15m.'
           info: 'Frontend container memory (working set/limit) on cluster {{ $labels.cluster }} is above 85% for 15m.'
-          runbook_url: 'https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend'
+          runbook_url: 'https://aka.ms/arohcp-runbook-frontend'
           summary: '{{ $labels.cluster }}: Frontend pod memory above 85% of limit for 15+ minutes'
           title: '{{ $labels.cluster }}: Frontend pod memory above 85% of limit for 15+ minutes'
         }

--- a/observability/alerts-rp-services.yaml
+++ b/observability/alerts-rp-services.yaml
@@ -4,6 +4,7 @@ prometheusRules:
   - alerts/cluster-provision-slo-prometheusRule.yaml
   - alerts/userJourneyClusterUpgradeMonitor-prometheusRule.yaml
   - alerts/nodepool-slo-prometheusRule.yaml
+  - alerts/frontend-slo-prometheusRule.yaml
   untestedRules: []
   testDependencies:
   - recording-rules-services.yaml

--- a/observability/alerts/frontend-slo-prometheusRule.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule.yaml
@@ -35,7 +35,6 @@ spec:
   # summary includes {{ $labels.cluster }} (Access / Node Pool convention; prometheus-rules
   # generator requires it). IcM.Title may also prepend cluster - same as other RP alerts.
   # component is on each rule (not group) for promtool compatibility.
-  # runbook_url uses the eng.ms Frontend UJ path (aka.ms/arohcp-runbook-frontend should alias the same URL once created).
   - name: arohcp_frontend_slo_error_alerts
     rules:
     - alert: userJourneyFrontendErrors1h5m
@@ -55,7 +54,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)"
         description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendErrors6h30m
       expr: |
         (
@@ -73,7 +72,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%)"
         description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendErrors3d6h
       expr: |
         (
@@ -91,7 +90,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)"
         description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_availability_alerts
     rules:
     - alert: userJourneyFrontendAvailability1h5m
@@ -111,7 +110,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)"
         description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendAvailability6h30m
       expr: |
         (
@@ -129,7 +128,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%)"
         description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendAvailability3d6h
       expr: |
         (
@@ -147,7 +146,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%)"
         description: "Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO on both the 3d and 6h windows (1x burn)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_latency_alerts
     rules:
     - alert: userJourneyFrontendLatency1h5m
@@ -167,7 +166,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI critically low (share <=1s <85.6%)"
         description: "Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendLatency6h30m
       expr: |
         (
@@ -185,7 +184,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%)"
         description: "Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% on both the 6h and 30m windows (6x burn)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendLatency3d6h
       expr: |
         (
@@ -203,7 +202,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%)"
         description: "Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% on both the 3d and 6h windows (1x burn of the p99 < 1s latency budget)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_traffic_alerts
     rules:
     - alert: userJourneyFrontendTrafficDrop
@@ -222,7 +221,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline"
         description: "Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_saturation_alerts
     rules:
     - alert: userJourneyFrontendSaturationCPU
@@ -236,7 +235,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend pod CPU above 85% of request for 15+ minutes"
         description: "Frontend container CPU (usage/request) on cluster {{ $labels.cluster }} is above 85% for 15m."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendSaturationMemory
       expr: |
         sli:frontend:saturation_memory:ratio5m > 0.85
@@ -248,4 +247,4 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend pod memory above 85% of limit for 15+ minutes"
         description: "Frontend container memory (working set/limit) on cluster {{ $labels.cluster }} is above 85% for 15m."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"

--- a/observability/alerts/frontend-slo-prometheusRule.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule.yaml
@@ -222,6 +222,11 @@ spec:
         summary: "{{ $labels.cluster }}: Frontend has no Ready replicas (kube /healthz)"
         description: "aro-hcp-frontend on cluster {{ $labels.cluster }} has 0 available replicas (kube readiness probes hit /healthz). This is a process outage, not an ARM traffic drought."
         runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+  # Traffic drought is Sev 4 (ticket). The 0.5 RPS 1d-baseline floor is a
+  # fleet-wide noise gate, not an SLO: 10% of 0.5 RPS is 0.05 RPS (~3 rpm),
+  # below which a 90% drop is scrape noise / idle INT, not a customer-visible
+  # ARM collapse. Replica death is userJourneyFrontendReady (Sev 3).
+  # One RP bicep is generated for all clouds, so the floor is not per-env.
   - name: arohcp_frontend_slo_traffic_alerts
     labels:
       component: slo
@@ -242,7 +247,7 @@ spec:
         slo: frontend-traffic
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline"
-        description: "Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS and pods are still Ready (traffic drought, not a replica outage)."
+        description: "Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the 1d baseline exceeded 0.5 RPS (fleet-wide noise floor) and pods are still Ready (traffic drought, not a replica outage)."
         runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - name: arohcp_frontend_slo_saturation_alerts
     labels:

--- a/observability/alerts/frontend-slo-prometheusRule.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule.yaml
@@ -11,9 +11,9 @@ metadata:
 spec:
   groups:
   # ========================================
-  # Frontend (ARM RP) SLO Alerts — Errors
+  # Frontend (ARM RP) SLO Alerts
   # ========================================
-  # Driven by errors:frontend_http:error_rate:rate5m (ARO-28705 recording rules).
+  # Driven by ARO-28705 recording rules (errors / availability / latency rate5m).
   # Naming: {Scope}{Subject}{Metric}{BurnRateTier} per ADR-001.
   #
   # Availability SLO 99.95% -> error budget 0.05% (0.0005):
@@ -21,21 +21,30 @@ spec:
   #   Medium (6x):  6 * 0.0005 = 0.003 -> 0.30% 5xx share
   #   Slow (1x):    1 * 0.0005 = 0.0005 -> 0.05% 5xx share
   #
-  # Rate-based SLI: 'for' approximates the short window (Access / Node Pool pattern).
+  # Multi-window multi-burn-rate (ADR 79 / Google MWMBR): fast and medium
+  # require BOTH long-window and short-window avg_over_time on the rate5m
+  # series (same pattern as kube-apiserver burnrate1h AND burnrate5m). `for`
+  # is a short pending duration only - not a substitute for the short window.
+  # Slow uses 3d long + 6h short at 1x.
+  #
   # Fast/medium Errors + Latency page Sev 3 (customer-facing UJ).
-  # Availability is Sev 4 only — complementary to Errors on the same denominator,
+  # Availability is Sev 4 only - complementary to Errors on the same denominator,
   # so dual Sev3 would open two IcMs per 5xx event (review feedback).
-  # Slow/degradation/traffic/saturation Sev 4 ticket.
+  # Slow/traffic/saturation Sev 4 ticket.
   #
   # summary includes {{ $labels.cluster }} (Access / Node Pool convention; prometheus-rules
-  # generator requires it). IcM.Title may also prepend cluster — same as other RP alerts.
+  # generator requires it). IcM.Title may also prepend cluster - same as other RP alerts.
   # component is on each rule (not group) for promtool compatibility.
   - name: arohcp_frontend_slo_error_alerts
     rules:
     - alert: userJourneyFrontendErrors1h5m
       expr: |
-        errors:frontend_http:error_rate:rate5m > 0.0072
-      for: 5m
+        (
+          avg_over_time(errors:frontend_http:error_rate:rate5m[1h]) > 0.0072
+          and
+          avg_over_time(errors:frontend_http:error_rate:rate5m[5m]) > 0.0072
+        )
+      for: 2m
       labels:
         component: slo
         severity: "3"
@@ -44,12 +53,16 @@ spec:
         short_window: 5m
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)"
-        description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% for 5m (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~12h."
+        description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~12h."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendErrors6h30m
       expr: |
-        errors:frontend_http:error_rate:rate5m > 0.003
-      for: 30m
+        (
+          avg_over_time(errors:frontend_http:error_rate:rate5m[6h]) > 0.003
+          and
+          avg_over_time(errors:frontend_http:error_rate:rate5m[30m]) > 0.003
+        )
+      for: 15m
       labels:
         component: slo
         severity: "3"
@@ -57,40 +70,37 @@ spec:
         long_window: 6h
         short_window: 30m
       annotations:
-        summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%) for 30+ minutes"
-        description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% for 30m (6x burn of the 0.05% error budget)."
+        summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%)"
+        description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-    - alert: userJourneyFrontendErrors3d
+    - alert: userJourneyFrontendErrors3d6h
       expr: |
-        errors:frontend_http:error_rate:rate5m > 0.0005
-      for: 6h
+        (
+          avg_over_time(errors:frontend_http:error_rate:rate5m[3d]) > 0.0005
+          and
+          avg_over_time(errors:frontend_http:error_rate:rate5m[6h]) > 0.0005
+        )
+      for: 1h
       labels:
         component: slo
         severity: "4"
         slo: frontend-errors
         long_window: 3d
+        short_window: 6h
       annotations:
-        summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%) for 6+ hours"
-        description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary for 6h (1x burn)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-    - alert: userJourneyFrontendErrorsDegradation
-      expr: |
-        errors:frontend_http:error_rate:rate5m > 0.0015
-      for: 30m
-      labels:
-        component: slo
-        severity: "4"
-        slo: frontend-errors
-      annotations:
-        summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds 0.15% for 30 minutes"
-        description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.15% (3x budget) for 30m - precursor before medium/fast burn pages."
+        summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)"
+        description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_availability_alerts
     rules:
     - alert: userJourneyFrontendAvailability1h5m
       expr: |
-        sli:frontend_http:availability:rate5m < 0.9928
-      for: 5m
+        (
+          avg_over_time(sli:frontend_http:availability:rate5m[1h]) < 0.9928
+          and
+          avg_over_time(sli:frontend_http:availability:rate5m[5m]) < 0.9928
+        )
+      for: 2m
       labels:
         component: slo
         severity: "4"
@@ -99,12 +109,16 @@ spec:
         short_window: 5m
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)"
-        description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket — Errors family pages on the complementary 5xx burn."
+        description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendAvailability6h30m
       expr: |
-        sli:frontend_http:availability:rate5m < 0.997
-      for: 30m
+        (
+          avg_over_time(sli:frontend_http:availability:rate5m[6h]) < 0.997
+          and
+          avg_over_time(sli:frontend_http:availability:rate5m[30m]) < 0.997
+        )
+      for: 15m
       labels:
         component: slo
         severity: "4"
@@ -112,28 +126,37 @@ spec:
         long_window: 6h
         short_window: 30m
       annotations:
-        summary: "{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%) for 30+ minutes"
-        description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.70% for 30m (6x burn). Sev4 ticket — Errors family pages on the complementary 5xx burn."
+        summary: "{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%)"
+        description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-    - alert: userJourneyFrontendAvailability3d
+    - alert: userJourneyFrontendAvailability3d6h
       expr: |
-        sli:frontend_http:availability:rate5m < 0.9995
-      for: 6h
+        (
+          avg_over_time(sli:frontend_http:availability:rate5m[3d]) < 0.9995
+          and
+          avg_over_time(sli:frontend_http:availability:rate5m[6h]) < 0.9995
+        )
+      for: 1h
       labels:
         component: slo
         severity: "4"
         slo: frontend-availability
         long_window: 3d
+        short_window: 6h
       annotations:
-        summary: "{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%) for 6+ hours"
-        description: "Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO for 6h (1x burn)."
+        summary: "{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%)"
+        description: "Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO on both the 3d and 6h windows (1x burn)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_latency_alerts
     rules:
     - alert: userJourneyFrontendLatency1h5m
       expr: |
-        sli:frontend_http:latency:rate5m < 0.856
-      for: 5m
+        (
+          avg_over_time(sli:frontend_http:latency:rate5m[1h]) < 0.856
+          and
+          avg_over_time(sli:frontend_http:latency:rate5m[5m]) < 0.856
+        )
+      for: 2m
       labels:
         component: slo
         severity: "3"
@@ -142,12 +165,16 @@ spec:
         short_window: 5m
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI critically low (share <=1s <85.6%)"
-        description: "Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% for 5m (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
+        description: "Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendLatency6h30m
       expr: |
-        sli:frontend_http:latency:rate5m < 0.94
-      for: 30m
+        (
+          avg_over_time(sli:frontend_http:latency:rate5m[6h]) < 0.94
+          and
+          avg_over_time(sli:frontend_http:latency:rate5m[30m]) < 0.94
+        )
+      for: 15m
       labels:
         component: slo
         severity: "3"
@@ -155,21 +182,26 @@ spec:
         long_window: 6h
         short_window: 30m
       annotations:
-        summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%) for 30+ minutes"
-        description: "Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% for 30m (6x burn)."
+        summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%)"
+        description: "Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% on both the 6h and 30m windows (6x burn)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-    - alert: userJourneyFrontendLatency3d
+    - alert: userJourneyFrontendLatency3d6h
       expr: |
-        sli:frontend_http:latency:rate5m < 0.99
-      for: 6h
+        (
+          avg_over_time(sli:frontend_http:latency:rate5m[3d]) < 0.99
+          and
+          avg_over_time(sli:frontend_http:latency:rate5m[6h]) < 0.99
+        )
+      for: 1h
       labels:
         component: slo
         severity: "4"
         slo: frontend-latency
         long_window: 3d
+        short_window: 6h
       annotations:
-        summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%) for 6+ hours"
-        description: "Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% for 6h (1x burn of the p99 < 1s latency budget)."
+        summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%)"
+        description: "Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% on both the 3d and 6h windows (1x burn of the p99 < 1s latency budget)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_traffic_alerts
     rules:

--- a/observability/alerts/frontend-slo-prometheusRule.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule.yaml
@@ -53,7 +53,7 @@ spec:
         short_window: 5m
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)"
-        description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~12h."
+        description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendErrors6h30m
       expr: |

--- a/observability/alerts/frontend-slo-prometheusRule.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule.yaml
@@ -13,13 +13,21 @@ spec:
   # ========================================
   # Frontend (ARM RP) SLO Alerts
   # ========================================
-  # Driven by ARO-28705 recording rules (errors / availability / latency rate5m).
+  # Driven by ARO-28705 recording rules (errors / availability / latency p99).
   # Naming: {Scope}{Subject}{Metric}{BurnRateTier} per ADR-001.
   #
   # Availability SLO 99.95% -> error budget 0.05% (0.0005):
   #   Fast (14.4x): 14.4 * 0.0005 = 0.0072 -> 0.72% 5xx share
   #   Medium (6x):  6 * 0.0005 = 0.003 -> 0.30% 5xx share
   #   Slow (1x):    1 * 0.0005 = 0.0005 -> 0.05% 5xx share
+  #
+  # Latency SLO p99 < 1s (histogram_quantile seconds, not a 1s-bucket share):
+  #   Fast 1h/5m:   p99 > 5s (severe miss)
+  #   Medium 6h/30m: p99 > 1s (SLO miss)
+  #   Slow 3d/6h:   p99 > 1s (ticket)
+  #
+  # Ready: kube /healthz via Deployment available/spec. Distinguishes a
+  # Frontend outage (ready=0) from an ARM traffic drought (HTTP SLIs absent).
   #
   # Multi-window multi-burn-rate (ADR 79 / Google MWMBR): fast and medium
   # require BOTH long-window and short-window avg_over_time on the rate5m
@@ -149,12 +157,12 @@ spec:
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_latency_alerts
     rules:
-    - alert: userJourneyFrontendLatency1h5m
+    - alert: userJourneyFrontendLatencyP991h5m
       expr: |
         (
-          avg_over_time(sli:frontend_http:latency:rate5m[1h]) < 0.856
+          avg_over_time(sli:frontend_http:latency_p99:rate5m[1h]) > 5
           and
-          avg_over_time(sli:frontend_http:latency:rate5m[5m]) < 0.856
+          avg_over_time(sli:frontend_http:latency_p99:rate5m[5m]) > 5
         )
       for: 2m
       labels:
@@ -164,15 +172,15 @@ spec:
         long_window: 1h
         short_window: 5m
       annotations:
-        summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI critically low (share <=1s <85.6%)"
-        description: "Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
+        summary: "{{ $labels.cluster }}: Frontend HTTP p99 latency critically high (>5s)"
+        description: "Frontend p99 latency on cluster {{ $labels.cluster }} is above 5s on both the 1h and 5m windows (severe miss of the p99 < 1s ARM sync SLO)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-    - alert: userJourneyFrontendLatency6h30m
+    - alert: userJourneyFrontendLatencyP996h30m
       expr: |
         (
-          avg_over_time(sli:frontend_http:latency:rate5m[6h]) < 0.94
+          avg_over_time(sli:frontend_http:latency_p99:rate5m[6h]) > 1
           and
-          avg_over_time(sli:frontend_http:latency:rate5m[30m]) < 0.94
+          avg_over_time(sli:frontend_http:latency_p99:rate5m[30m]) > 1
         )
       for: 15m
       labels:
@@ -182,15 +190,15 @@ spec:
         long_window: 6h
         short_window: 30m
       annotations:
-        summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%)"
-        description: "Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% on both the 6h and 30m windows (6x burn)."
+        summary: "{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)"
+        description: "Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 6h and 30m windows (p99 < 1s ARM sync SLO miss)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-    - alert: userJourneyFrontendLatency3d6h
+    - alert: userJourneyFrontendLatencyP993d6h
       expr: |
         (
-          avg_over_time(sli:frontend_http:latency:rate5m[3d]) < 0.99
+          avg_over_time(sli:frontend_http:latency_p99:rate5m[3d]) > 1
           and
-          avg_over_time(sli:frontend_http:latency:rate5m[6h]) < 0.99
+          avg_over_time(sli:frontend_http:latency_p99:rate5m[6h]) > 1
         )
       for: 1h
       labels:
@@ -200,8 +208,22 @@ spec:
         long_window: 3d
         short_window: 6h
       annotations:
-        summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%)"
-        description: "Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% on both the 3d and 6h windows (1x burn of the p99 < 1s latency budget)."
+        summary: "{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)"
+        description: "Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 3d and 6h windows (1x burn of the p99 < 1s SLO)."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+  - name: arohcp_frontend_slo_ready_alerts
+    rules:
+    - alert: userJourneyFrontendReady
+      expr: |
+        sli:frontend:ready:ratio5m == 0
+      for: 5m
+      labels:
+        component: slo
+        severity: "3"
+        slo: frontend-ready
+      annotations:
+        summary: "{{ $labels.cluster }}: Frontend has no Ready replicas (kube /healthz)"
+        description: "aro-hcp-frontend on cluster {{ $labels.cluster }} has 0 available replicas (kube readiness probes hit /healthz). This is a process outage, not an ARM traffic drought."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_traffic_alerts
     rules:
@@ -213,6 +235,8 @@ spec:
         )
         and
         avg_over_time(traffic:frontend_http:request_rate:rate5m[1d]) > 0.5
+        and
+        sli:frontend:ready:ratio5m > 0
       for: 15m
       labels:
         component: slo
@@ -220,7 +244,7 @@ spec:
         slo: frontend-traffic
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline"
-        description: "Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS."
+        description: "Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS and pods are still Ready (traffic drought, not a replica outage)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_saturation_alerts
     rules:

--- a/observability/alerts/frontend-slo-prometheusRule.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule.yaml
@@ -42,8 +42,9 @@ spec:
   #
   # summary includes {{ $labels.cluster }} (Access / Node Pool convention; prometheus-rules
   # generator requires it). IcM.Title may also prepend cluster - same as other RP alerts.
-  # component is on each rule (not group) for promtool compatibility.
   - name: arohcp_frontend_slo_error_alerts
+    labels:
+      component: slo
     rules:
     - alert: userJourneyFrontendErrors1h5m
       expr: |
@@ -54,7 +55,6 @@ spec:
         )
       for: 2m
       labels:
-        component: slo
         severity: "3"
         slo: frontend-errors
         long_window: 1h
@@ -72,7 +72,6 @@ spec:
         )
       for: 15m
       labels:
-        component: slo
         severity: "3"
         slo: frontend-errors
         long_window: 6h
@@ -90,7 +89,6 @@ spec:
         )
       for: 1h
       labels:
-        component: slo
         severity: "4"
         slo: frontend-errors
         long_window: 3d
@@ -100,6 +98,8 @@ spec:
         description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_availability_alerts
+    labels:
+      component: slo
     rules:
     - alert: userJourneyFrontendAvailability1h5m
       expr: |
@@ -110,7 +110,6 @@ spec:
         )
       for: 2m
       labels:
-        component: slo
         severity: "4"
         slo: frontend-availability
         long_window: 1h
@@ -128,7 +127,6 @@ spec:
         )
       for: 15m
       labels:
-        component: slo
         severity: "4"
         slo: frontend-availability
         long_window: 6h
@@ -146,7 +144,6 @@ spec:
         )
       for: 1h
       labels:
-        component: slo
         severity: "4"
         slo: frontend-availability
         long_window: 3d
@@ -156,6 +153,8 @@ spec:
         description: "Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO on both the 3d and 6h windows (1x burn)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_latency_alerts
+    labels:
+      component: slo
     rules:
     - alert: userJourneyFrontendLatencyP991h5m
       expr: |
@@ -166,7 +165,6 @@ spec:
         )
       for: 2m
       labels:
-        component: slo
         severity: "3"
         slo: frontend-latency
         long_window: 1h
@@ -184,7 +182,6 @@ spec:
         )
       for: 15m
       labels:
-        component: slo
         severity: "3"
         slo: frontend-latency
         long_window: 6h
@@ -202,7 +199,6 @@ spec:
         )
       for: 1h
       labels:
-        component: slo
         severity: "4"
         slo: frontend-latency
         long_window: 3d
@@ -212,13 +208,14 @@ spec:
         description: "Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 3d and 6h windows (1x burn of the p99 < 1s SLO)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_ready_alerts
+    labels:
+      component: slo
     rules:
     - alert: userJourneyFrontendReady
       expr: |
         sli:frontend:ready:ratio5m == 0
       for: 5m
       labels:
-        component: slo
         severity: "3"
         slo: frontend-ready
       annotations:
@@ -226,6 +223,8 @@ spec:
         description: "aro-hcp-frontend on cluster {{ $labels.cluster }} has 0 available replicas (kube readiness probes hit /healthz). This is a process outage, not an ARM traffic drought."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_traffic_alerts
+    labels:
+      component: slo
     rules:
     - alert: userJourneyFrontendTrafficDrop
       expr: |
@@ -239,7 +238,6 @@ spec:
         sli:frontend:ready:ratio5m > 0
       for: 15m
       labels:
-        component: slo
         severity: "4"
         slo: frontend-traffic
       annotations:
@@ -247,13 +245,14 @@ spec:
         description: "Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS and pods are still Ready (traffic drought, not a replica outage)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_saturation_alerts
+    labels:
+      component: slo
     rules:
     - alert: userJourneyFrontendSaturationCPU
       expr: |
         sli:frontend:saturation_cpu:ratio5m > 0.85
       for: 15m
       labels:
-        component: slo
         severity: "4"
         slo: frontend-saturation
       annotations:
@@ -265,7 +264,6 @@ spec:
         sli:frontend:saturation_memory:ratio5m > 0.85
       for: 15m
       labels:
-        component: slo
         severity: "4"
         slo: frontend-saturation
       annotations:

--- a/observability/alerts/frontend-slo-prometheusRule.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule.yaml
@@ -35,6 +35,7 @@ spec:
   # summary includes {{ $labels.cluster }} (Access / Node Pool convention; prometheus-rules
   # generator requires it). IcM.Title may also prepend cluster - same as other RP alerts.
   # component is on each rule (not group) for promtool compatibility.
+  # runbook_url uses the eng.ms Frontend UJ path (aka.ms/arohcp-runbook-frontend should alias the same URL once created).
   - name: arohcp_frontend_slo_error_alerts
     rules:
     - alert: userJourneyFrontendErrors1h5m
@@ -54,7 +55,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)"
         description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
     - alert: userJourneyFrontendErrors6h30m
       expr: |
         (
@@ -72,7 +73,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%)"
         description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
     - alert: userJourneyFrontendErrors3d6h
       expr: |
         (
@@ -90,7 +91,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)"
         description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - name: arohcp_frontend_slo_availability_alerts
     rules:
     - alert: userJourneyFrontendAvailability1h5m
@@ -110,7 +111,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)"
         description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
     - alert: userJourneyFrontendAvailability6h30m
       expr: |
         (
@@ -128,7 +129,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%)"
         description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
     - alert: userJourneyFrontendAvailability3d6h
       expr: |
         (
@@ -146,7 +147,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%)"
         description: "Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO on both the 3d and 6h windows (1x burn)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - name: arohcp_frontend_slo_latency_alerts
     rules:
     - alert: userJourneyFrontendLatency1h5m
@@ -166,7 +167,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI critically low (share <=1s <85.6%)"
         description: "Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
     - alert: userJourneyFrontendLatency6h30m
       expr: |
         (
@@ -184,7 +185,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%)"
         description: "Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% on both the 6h and 30m windows (6x burn)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
     - alert: userJourneyFrontendLatency3d6h
       expr: |
         (
@@ -202,7 +203,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%)"
         description: "Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% on both the 3d and 6h windows (1x burn of the p99 < 1s latency budget)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - name: arohcp_frontend_slo_traffic_alerts
     rules:
     - alert: userJourneyFrontendTrafficDrop
@@ -221,7 +222,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline"
         description: "Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - name: arohcp_frontend_slo_saturation_alerts
     rules:
     - alert: userJourneyFrontendSaturationCPU
@@ -235,7 +236,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend pod CPU above 85% of request for 15+ minutes"
         description: "Frontend container CPU (usage/request) on cluster {{ $labels.cluster }} is above 85% for 15m."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
     - alert: userJourneyFrontendSaturationMemory
       expr: |
         sli:frontend:saturation_memory:ratio5m > 0.85
@@ -247,4 +248,4 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend pod memory above 85% of limit for 15+ minutes"
         description: "Frontend container memory (working set/limit) on cluster {{ $labels.cluster }} is above 85% for 15m."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"

--- a/observability/alerts/frontend-slo-prometheusRule.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule.yaml
@@ -62,7 +62,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)"
         description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
     - alert: userJourneyFrontendErrors6h30m
       expr: |
         (
@@ -79,7 +79,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%)"
         description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
     - alert: userJourneyFrontendErrors3d6h
       expr: |
         (
@@ -96,7 +96,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)"
         description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - name: arohcp_frontend_slo_availability_alerts
     labels:
       component: slo
@@ -117,7 +117,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)"
         description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
     - alert: userJourneyFrontendAvailability6h30m
       expr: |
         (
@@ -134,7 +134,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%)"
         description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
     - alert: userJourneyFrontendAvailability3d6h
       expr: |
         (
@@ -151,7 +151,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%)"
         description: "Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO on both the 3d and 6h windows (1x burn)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - name: arohcp_frontend_slo_latency_alerts
     labels:
       component: slo
@@ -172,7 +172,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP p99 latency critically high (>5s)"
         description: "Frontend p99 latency on cluster {{ $labels.cluster }} is above 5s on both the 1h and 5m windows (severe miss of the p99 < 1s ARM sync SLO)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
     - alert: userJourneyFrontendLatencyP996h30m
       expr: |
         (
@@ -189,7 +189,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)"
         description: "Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 6h and 30m windows (p99 < 1s ARM sync SLO miss)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
     - alert: userJourneyFrontendLatencyP993d6h
       expr: |
         (
@@ -206,7 +206,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)"
         description: "Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 3d and 6h windows (1x burn of the p99 < 1s SLO)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - name: arohcp_frontend_slo_ready_alerts
     labels:
       component: slo
@@ -221,7 +221,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend has no Ready replicas (kube /healthz)"
         description: "aro-hcp-frontend on cluster {{ $labels.cluster }} has 0 available replicas (kube readiness probes hit /healthz). This is a process outage, not an ARM traffic drought."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - name: arohcp_frontend_slo_traffic_alerts
     labels:
       component: slo
@@ -243,7 +243,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline"
         description: "Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS and pods are still Ready (traffic drought, not a replica outage)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - name: arohcp_frontend_slo_saturation_alerts
     labels:
       component: slo
@@ -258,7 +258,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend pod CPU above 85% of request for 15+ minutes"
         description: "Frontend container CPU (usage/request) on cluster {{ $labels.cluster }} is above 85% for 15m."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
     - alert: userJourneyFrontendSaturationMemory
       expr: |
         sli:frontend:saturation_memory:ratio5m > 0.85
@@ -269,4 +269,4 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend pod memory above 85% of limit for 15+ minutes"
         description: "Frontend container memory (working set/limit) on cluster {{ $labels.cluster }} is above 85% for 15m."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"

--- a/observability/alerts/frontend-slo-prometheusRule.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule.yaml
@@ -22,7 +22,10 @@ spec:
   #   Slow (1x):    1 * 0.0005 = 0.0005 -> 0.05% 5xx share
   #
   # Rate-based SLI: 'for' approximates the short window (Access / Node Pool pattern).
-  # Fast/medium page Sev 3 (customer-facing UJ). Slow/degradation Sev 4 ticket.
+  # Fast/medium Errors + Latency page Sev 3 (customer-facing UJ).
+  # Availability is Sev 4 only — complementary to Errors on the same denominator,
+  # so dual Sev3 would open two IcMs per 5xx event (review feedback).
+  # Slow/degradation/traffic/saturation Sev 4 ticket.
   #
   # summary includes {{ $labels.cluster }} (Access / Node Pool convention; prometheus-rules
   # generator requires it). IcM.Title may also prepend cluster — same as other RP alerts.
@@ -90,13 +93,13 @@ spec:
       for: 5m
       labels:
         component: slo
-        severity: "3"
+        severity: "4"
         slo: frontend-availability
         long_window: 1h
         short_window: 5m
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)"
-        description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget)."
+        description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket — Errors family pages on the complementary 5xx burn."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendAvailability6h30m
       expr: |
@@ -104,13 +107,13 @@ spec:
       for: 30m
       labels:
         component: slo
-        severity: "3"
+        severity: "4"
         slo: frontend-availability
         long_window: 6h
         short_window: 30m
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%) for 30+ minutes"
-        description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.70% for 30m (6x burn)."
+        description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.70% for 30m (6x burn). Sev4 ticket — Errors family pages on the complementary 5xx burn."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendAvailability3d
       expr: |

--- a/observability/alerts/frontend-slo-prometheusRule.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule.yaml
@@ -1,0 +1,214 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: k8s
+    role: alert-rules
+  name: frontend-slo-rules
+  namespace: monitoring
+spec:
+  groups:
+  # ========================================
+  # Frontend (ARM RP) SLO Alerts — Errors
+  # ========================================
+  # Driven by errors:frontend_http:error_rate:rate5m (ARO-28705 recording rules).
+  # Naming: {Scope}{Subject}{Metric}{BurnRateTier} per ADR-001.
+  #
+  # Availability SLO 99.95% -> error budget 0.05% (0.0005):
+  #   Fast (14.4x): 14.4 * 0.0005 = 0.0072 -> 0.72% 5xx share
+  #   Medium (6x):  6 * 0.0005 = 0.003 -> 0.30% 5xx share
+  #   Slow (1x):    1 * 0.0005 = 0.0005 -> 0.05% 5xx share
+  #
+  # Rate-based SLI: 'for' approximates the short window (Access / Node Pool pattern).
+  # Fast/medium page Sev 3 (customer-facing UJ). Slow/degradation Sev 4 ticket.
+  #
+  # summary must NOT include {{ $labels.cluster }} — RP bicep prepends cluster.
+  # component is on each rule (not group) for promtool compatibility.
+  - name: arohcp_frontend_slo_error_alerts
+    rules:
+    - alert: userJourneyFrontendErrors1h5m
+      expr: |
+        errors:frontend_http:error_rate:rate5m > 0.0072
+      for: 5m
+      labels:
+        component: slo
+        severity: "3"
+        slo: frontend-errors
+        long_window: 1h
+        short_window: 5m
+      annotations:
+        summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)"
+        description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% for 5m (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~12h."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+    - alert: userJourneyFrontendErrors6h30m
+      expr: |
+        errors:frontend_http:error_rate:rate5m > 0.003
+      for: 30m
+      labels:
+        component: slo
+        severity: "3"
+        slo: frontend-errors
+        long_window: 6h
+        short_window: 30m
+      annotations:
+        summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%) for 30+ minutes"
+        description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% for 30m (6x burn of the 0.05% error budget)."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+    - alert: userJourneyFrontendErrors3d
+      expr: |
+        errors:frontend_http:error_rate:rate5m > 0.0005
+      for: 6h
+      labels:
+        component: slo
+        severity: "4"
+        slo: frontend-errors
+        long_window: 3d
+      annotations:
+        summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%) for 6+ hours"
+        description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary for 6h (1x burn)."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+    - alert: userJourneyFrontendErrorsDegradation
+      expr: |
+        errors:frontend_http:error_rate:rate5m > 0.0015
+      for: 30m
+      labels:
+        component: slo
+        severity: "4"
+        slo: frontend-errors
+      annotations:
+        summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds 0.15% for 30 minutes"
+        description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.15% (3x budget) for 30m - precursor before medium/fast burn pages."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+  - name: arohcp_frontend_slo_availability_alerts
+    rules:
+    - alert: userJourneyFrontendAvailability1h5m
+      expr: |
+        sli:frontend_http:availability:rate5m < 0.9928
+      for: 5m
+      labels:
+        component: slo
+        severity: "3"
+        slo: frontend-availability
+        long_window: 1h
+        short_window: 5m
+      annotations:
+        summary: "{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)"
+        description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget)."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+    - alert: userJourneyFrontendAvailability6h30m
+      expr: |
+        sli:frontend_http:availability:rate5m < 0.997
+      for: 30m
+      labels:
+        component: slo
+        severity: "3"
+        slo: frontend-availability
+        long_window: 6h
+        short_window: 30m
+      annotations:
+        summary: "{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%) for 30+ minutes"
+        description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.70% for 30m (6x burn)."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+    - alert: userJourneyFrontendAvailability3d
+      expr: |
+        sli:frontend_http:availability:rate5m < 0.9995
+      for: 6h
+      labels:
+        component: slo
+        severity: "4"
+        slo: frontend-availability
+        long_window: 3d
+      annotations:
+        summary: "{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%) for 6+ hours"
+        description: "Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO for 6h (1x burn)."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+  - name: arohcp_frontend_slo_latency_alerts
+    rules:
+    - alert: userJourneyFrontendLatency1h5m
+      expr: |
+        sli:frontend_http:latency:rate5m < 0.856
+      for: 5m
+      labels:
+        component: slo
+        severity: "3"
+        slo: frontend-latency
+        long_window: 1h
+        short_window: 5m
+      annotations:
+        summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI critically low (share <=1s <85.6%)"
+        description: "Share of Frontend requests completing within 1s on cluster {{ $labels.cluster }} is below 85.6% for 5m (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+    - alert: userJourneyFrontendLatency6h30m
+      expr: |
+        sli:frontend_http:latency:rate5m < 0.94
+      for: 30m
+      labels:
+        component: slo
+        severity: "3"
+        slo: frontend-latency
+        long_window: 6h
+        short_window: 30m
+      annotations:
+        summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI degraded (share <=1s <94%) for 30+ minutes"
+        description: "Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 94% for 30m (6x burn)."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+    - alert: userJourneyFrontendLatency3d
+      expr: |
+        sli:frontend_http:latency:rate5m < 0.99
+      for: 6h
+      labels:
+        component: slo
+        severity: "4"
+        slo: frontend-latency
+        long_window: 3d
+      annotations:
+        summary: "{{ $labels.cluster }}: Frontend HTTP latency SLI below target (share <=1s <99%) for 6+ hours"
+        description: "Share of Frontend requests within 1s on cluster {{ $labels.cluster }} is below 99% for 6h (1x burn of the p99 < 1s latency budget)."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+  - name: arohcp_frontend_slo_traffic_alerts
+    rules:
+    - alert: userJourneyFrontendTrafficDrop
+      expr: |
+        (
+          avg_over_time(traffic:frontend_http:request_rate:rate5m[15m])
+          < 0.1 * avg_over_time(traffic:frontend_http:request_rate:rate5m[1d])
+        )
+        and
+        avg_over_time(traffic:frontend_http:request_rate:rate5m[1d]) > 0.5
+      for: 15m
+      labels:
+        component: slo
+        severity: "4"
+        slo: frontend-traffic
+      annotations:
+        summary: "{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline"
+        description: "Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+  - name: arohcp_frontend_slo_saturation_alerts
+    rules:
+    - alert: userJourneyFrontendSaturationCPU
+      expr: |
+        sli:frontend:saturation_cpu:ratio5m > 0.85
+      for: 15m
+      labels:
+        component: slo
+        severity: "4"
+        slo: frontend-saturation
+      annotations:
+        summary: "{{ $labels.cluster }}: Frontend pod CPU above 85% of request for 15+ minutes"
+        description: "Frontend container CPU (usage/request) on cluster {{ $labels.cluster }} is above 85% for 15m."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+    - alert: userJourneyFrontendSaturationMemory
+      expr: |
+        sli:frontend:saturation_memory:ratio5m > 0.85
+      for: 15m
+      labels:
+        component: slo
+        severity: "4"
+        slo: frontend-saturation
+      annotations:
+        summary: "{{ $labels.cluster }}: Frontend pod memory above 85% of limit for 15+ minutes"
+        description: "Frontend container memory (working set/limit) on cluster {{ $labels.cluster }} is above 85% for 15m."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"

--- a/observability/alerts/frontend-slo-prometheusRule.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule.yaml
@@ -24,7 +24,8 @@ spec:
   # Rate-based SLI: 'for' approximates the short window (Access / Node Pool pattern).
   # Fast/medium page Sev 3 (customer-facing UJ). Slow/degradation Sev 4 ticket.
   #
-  # summary must NOT include {{ $labels.cluster }} — RP bicep prepends cluster.
+  # summary includes {{ $labels.cluster }} (Access / Node Pool convention; prometheus-rules
+  # generator requires it). IcM.Title may also prepend cluster — same as other RP alerts.
   # component is on each rule (not group) for promtool compatibility.
   - name: arohcp_frontend_slo_error_alerts
     rules:

--- a/observability/alerts/frontend-slo-prometheusRule.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule.yaml
@@ -62,7 +62,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate critically high (>0.72%)"
         description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendErrors6h30m
       expr: |
         (
@@ -79,7 +79,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate elevated (>0.30%)"
         description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendErrors3d6h
       expr: |
         (
@@ -96,7 +96,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)"
         description: "Frontend 5xx share on cluster {{ $labels.cluster }} is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_availability_alerts
     labels:
       component: slo
@@ -117,7 +117,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP availability critically low (<99.28%)"
         description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendAvailability6h30m
       expr: |
         (
@@ -134,7 +134,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP availability degraded (<99.70%)"
         description: "Frontend availability on cluster {{ $labels.cluster }} is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendAvailability3d6h
       expr: |
         (
@@ -151,7 +151,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP availability below SLO (<99.95%)"
         description: "Frontend availability on cluster {{ $labels.cluster }} is below the 99.95% SLO on both the 3d and 6h windows (1x burn)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_latency_alerts
     labels:
       component: slo
@@ -172,7 +172,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP p99 latency critically high (>5s)"
         description: "Frontend p99 latency on cluster {{ $labels.cluster }} is above 5s on both the 1h and 5m windows (severe miss of the p99 < 1s ARM sync SLO)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendLatencyP996h30m
       expr: |
         (
@@ -189,7 +189,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)"
         description: "Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 6h and 30m windows (p99 < 1s ARM sync SLO miss)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendLatencyP993d6h
       expr: |
         (
@@ -206,7 +206,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP p99 latency above SLO (>1s)"
         description: "Frontend p99 latency on cluster {{ $labels.cluster }} is above 1s on both the 3d and 6h windows (1x burn of the p99 < 1s SLO)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_ready_alerts
     labels:
       component: slo
@@ -221,7 +221,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend has no Ready replicas (kube /healthz)"
         description: "aro-hcp-frontend on cluster {{ $labels.cluster }} has 0 available replicas (kube readiness probes hit /healthz). This is a process outage, not an ARM traffic drought."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   # Traffic drought is Sev 4 (ticket). The 0.5 RPS 1d-baseline floor is a
   # fleet-wide noise gate, not an SLO: 10% of 0.5 RPS is 0.05 RPS (~3 rpm),
   # below which a 90% drop is scrape noise / idle INT, not a customer-visible
@@ -248,7 +248,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend HTTP traffic collapsed below 10% of 1d baseline"
         description: "Frontend request rate on cluster {{ $labels.cluster }} is below 10% of its 1-day average for 15m while the 1d baseline exceeded 0.5 RPS (fleet-wide noise floor) and pods are still Ready (traffic drought, not a replica outage)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - name: arohcp_frontend_slo_saturation_alerts
     labels:
       component: slo
@@ -263,7 +263,7 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend pod CPU above 85% of request for 15+ minutes"
         description: "Frontend container CPU (usage/request) on cluster {{ $labels.cluster }} is above 85% for 15m."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
     - alert: userJourneyFrontendSaturationMemory
       expr: |
         sli:frontend:saturation_memory:ratio5m > 0.85
@@ -274,4 +274,4 @@ spec:
       annotations:
         summary: "{{ $labels.cluster }}: Frontend pod memory above 85% of limit for 15+ minutes"
         description: "Frontend container memory (working set/limit) on cluster {{ $labels.cluster }} is above 85% for 15m."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -56,12 +56,11 @@ tests:
   - eval_time: 70m
     alertname: userJourneyFrontendTrafficDrop
     exp_alerts: []
-# ----------------------------------------
 - interval: 1m
   # ----------------------------------------
 
+  # ----------------------------------------
   # Errors fast burn + Availability fast (MWMBR 1h AND 5m)
-
   input_series:
   - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
     values: "0.01+0x80"
@@ -102,7 +101,6 @@ tests:
   # Errors medium burn (0.4%) - not fast
 
   # ----------------------------------------
-
   input_series:
   - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
     values: "0.004+0x80"
@@ -125,12 +123,11 @@ tests:
   - eval_time: 50m
     alertname: userJourneyFrontendErrors1h5m
     exp_alerts: []
-# ----------------------------------------
 - interval: 1m
   # ----------------------------------------
 
+  # ----------------------------------------
   # Availability medium burn - not fast
-
   input_series:
   - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
     values: "0.995+0x80"
@@ -157,7 +154,6 @@ tests:
   # Latency medium burn - not fast
 
   # ----------------------------------------
-
   input_series:
   - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
     values: "0.90+0x80"
@@ -180,12 +176,11 @@ tests:
   - eval_time: 50m
     alertname: userJourneyFrontendLatency1h5m
     exp_alerts: []
-# ----------------------------------------
 - interval: 1m
   # ----------------------------------------
 
+  # ----------------------------------------
   # Latency fast burn
-
   input_series:
   - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
     values: "0.8+0x80"
@@ -205,12 +200,11 @@ tests:
         summary: "svc-1: Frontend HTTP latency SLI critically low (share <=1s <85.6%)"
         description: "Share of Frontend requests completing within 1s on cluster svc-1 is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-# ----------------------------------------
 - interval: 1m
   # ----------------------------------------
 
+  # ----------------------------------------
   # Saturation CPU + memory
-
   input_series:
   - series: 'sli:frontend:saturation_cpu:ratio5m{cluster="svc-1"}'
     values: "0.9+0x35"
@@ -243,12 +237,11 @@ tests:
         summary: "svc-1: Frontend pod memory above 85% of limit for 15+ minutes"
         description: "Frontend container memory (working set/limit) on cluster svc-1 is above 85% for 15m."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-# (~24h @ 5m step), then 0.2x13 = 13 samples (~65m) so drop is active by eval_time 25h.
 - interval: 5m
   # ----------------------------------------
 
+  # (~24h @ 5m step), then 0.2x13 = 13 samples (~65m) so drop is active by eval_time 25h.
   # promtool expand counts are decimal (not hex): 5x288 = 288 samples @ 5 RPS
-
   input_series:
   - series: 'traffic:frontend_http:request_rate:rate5m{cluster="svc-1"}'
     values: "5x288 0.2x13"

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -255,8 +255,20 @@ tests:
         slo: frontend-traffic
       exp_annotations:
         summary: "svc-1: Frontend HTTP traffic collapsed below 10% of 1d baseline"
-        description: "Frontend request rate on cluster svc-1 is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS and pods are still Ready (traffic drought, not a replica outage)."
+        description: "Frontend request rate on cluster svc-1 is below 10% of its 1-day average for 15m while the 1d baseline exceeded 0.5 RPS (fleet-wide noise floor) and pods are still Ready (traffic drought, not a replica outage)."
         runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+- interval: 5m
+  # Baseline 0.3 RPS is under the 0.5 RPS noise floor, then a 90% drop.
+  # Must not fire even though the relative collapse matches the 10% rule.
+  input_series:
+  - series: 'traffic:frontend_http:request_rate:rate5m{cluster="svc-1"}'
+    values: "0.3x288 0.02x13"
+  - series: 'sli:frontend:ready:ratio5m{cluster="svc-1"}'
+    values: "1x301"
+  alert_rule_test:
+  - eval_time: 25h
+    alertname: userJourneyFrontendTrafficDrop
+    exp_alerts: []
 - interval: 1m
   # Replica outage — ready=0 pages; HTTP drought path does not apply.
 

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -11,8 +11,10 @@ tests:
     values: "0.0001+0x80"
   - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
     values: "0.9999+0x80"
-  - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
-    values: "0.995+0x80"
+  - series: 'sli:frontend_http:latency_p99:rate5m{cluster="svc-1"}'
+    values: "0.5+0x80"
+  - series: 'sli:frontend:ready:ratio5m{cluster="svc-1"}'
+    values: "1+0x80"
   - series: 'sli:frontend:saturation_cpu:ratio5m{cluster="svc-1"}'
     values: "0.4+0x80"
   - series: 'sli:frontend:saturation_memory:ratio5m{cluster="svc-1"}'
@@ -39,13 +41,13 @@ tests:
     alertname: userJourneyFrontendAvailability3d6h
     exp_alerts: []
   - eval_time: 70m
-    alertname: userJourneyFrontendLatency1h5m
+    alertname: userJourneyFrontendLatencyP991h5m
     exp_alerts: []
   - eval_time: 70m
-    alertname: userJourneyFrontendLatency6h30m
+    alertname: userJourneyFrontendLatencyP996h30m
     exp_alerts: []
   - eval_time: 70m
-    alertname: userJourneyFrontendLatency3d6h
+    alertname: userJourneyFrontendLatencyP993d6h
     exp_alerts: []
   - eval_time: 70m
     alertname: userJourneyFrontendSaturationCPU
@@ -55,6 +57,9 @@ tests:
     exp_alerts: []
   - eval_time: 70m
     alertname: userJourneyFrontendTrafficDrop
+    exp_alerts: []
+  - eval_time: 70m
+    alertname: userJourneyFrontendReady
     exp_alerts: []
 - interval: 1m
   # ----------------------------------------
@@ -151,18 +156,18 @@ tests:
     alertname: userJourneyFrontendAvailability1h5m
     exp_alerts: []
 - interval: 1m
-  # Latency medium burn - not fast
+  # Latency medium (p99 > 1s) - not fast (p99 > 5s)
 
   # ----------------------------------------
   input_series:
-  - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
-    values: "0.90+0x80"
+  - series: 'sli:frontend_http:latency_p99:rate5m{cluster="svc-1"}'
+    values: "1.2+0x80"
   alert_rule_test:
   - eval_time: 50m
-    alertname: userJourneyFrontendLatency6h30m
+    alertname: userJourneyFrontendLatencyP996h30m
     exp_alerts:
     - exp_labels:
-        alertname: userJourneyFrontendLatency6h30m
+        alertname: userJourneyFrontendLatencyP996h30m
         cluster: svc-1
         component: slo
         severity: "3"
@@ -170,26 +175,26 @@ tests:
         long_window: 6h
         short_window: 30m
       exp_annotations:
-        summary: "svc-1: Frontend HTTP latency SLI degraded (share <=1s <94%)"
-        description: "Share of Frontend requests within 1s on cluster svc-1 is below 94% on both the 6h and 30m windows (6x burn)."
+        summary: "svc-1: Frontend HTTP p99 latency above SLO (>1s)"
+        description: "Frontend p99 latency on cluster svc-1 is above 1s on both the 6h and 30m windows (p99 < 1s ARM sync SLO miss)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 50m
-    alertname: userJourneyFrontendLatency1h5m
+    alertname: userJourneyFrontendLatencyP991h5m
     exp_alerts: []
 - interval: 1m
   # ----------------------------------------
 
   # ----------------------------------------
-  # Latency fast burn
+  # Latency fast (p99 > 5s)
   input_series:
-  - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
-    values: "0.8+0x80"
+  - series: 'sli:frontend_http:latency_p99:rate5m{cluster="svc-1"}'
+    values: "6+0x80"
   alert_rule_test:
   - eval_time: 10m
-    alertname: userJourneyFrontendLatency1h5m
+    alertname: userJourneyFrontendLatencyP991h5m
     exp_alerts:
     - exp_labels:
-        alertname: userJourneyFrontendLatency1h5m
+        alertname: userJourneyFrontendLatencyP991h5m
         cluster: svc-1
         component: slo
         severity: "3"
@@ -197,8 +202,8 @@ tests:
         long_window: 1h
         short_window: 5m
       exp_annotations:
-        summary: "svc-1: Frontend HTTP latency SLI critically low (share <=1s <85.6%)"
-        description: "Share of Frontend requests completing within 1s on cluster svc-1 is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
+        summary: "svc-1: Frontend HTTP p99 latency critically high (>5s)"
+        description: "Frontend p99 latency on cluster svc-1 is above 5s on both the 1h and 5m windows (severe miss of the p99 < 1s ARM sync SLO)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
 - interval: 1m
   # ----------------------------------------
@@ -245,6 +250,8 @@ tests:
   input_series:
   - series: 'traffic:frontend_http:request_rate:rate5m{cluster="svc-1"}'
     values: "5x288 0.2x13"
+  - series: 'sli:frontend:ready:ratio5m{cluster="svc-1"}'
+    values: "1x301"
   alert_rule_test:
   - eval_time: 25h
     alertname: userJourneyFrontendTrafficDrop
@@ -257,5 +264,25 @@ tests:
         slo: frontend-traffic
       exp_annotations:
         summary: "svc-1: Frontend HTTP traffic collapsed below 10% of 1d baseline"
-        description: "Frontend request rate on cluster svc-1 is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS."
+        description: "Frontend request rate on cluster svc-1 is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS and pods are still Ready (traffic drought, not a replica outage)."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+- interval: 1m
+  # Replica outage — ready=0 pages; HTTP drought path does not apply.
+
+  input_series:
+  - series: 'sli:frontend:ready:ratio5m{cluster="svc-1"}'
+    values: "0+0x15"
+  alert_rule_test:
+  - eval_time: 7m
+    alertname: userJourneyFrontendReady
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyFrontendReady
+        cluster: svc-1
+        component: slo
+        severity: "3"
+        slo: frontend-ready
+      exp_annotations:
+        summary: "svc-1: Frontend has no Ready replicas (kube /healthz)"
+        description: "aro-hcp-frontend on cluster svc-1 has 0 available replicas (kube readiness probes hit /healthz). This is a process outage, not an ARM traffic drought."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -80,7 +80,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP 5xx error rate critically high (>0.72%)"
         description: "Frontend 5xx share on cluster svc-1 is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - eval_time: 10m
     alertname: userJourneyFrontendAvailability1h5m
     exp_alerts:
@@ -95,7 +95,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP availability critically low (<99.28%)"
         description: "Frontend availability on cluster svc-1 is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
 # Errors medium burn (0.4%) - not fast
 # ----------------------------------------
 - interval: 1m
@@ -117,7 +117,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP 5xx error rate elevated (>0.30%)"
         description: "Frontend 5xx share on cluster svc-1 is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - eval_time: 50m
     alertname: userJourneyFrontendErrors1h5m
     exp_alerts: []
@@ -143,7 +143,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP availability degraded (<99.70%)"
         description: "Frontend availability on cluster svc-1 is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - eval_time: 50m
     alertname: userJourneyFrontendAvailability1h5m
     exp_alerts: []
@@ -168,7 +168,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP latency SLI degraded (share <=1s <94%)"
         description: "Share of Frontend requests within 1s on cluster svc-1 is below 94% on both the 6h and 30m windows (6x burn)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - eval_time: 50m
     alertname: userJourneyFrontendLatency1h5m
     exp_alerts: []
@@ -194,7 +194,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP latency SLI critically low (share <=1s <85.6%)"
         description: "Share of Frontend requests completing within 1s on cluster svc-1 is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
 # ----------------------------------------
 # Saturation CPU + memory
 # ----------------------------------------
@@ -217,7 +217,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend pod CPU above 85% of request for 15+ minutes"
         description: "Frontend container CPU (usage/request) on cluster svc-1 is above 85% for 15m."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - eval_time: 17m
     alertname: userJourneyFrontendSaturationMemory
     exp_alerts:
@@ -230,7 +230,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend pod memory above 85% of limit for 15+ minutes"
         description: "Frontend container memory (working set/limit) on cluster svc-1 is above 85% for 15m."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
 # ----------------------------------------
 # promtool expand counts are decimal (not hex): 5x288 = 288 samples @ 5 RPS
 # (~24h @ 5m step), then 0.2x13 = 13 samples (~65m) so drop is active by eval_time 25h.
@@ -251,4 +251,4 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP traffic collapsed below 10% of 1d baseline"
         description: "Frontend request rate on cluster svc-1 is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -286,3 +286,96 @@ tests:
         summary: "svc-1: Frontend has no Ready replicas (kube /healthz)"
         description: "aro-hcp-frontend on cluster svc-1 has 0 available replicas (kube readiness probes hit /healthz). This is a process outage, not an ARM traffic drought."
         runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+- interval: 1h
+  # Slow 3d/6h firing (1x burn). Hourly samples so the 3d window is populated
+  # without a 1m series. Error/availability values stay below fast/medium
+  # thresholds. 3d + for:1h → eval_time 73h.
+  input_series:
+  - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
+    values: "0.001x80"
+  - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
+    values: "0.999x80"
+  - series: 'sli:frontend_http:latency_p99:rate5m{cluster="svc-1"}'
+    values: "1.2x80"
+  alert_rule_test:
+  - eval_time: 73h
+    alertname: userJourneyFrontendErrors3d6h
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyFrontendErrors3d6h
+        cluster: svc-1
+        component: slo
+        severity: "4"
+        slo: frontend-errors
+        long_window: 3d
+        short_window: 6h
+      exp_annotations:
+        summary: "svc-1: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)"
+        description: "Frontend 5xx share on cluster svc-1 is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn)."
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+  - eval_time: 73h
+    alertname: userJourneyFrontendErrors6h30m
+    exp_alerts: []
+  - eval_time: 73h
+    alertname: userJourneyFrontendErrors1h5m
+    exp_alerts: []
+  - eval_time: 73h
+    alertname: userJourneyFrontendAvailability3d6h
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyFrontendAvailability3d6h
+        cluster: svc-1
+        component: slo
+        severity: "4"
+        slo: frontend-availability
+        long_window: 3d
+        short_window: 6h
+      exp_annotations:
+        summary: "svc-1: Frontend HTTP availability below SLO (<99.95%)"
+        description: "Frontend availability on cluster svc-1 is below the 99.95% SLO on both the 3d and 6h windows (1x burn)."
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+  - eval_time: 73h
+    alertname: userJourneyFrontendAvailability6h30m
+    exp_alerts: []
+  - eval_time: 73h
+    alertname: userJourneyFrontendAvailability1h5m
+    exp_alerts: []
+  - eval_time: 73h
+    alertname: userJourneyFrontendLatencyP993d6h
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyFrontendLatencyP993d6h
+        cluster: svc-1
+        component: slo
+        severity: "4"
+        slo: frontend-latency
+        long_window: 3d
+        short_window: 6h
+      exp_annotations:
+        summary: "svc-1: Frontend HTTP p99 latency above SLO (>1s)"
+        description: "Frontend p99 latency on cluster svc-1 is above 1s on both the 3d and 6h windows (1x burn of the p99 < 1s SLO)."
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+  - eval_time: 73h
+    alertname: userJourneyFrontendLatencyP991h5m
+    exp_alerts: []
+- interval: 1h
+  # Short window only: last 7h above 1x, rest of 3d healthy. MWMBR AND must
+
+  # not fire 3d/6h (3d avg stays under the SLO line).
+  input_series:
+  - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
+    values: "0.0001x66 0.001x14"
+  - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
+    values: "0.9999x66 0.999x14"
+  - series: 'sli:frontend_http:latency_p99:rate5m{cluster="svc-1"}'
+    values: "0.5x66 1.2x14"
+  alert_rule_test:
+  - eval_time: 73h
+    alertname: userJourneyFrontendErrors3d6h
+    exp_alerts: []
+  - eval_time: 73h
+    alertname: userJourneyFrontendAvailability3d6h
+    exp_alerts: []
+  - eval_time: 73h
+    alertname: userJourneyFrontendLatencyP993d6h
+    exp_alerts: []

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -56,10 +56,11 @@ tests:
   - eval_time: 70m
     alertname: userJourneyFrontendTrafficDrop
     exp_alerts: []
-# ----------------------------------------
 # Errors fast burn + Availability fast (MWMBR 1h AND 5m)
 # ----------------------------------------
 - interval: 1m
+  # ----------------------------------------
+
   input_series:
   - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
     values: "0.01+0x80"
@@ -80,7 +81,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP 5xx error rate critically high (>0.72%)"
         description: "Frontend 5xx share on cluster svc-1 is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 10m
     alertname: userJourneyFrontendAvailability1h5m
     exp_alerts:
@@ -95,10 +96,11 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP availability critically low (<99.28%)"
         description: "Frontend availability on cluster svc-1 is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
-# Errors medium burn (0.4%) - not fast
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
 # ----------------------------------------
 - interval: 1m
+  # Errors medium burn (0.4%) - not fast
+
   input_series:
   - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
     values: "0.004+0x80"
@@ -117,14 +119,15 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP 5xx error rate elevated (>0.30%)"
         description: "Frontend 5xx share on cluster svc-1 is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 50m
     alertname: userJourneyFrontendErrors1h5m
     exp_alerts: []
-# ----------------------------------------
 # Availability medium burn - not fast
 # ----------------------------------------
 - interval: 1m
+  # ----------------------------------------
+
   input_series:
   - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
     values: "0.995+0x80"
@@ -143,13 +146,14 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP availability degraded (<99.70%)"
         description: "Frontend availability on cluster svc-1 is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 50m
     alertname: userJourneyFrontendAvailability1h5m
     exp_alerts: []
-# Latency medium burn - not fast
 # ----------------------------------------
 - interval: 1m
+  # Latency medium burn - not fast
+
   input_series:
   - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
     values: "0.90+0x80"
@@ -168,14 +172,15 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP latency SLI degraded (share <=1s <94%)"
         description: "Share of Frontend requests within 1s on cluster svc-1 is below 94% on both the 6h and 30m windows (6x burn)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 50m
     alertname: userJourneyFrontendLatency1h5m
     exp_alerts: []
-# ----------------------------------------
 # Latency fast burn
 # ----------------------------------------
 - interval: 1m
+  # ----------------------------------------
+
   input_series:
   - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
     values: "0.8+0x80"
@@ -194,11 +199,12 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP latency SLI critically low (share <=1s <85.6%)"
         description: "Share of Frontend requests completing within 1s on cluster svc-1 is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
-# ----------------------------------------
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
 # Saturation CPU + memory
 # ----------------------------------------
 - interval: 1m
+  # ----------------------------------------
+
   input_series:
   - series: 'sli:frontend:saturation_cpu:ratio5m{cluster="svc-1"}'
     values: "0.9+0x35"
@@ -217,7 +223,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend pod CPU above 85% of request for 15+ minutes"
         description: "Frontend container CPU (usage/request) on cluster svc-1 is above 85% for 15m."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 17m
     alertname: userJourneyFrontendSaturationMemory
     exp_alerts:
@@ -230,11 +236,12 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend pod memory above 85% of limit for 15+ minutes"
         description: "Frontend container memory (working set/limit) on cluster svc-1 is above 85% for 15m."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
-# ----------------------------------------
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
 # promtool expand counts are decimal (not hex): 5x288 = 288 samples @ 5 RPS
 # (~24h @ 5m step), then 0.2x13 = 13 samples (~65m) so drop is active by eval_time 25h.
 - interval: 5m
+  # ----------------------------------------
+
   input_series:
   - series: 'traffic:frontend_http:request_rate:rate5m{cluster="svc-1"}'
     values: "5x288 0.2x13"
@@ -251,4 +258,4 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP traffic collapsed below 10% of 1d baseline"
         description: "Frontend request rate on cluster svc-1 is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -3,75 +3,70 @@ rule_files:
 evaluation_interval: 1m
 tests:
 # ----------------------------------------
-# Healthy — no alerts
+# Healthy - no alerts
 # ----------------------------------------
 - interval: 1m
   input_series:
   - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
-    values: "0.0001+0x50"
+    values: "0.0001+0x80"
   - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
-    values: "0.9999+0x50"
+    values: "0.9999+0x80"
   - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
-    values: "0.995+0x50"
+    values: "0.995+0x80"
   - series: 'sli:frontend:saturation_cpu:ratio5m{cluster="svc-1"}'
-    values: "0.4+0x50"
+    values: "0.4+0x80"
   - series: 'sli:frontend:saturation_memory:ratio5m{cluster="svc-1"}'
-    values: "0.4+0x50"
+    values: "0.4+0x80"
   - series: 'traffic:frontend_http:request_rate:rate5m{cluster="svc-1"}'
-    values: "2+0x50"
+    values: "2+0x80"
   alert_rule_test:
-  - eval_time: 40m
+  - eval_time: 70m
     alertname: userJourneyFrontendErrors1h5m
     exp_alerts: []
-  - eval_time: 40m
+  - eval_time: 70m
     alertname: userJourneyFrontendErrors6h30m
     exp_alerts: []
-  - eval_time: 40m
-    alertname: userJourneyFrontendErrors3d
+  - eval_time: 70m
+    alertname: userJourneyFrontendErrors3d6h
     exp_alerts: []
-  - eval_time: 40m
-    alertname: userJourneyFrontendErrorsDegradation
-    exp_alerts: []
-  - eval_time: 40m
+  - eval_time: 70m
     alertname: userJourneyFrontendAvailability1h5m
     exp_alerts: []
-  - eval_time: 40m
+  - eval_time: 70m
     alertname: userJourneyFrontendAvailability6h30m
     exp_alerts: []
-  - eval_time: 40m
-    alertname: userJourneyFrontendAvailability3d
+  - eval_time: 70m
+    alertname: userJourneyFrontendAvailability3d6h
     exp_alerts: []
-  - eval_time: 40m
+  - eval_time: 70m
     alertname: userJourneyFrontendLatency1h5m
     exp_alerts: []
-  - eval_time: 40m
+  - eval_time: 70m
     alertname: userJourneyFrontendLatency6h30m
     exp_alerts: []
-  - eval_time: 40m
-    alertname: userJourneyFrontendLatency3d
+  - eval_time: 70m
+    alertname: userJourneyFrontendLatency3d6h
     exp_alerts: []
-  - eval_time: 40m
+  - eval_time: 70m
     alertname: userJourneyFrontendSaturationCPU
     exp_alerts: []
-  - eval_time: 40m
+  - eval_time: 70m
     alertname: userJourneyFrontendSaturationMemory
     exp_alerts: []
-  - eval_time: 40m
+  - eval_time: 70m
     alertname: userJourneyFrontendTrafficDrop
     exp_alerts: []
 # ----------------------------------------
+# Errors fast burn + Availability fast (MWMBR 1h AND 5m)
+# ----------------------------------------
 - interval: 1m
-  # ----------------------------------------
-
-  # Errors fast burn + degradation + Availability fast
-
   input_series:
   - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
-    values: "0.01+0x50"
+    values: "0.01+0x80"
   - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
-    values: "0.99+0x50"
+    values: "0.99+0x80"
   alert_rule_test:
-  - eval_time: 7m
+  - eval_time: 10m
     alertname: userJourneyFrontendErrors1h5m
     exp_alerts:
     - exp_labels:
@@ -84,22 +79,9 @@ tests:
         short_window: 5m
       exp_annotations:
         summary: "svc-1: Frontend HTTP 5xx error rate critically high (>0.72%)"
-        description: "Frontend 5xx share on cluster svc-1 is above 0.72% for 5m (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~12h."
+        description: "Frontend 5xx share on cluster svc-1 is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~12h."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-  - eval_time: 32m
-    alertname: userJourneyFrontendErrorsDegradation
-    exp_alerts:
-    - exp_labels:
-        alertname: userJourneyFrontendErrorsDegradation
-        cluster: svc-1
-        component: slo
-        severity: "4"
-        slo: frontend-errors
-      exp_annotations:
-        summary: "svc-1: Frontend HTTP 5xx error rate exceeds 0.15% for 30 minutes"
-        description: "Frontend 5xx share on cluster svc-1 is above 0.15% (3x budget) for 30m - precursor before medium/fast burn pages."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-  - eval_time: 7m
+  - eval_time: 10m
     alertname: userJourneyFrontendAvailability1h5m
     exp_alerts:
     - exp_labels:
@@ -112,18 +94,16 @@ tests:
         short_window: 5m
       exp_annotations:
         summary: "svc-1: Frontend HTTP availability critically low (<99.28%)"
-        description: "Frontend availability on cluster svc-1 is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket — Errors family pages on the complementary 5xx burn."
+        description: "Frontend availability on cluster svc-1 is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-# Errors medium burn (0.4%) — not fast
+# Errors medium burn (0.4%) - not fast
 # ----------------------------------------
 - interval: 1m
-  # ----------------------------------------
-
   input_series:
   - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
-    values: "0.004+0x50"
+    values: "0.004+0x80"
   alert_rule_test:
-  - eval_time: 32m
+  - eval_time: 50m
     alertname: userJourneyFrontendErrors6h30m
     exp_alerts:
     - exp_labels:
@@ -135,23 +115,21 @@ tests:
         long_window: 6h
         short_window: 30m
       exp_annotations:
-        summary: "svc-1: Frontend HTTP 5xx error rate elevated (>0.30%) for 30+ minutes"
-        description: "Frontend 5xx share on cluster svc-1 is above 0.30% for 30m (6x burn of the 0.05% error budget)."
+        summary: "svc-1: Frontend HTTP 5xx error rate elevated (>0.30%)"
+        description: "Frontend 5xx share on cluster svc-1 is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-  - eval_time: 32m
+  - eval_time: 50m
     alertname: userJourneyFrontendErrors1h5m
     exp_alerts: []
 # ----------------------------------------
+# Availability medium burn - not fast
+# ----------------------------------------
 - interval: 1m
-  # ----------------------------------------
-
-  # Availability medium burn — not fast
-
   input_series:
   - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
-    values: "0.995+0x50"
+    values: "0.995+0x80"
   alert_rule_test:
-  - eval_time: 32m
+  - eval_time: 50m
     alertname: userJourneyFrontendAvailability6h30m
     exp_alerts:
     - exp_labels:
@@ -163,22 +141,20 @@ tests:
         long_window: 6h
         short_window: 30m
       exp_annotations:
-        summary: "svc-1: Frontend HTTP availability degraded (<99.70%) for 30+ minutes"
-        description: "Frontend availability on cluster svc-1 is below 99.70% for 30m (6x burn). Sev4 ticket — Errors family pages on the complementary 5xx burn."
+        summary: "svc-1: Frontend HTTP availability degraded (<99.70%)"
+        description: "Frontend availability on cluster svc-1 is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-  - eval_time: 32m
+  - eval_time: 50m
     alertname: userJourneyFrontendAvailability1h5m
     exp_alerts: []
-# Latency medium burn — not fast
+# Latency medium burn - not fast
 # ----------------------------------------
 - interval: 1m
-  # ----------------------------------------
-
   input_series:
   - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
-    values: "0.90+0x50"
+    values: "0.90+0x80"
   alert_rule_test:
-  - eval_time: 32m
+  - eval_time: 50m
     alertname: userJourneyFrontendLatency6h30m
     exp_alerts:
     - exp_labels:
@@ -190,23 +166,21 @@ tests:
         long_window: 6h
         short_window: 30m
       exp_annotations:
-        summary: "svc-1: Frontend HTTP latency SLI degraded (share <=1s <94%) for 30+ minutes"
-        description: "Share of Frontend requests within 1s on cluster svc-1 is below 94% for 30m (6x burn)."
+        summary: "svc-1: Frontend HTTP latency SLI degraded (share <=1s <94%)"
+        description: "Share of Frontend requests within 1s on cluster svc-1 is below 94% on both the 6h and 30m windows (6x burn)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-  - eval_time: 32m
+  - eval_time: 50m
     alertname: userJourneyFrontendLatency1h5m
     exp_alerts: []
 # ----------------------------------------
+# Latency fast burn
+# ----------------------------------------
 - interval: 1m
-  # ----------------------------------------
-
-  # Latency fast burn
-
   input_series:
   - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
-    values: "0.8+0x35"
+    values: "0.8+0x80"
   alert_rule_test:
-  - eval_time: 7m
+  - eval_time: 10m
     alertname: userJourneyFrontendLatency1h5m
     exp_alerts:
     - exp_labels:
@@ -219,14 +193,12 @@ tests:
         short_window: 5m
       exp_annotations:
         summary: "svc-1: Frontend HTTP latency SLI critically low (share <=1s <85.6%)"
-        description: "Share of Frontend requests completing within 1s on cluster svc-1 is below 85.6% for 5m (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
+        description: "Share of Frontend requests completing within 1s on cluster svc-1 is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
 # ----------------------------------------
+# Saturation CPU + memory
+# ----------------------------------------
 - interval: 1m
-  # ----------------------------------------
-
-  # Saturation CPU + memory
-
   input_series:
   - series: 'sli:frontend:saturation_cpu:ratio5m{cluster="svc-1"}'
     values: "0.9+0x35"
@@ -263,10 +235,6 @@ tests:
 # promtool expand counts are decimal (not hex): 5x288 = 288 samples @ 5 RPS
 # (~24h @ 5m step), then 0.2x13 = 13 samples (~65m) so drop is active by eval_time 25h.
 - interval: 5m
-  # ----------------------------------------
-
-  # Traffic drop vs 1d baseline (5m step)
-
   input_series:
   - series: 'traffic:frontend_http:request_rate:rate5m{cluster="svc-1"}'
     values: "5x288 0.2x13"

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -62,17 +62,15 @@ tests:
     alertname: userJourneyFrontendReady
     exp_alerts: []
 - interval: 1m
-  # ----------------------------------------
-
-  # ----------------------------------------
-  # Errors fast burn + Availability fast (MWMBR 1h AND 5m)
+  # Errors fast burn + Availability fast (MWMBR 1h AND 5m).
+  # eval_time 62m = 1h window + for:2m so the long window is fully populated.
   input_series:
   - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
     values: "0.01+0x80"
   - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
     values: "0.99+0x80"
   alert_rule_test:
-  - eval_time: 10m
+  - eval_time: 62m
     alertname: userJourneyFrontendErrors1h5m
     exp_alerts:
     - exp_labels:
@@ -87,7 +85,7 @@ tests:
         summary: "svc-1: Frontend HTTP 5xx error rate critically high (>0.72%)"
         description: "Frontend 5xx share on cluster svc-1 is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h)."
         runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
-  - eval_time: 10m
+  - eval_time: 62m
     alertname: userJourneyFrontendAvailability1h5m
     exp_alerts:
     - exp_labels:
@@ -102,15 +100,14 @@ tests:
         summary: "svc-1: Frontend HTTP availability critically low (<99.28%)"
         description: "Frontend availability on cluster svc-1 is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn."
         runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
-- interval: 1m
-  # Errors medium burn (0.4%) - not fast
-
-  # ----------------------------------------
+- interval: 5m
+  # Errors medium burn (0.4%) - not fast.
+  # 5m step x90 covers 7h30m so avg_over_time[6h] is populated; eval after 6h+for:15m.
   input_series:
   - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
-    values: "0.004+0x80"
+    values: "0.004x90"
   alert_rule_test:
-  - eval_time: 50m
+  - eval_time: 6h20m
     alertname: userJourneyFrontendErrors6h30m
     exp_alerts:
     - exp_labels:
@@ -125,19 +122,17 @@ tests:
         summary: "svc-1: Frontend HTTP 5xx error rate elevated (>0.30%)"
         description: "Frontend 5xx share on cluster svc-1 is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget)."
         runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
-  - eval_time: 50m
+  - eval_time: 6h20m
     alertname: userJourneyFrontendErrors1h5m
     exp_alerts: []
-- interval: 1m
-  # ----------------------------------------
-
-  # ----------------------------------------
-  # Availability medium burn - not fast
+- interval: 5m
+  # Availability medium burn - not fast.
+  # 5m step x90 covers 7h30m so avg_over_time[6h] is populated; eval after 6h+for:15m.
   input_series:
   - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
-    values: "0.995+0x80"
+    values: "0.995x90"
   alert_rule_test:
-  - eval_time: 50m
+  - eval_time: 6h20m
     alertname: userJourneyFrontendAvailability6h30m
     exp_alerts:
     - exp_labels:
@@ -152,18 +147,17 @@ tests:
         summary: "svc-1: Frontend HTTP availability degraded (<99.70%)"
         description: "Frontend availability on cluster svc-1 is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn."
         runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
-  - eval_time: 50m
+  - eval_time: 6h20m
     alertname: userJourneyFrontendAvailability1h5m
     exp_alerts: []
-- interval: 1m
-  # Latency medium (p99 > 1s) - not fast (p99 > 5s)
-
-  # ----------------------------------------
+- interval: 5m
+  # Latency medium (p99 > 1s) - not fast (p99 > 5s).
+  # 5m step x90 covers 7h30m so avg_over_time[6h] is populated; eval after 6h+for:15m.
   input_series:
   - series: 'sli:frontend_http:latency_p99:rate5m{cluster="svc-1"}'
-    values: "1.2+0x80"
+    values: "1.2x90"
   alert_rule_test:
-  - eval_time: 50m
+  - eval_time: 6h20m
     alertname: userJourneyFrontendLatencyP996h30m
     exp_alerts:
     - exp_labels:
@@ -178,19 +172,16 @@ tests:
         summary: "svc-1: Frontend HTTP p99 latency above SLO (>1s)"
         description: "Frontend p99 latency on cluster svc-1 is above 1s on both the 6h and 30m windows (p99 < 1s ARM sync SLO miss)."
         runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
-  - eval_time: 50m
+  - eval_time: 6h20m
     alertname: userJourneyFrontendLatencyP991h5m
     exp_alerts: []
 - interval: 1m
-  # ----------------------------------------
-
-  # ----------------------------------------
-  # Latency fast (p99 > 5s)
+  # Latency fast (p99 > 5s). eval_time 62m = 1h window + for:2m.
   input_series:
   - series: 'sli:frontend_http:latency_p99:rate5m{cluster="svc-1"}'
     values: "6+0x80"
   alert_rule_test:
-  - eval_time: 10m
+  - eval_time: 62m
     alertname: userJourneyFrontendLatencyP991h5m
     exp_alerts:
     - exp_labels:

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -86,7 +86,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP 5xx error rate critically high (>0.72%)"
         description: "Frontend 5xx share on cluster svc-1 is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - eval_time: 10m
     alertname: userJourneyFrontendAvailability1h5m
     exp_alerts:
@@ -101,7 +101,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP availability critically low (<99.28%)"
         description: "Frontend availability on cluster svc-1 is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
 - interval: 1m
   # Errors medium burn (0.4%) - not fast
 
@@ -124,7 +124,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP 5xx error rate elevated (>0.30%)"
         description: "Frontend 5xx share on cluster svc-1 is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - eval_time: 50m
     alertname: userJourneyFrontendErrors1h5m
     exp_alerts: []
@@ -151,7 +151,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP availability degraded (<99.70%)"
         description: "Frontend availability on cluster svc-1 is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - eval_time: 50m
     alertname: userJourneyFrontendAvailability1h5m
     exp_alerts: []
@@ -177,7 +177,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP p99 latency above SLO (>1s)"
         description: "Frontend p99 latency on cluster svc-1 is above 1s on both the 6h and 30m windows (p99 < 1s ARM sync SLO miss)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - eval_time: 50m
     alertname: userJourneyFrontendLatencyP991h5m
     exp_alerts: []
@@ -204,7 +204,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP p99 latency critically high (>5s)"
         description: "Frontend p99 latency on cluster svc-1 is above 5s on both the 1h and 5m windows (severe miss of the p99 < 1s ARM sync SLO)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
 - interval: 1m
   # ----------------------------------------
 
@@ -228,7 +228,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend pod CPU above 85% of request for 15+ minutes"
         description: "Frontend container CPU (usage/request) on cluster svc-1 is above 85% for 15m."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
   - eval_time: 17m
     alertname: userJourneyFrontendSaturationMemory
     exp_alerts:
@@ -241,7 +241,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend pod memory above 85% of limit for 15+ minutes"
         description: "Frontend container memory (working set/limit) on cluster svc-1 is above 85% for 15m."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
 - interval: 5m
   # ----------------------------------------
 
@@ -265,7 +265,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP traffic collapsed below 10% of 1d baseline"
         description: "Frontend request rate on cluster svc-1 is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS and pods are still Ready (traffic drought, not a replica outage)."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
 - interval: 1m
   # Replica outage — ready=0 pages; HTTP drought path does not apply.
 
@@ -285,4 +285,4 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend has no Ready replicas (kube /healthz)"
         description: "aro-hcp-frontend on cluster svc-1 has 0 available replicas (kube readiness probes hit /healthz). This is a process outage, not an ARM traffic drought."
-        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -56,10 +56,11 @@ tests:
   - eval_time: 70m
     alertname: userJourneyFrontendTrafficDrop
     exp_alerts: []
-# Errors fast burn + Availability fast (MWMBR 1h AND 5m)
 # ----------------------------------------
 - interval: 1m
   # ----------------------------------------
+
+  # Errors fast burn + Availability fast (MWMBR 1h AND 5m)
 
   input_series:
   - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
@@ -97,9 +98,10 @@ tests:
         summary: "svc-1: Frontend HTTP availability critically low (<99.28%)"
         description: "Frontend availability on cluster svc-1 is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-# ----------------------------------------
 - interval: 1m
   # Errors medium burn (0.4%) - not fast
+
+  # ----------------------------------------
 
   input_series:
   - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
@@ -123,10 +125,11 @@ tests:
   - eval_time: 50m
     alertname: userJourneyFrontendErrors1h5m
     exp_alerts: []
-# Availability medium burn - not fast
 # ----------------------------------------
 - interval: 1m
   # ----------------------------------------
+
+  # Availability medium burn - not fast
 
   input_series:
   - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
@@ -150,9 +153,10 @@ tests:
   - eval_time: 50m
     alertname: userJourneyFrontendAvailability1h5m
     exp_alerts: []
-# ----------------------------------------
 - interval: 1m
   # Latency medium burn - not fast
+
+  # ----------------------------------------
 
   input_series:
   - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
@@ -176,10 +180,11 @@ tests:
   - eval_time: 50m
     alertname: userJourneyFrontendLatency1h5m
     exp_alerts: []
-# Latency fast burn
 # ----------------------------------------
 - interval: 1m
   # ----------------------------------------
+
+  # Latency fast burn
 
   input_series:
   - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
@@ -200,10 +205,11 @@ tests:
         summary: "svc-1: Frontend HTTP latency SLI critically low (share <=1s <85.6%)"
         description: "Share of Frontend requests completing within 1s on cluster svc-1 is below 85.6% on both the 1h and 5m windows (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-# Saturation CPU + memory
 # ----------------------------------------
 - interval: 1m
   # ----------------------------------------
+
+  # Saturation CPU + memory
 
   input_series:
   - series: 'sli:frontend:saturation_cpu:ratio5m{cluster="svc-1"}'
@@ -237,10 +243,11 @@ tests:
         summary: "svc-1: Frontend pod memory above 85% of limit for 15+ minutes"
         description: "Frontend container memory (working set/limit) on cluster svc-1 is above 85% for 15m."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-# promtool expand counts are decimal (not hex): 5x288 = 288 samples @ 5 RPS
 # (~24h @ 5m step), then 0.2x13 = 13 samples (~65m) so drop is active by eval_time 25h.
 - interval: 5m
   # ----------------------------------------
+
+  # promtool expand counts are decimal (not hex): 5x288 = 288 samples @ 5 RPS
 
   input_series:
   - series: 'traffic:frontend_http:request_rate:rate5m{cluster="svc-1"}'

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -79,7 +79,7 @@ tests:
         short_window: 5m
       exp_annotations:
         summary: "svc-1: Frontend HTTP 5xx error rate critically high (>0.72%)"
-        description: "Frontend 5xx share on cluster svc-1 is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~12h."
+        description: "Frontend 5xx share on cluster svc-1 is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 10m
     alertname: userJourneyFrontendAvailability1h5m

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -200,11 +200,12 @@ tests:
 # ----------------------------------------
 # Traffic drop vs 1d baseline (5m step)
 # ----------------------------------------
-# 288 samples @ 5 RPS (~24h @ 5m step), then 11 samples @ 0.2 RPS (~55m).
+# promtool expand counts are decimal (not hex): 5x288 = 288 samples @ 5 RPS
+# (~24h @ 5m step), then 0.2x13 = 13 samples (~65m) so drop is active by eval_time 25h.
 - interval: 5m
   input_series:
   - series: 'traffic:frontend_http:request_rate:rate5m{cluster="svc-1"}'
-    values: "5+0x287 0.2+0x10"
+    values: "5x288 0.2x13"
   alert_rule_test:
   - eval_time: 25h
     alertname: userJourneyFrontendTrafficDrop

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -59,10 +59,11 @@ tests:
   - eval_time: 40m
     alertname: userJourneyFrontendTrafficDrop
     exp_alerts: []
-# Errors fast burn + degradation + Availability fast
 # ----------------------------------------
 - interval: 1m
   # ----------------------------------------
+
+  # Errors fast burn + degradation + Availability fast
 
   input_series:
   - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
@@ -105,13 +106,13 @@ tests:
         alertname: userJourneyFrontendAvailability1h5m
         cluster: svc-1
         component: slo
-        severity: "3"
+        severity: "4"
         slo: frontend-availability
         long_window: 1h
         short_window: 5m
       exp_annotations:
         summary: "svc-1: Frontend HTTP availability critically low (<99.28%)"
-        description: "Frontend availability on cluster svc-1 is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget)."
+        description: "Frontend availability on cluster svc-1 is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket — Errors family pages on the complementary 5xx burn."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
 # Errors medium burn (0.4%) — not fast
 # ----------------------------------------
@@ -140,10 +141,11 @@ tests:
   - eval_time: 32m
     alertname: userJourneyFrontendErrors1h5m
     exp_alerts: []
-# Availability medium burn — not fast
 # ----------------------------------------
 - interval: 1m
   # ----------------------------------------
+
+  # Availability medium burn — not fast
 
   input_series:
   - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
@@ -156,13 +158,13 @@ tests:
         alertname: userJourneyFrontendAvailability6h30m
         cluster: svc-1
         component: slo
-        severity: "3"
+        severity: "4"
         slo: frontend-availability
         long_window: 6h
         short_window: 30m
       exp_annotations:
         summary: "svc-1: Frontend HTTP availability degraded (<99.70%) for 30+ minutes"
-        description: "Frontend availability on cluster svc-1 is below 99.70% for 30m (6x burn)."
+        description: "Frontend availability on cluster svc-1 is below 99.70% for 30m (6x burn). Sev4 ticket — Errors family pages on the complementary 5xx burn."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 32m
     alertname: userJourneyFrontendAvailability1h5m
@@ -194,10 +196,11 @@ tests:
   - eval_time: 32m
     alertname: userJourneyFrontendLatency1h5m
     exp_alerts: []
-# Latency fast burn
 # ----------------------------------------
 - interval: 1m
   # ----------------------------------------
+
+  # Latency fast burn
 
   input_series:
   - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
@@ -218,10 +221,11 @@ tests:
         summary: "svc-1: Frontend HTTP latency SLI critically low (share <=1s <85.6%)"
         description: "Share of Frontend requests completing within 1s on cluster svc-1 is below 85.6% for 5m (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-# Saturation CPU + memory
 # ----------------------------------------
 - interval: 1m
   # ----------------------------------------
+
+  # Saturation CPU + memory
 
   input_series:
   - series: 'sli:frontend:saturation_cpu:ratio5m{cluster="svc-1"}'
@@ -255,12 +259,13 @@ tests:
         summary: "svc-1: Frontend pod memory above 85% of limit for 15+ minutes"
         description: "Frontend container memory (working set/limit) on cluster svc-1 is above 85% for 15m."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-# Traffic drop vs 1d baseline (5m step)
 # ----------------------------------------
 # promtool expand counts are decimal (not hex): 5x288 = 288 samples @ 5 RPS
 # (~24h @ 5m step), then 0.2x13 = 13 samples (~65m) so drop is active by eval_time 25h.
 - interval: 5m
   # ----------------------------------------
+
+  # Traffic drop vs 1d baseline (5m step)
 
   input_series:
   - series: 'traffic:frontend_http:request_rate:rate5m{cluster="svc-1"}'

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -22,30 +22,43 @@ tests:
   alert_rule_test:
   - eval_time: 40m
     alertname: userJourneyFrontendErrors1h5m
+    exp_alerts: []
   - eval_time: 40m
     alertname: userJourneyFrontendErrors6h30m
+    exp_alerts: []
   - eval_time: 40m
     alertname: userJourneyFrontendErrors3d
+    exp_alerts: []
   - eval_time: 40m
     alertname: userJourneyFrontendErrorsDegradation
+    exp_alerts: []
   - eval_time: 40m
     alertname: userJourneyFrontendAvailability1h5m
+    exp_alerts: []
   - eval_time: 40m
     alertname: userJourneyFrontendAvailability6h30m
+    exp_alerts: []
   - eval_time: 40m
     alertname: userJourneyFrontendAvailability3d
+    exp_alerts: []
   - eval_time: 40m
     alertname: userJourneyFrontendLatency1h5m
+    exp_alerts: []
   - eval_time: 40m
     alertname: userJourneyFrontendLatency6h30m
+    exp_alerts: []
   - eval_time: 40m
     alertname: userJourneyFrontendLatency3d
+    exp_alerts: []
   - eval_time: 40m
     alertname: userJourneyFrontendSaturationCPU
+    exp_alerts: []
   - eval_time: 40m
     alertname: userJourneyFrontendSaturationMemory
+    exp_alerts: []
   - eval_time: 40m
     alertname: userJourneyFrontendTrafficDrop
+    exp_alerts: []
 
 # ----------------------------------------
 # Errors fast burn + degradation + Availability fast
@@ -126,6 +139,7 @@ tests:
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 32m
     alertname: userJourneyFrontendErrors1h5m
+    exp_alerts: []
 
 # ----------------------------------------
 # Latency fast burn
@@ -191,7 +205,7 @@ tests:
 # ----------------------------------------
 # Traffic drop vs 1d baseline (5m step)
 # ----------------------------------------
-# 288 samples @ 5 RPS (~24h), then 6 samples @ 0.2 RPS (~30m).
+# 288 samples @ 5 RPS (~24h @ 5m step), then 11 samples @ 0.2 RPS (~55m).
 - interval: 5m
   input_series:
   - series: 'traffic:frontend_http:request_rate:rate5m{cluster="svc-1"}'

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -1,0 +1,212 @@
+rule_files:
+- frontend-slo-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+# ----------------------------------------
+# Healthy — no alerts
+# ----------------------------------------
+- interval: 1m
+  input_series:
+  - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
+    values: "0.0001+0x40"
+  - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
+    values: "0.9999+0x40"
+  - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
+    values: "0.995+0x40"
+  - series: 'sli:frontend:saturation_cpu:ratio5m{cluster="svc-1"}'
+    values: "0.4+0x40"
+  - series: 'sli:frontend:saturation_memory:ratio5m{cluster="svc-1"}'
+    values: "0.4+0x40"
+  - series: 'traffic:frontend_http:request_rate:rate5m{cluster="svc-1"}'
+    values: "2+0x40"
+  alert_rule_test:
+  - eval_time: 40m
+    alertname: userJourneyFrontendErrors1h5m
+  - eval_time: 40m
+    alertname: userJourneyFrontendErrors6h30m
+  - eval_time: 40m
+    alertname: userJourneyFrontendErrors3d
+  - eval_time: 40m
+    alertname: userJourneyFrontendErrorsDegradation
+  - eval_time: 40m
+    alertname: userJourneyFrontendAvailability1h5m
+  - eval_time: 40m
+    alertname: userJourneyFrontendAvailability6h30m
+  - eval_time: 40m
+    alertname: userJourneyFrontendAvailability3d
+  - eval_time: 40m
+    alertname: userJourneyFrontendLatency1h5m
+  - eval_time: 40m
+    alertname: userJourneyFrontendLatency6h30m
+  - eval_time: 40m
+    alertname: userJourneyFrontendLatency3d
+  - eval_time: 40m
+    alertname: userJourneyFrontendSaturationCPU
+  - eval_time: 40m
+    alertname: userJourneyFrontendSaturationMemory
+  - eval_time: 40m
+    alertname: userJourneyFrontendTrafficDrop
+
+# ----------------------------------------
+# Errors fast burn + degradation + Availability fast
+# ----------------------------------------
+- interval: 1m
+  input_series:
+  - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
+    values: "0.01+0x40"
+  - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
+    values: "0.99+0x40"
+  alert_rule_test:
+  - eval_time: 7m
+    alertname: userJourneyFrontendErrors1h5m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyFrontendErrors1h5m
+        cluster: svc-1
+        component: slo
+        severity: "3"
+        slo: frontend-errors
+        long_window: 1h
+        short_window: 5m
+      exp_annotations:
+        summary: "svc-1: Frontend HTTP 5xx error rate critically high (>0.72%)"
+        description: "Frontend 5xx share on cluster svc-1 is above 0.72% for 5m (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~12h."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+  - eval_time: 32m
+    alertname: userJourneyFrontendErrorsDegradation
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyFrontendErrorsDegradation
+        cluster: svc-1
+        component: slo
+        severity: "4"
+        slo: frontend-errors
+      exp_annotations:
+        summary: "svc-1: Frontend HTTP 5xx error rate exceeds 0.15% for 30 minutes"
+        description: "Frontend 5xx share on cluster svc-1 is above 0.15% (3x budget) for 30m - precursor before medium/fast burn pages."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+  - eval_time: 7m
+    alertname: userJourneyFrontendAvailability1h5m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyFrontendAvailability1h5m
+        cluster: svc-1
+        component: slo
+        severity: "3"
+        slo: frontend-availability
+        long_window: 1h
+        short_window: 5m
+      exp_annotations:
+        summary: "svc-1: Frontend HTTP availability critically low (<99.28%)"
+        description: "Frontend availability on cluster svc-1 is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget)."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+
+# ----------------------------------------
+# Errors medium burn (0.4%) — not fast
+# ----------------------------------------
+- interval: 1m
+  input_series:
+  - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
+    values: "0.004+0x40"
+  alert_rule_test:
+  - eval_time: 32m
+    alertname: userJourneyFrontendErrors6h30m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyFrontendErrors6h30m
+        cluster: svc-1
+        component: slo
+        severity: "3"
+        slo: frontend-errors
+        long_window: 6h
+        short_window: 30m
+      exp_annotations:
+        summary: "svc-1: Frontend HTTP 5xx error rate elevated (>0.30%) for 30+ minutes"
+        description: "Frontend 5xx share on cluster svc-1 is above 0.30% for 30m (6x burn of the 0.05% error budget)."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+  - eval_time: 32m
+    alertname: userJourneyFrontendErrors1h5m
+
+# ----------------------------------------
+# Latency fast burn
+# ----------------------------------------
+- interval: 1m
+  input_series:
+  - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
+    values: "0.8+0x20"
+  alert_rule_test:
+  - eval_time: 7m
+    alertname: userJourneyFrontendLatency1h5m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyFrontendLatency1h5m
+        cluster: svc-1
+        component: slo
+        severity: "3"
+        slo: frontend-latency
+        long_window: 1h
+        short_window: 5m
+      exp_annotations:
+        summary: "svc-1: Frontend HTTP latency SLI critically low (share <=1s <85.6%)"
+        description: "Share of Frontend requests completing within 1s on cluster svc-1 is below 85.6% for 5m (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+
+# ----------------------------------------
+# Saturation CPU + memory
+# ----------------------------------------
+- interval: 1m
+  input_series:
+  - series: 'sli:frontend:saturation_cpu:ratio5m{cluster="svc-1"}'
+    values: "0.9+0x25"
+  - series: 'sli:frontend:saturation_memory:ratio5m{cluster="svc-1"}'
+    values: "0.9+0x25"
+  alert_rule_test:
+  - eval_time: 17m
+    alertname: userJourneyFrontendSaturationCPU
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyFrontendSaturationCPU
+        cluster: svc-1
+        component: slo
+        severity: "4"
+        slo: frontend-saturation
+      exp_annotations:
+        summary: "svc-1: Frontend pod CPU above 85% of request for 15+ minutes"
+        description: "Frontend container CPU (usage/request) on cluster svc-1 is above 85% for 15m."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+  - eval_time: 17m
+    alertname: userJourneyFrontendSaturationMemory
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyFrontendSaturationMemory
+        cluster: svc-1
+        component: slo
+        severity: "4"
+        slo: frontend-saturation
+      exp_annotations:
+        summary: "svc-1: Frontend pod memory above 85% of limit for 15+ minutes"
+        description: "Frontend container memory (working set/limit) on cluster svc-1 is above 85% for 15m."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+
+# ----------------------------------------
+# Traffic drop vs 1d baseline (5m step)
+# ----------------------------------------
+# 288 samples @ 5 RPS (~24h), then 6 samples @ 0.2 RPS (~30m).
+- interval: 5m
+  input_series:
+  - series: 'traffic:frontend_http:request_rate:rate5m{cluster="svc-1"}'
+    values: "5+0x287 0.2+0x10"
+  alert_rule_test:
+  - eval_time: 25h
+    alertname: userJourneyFrontendTrafficDrop
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyFrontendTrafficDrop
+        cluster: svc-1
+        component: slo
+        severity: "4"
+        slo: frontend-traffic
+      exp_annotations:
+        summary: "svc-1: Frontend HTTP traffic collapsed below 10% of 1d baseline"
+        description: "Frontend request rate on cluster svc-1 is below 10% of its 1-day average for 15m while the baseline exceeded 0.5 RPS."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -8,17 +8,17 @@ tests:
 - interval: 1m
   input_series:
   - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
-    values: "0.0001+0x40"
+    values: "0.0001+0x50"
   - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
-    values: "0.9999+0x40"
+    values: "0.9999+0x50"
   - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
-    values: "0.995+0x40"
+    values: "0.995+0x50"
   - series: 'sli:frontend:saturation_cpu:ratio5m{cluster="svc-1"}'
-    values: "0.4+0x40"
+    values: "0.4+0x50"
   - series: 'sli:frontend:saturation_memory:ratio5m{cluster="svc-1"}'
-    values: "0.4+0x40"
+    values: "0.4+0x50"
   - series: 'traffic:frontend_http:request_rate:rate5m{cluster="svc-1"}'
-    values: "2+0x40"
+    values: "2+0x50"
   alert_rule_test:
   - eval_time: 40m
     alertname: userJourneyFrontendErrors1h5m
@@ -59,15 +59,16 @@ tests:
   - eval_time: 40m
     alertname: userJourneyFrontendTrafficDrop
     exp_alerts: []
-# ----------------------------------------
 # Errors fast burn + degradation + Availability fast
 # ----------------------------------------
 - interval: 1m
+  # ----------------------------------------
+
   input_series:
   - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
-    values: "0.01+0x40"
+    values: "0.01+0x50"
   - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
-    values: "0.99+0x40"
+    values: "0.99+0x50"
   alert_rule_test:
   - eval_time: 7m
     alertname: userJourneyFrontendErrors1h5m
@@ -112,13 +113,14 @@ tests:
         summary: "svc-1: Frontend HTTP availability critically low (<99.28%)"
         description: "Frontend availability on cluster svc-1 is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-# ----------------------------------------
 # Errors medium burn (0.4%) — not fast
 # ----------------------------------------
 - interval: 1m
+  # ----------------------------------------
+
   input_series:
   - series: 'errors:frontend_http:error_rate:rate5m{cluster="svc-1"}'
-    values: "0.004+0x40"
+    values: "0.004+0x50"
   alert_rule_test:
   - eval_time: 32m
     alertname: userJourneyFrontendErrors6h30m
@@ -138,13 +140,68 @@ tests:
   - eval_time: 32m
     alertname: userJourneyFrontendErrors1h5m
     exp_alerts: []
+# Availability medium burn — not fast
 # ----------------------------------------
+- interval: 1m
+  # ----------------------------------------
+
+  input_series:
+  - series: 'sli:frontend_http:availability:rate5m{cluster="svc-1"}'
+    values: "0.995+0x50"
+  alert_rule_test:
+  - eval_time: 32m
+    alertname: userJourneyFrontendAvailability6h30m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyFrontendAvailability6h30m
+        cluster: svc-1
+        component: slo
+        severity: "3"
+        slo: frontend-availability
+        long_window: 6h
+        short_window: 30m
+      exp_annotations:
+        summary: "svc-1: Frontend HTTP availability degraded (<99.70%) for 30+ minutes"
+        description: "Frontend availability on cluster svc-1 is below 99.70% for 30m (6x burn)."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+  - eval_time: 32m
+    alertname: userJourneyFrontendAvailability1h5m
+    exp_alerts: []
+# Latency medium burn — not fast
+# ----------------------------------------
+- interval: 1m
+  # ----------------------------------------
+
+  input_series:
+  - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
+    values: "0.90+0x50"
+  alert_rule_test:
+  - eval_time: 32m
+    alertname: userJourneyFrontendLatency6h30m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyFrontendLatency6h30m
+        cluster: svc-1
+        component: slo
+        severity: "3"
+        slo: frontend-latency
+        long_window: 6h
+        short_window: 30m
+      exp_annotations:
+        summary: "svc-1: Frontend HTTP latency SLI degraded (share <=1s <94%) for 30+ minutes"
+        description: "Share of Frontend requests within 1s on cluster svc-1 is below 94% for 30m (6x burn)."
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
+  - eval_time: 32m
+    alertname: userJourneyFrontendLatency1h5m
+    exp_alerts: []
 # Latency fast burn
 # ----------------------------------------
 - interval: 1m
+  # ----------------------------------------
+
   input_series:
   - series: 'sli:frontend_http:latency:rate5m{cluster="svc-1"}'
-    values: "0.8+0x20"
+    values: "0.8+0x35"
   alert_rule_test:
   - eval_time: 7m
     alertname: userJourneyFrontendLatency1h5m
@@ -161,15 +218,16 @@ tests:
         summary: "svc-1: Frontend HTTP latency SLI critically low (share <=1s <85.6%)"
         description: "Share of Frontend requests completing within 1s on cluster svc-1 is below 85.6% for 5m (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-# ----------------------------------------
 # Saturation CPU + memory
 # ----------------------------------------
 - interval: 1m
+  # ----------------------------------------
+
   input_series:
   - series: 'sli:frontend:saturation_cpu:ratio5m{cluster="svc-1"}'
-    values: "0.9+0x25"
+    values: "0.9+0x35"
   - series: 'sli:frontend:saturation_memory:ratio5m{cluster="svc-1"}'
-    values: "0.9+0x25"
+    values: "0.9+0x35"
   alert_rule_test:
   - eval_time: 17m
     alertname: userJourneyFrontendSaturationCPU
@@ -197,12 +255,13 @@ tests:
         summary: "svc-1: Frontend pod memory above 85% of limit for 15+ minutes"
         description: "Frontend container memory (working set/limit) on cluster svc-1 is above 85% for 15m."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-# ----------------------------------------
 # Traffic drop vs 1d baseline (5m step)
 # ----------------------------------------
 # promtool expand counts are decimal (not hex): 5x288 = 288 samples @ 5 RPS
 # (~24h @ 5m step), then 0.2x13 = 13 samples (~65m) so drop is active by eval_time 25h.
 - interval: 5m
+  # ----------------------------------------
+
   input_series:
   - series: 'traffic:frontend_http:request_rate:rate5m{cluster="svc-1"}'
     values: "5x288 0.2x13"

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -59,7 +59,6 @@ tests:
   - eval_time: 40m
     alertname: userJourneyFrontendTrafficDrop
     exp_alerts: []
-
 # ----------------------------------------
 # Errors fast burn + degradation + Availability fast
 # ----------------------------------------
@@ -113,7 +112,6 @@ tests:
         summary: "svc-1: Frontend HTTP availability critically low (<99.28%)"
         description: "Frontend availability on cluster svc-1 is below 99.28% for 5m (14.4x burn of the 99.95% SLO / 0.05% error budget)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-
 # ----------------------------------------
 # Errors medium burn (0.4%) — not fast
 # ----------------------------------------
@@ -140,7 +138,6 @@ tests:
   - eval_time: 32m
     alertname: userJourneyFrontendErrors1h5m
     exp_alerts: []
-
 # ----------------------------------------
 # Latency fast burn
 # ----------------------------------------
@@ -164,7 +161,6 @@ tests:
         summary: "svc-1: Frontend HTTP latency SLI critically low (share <=1s <85.6%)"
         description: "Share of Frontend requests completing within 1s on cluster svc-1 is below 85.6% for 5m (14.4x burn of the 1% latency budget for the p99 < 1s SLO)."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-
 # ----------------------------------------
 # Saturation CPU + memory
 # ----------------------------------------
@@ -201,7 +197,6 @@ tests:
         summary: "svc-1: Frontend pod memory above 85% of limit for 15+ minutes"
         description: "Frontend container memory (working set/limit) on cluster svc-1 is above 85% for 15m."
         runbook_url: "https://aka.ms/arohcp-runbook-frontend"
-
 # ----------------------------------------
 # Traffic drop vs 1d baseline (5m step)
 # ----------------------------------------

--- a/observability/alerts/frontend-slo-prometheusRule_test.yaml
+++ b/observability/alerts/frontend-slo-prometheusRule_test.yaml
@@ -84,7 +84,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP 5xx error rate critically high (>0.72%)"
         description: "Frontend 5xx share on cluster svc-1 is above 0.72% on both the 1h and 5m windows (14.4x burn of the 99.95% availability / 0.05% error budget). Would exhaust the 30d budget in ~2d (~50h)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 62m
     alertname: userJourneyFrontendAvailability1h5m
     exp_alerts:
@@ -99,7 +99,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP availability critically low (<99.28%)"
         description: "Frontend availability on cluster svc-1 is below 99.28% on both the 1h and 5m windows (14.4x burn of the 99.95% SLO / 0.05% error budget). Sev4 ticket - Errors family pages on the complementary 5xx burn."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
 - interval: 5m
   # Errors medium burn (0.4%) - not fast.
   # 5m step x90 covers 7h30m so avg_over_time[6h] is populated; eval after 6h+for:15m.
@@ -121,7 +121,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP 5xx error rate elevated (>0.30%)"
         description: "Frontend 5xx share on cluster svc-1 is above 0.30% on both the 6h and 30m windows (6x burn of the 0.05% error budget)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 6h20m
     alertname: userJourneyFrontendErrors1h5m
     exp_alerts: []
@@ -146,7 +146,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP availability degraded (<99.70%)"
         description: "Frontend availability on cluster svc-1 is below 99.70% on both the 6h and 30m windows (6x burn). Sev4 ticket - Errors family pages on the complementary 5xx burn."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 6h20m
     alertname: userJourneyFrontendAvailability1h5m
     exp_alerts: []
@@ -171,7 +171,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP p99 latency above SLO (>1s)"
         description: "Frontend p99 latency on cluster svc-1 is above 1s on both the 6h and 30m windows (p99 < 1s ARM sync SLO miss)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 6h20m
     alertname: userJourneyFrontendLatencyP991h5m
     exp_alerts: []
@@ -195,7 +195,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP p99 latency critically high (>5s)"
         description: "Frontend p99 latency on cluster svc-1 is above 5s on both the 1h and 5m windows (severe miss of the p99 < 1s ARM sync SLO)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
 - interval: 1m
   # ----------------------------------------
 
@@ -219,7 +219,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend pod CPU above 85% of request for 15+ minutes"
         description: "Frontend container CPU (usage/request) on cluster svc-1 is above 85% for 15m."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 17m
     alertname: userJourneyFrontendSaturationMemory
     exp_alerts:
@@ -232,7 +232,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend pod memory above 85% of limit for 15+ minutes"
         description: "Frontend container memory (working set/limit) on cluster svc-1 is above 85% for 15m."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
 - interval: 5m
   # ----------------------------------------
 
@@ -256,7 +256,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP traffic collapsed below 10% of 1d baseline"
         description: "Frontend request rate on cluster svc-1 is below 10% of its 1-day average for 15m while the 1d baseline exceeded 0.5 RPS (fleet-wide noise floor) and pods are still Ready (traffic drought, not a replica outage)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
 - interval: 5m
   # Baseline 0.3 RPS is under the 0.5 RPS noise floor, then a 90% drop.
   # Must not fire even though the relative collapse matches the 10% rule.
@@ -288,7 +288,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend has no Ready replicas (kube /healthz)"
         description: "aro-hcp-frontend on cluster svc-1 has 0 available replicas (kube readiness probes hit /healthz). This is a process outage, not an ARM traffic drought."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
 - interval: 1h
   # Slow 3d/6h firing (1x burn). Hourly samples so the 3d window is populated
   # without a 1m series. Error/availability values stay below fast/medium
@@ -315,7 +315,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP 5xx error rate exceeds SLO (>0.05%)"
         description: "Frontend 5xx share on cluster svc-1 is above the 0.05% SLO boundary on both the 3d and 6h windows (1x burn)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 73h
     alertname: userJourneyFrontendErrors6h30m
     exp_alerts: []
@@ -336,7 +336,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP availability below SLO (<99.95%)"
         description: "Frontend availability on cluster svc-1 is below the 99.95% SLO on both the 3d and 6h windows (1x burn)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 73h
     alertname: userJourneyFrontendAvailability6h30m
     exp_alerts: []
@@ -357,7 +357,7 @@ tests:
       exp_annotations:
         summary: "svc-1: Frontend HTTP p99 latency above SLO (>1s)"
         description: "Frontend p99 latency on cluster svc-1 is above 1s on both the 3d and 6h windows (1x burn of the p99 < 1s SLO)."
-        runbook_url: "https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend"
+        runbook_url: "https://aka.ms/arohcp-runbook-frontend"
   - eval_time: 73h
     alertname: userJourneyFrontendLatencyP991h5m
     exp_alerts: []


### PR DESCRIPTION
## Summary
- Adds Frontend (ARM RP) user-journey SLO burn-rate alerts for [ARO-28707](https://redhat.atlassian.net/browse/ARO-28707).
- Covers Errors, Availability, and Latency MWMBR (14.4x / 6x / 1x) against the 99.95% availability and p99 < 1s budgets, plus traffic drop vs 1d baseline and CPU/memory saturation (>85%).
- Alert names follow `userJourneyFrontend{Metric}{Tier}`. Fast/medium Errors + Latency page Sev 3; Availability is Sev 4 only (avoids dual Sev3 IcMs on the same 5xx burn). Slow/traffic/saturation Sev 4.
- Wired into the RP services alert lane (`alerts-rp-services.yaml`) with regenerated `generatedRPPrometheusAlertingRules.bicep`.
- **Depends on** recording rules from [#6554](https://github.com/Azure/ARO-HCP/pull/6554) ([ARO-28705](https://redhat.atlassian.net/browse/ARO-28705)).
- `runbook_url` is `https://aka.ms/arohcp-runbook-frontend` (same pattern as nodepool/access). Destination for that alias is the published Frontend UJ runbook:
  `https://eng.ms/docs/cloud-ai-platform/azure-core/azure-cloud-native-and-management-platform/control-plane-bburns/azure-red-hat-openshift/azure-redhat-openshift-team-doc/hcp/runbooks/user-journey/frontend`

## Screenshots
This PR is Prometheus alert YAML + generated RP bicep only (no Grafana JSON). CONTRIBUTING screenshots for the **graphs/panels** these alerts consume are on the dashboard sibling and Jira:

- Dashboard / Explore (prod `australiaeast` / `prod-australiaeast-svc-1`): [#6555](https://github.com/Azure/ARO-HCP/pull/6555), [ARO-28706](https://redhat.atlassian.net/browse/ARO-28706)
- Prod alert-tester (thresholds vs IcM storm): [last week](https://github.com/Azure/ARO-HCP/pull/6557#issuecomment-5335911252) · [30d](https://github.com/Azure/ARO-HCP/pull/6557#issuecomment-5349435505) · [Latency p99 + Ready](https://github.com/Azure/ARO-HCP/pull/6557#issuecomment-5485101167)

## Test plan
- [x] `promtool test rules` for `frontend-slo-prometheusRule_test.yaml`
- [x] CI `observability-prometheus` / `observability-verify` / `bicep-lint`
- [x] Merge after [#6554](https://github.com/Azure/ARO-HCP/pull/6554)
- [x] After deploy: confirm alerts evaluate on INT/svc Prometheus

## Related
- Epic: [ARO-28703](https://redhat.atlassian.net/browse/ARO-28703) · Story: [ARO-28707](https://redhat.atlassian.net/browse/ARO-28707)
- SLIs: [#6554](https://github.com/Azure/ARO-HCP/pull/6554) · Dashboard: [#6555](https://github.com/Azure/ARO-HCP/pull/6555)
- Merge order: **#6554 → #6555 → #6557**
