### PR TITLE
fix: revert opstool istio version bump in config-dev-ci.yaml  

### DIFF
--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -78,7 +78,7 @@ clouds:
             zones: "1"
             zoneRedundantMode: "Disabled"
         istio:
-          versions: "asm-1-29"
+          versions: "asm-1-28"
         monitoring:
           workspaceName: "opstool-monitor-{{ .ctx.regionShort }}"
         prometheus:


### PR DESCRIPTION
### What

Revert `opstool.istio.versions` in `config/config-dev-ci.yaml` from `asm-1-29` back to `asm-1-28`.

### Why

PR #6236 (Cut over Istio upgrades to ARO-Tools istio-upgrade) bumped `opstool.istio.versions` to `asm-1-29`. `dev-ci-pipeline-postsubmit`'s ARM deployment for the opstool cluster then failed with an "arbitrary revision change not allowed" error. This unblocks dev-ci-pipeline-postsubmit.

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-dev-ci-pipeline-postsubmit/2089239860891095040

opstool clusters don't run the `IstioUpgrade` pipeline step, so `opstool-cluster.tmpl.bicepparam` passes `istioVersions` directly into ARM on every deploy. Bumping the config value without the cluster's actual istiod revision already matching caused AKS to reject the deployment as an unsupported/direct revision jump.

Reverting to `asm-1-28` unblocks the pipeline until opstool clusters have an actual, supported upgrade path (they currently have none - this value is a raw ARM passthrough, not managed by `IstioUpgrade`).

### Testing

- No unit/integration/E2E tests added — this is a single config value revert with no behavioral code change.
- Will confirm `dev-ci-pipeline-postsubmit` passes cleanly on the next postsubmit run after merge.

### Special notes for your reviewer

- Scoped to the `dev-ci` opstool cluster only — no impact to dev, int, stg, prod, or CSPR.
- Related: #6236