### PR TITLE
feat(hcpctl): collect cosmosResourceSnapshots in must-gather

### DIFF
--- a/tooling/hcpctl/README.md
+++ b/tooling/hcpctl/README.md
@@ -129,6 +129,7 @@ What is gathered?
 - All service logs, that contain the subscription id and resourcegroup name or are in the cluster namespace (aka hcp logs)
 - All Kubernetes events from the mgmt and service cluster (excluding HCP)
 - All Kubernetes events from the mgmt cluster withing the HCP namespace
+- Cosmos DB document snapshots (`cosmosResourceSnapshots`) for resources in the resource group, written to the custom logs directory
 - Optionally: Systemd logs from the management and service cluster (turn on using --collect-systemd-logs)
 
 ```bash

--- a/tooling/hcpctl/pkg/kusto/templates/custom/queries.yaml
+++ b/tooling/hcpctl/pkg/kusto/templates/custom/queries.yaml
@@ -45,6 +45,7 @@
 - name: cosmosResourceSnapshots
   database: ServiceLogs
   queryType: custom-logs
+  includeInMustGather: true
   templatePath: templates/custom/cosmos_resource_snapshots.kql.gotmpl
 - name: hostedControlPlaneLogs
   database: HostedControlPlaneLogs


### PR DESCRIPTION
The cosmosResourceSnapshots custom query already existed but was not gathered by must-gather. Flag it includeInMustGather so `hcpctl must-gather query` collects Cosmos DB document snapshots for the resource group (RG- and time-window-scoped) into the custom logs directory, alongside the existing custom queries.

The RG-scoped variant is used (not cosmosResourceSnapshotsInfra, which filters by a single cluster name that is empty in the standard RG-scoped flow). The query template only needs TimestampMin/Max and ResourceGroupName, all provided by the must-gather custom-query flow, so no template change is required.

