### PR TITLE
fix: align aksNetworkPolicy value correctly

### DIFF
--- a/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/mgmt-cluster.tmpl.bicepparam
@@ -36,7 +36,7 @@ param infraOsDiskSizeGB = {{ .mgmt.aks.infraAgentPool.osDiskSizeGB }}
 param infraZoneRedundantMode = '{{ .mgmt.aks.infraAgentPool.zoneRedundantMode }}'
 param aksClusterOutboundIPAddressIPTags = '{{ .mgmt.aks.clusterOutboundIPAddressIPTags }}'
 param aksNetworkDataplane = '{{ .mgmt.aks.networkDataplane }}'
-param aksNetworkPolicy = '{{ .mgmt.aks.networkDataplane }}'
+param aksNetworkPolicy = '{{ .mgmt.aks.networkPolicy }}'
 param aksUpgradeSettingsMaxSurge = '{{ .mgmt.aks.upgradeSettings.maxSurge }}'
 param aksUpgradeSettingsMaxUnavailable = '{{ .mgmt.aks.upgradeSettings.maxUnavailable }}'
 

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -41,7 +41,7 @@ param infraOsDiskSizeGB = {{ .svc.aks.infraAgentPool.osDiskSizeGB }}
 param userOsDiskSizeGB = {{ .svc.aks.userAgentPool.osDiskSizeGB }}
 param aksClusterOutboundIPAddressIPTags = '{{ .svc.aks.clusterOutboundIPAddressIPTags }}'
 param aksNetworkDataplane = '{{ .svc.aks.networkDataplane }}'
-param aksNetworkPolicy = '{{ .svc.aks.networkDataplane }}'
+param aksNetworkPolicy = '{{ .svc.aks.networkPolicy }}'
 param aksUpgradeSettingsMaxSurge = '{{ .svc.aks.upgradeSettings.maxSurge }}'
 param aksUpgradeSettingsMaxUnavailable = '{{ .svc.aks.upgradeSettings.maxUnavailable }}'
 


### PR DESCRIPTION
### What

Correct the service-cluster and management-cluster Bicep parameter templates so `aksNetworkPolicy` is populated from the configured `networkPolicy` value rather than `networkDataplane`.

### Why

`networkDataplane` and `networkPolicy` are separate configuration settings.  They currently have matching values, but using the dataplane value for both means future policy changes would be ignored when rendering AKS cluster parameters.

### Testing

No unit, integration, or E2E tests were added because this is a configuration template wiring fix. Current rendered values remain unchanged because the two settings are currently identical.

- Unit tests: Not applicable
- Integration tests: Not run
- E2E tests: Not run
- Reviewed the rendered configuration impact

### Special notes for your reviewer

Please verify both service-cluster and management-cluster templates. The opstool-cluster template already uses the correct `networkPolicy` reference.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (not applicable)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge