### PR TITLE
fix: point stg V2 kusto-lookup at stgGlobalV2.kustoName (AROSLSRE-1744)

### DIFF
--- a/dev-infrastructure/configurations/kusto-lookup-stg.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/kusto-lookup-stg.tmpl.bicepparam
@@ -1,0 +1,11 @@
+// TRANSIENT: STG-global "V2" copy of kusto-lookup.tmpl.bicepparam. Identical to the
+// canonical file except the (globally-unique) Kusto cluster name is sourced from the
+// transient stgGlobalV2 block, so the lookup resolves the same cluster that
+// kusto-stg.tmpl.bicepparam deploys instead of the live V1 cluster.
+// Remove together with kusto-stg.tmpl.bicepparam and geography-pipeline-stg.yaml once
+// stgGlobalV2 is retired and stg uksouth is served solely by the canonical pipeline.
+using '../templates/kusto-lookup.bicep'
+
+param kustoName = '{{ .stgGlobalV2.kustoName }}'
+
+param kustoEnabled = {{ .arobit.kusto.enabled }}

--- a/dev-infrastructure/geography-pipeline-stg.yaml
+++ b/dev-infrastructure/geography-pipeline-stg.yaml
@@ -69,7 +69,9 @@ resourceGroups:
   - name: kusto-lookup
     action: ARM
     template: templates/kusto-lookup.bicep
-    parameters: configurations/kusto-lookup.tmpl.bicepparam
+    # Must source the cluster name from stgGlobalV2 (like the deploy step above),
+    # otherwise the lookup targets the live V1 cluster and fails with ResourceNotFound.
+    parameters: configurations/kusto-lookup-stg.tmpl.bicepparam
     deploymentLevel: ResourceGroup
     outputOnly: true
     dependsOn:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1744

### What

Adds `dev-infrastructure/configurations/kusto-lookup-stg.tmpl.bicepparam`, a V2 copy of the canonical lookup bicepparam that sources the cluster name from `{{ .stgGlobalV2.kustoName }}`, and points the `kusto-lookup` step in `geography-pipeline-stg.yaml` at it.

### Why

In the transient STG-global V2 geography pipeline, the two steps in the `kusto-infra` group read different config keys:

- `deploy` -> `kusto-stg.tmpl.bicepparam` -> `{{ .stgGlobalV2.kustoName }}` = `hcp-stg-uk-3`
- `kusto-lookup` -> `kusto-lookup.tmpl.bicepparam` -> `{{ .kusto.kustoName }}` = `hcp-stg-uk-2`

So the pipeline created one cluster and then looked up a different one in the same RG/subscription (`hcp-stg-global`), failing with `ResourceNotFound`. `hcp-stg-uk-2` is the live V1 cluster and lives in a different subscription, so that lookup could never succeed.

This also closes a latent hazard: `kusto-monitoring` is an `ARMStack` with `actionOnUnmanage: delete` that takes `kustoClusterId` directly from the `kusto-lookup` output. Had the lookup ever resolved `hcp-stg-uk-2`, that stack would have been applied against the live V1 cluster with delete-on-unmanage semantics.

Scope is uksouth only — the V2 pipeline's `kusto-infra` group is gated to `regions: [uksouth]` and pinned to `subscription: 'hcp-stg-global'`. The canonical `geography-pipeline.yaml` is unaffected: both of its steps read `.kusto.kustoName`, and it remains the pipeline that owns V1 (`hcp-stg-uk-2`) for stg uksouth.

### Testing

No automated tests — this is a pipeline/config wiring change with no Go code and no rendered-config delta.

- `cd config && make materialize` passes (`templatize configuration validate` + full helm fixture regeneration, all `TestHelmTemplate` / `TestACRValues` / `TestNodeRolloutConfig` green).
- Verified by inspection that `kusto-lookup.tmpl.bicepparam` still has exactly four consumers — `geography-pipeline.yaml`, `mgmt-pipeline.yaml`, `region-pipeline.yaml`, `svc-pipeline.yaml` — none of which are modified here, so the V1 path is untouched.
- Real verification is the next STG V2 geography rollout: the `Geography.kusto-infra.kusto-lookup` step should resolve `hcp-stg-uk-3` instead of failing with `ResourceNotFound`.

### Special notes for your reviewer

Both files are marked `TRANSIENT` and are removed at V2 decommission, consistent with the existing `kusto-stg.tmpl.bicepparam` / `geography-pipeline-stg.yaml` pattern.

Worth a second pair of eyes on the claim that nothing else in the V2 pipeline still reads `.kusto.kustoName`. `detach-legacy-monitoring-stack` uses `configRef: kusto.rg`, which resolves to the same RG *name* in both subscriptions — it is correct today only because the `kusto-infra` group hardcodes `subscription: 'hcp-stg-global'`.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes) — n/a
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable) — n/a
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge