### PR TITLE
fix(e2e): skip purge protected keyvaults on test cleanup

### DIFF
--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -268,6 +268,12 @@ func (tc *perItOrDescribeTestContext) deleteCreatedResources(ctx context.Context
 	tc.contextLock.RUnlock()
 	ginkgo.GinkgoLogr.Info("deleting created resources")
 
+	if subscriptionID, err := tc.SubscriptionID(ctx); err != nil {
+		ginkgo.GinkgoLogr.Error(err, "failed to get subscription ID for role assignment cleanup")
+	} else if err := tc.cleanupRoleAssignments(ctx, subscriptionID); err != nil {
+		ginkgo.GinkgoLogr.Error(err, "failed to cleanup role assignments before resource group deletion")
+	}
+
 	opts := CleanupResourceGroupsOptions{
 		ResourceGroupNames: resourceGroupNames,
 		Timeout:            60 * time.Minute,
@@ -804,6 +810,11 @@ func (tc *perItOrDescribeTestContext) purgeDeletedKeyVaultsInResourceGroup(ctx c
 			if !strings.Contains(strings.ToLower(*deleted.Properties.VaultID), rgMarker) {
 				continue
 			}
+			if keyVaultPurgeProtected(deleted.Properties) {
+				ginkgo.GinkgoLogr.Info("skipping purge of soft-deleted key vault with purge protection enabled",
+					"keyVault", *deleted.Name, "resourceGroup", resourceGroupName)
+				continue
+			}
 			ginkgo.GinkgoLogr.Info("purging soft-deleted key vault",
 				"keyVault", *deleted.Name, "location", *deleted.Properties.Location, "resourceGroup", resourceGroupName)
 			poller, err := vaultsClient.BeginPurgeDeleted(ctx, *deleted.Name, *deleted.Properties.Location, nil)
@@ -827,6 +838,12 @@ func (tc *perItOrDescribeTestContext) purgeDeletedKeyVaultsInResourceGroup(ctx c
 			}
 		}
 	}
+}
+
+// keyVaultPurgeProtected reports whether a soft-deleted vault has purge
+// protection enabled, meaning the purge API will reject any purge attempt.
+func keyVaultPurgeProtected(props *armkeyvault.DeletedVaultProperties) bool {
+	return props != nil && props.PurgeProtectionEnabled != nil && *props.PurgeProtectionEnabled
 }
 
 // isKeyVaultNotFound reports whether err is an Azure 404 response, which for a

--- a/test/util/framework/per_test_framework_test.go
+++ b/test/util/framework/per_test_framework_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/keyvault/armkeyvault"
 )
 
 func TestIsResourceGroupNotFoundError(t *testing.T) {
@@ -143,6 +144,48 @@ func TestIsKeyVaultNotFound(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := isKeyVaultNotFound(tt.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestKeyVaultPurgeProtected(t *testing.T) {
+	t.Parallel()
+
+	trueVal := true
+	falseVal := false
+
+	tests := []struct {
+		name  string
+		props *armkeyvault.DeletedVaultProperties
+		want  bool
+	}{
+		{
+			name:  "nil properties",
+			props: nil,
+			want:  false,
+		},
+		{
+			name:  "nil PurgeProtectionEnabled",
+			props: &armkeyvault.DeletedVaultProperties{PurgeProtectionEnabled: nil},
+			want:  false,
+		},
+		{
+			name:  "purge protection disabled",
+			props: &armkeyvault.DeletedVaultProperties{PurgeProtectionEnabled: &falseVal},
+			want:  false,
+		},
+		{
+			name:  "purge protection enabled",
+			props: &armkeyvault.DeletedVaultProperties{PurgeProtectionEnabled: &trueVal},
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := keyVaultPurgeProtected(tt.props)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-29081
<!-- Link to Jira issue -->

### What

The BYOK e2e test passes, but has 2 errors in cleanup:

```
https://management.azure.com/subscriptions/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/providers/Microsoft.KeyVault/locations/uksouth/deletedVaults/cust-kv-x/purge\\n--------------------------------------------------------------------------------\\nRESPONSE 400: 400 Bad Request\\nERROR CODE: MethodNotAllowed\\n--------------------------------------------------------------------------------\\n{\\n  \\\"error\\\": {\\n    \\\"code\\\": \\\"MethodNotAllowed\\\",\\n    \\\"message\\\": \\\"Operation 'DeletedVaultPurge' is not allowed.\\\"\\n  }\\n}\\n--------------------------------------------------------------------------------\\n\" 

does not have authorization to perform action 'Microsoft.Authorization/roleAssignments/delete' over scope '/subscriptions/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/resourceGroups/des-encrypt-5btwpbgw2vw7/providers/Microsoft.KeyVault/vaults/cust-kv-s7ionugrizfvo/providers/Microsoft.Authorization/roleAssignments/24acdcf7-77c0-5eb5-8141-3560c8dc20fb' or the scope is invalid
```
https://github.com/Azure/ARO-HCP/pull/6556 was opened to revert the PR that introduced it but it was investigated and determined to be just an issue with the cleanup. This is the followup PR to fix that cleanup:

- Delete the additional role assignments before cleaning up the resource group to avoid the scope failure
- Skip purge protected keyvaults on test cleanup to avoid unnecessary errors

<!-- Briefly describe what this PR does -->

### Why

- This is required because the BYOK OS Disk e2e test requires a non-purgeable keyvault. This keyvault is already configured to automatically delete in 7 days.

<!-- Briefly explain why this change is needed -->

### Testing

- unit and e2e

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge
