### PR TITLE
fix: keep oc-mirror ACR credential helper silent on az acr login's probe

### DIFF
--- a/image-sync/oc-mirror/docker-login.sh
+++ b/image-sync/oc-mirror/docker-login.sh
@@ -10,6 +10,17 @@ set -euo pipefail
 #   < 2.88.0  ->  login --username <user> --password <token> <registry>
 #   >= 2.88.0 ->  login --username <user> --password-stdin <registry>, token on stdin
 # Parse the flags rather than relying on positional arguments so both forms work.
+# `az acr login` also probes this helper with `ps` before sending the login
+# (get_docker_command in azure-cli's acr/custom.py) and treats *any* stderr
+# output from that probe as a fatal "container runtime unusable" error --
+# it never looks at the exit code. Non-login invocations must therefore
+# exit 0 and stay silent, or the login is never attempted.
+
+if [[ "${1:-}" != "login" ]]; then
+    exit 0
+fi
+shift
+
 USERNAME=""
 PASSWORD=""
 


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Adds a guard at the top of `image-sync/oc-mirror/docker-login.sh`: if the first argument isn't `login`, exit 0 without printing anything.

```
if [[ "${1:-}" != "login" ]]; then
    exit 0
fi
shift
```

No other changes. The flag parsing added in #6540 is correct and untouched.

### Why

`az acr login` invokes `DOCKER_COMMAND` **twice**, and the first call is not a login:

1. `get_docker_command()` runs `<cmd> ps` to check the container runtime is usable.

2. `_perform_registry_login()` then runs `<cmd> login --username <guid> --password-stdin <registry>` with the token on stdin.

Step 1 fails on **any stderr output** — it raises before it ever looks at the exit code. Our helper only ever knew how to handle step 2.

| `docker-login.sh ps` | stderr | exit | probe outcome |
| --- | --- | --- | --- |
| before #6540 | none | 0 | passes |
| after #6540 | error message | 1 | **fatal — login never runs** |
| this PR | none | 0 | passes |

### Why it worked before


The old helper read credentials positionally (`$3`/`$5`) and had no `set -e`. Called with `ps`, both variables were simply empty: it wrote a junk `auth.json` entry, exited 0, and **said nothing**. Accidentally silent, so the probe passed and the real login proceeded — which is why the only visible symptom was the bad credential #6540 diagnosed.

### Testing

No automated tests exist for these scripts. Verified with a harness reproducing both azure-cli invocations against the merged script and the patched one:

| Invocation | merged | patched |
| --- | --- | --- |
| `ps` | exit 1, stderr → probe fatal | exit 0, silent → probe passes |
| `login --username U --password-stdin R` (token on stdin) | correct credential | correct credential |

Pre-existing `registry.redhat.io` entry preserved in both cases.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
