### PR TITLE
feat: add prod-canary e2e suite for testing against canary ARM endpoints

### DIFF
--- a/test/util/framework/per_invocation_framework.go
+++ b/test/util/framework/per_invocation_framework.go
@@ -29,6 +29,8 @@ import (
 	"sync"
 	"time"
 
+	_ "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime" // contains init() function which populates ARM cloud services
+
 	"github.com/onsi/ginkgo/v2/types"
 	"golang.org/x/net/http2"
 
@@ -200,7 +202,7 @@ func (tc *perBinaryInvocationTestContext) getClientFactoryOptions() *azcorearm.C
 			ActiveDirectoryAuthorityHost: cloud.AzurePublic.ActiveDirectoryAuthorityHost,
 			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
 				cloud.ResourceManager: {
-					Audience: "https://management.core.windows.net/",
+					Audience: cloud.AzurePublic.Services[cloud.ResourceManager].Audience,
 					Endpoint: tc.resourceManagerEndpoint,
 				},
 			},
@@ -220,7 +222,7 @@ func (tc *perBinaryInvocationTestContext) getHCPClientFactoryOptions() *azcorear
 			ActiveDirectoryAuthorityHost: cloud.AzurePublic.ActiveDirectoryAuthorityHost,
 			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
 				cloud.ResourceManager: {
-					Audience: "https://management.core.windows.net/",
+					Audience: cloud.AzurePublic.Services[cloud.ResourceManager].Audience,
 					Endpoint: tc.resourceManagerEndpoint,
 				},
 			},
@@ -241,7 +243,7 @@ func (tc *perBinaryInvocationTestContext) getHCPClientFactoryOptions() *azcorear
 			ActiveDirectoryAuthorityHost: cloud.AzurePublic.ActiveDirectoryAuthorityHost,
 			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
 				cloud.ResourceManager: {
-					Audience: "https://management.core.windows.net/",
+					Audience: cloud.AzurePublic.Services[cloud.ResourceManager].Audience,
 					Endpoint: tc.frontendAddress,
 				},
 			},

--- a/test/util/framework/per_invocation_framework.go
+++ b/test/util/framework/per_invocation_framework.go
@@ -53,6 +53,7 @@ type perBinaryInvocationTestContext struct {
 	pullSecretPath           string
 	frontendAddress          string
 	adminAPIAddress          string
+	resourceManagerEndpoint  string
 	skipCertVerification     bool
 	isDevelopmentEnvironment bool
 	skipCleanup              bool
@@ -113,6 +114,7 @@ func invocationContext() *perBinaryInvocationTestContext {
 			pullSecretPath:                       pullSecretPath(),
 			frontendAddress:                      frontendAddress(),
 			adminAPIAddress:                      adminAPIAddress(),
+			resourceManagerEndpoint:              resourceManagerEndpoint(),
 			skipCertVerification:                 skipCertVerification(),
 			isDevelopmentEnvironment:             IsDevelopmentEnvironment(),
 			skipCleanup:                          skipCleanup(),
@@ -192,21 +194,51 @@ func (tc *perBinaryInvocationTestContext) getClientFactoryOptions() *azcorearm.C
 		}
 		clientOpts.PerCallPolicies = append([]policy.Policy{&requestIDPolicy{}}, clientOpts.PerCallPolicies...)
 	}
+
+	if tc.resourceManagerEndpoint != "" {
+		clientOpts.Cloud = cloud.Configuration{
+			ActiveDirectoryAuthorityHost: cloud.AzurePublic.ActiveDirectoryAuthorityHost,
+			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+				cloud.ResourceManager: {
+					Audience: "https://management.core.windows.net/",
+					Endpoint: tc.resourceManagerEndpoint,
+				},
+			},
+		}
+	}
+
 	return &azcorearm.ClientOptions{
 		ClientOptions: clientOpts,
 	}
 }
 
 func (tc *perBinaryInvocationTestContext) getHCPClientFactoryOptions() *azcorearm.ClientOptions {
+	clientOpts := azsdk.NewClientOptions(azsdk.ComponentE2E)
+	clientOpts.Retry = azureRetryOptions
+	if tc.resourceManagerEndpoint != "" {
+		clientOpts.Cloud = cloud.Configuration{
+			ActiveDirectoryAuthorityHost: cloud.AzurePublic.ActiveDirectoryAuthorityHost,
+			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+				cloud.ResourceManager: {
+					Audience: "https://management.core.windows.net/",
+					Endpoint: tc.resourceManagerEndpoint,
+				},
+			},
+		}
+	}
+	clientOpts.PerCallPolicies = []policy.Policy{
+		NewRetryVersionNotFoundPolicy(),
+		&sanitizeAuthHeaderPolicy{},
+	}
+
 	if tc.isDevelopmentEnvironment {
 		transport := tc.defaultTransport
 		if tc.skipCertVerification {
 			transport.TLSClientConfig.InsecureSkipVerify = true
 		}
-		clientOpts := azsdk.NewClientOptions(azsdk.ComponentE2E)
-		clientOpts.Retry = azureRetryOptions
+
 		clientOpts.Cloud = cloud.Configuration{
-			ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+			ActiveDirectoryAuthorityHost: cloud.AzurePublic.ActiveDirectoryAuthorityHost,
 			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
 				cloud.ResourceManager: {
 					Audience: "https://management.core.windows.net/",
@@ -214,6 +246,7 @@ func (tc *perBinaryInvocationTestContext) getHCPClientFactoryOptions() *azcorear
 				},
 			},
 		}
+
 		clientOpts.Transport = &proxiedConnectionTransporter{
 			delegate: transport,
 		}
@@ -225,16 +258,8 @@ func (tc *perBinaryInvocationTestContext) getHCPClientFactoryOptions() *azcorear
 			NewRetryVersionNotFoundPolicy(),
 			&sanitizeAuthHeaderPolicy{},
 		}
-		return &azcorearm.ClientOptions{
-			ClientOptions: clientOpts,
-		}
 	}
-	clientOpts := azsdk.NewClientOptions(azsdk.ComponentE2E)
-	clientOpts.Retry = azureRetryOptions
-	clientOpts.PerCallPolicies = []policy.Policy{
-		NewRetryVersionNotFoundPolicy(),
-		&sanitizeAuthHeaderPolicy{},
-	}
+
 	return &azcorearm.ClientOptions{
 		ClientOptions: clientOpts,
 	}
@@ -416,6 +441,13 @@ func adminAPIAddress() string {
 		return "http://localhost:8444"
 	}
 	return address
+}
+
+// resourceManagerEndpoint returns the value of RESOURCE_MANAGER_ENDPOINT environment variable.
+// When set, it overrides the Azure Resource Manager endpoint used by HCP SDK clients,
+// allowing tests to target canary regions (e.g. https://eastus2euap.management.azure.com).
+func resourceManagerEndpoint() string {
+	return os.Getenv("RESOURCE_MANAGER_ENDPOINT")
 }
 
 // skipCertVerification returns the value of SKIP_CERT_VERIFICATION environment variable


### PR DESCRIPTION
Allow e2e tests to target canary ARM regions (e.g. eastus2euap) by overriding the Resource Manager endpoint via `RESOURCE_MANAGER_ENDPOINT` env var, enabling validation of new API versions before an ARM Manifest rollout completes.

### Why

This will allow us to create a job in prow that can run against a canary region to validate that an API rolling out correctly functions.  

Eventually we can plumb that job into a health signal / managed validation step in our ARM manifest release to run this as a gate following the canary regions.  

### Testing

local run, eventually openshift/release rehearsal job.  

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
