### PR TITLE
fix: check control plane identity permissions on the cluster subnet and vnet

### DIFF
--- a/backend/pkg/utils/validationutils/control_plane_identities_permissions_cluster_validation.go
+++ b/backend/pkg/utils/validationutils/control_plane_identities_permissions_cluster_validation.go
@@ -217,12 +217,20 @@ func (v *ControlPlaneIdentitiesPermissionsClusterValidation) findMissingActionsF
 		results = append(results, nsgResult)
 	}
 
-	vnetResult, err := v.checkMissingPermissionsForVNet(ctx, checkAccessV2Client, cluster.CustomerProperties.Platform.SubnetID, identity, roleActions, roleDataActions, token)
+	vnetResult, err := v.checkMissingPermissionsForVNet(ctx, checkAccessV2Client, cluster.CustomerProperties.Platform.SubnetID.Parent, identity, roleActions, roleDataActions, token)
 	if err != nil {
 		return nil, err
 	}
 	if vnetResult != nil {
 		results = append(results, vnetResult)
+	}
+
+	subnetResult, err := v.checkMissingPermissionsForSubnet(ctx, checkAccessV2Client, cluster.CustomerProperties.Platform.SubnetID, identity, roleActions, roleDataActions, token)
+	if err != nil {
+		return nil, err
+	}
+	if subnetResult != nil {
+		results = append(results, subnetResult)
 	}
 
 	rtResult, err := v.checkMissingPermissionsForRouteTable(ctx, checkAccessV2Client, clusterSubnet, identity, roleActions, roleDataActions, token)
@@ -240,7 +248,7 @@ func (v *ControlPlaneIdentitiesPermissionsClusterValidation) findMissingActionsF
 // Only actions from roleActions/roleDataActions that are relevant to NSG resources are checked (via intersection with the known NSG action set); actions irrelevant to NSGs are skipped.
 // It returns:
 //   - (nil, nil) if the identity has all required permissions, or if none of the role's actions apply to NSG resources.
-//   - a non-nil *IdentityResourceMissingPermissions populated with the NSG resource ID, the identity, and the slice of NotAllowed/Denied decisions, if any permission is missing.
+//   - a non-nil *identityResourceMissingPermissions populated with the NSG resource ID, the identity, and the slice of NotAllowed/Denied decisions, if any permission is missing.
 func (v *ControlPlaneIdentitiesPermissionsClusterValidation) checkMissingPermissionsForNetworkSecurityGroup(ctx context.Context, checkAccessV2Client azureclient.CheckAccessV2Client, nsgID *azcorearm.ResourceID, identity *azcorearm.ResourceID, roleActions []string, roleDataActions []string, token azcore.AccessToken) (*identityResourceMissingPermissions, error) {
 	decisions, err := v.checkNotAllowedAndDeniedActionsForNetworkSecurityGroup(ctx, checkAccessV2Client, nsgID, roleActions, roleDataActions, token)
 	if err != nil {
@@ -256,14 +264,13 @@ func (v *ControlPlaneIdentitiesPermissionsClusterValidation) checkMissingPermiss
 	}, nil
 }
 
-// checkMissingPermissionsForVNet checks whether the given identity has all required permissions on the VNet that contains the cluster subnet. The VNet resource ID is derived from the subnet ID's parent.
+// checkMissingPermissionsForVNet checks whether the given identity has all required permissions on the given VNet that contains the cluster subnet.
 // Only actions from roleActions/roleDataActions that are relevant to VNet resources are checked (via intersection with the known VNet action set); actions irrelevant to VNets are skipped.
 // It returns:
 //   - (nil, nil) if the identity has all required permissions, or if none of the role's actions apply to VNet resources.
-//   - a non-nil *IdentityResourceMissingPermissions populated with the VNet resource ID, the identity, and the slice of NotAllowed/Denied decisions, if any permission is missing.
-func (v *ControlPlaneIdentitiesPermissionsClusterValidation) checkMissingPermissionsForVNet(ctx context.Context, checkAccessV2Client azureclient.CheckAccessV2Client, subnetID *azcorearm.ResourceID, identity *azcorearm.ResourceID, roleActions []string, roleDataActions []string, token azcore.AccessToken) (*identityResourceMissingPermissions, error) {
-	vnetResourceID := subnetID.Parent
-	decisions, err := v.checkNotAllowedAndDeniedActionsForVNet(ctx, checkAccessV2Client, vnetResourceID, roleActions, roleDataActions, token)
+//   - a non-nil *identityResourceMissingPermissions populated with the VNet resource ID, the identity, and the slice of NotAllowed/Denied decisions, if any permission is missing.
+func (v *ControlPlaneIdentitiesPermissionsClusterValidation) checkMissingPermissionsForVNet(ctx context.Context, checkAccessV2Client azureclient.CheckAccessV2Client, vnetID *azcorearm.ResourceID, identity *azcorearm.ResourceID, roleActions []string, roleDataActions []string, token azcore.AccessToken) (*identityResourceMissingPermissions, error) {
+	decisions, err := v.checkNotAllowedAndDeniedActionsForVNet(ctx, checkAccessV2Client, vnetID, roleActions, roleDataActions, token)
 	if err != nil {
 		return nil, utils.TrackError(err)
 	}
@@ -271,7 +278,27 @@ func (v *ControlPlaneIdentitiesPermissionsClusterValidation) checkMissingPermiss
 		return nil, nil
 	}
 	return &identityResourceMissingPermissions{
-		Resource:  vnetResourceID,
+		Resource:  vnetID,
+		Identity:  identity,
+		Decisions: decisions,
+	}, nil
+}
+
+// checkMissingPermissionsForSubnet checks whether the given identity has all required permissions on the cluster subnet.
+// Only actions from roleActions/roleDataActions that are relevant to subnet resources are checked (via intersection with the known subnet action set); actions irrelevant to subnets are skipped.
+// It returns:
+//   - (nil, nil) if the identity has all required permissions, or if none of the role's actions apply to subnet resources.
+//   - a non-nil *identityResourceMissingPermissions populated with the subnet resource ID, the identity, and the slice of NotAllowed/Denied decisions, if any permission is missing.
+func (v *ControlPlaneIdentitiesPermissionsClusterValidation) checkMissingPermissionsForSubnet(ctx context.Context, checkAccessV2Client azureclient.CheckAccessV2Client, subnetID *azcorearm.ResourceID, identity *azcorearm.ResourceID, roleActions []string, roleDataActions []string, token azcore.AccessToken) (*identityResourceMissingPermissions, error) {
+	decisions, err := v.checkNotAllowedAndDeniedActionsForSubnet(ctx, checkAccessV2Client, subnetID, roleActions, roleDataActions, token)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	if len(decisions) == 0 {
+		return nil, nil
+	}
+	return &identityResourceMissingPermissions{
+		Resource:  subnetID,
 		Identity:  identity,
 		Decisions: decisions,
 	}, nil
@@ -281,7 +308,7 @@ func (v *ControlPlaneIdentitiesPermissionsClusterValidation) checkMissingPermiss
 // Only actions from roleActions/roleDataActions that are relevant to route table resources are checked (via intersection with the known route table action set).
 // It returns:
 //   - (nil, nil) if the subnet has no attached route table, if the identity has all required permissions, or if none of the role's actions apply to route table resources.
-//   - a non-nil *IdentityResourceMissingPermissions populated with the route table resource ID, the identity, and the slice of NotAllowed/Denied decisions, if any permission is missing.
+//   - a non-nil *identityResourceMissingPermissions populated with the route table resource ID, the identity, and the slice of NotAllowed/Denied decisions, if any permission is missing.
 //   - (nil, error) if the route table resource ID cannot be parsed or the CheckAccessV2 API call fails.
 func (v *ControlPlaneIdentitiesPermissionsClusterValidation) checkMissingPermissionsForRouteTable(ctx context.Context, checkAccessV2Client azureclient.CheckAccessV2Client, clusterSubnet *armnetwork.Subnet, identity *azcorearm.ResourceID, roleActions []string, roleDataActions []string, token azcore.AccessToken) (*identityResourceMissingPermissions, error) {
 	if clusterSubnet.Properties.RouteTable == nil {
@@ -373,12 +400,24 @@ func (v *ControlPlaneIdentitiesPermissionsClusterValidation) checkNotAllowedAndD
 	return notAllowedAndDeniedActions, nil
 }
 
-func (v *ControlPlaneIdentitiesPermissionsClusterValidation) checkNotAllowedAndDeniedActionsForVNet(ctx context.Context, checkAccessV2Client azureclient.CheckAccessV2Client, resourceId *azcorearm.ResourceID, roleDefinitionActions []string, roleDefinitionDataActions []string, token azcore.AccessToken) ([]*checkaccessv2AuthorizationDecisionData, error) {
-	// Union of all Microsoft.Network/virtualNetworks/* and Microsoft.Network/virtualNetworks/subnets/* actions that appear across any operator role in internal/azure/cluster_scoped_identities_config.go
-	subnetActions := []string{
+func (v *ControlPlaneIdentitiesPermissionsClusterValidation) checkNotAllowedAndDeniedActionsForVNet(ctx context.Context, checkAccessV2Client azureclient.CheckAccessV2Client, vnetID *azcorearm.ResourceID, roleDefinitionActions []string, roleDefinitionDataActions []string, token azcore.AccessToken) ([]*checkaccessv2AuthorizationDecisionData, error) {
+	// Union of all Microsoft.Network/virtualNetworks/* actions (excluding subnets/*) that appear across any operator role in internal/azure/cluster_scoped_identities_config.go
+	vnetActions := []string{
 		"Microsoft.Network/virtualNetworks/join/action",
 		"Microsoft.Network/virtualNetworks/read",
 		"Microsoft.Network/virtualNetworks/write",
+	}
+	var vnetDataActions []string
+
+	requiredActions := azurehelpers.IntersectActions(vnetActions, roleDefinitionActions)
+	requiredDataActions := azurehelpers.IntersectActions(vnetDataActions, roleDefinitionDataActions)
+
+	return v.checkNotAllowedAndDeniedActionsForResourceID(ctx, checkAccessV2Client, vnetID, requiredActions, requiredDataActions, token)
+}
+
+func (v *ControlPlaneIdentitiesPermissionsClusterValidation) checkNotAllowedAndDeniedActionsForSubnet(ctx context.Context, checkAccessV2Client azureclient.CheckAccessV2Client, subnetID *azcorearm.ResourceID, roleDefinitionActions []string, roleDefinitionDataActions []string, token azcore.AccessToken) ([]*checkaccessv2AuthorizationDecisionData, error) {
+	// Union of all Microsoft.Network/virtualNetworks/subnets/* actions that appear across any operator role in internal/azure/cluster_scoped_identities_config.go
+	subnetActions := []string{
 		"Microsoft.Network/virtualNetworks/subnets/join/action",
 		"Microsoft.Network/virtualNetworks/subnets/read",
 		"Microsoft.Network/virtualNetworks/subnets/write",
@@ -388,7 +427,7 @@ func (v *ControlPlaneIdentitiesPermissionsClusterValidation) checkNotAllowedAndD
 	requiredActions := azurehelpers.IntersectActions(subnetActions, roleDefinitionActions)
 	requiredDataActions := azurehelpers.IntersectActions(subnetDataActions, roleDefinitionDataActions)
 
-	return v.checkNotAllowedAndDeniedActionsForResourceID(ctx, checkAccessV2Client, resourceId, requiredActions, requiredDataActions, token)
+	return v.checkNotAllowedAndDeniedActionsForResourceID(ctx, checkAccessV2Client, subnetID, requiredActions, requiredDataActions, token)
 }
 
 func (v *ControlPlaneIdentitiesPermissionsClusterValidation) checkNotAllowedAndDeniedActionsForRouteTable(ctx context.Context, checkAccessV2Client azureclient.CheckAccessV2Client, routeTable *armnetwork.RouteTable, roleDefinitionActions []string, roleDefinitionDataActions []string, token azcore.AccessToken) ([]*checkaccessv2AuthorizationDecisionData, error) {

--- a/backend/pkg/utils/validationutils/control_plane_identities_permissions_cluster_validation_test.go
+++ b/backend/pkg/utils/validationutils/control_plane_identities_permissions_cluster_validation_test.go
@@ -369,7 +369,7 @@ func TestCheckNotAllowedAndDeniedActionsForVNet(t *testing.T) {
 		},
 		{
 			name:                      "overlap with VNet actions checks intersection and returns allowed",
-			roleDefinitionActions:     []string{"Microsoft.Network/virtualNetworks/read", "Microsoft.Network/virtualNetworks/subnets/read"},
+			roleDefinitionActions:     []string{"Microsoft.Network/virtualNetworks/read", "Microsoft.Compute/virtualMachines/read"},
 			roleDefinitionDataActions: nil,
 			setupMock: func(m *azureclient.MockCheckAccessV2Client) {
 				m.EXPECT().CreateAuthorizationRequest(vnetResourceID.String(), gomock.Any(), fakeToken.Token).
@@ -378,12 +378,18 @@ func TestCheckNotAllowedAndDeniedActionsForVNet(t *testing.T) {
 					Return(&azurecheckaccessv2client.AuthorizationDecisionResponse{
 						Value: []azurecheckaccessv2client.AuthorizationDecision{
 							{ActionId: "Microsoft.Network/virtualNetworks/read", AccessDecision: azurecheckaccessv2client.Allowed},
-							{ActionId: "Microsoft.Network/virtualNetworks/subnets/read", AccessDecision: azurecheckaccessv2client.Allowed},
 						},
 					}, nil)
 			},
 			wantResult: nil,
 			wantErr:    false,
+		},
+		{
+			name:                      "subnet-only actions are not checked against the VNet",
+			roleDefinitionActions:     []string{"Microsoft.Network/virtualNetworks/subnets/read"},
+			roleDefinitionDataActions: nil,
+			wantResult:                nil,
+			wantErr:                   false,
 		},
 		{
 			name:                      "CheckAccessV2 returns not allowed produces decisions",
@@ -416,6 +422,93 @@ func TestCheckNotAllowedAndDeniedActionsForVNet(t *testing.T) {
 
 			v := &ControlPlaneIdentitiesPermissionsClusterValidation{}
 			result, err := v.checkNotAllowedAndDeniedActionsForVNet(context.Background(), mockClient, vnetResourceID, tt.roleDefinitionActions, tt.roleDefinitionDataActions, fakeToken)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantResult, result)
+		})
+	}
+}
+
+func TestCheckNotAllowedAndDeniedActionsForSubnet(t *testing.T) {
+	subnetResourceID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet")
+	require.NoError(t, err)
+
+	fakeToken := azcore.AccessToken{Token: "fake-jwt-token"}
+
+	tests := []struct {
+		name                      string
+		roleDefinitionActions     []string
+		roleDefinitionDataActions []string
+		setupMock                 func(*azureclient.MockCheckAccessV2Client)
+		wantResult                []*checkaccessv2AuthorizationDecisionData
+		wantErr                   bool
+	}{
+		{
+			name:                      "no overlap with subnet actions returns nil without API call",
+			roleDefinitionActions:     []string{"Microsoft.Compute/virtualMachines/read"},
+			roleDefinitionDataActions: nil,
+			wantResult:                nil,
+			wantErr:                   false,
+		},
+		{
+			name:                      "vnet-only actions are not checked against the subnet",
+			roleDefinitionActions:     []string{"Microsoft.Network/virtualNetworks/read"},
+			roleDefinitionDataActions: nil,
+			wantResult:                nil,
+			wantErr:                   false,
+		},
+		{
+			name:                      "overlap with subnet actions checks intersection and returns allowed",
+			roleDefinitionActions:     []string{"Microsoft.Network/virtualNetworks/subnets/read", "Microsoft.Compute/virtualMachines/read"},
+			roleDefinitionDataActions: nil,
+			setupMock: func(m *azureclient.MockCheckAccessV2Client) {
+				m.EXPECT().CreateAuthorizationRequest(subnetResourceID.String(), gomock.Any(), fakeToken.Token).
+					Return(&azurecheckaccessv2client.AuthorizationRequest{}, nil)
+				m.EXPECT().CheckAccess(gomock.Any(), gomock.Any()).
+					Return(&azurecheckaccessv2client.AuthorizationDecisionResponse{
+						Value: []azurecheckaccessv2client.AuthorizationDecision{
+							{ActionId: "Microsoft.Network/virtualNetworks/subnets/read", AccessDecision: azurecheckaccessv2client.Allowed},
+						},
+					}, nil)
+			},
+			wantResult: nil,
+			wantErr:    false,
+		},
+		{
+			name:                      "CheckAccessV2 returns not allowed produces decisions",
+			roleDefinitionActions:     []string{"Microsoft.Network/virtualNetworks/subnets/join/action"},
+			roleDefinitionDataActions: nil,
+			setupMock: func(m *azureclient.MockCheckAccessV2Client) {
+				m.EXPECT().CreateAuthorizationRequest(subnetResourceID.String(), gomock.Any(), fakeToken.Token).
+					Return(&azurecheckaccessv2client.AuthorizationRequest{}, nil)
+				m.EXPECT().CheckAccess(gomock.Any(), gomock.Any()).
+					Return(&azurecheckaccessv2client.AuthorizationDecisionResponse{
+						Value: []azurecheckaccessv2client.AuthorizationDecision{
+							{ActionId: "Microsoft.Network/virtualNetworks/subnets/join/action", AccessDecision: azurecheckaccessv2client.NotAllowed},
+						},
+					}, nil)
+			},
+			wantResult: []*checkaccessv2AuthorizationDecisionData{
+				{ActionID: "Microsoft.Network/virtualNetworks/subnets/join/action", IsDataAction: false, AccessDecision: azurecheckaccessv2client.NotAllowed},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockClient := azureclient.NewMockCheckAccessV2Client(ctrl)
+			if tt.setupMock != nil {
+				tt.setupMock(mockClient)
+			}
+
+			v := &ControlPlaneIdentitiesPermissionsClusterValidation{}
+			result, err := v.checkNotAllowedAndDeniedActionsForSubnet(context.Background(), mockClient, subnetResourceID, tt.roleDefinitionActions, tt.roleDefinitionDataActions, fakeToken)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -599,10 +692,8 @@ func TestCheckMissingPermissionsForNetworkSecurityGroup(t *testing.T) {
 }
 
 func TestCheckMissingPermissionsForVNet(t *testing.T) {
-	subnetResourceID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet")
+	vnetResourceID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet")
 	require.NoError(t, err)
-
-	vnetResourceID := subnetResourceID.Parent
 
 	identityResourceID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity")
 	require.NoError(t, err)
@@ -633,10 +724,87 @@ func TestCheckMissingPermissionsForVNet(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name:    "missing permissions returns result with VNet parent as resource",
-			actions: []string{"Microsoft.Network/virtualNetworks/subnets/join/action"},
+			name:    "missing permissions returns result with VNet as resource",
+			actions: []string{"Microsoft.Network/virtualNetworks/join/action"},
 			setupMock: func(m *azureclient.MockCheckAccessV2Client) {
 				m.EXPECT().CreateAuthorizationRequest(vnetResourceID.String(), gomock.Any(), fakeToken.Token).
+					Return(&azurecheckaccessv2client.AuthorizationRequest{}, nil)
+				m.EXPECT().CheckAccess(gomock.Any(), gomock.Any()).
+					Return(&azurecheckaccessv2client.AuthorizationDecisionResponse{
+						Value: []azurecheckaccessv2client.AuthorizationDecision{
+							{ActionId: "Microsoft.Network/virtualNetworks/join/action", AccessDecision: azurecheckaccessv2client.Denied},
+						},
+					}, nil)
+			},
+			wantResult: &identityResourceMissingPermissions{
+				Resource: vnetResourceID,
+				Identity: identityResourceID,
+				Decisions: []*checkaccessv2AuthorizationDecisionData{
+					{ActionID: "Microsoft.Network/virtualNetworks/join/action", IsDataAction: false, AccessDecision: azurecheckaccessv2client.Denied},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockClient := azureclient.NewMockCheckAccessV2Client(ctrl)
+			if tt.setupMock != nil {
+				tt.setupMock(mockClient)
+			}
+
+			v := &ControlPlaneIdentitiesPermissionsClusterValidation{}
+			result, err := v.checkMissingPermissionsForVNet(context.Background(), mockClient, vnetResourceID, identityResourceID, tt.actions, nil, fakeToken)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantResult, result)
+		})
+	}
+}
+
+func TestCheckMissingPermissionsForSubnet(t *testing.T) {
+	subnetResourceID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/test-subnet")
+	require.NoError(t, err)
+
+	identityResourceID, err := azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-identity")
+	require.NoError(t, err)
+
+	fakeToken := azcore.AccessToken{Token: "fake-jwt-token"}
+
+	tests := []struct {
+		name       string
+		actions    []string
+		setupMock  func(*azureclient.MockCheckAccessV2Client)
+		wantResult *identityResourceMissingPermissions
+		wantErr    bool
+	}{
+		{
+			name:    "no missing permissions returns nil",
+			actions: []string{"Microsoft.Network/virtualNetworks/subnets/read"},
+			setupMock: func(m *azureclient.MockCheckAccessV2Client) {
+				m.EXPECT().CreateAuthorizationRequest(subnetResourceID.String(), gomock.Any(), fakeToken.Token).
+					Return(&azurecheckaccessv2client.AuthorizationRequest{}, nil)
+				m.EXPECT().CheckAccess(gomock.Any(), gomock.Any()).
+					Return(&azurecheckaccessv2client.AuthorizationDecisionResponse{
+						Value: []azurecheckaccessv2client.AuthorizationDecision{
+							{ActionId: "Microsoft.Network/virtualNetworks/subnets/read", AccessDecision: azurecheckaccessv2client.Allowed},
+						},
+					}, nil)
+			},
+			wantResult: nil,
+			wantErr:    false,
+		},
+		{
+			name:    "missing permissions returns result with subnet as resource",
+			actions: []string{"Microsoft.Network/virtualNetworks/subnets/join/action"},
+			setupMock: func(m *azureclient.MockCheckAccessV2Client) {
+				m.EXPECT().CreateAuthorizationRequest(subnetResourceID.String(), gomock.Any(), fakeToken.Token).
 					Return(&azurecheckaccessv2client.AuthorizationRequest{}, nil)
 				m.EXPECT().CheckAccess(gomock.Any(), gomock.Any()).
 					Return(&azurecheckaccessv2client.AuthorizationDecisionResponse{
@@ -646,7 +814,7 @@ func TestCheckMissingPermissionsForVNet(t *testing.T) {
 					}, nil)
 			},
 			wantResult: &identityResourceMissingPermissions{
-				Resource: vnetResourceID,
+				Resource: subnetResourceID,
 				Identity: identityResourceID,
 				Decisions: []*checkaccessv2AuthorizationDecisionData{
 					{ActionID: "Microsoft.Network/virtualNetworks/subnets/join/action", IsDataAction: false, AccessDecision: azurecheckaccessv2client.Denied},
@@ -665,7 +833,7 @@ func TestCheckMissingPermissionsForVNet(t *testing.T) {
 			}
 
 			v := &ControlPlaneIdentitiesPermissionsClusterValidation{}
-			result, err := v.checkMissingPermissionsForVNet(context.Background(), mockClient, subnetResourceID, identityResourceID, tt.actions, nil, fakeToken)
+			result, err := v.checkMissingPermissionsForSubnet(context.Background(), mockClient, subnetResourceID, identityResourceID, tt.actions, nil, fakeToken)
 
 			if tt.wantErr {
 				assert.Error(t, err)


### PR DESCRIPTION
Split VNet and Subnet permission checks so subnet actions are evaluated against the subnet resource instead of the parent VNet.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
