### PR TITLE
fix: increase ARM operationStatus retry budget for eventual consistency

### DIFF
--- a/tooling/templatize/pkg/pipeline/arm_retry_policy.go
+++ b/tooling/templatize/pkg/pipeline/arm_retry_policy.go
@@ -41,7 +41,7 @@ func newLROPollerRetryDeploymentNotFoundPolicy() *lroPollerRetryDeploymentNotFou
 			Duration: time.Second,
 			Factor:   2,
 			Jitter:   0.1,
-			Steps:    3,
+			Steps:    6,
 		},
 	}
 }


### PR DESCRIPTION
## Summary

- Increase ARM operationStatus 404 retry steps from 3 (~7s) to 6 (~63s) to handle Azure eventual consistency lag
- Only affects operationStatus polling after successful `BeginCreateOrUpdate` — no impact on deployment existence checks

## Why

Azure ARM can return `DeploymentNotFound` on the operationStatus endpoint immediately after accepting a deployment. The existing 3-step retry policy (~7s max) is too short — Azure's own docs suggest EC propagation can take up to 5 minutes. CI runs fail intermittently because of this, with the gather step later confirming the deployment actually succeeded.

## Test plan

- [x] Existing retry policy tests pass (tests use their own backoff config, independent of production value)
- [ ] CI e2e should stop seeing intermittent `DeploymentNotFound` failures

Ref: [ARO-29077](https://redhat.atlassian.net/browse/ARO-29077)