### PR TITLE
add kubeApplierLogs table

### DIFF
--- a/dev-infrastructure/modules/logs/kusto/main.bicep
+++ b/dev-infrastructure/modules/logs/kusto/main.bicep
@@ -52,6 +52,7 @@ var dummyScript = '.create-or-alter function with (docstring = \'dummy function 
 
 var allServiceLogsTablesKQL = {
   backendLogs: loadTextContent('tables/backendLogs.kql')
+  kubeApplierLogs: loadTextContent('tables/kubeApplierLogs.kql')
   containerlogs: loadTextContent('tables/containerLogs.kql')
   fleetLogs: loadTextContent('tables/fleetLogs.kql')
   frontendLogs: loadTextContent('tables/frontendLogs.kql')

--- a/dev-infrastructure/modules/logs/kusto/tables/kubeApplierLogs.kql
+++ b/dev-infrastructure/modules/logs/kusto/tables/kubeApplierLogs.kql
@@ -1,4 +1,4 @@
-.create-merge table backendLogs (
+.create-merge table kubeApplierLogs (
   timestamp: datetime,
   log: dynamic,
   environment: string,
@@ -30,7 +30,7 @@
   container_status_image_id: string  // fluentbit: kubernetes.container_hash (k8s status.containerStatuses.imageID)
 )
 
-.create-or-alter table backendLogs ingestion json mapping 'ingestionMapping'
+.create-or-alter table kubeApplierLogs ingestion json mapping 'ingestionMapping'
 ```
 [
   {"column":"log","Properties":{"path":"$.log.log"}},

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
@@ -212,6 +212,7 @@ data:
         Rule            $kubernetes['container_name'] ^aro-hcp-backend* aro-hcp-backend.logs false
         Rule            $kubernetes['container_name'] ^clusters-service* clusters-service.logs false
         Rule            $kubernetes['container_name'] ^fleet-controller* fleet-controller.logs false
+        Rule            $kubernetes['container_name'] ^kube-applier* kube-applier.logs false
         Rule            $kubernetes['container_name'] ^kube-events* kube-events.logs false
         Rule            $kubernetes['container_name'] ^mgmt-agent-controller* mgmt-agent.logs true
         Emitter_Name    re_emitted_container_name_router
@@ -221,7 +222,7 @@ data:
     [FILTER]
         # Parse the log key and make it a json object again under $
         Name Parser
-        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller|mgmt-agent)\.logs
+        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller|kube-applier|mgmt-agent)\.logs
         Key_Name log
         Parser containerlogs
         Preserve_Key On
@@ -354,6 +355,31 @@ data:
         Table_Name fleetLogs
         ingestion_mapping_reference ingestionMapping
         azure_kusto_buffer_key fleetLogs
+        buffer_dir "/var/kusto"
+        buffering_enabled           true 
+        upload_timeout              1m
+        upload_file_size            16M
+        buffer_file_delete_early    false
+        unify_tag                   true
+        store_dir_limit_size        1.8GB
+        blob_uri_length             128
+        scheduler_max_retries       9
+        delete_on_max_upload_error  true
+        io_timeout                  60s
+
+    [OUTPUT]
+        Match kube-applier.logs
+        Name azure_kusto
+        Retry_Limit 5
+        auth_type workload_identity
+        tenant_id __tenantId__
+        client_id __msiClientId__
+        workload_identity_token_file ${AZURE_FEDERATED_TOKEN_FILE}
+        Ingestion_Endpoint __kustoDataIngestionUri__
+        Database_Name ServiceLogs
+        Table_Name kubeApplierLogs
+        ingestion_mapping_reference ingestionMapping
+        azure_kusto_buffer_key kubeApplierLogs
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
@@ -620,7 +646,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 1cc3fb715040f14fbbe9c5c0775b900d1dc87f808bb9b283ce6fa2ac3f5a7bf4
+        checksum/configmap: fe502ded07d21848414235f1a89e688b14132eec63e8756d0ea861cafd5f8142
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
@@ -212,6 +212,7 @@ data:
         Rule            $kubernetes['container_name'] ^aro-hcp-backend* aro-hcp-backend.logs false
         Rule            $kubernetes['container_name'] ^clusters-service* clusters-service.logs false
         Rule            $kubernetes['container_name'] ^fleet-controller* fleet-controller.logs false
+        Rule            $kubernetes['container_name'] ^kube-applier* kube-applier.logs false
         Rule            $kubernetes['container_name'] ^kube-events* kube-events.logs false
         Rule            $kubernetes['container_name'] ^mgmt-agent-controller* mgmt-agent.logs true
         Emitter_Name    re_emitted_container_name_router
@@ -221,7 +222,7 @@ data:
     [FILTER]
         # Parse the log key and make it a json object again under $
         Name Parser
-        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller|mgmt-agent)\.logs
+        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller|kube-applier|mgmt-agent)\.logs
         Key_Name log
         Parser containerlogs
         Preserve_Key On
@@ -330,6 +331,31 @@ data:
         Table_Name fleetLogs
         ingestion_mapping_reference ingestionMapping
         azure_kusto_buffer_key fleetLogs
+        buffer_dir "/var/kusto"
+        buffering_enabled           true 
+        upload_timeout              1m
+        upload_file_size            16M
+        buffer_file_delete_early    false
+        unify_tag                   true
+        store_dir_limit_size        1.8GB
+        blob_uri_length             128
+        scheduler_max_retries       9
+        delete_on_max_upload_error  true
+        io_timeout                  60s
+
+    [OUTPUT]
+        Match kube-applier.logs
+        Name azure_kusto
+        Retry_Limit 5
+        auth_type workload_identity
+        tenant_id __tenantId__
+        client_id __msiClientId__
+        workload_identity_token_file ${AZURE_FEDERATED_TOKEN_FILE}
+        Ingestion_Endpoint __kustoDataIngestionUri__
+        Database_Name ServiceLogs
+        Table_Name kubeApplierLogs
+        ingestion_mapping_reference ingestionMapping
+        azure_kusto_buffer_key kubeApplierLogs
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
@@ -596,7 +622,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 88f7ce4fc451e9a6dce04a533921d4ba5216b63e32e447b5b9dba0fc38f5d299
+        checksum/configmap: 08ccb06bd8ab41ed5fc926fdc35511013316ffd39063d09addc8d5ae9cc120b5
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -44,11 +44,12 @@ Table schemas are defined in KQL files under [`dev-infrastructure/modules/logs/k
 ### ServiceLogs Database
 
 1. **`frontendLogs`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/frontendLogs.kql)): Frontend service logs with HTTP request/response details and tracking IDs
-2. **`backendLogs`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/backendLogs.kql)): Backend service logs with operation tracking and error codes
-3. **`clustersServiceLogs`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/clustersServiceLogs.kql)): Clusters-service logs with cluster resource IDs
-4. **`fleetLogs`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/fleetLogs.kql)): Fleet controller logs with controller name, resource identifiers, and resource type
-5. **`containerLogs`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/containerLogs.kql)): General container logs from non-OCM namespaces
-6. **`kubernetesEvents`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/kubernetesEvents.kql)): Kubernetes events from all clusters
+2. **`backendLogs`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/backendLogs.kql)): Backend service logs with operation tracking, controller name, and error codes
+3. **`kubeApplierLogs`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/kubeApplierLogs.kql)): kube-applier logs, schema-compatible with `backendLogs` (same columns, incl. controller name) so queries port between them
+4. **`clustersServiceLogs`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/clustersServiceLogs.kql)): Clusters-service logs with cluster resource IDs
+5. **`fleetLogs`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/fleetLogs.kql)): Fleet controller logs with controller name, resource identifiers, and resource type
+6. **`containerLogs`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/containerLogs.kql)): General container logs from non-OCM namespaces
+7. **`kubernetesEvents`** ([schema](../../dev-infrastructure/modules/logs/kusto/tables/kubernetesEvents.kql)): Kubernetes events from all clusters
 
 ### HostedControlPlaneLogs Database
 
@@ -79,6 +80,7 @@ Fluent Bit authenticates using **Azure Workload Identity** (MSI client ID, token
 | Backend | Non-OCM | `aro-hcp-backend*` | ServiceLogs | `backendLogs` |
 | Clusters Service | Non-OCM | `clusters-service*` | ServiceLogs | `clustersServiceLogs` |
 | Fleet | Non-OCM | `fleet-controller*` | ServiceLogs | `fleetLogs` |
+| kube-applier | Non-OCM | `kube-applier*` | ServiceLogs | `kubeApplierLogs` |
 | Kubernetes Events | Any | `kube-events*` | ServiceLogs | `kubernetesEvents` |
 | General Containers | Non-OCM | Other | ServiceLogs | `containerLogs` |
 | HCP Containers | `ocm-*` | Any | HostedControlPlaneLogs | `containerLogs` |

--- a/kube-applier/pipeline.yaml
+++ b/kube-applier/pipeline.yaml
@@ -84,7 +84,7 @@ resourceGroups:
       step: kusto-lookup
       name: kustoUri
     kustoDatabase: '{{ .kusto.serviceLogsDatabase }}'
-    kustoTable: 'containerLogs'
+    kustoTable: 'kubeApplierLogs'
     inputVariables:
       imagePullerMsiClientId:
         resourceGroup: management

--- a/observability/arobit/deploy/templates/forwarder-configmap.yaml
+++ b/observability/arobit/deploy/templates/forwarder-configmap.yaml
@@ -218,6 +218,7 @@ data:
         Rule            $kubernetes['container_name'] ^aro-hcp-backend* aro-hcp-backend.logs false
         Rule            $kubernetes['container_name'] ^clusters-service* clusters-service.logs false
         Rule            $kubernetes['container_name'] ^fleet-controller* fleet-controller.logs false
+        Rule            $kubernetes['container_name'] ^kube-applier* kube-applier.logs false
         Rule            $kubernetes['container_name'] ^kube-events* kube-events.logs false
         Rule            $kubernetes['container_name'] ^mgmt-agent-controller* mgmt-agent.logs true
         Emitter_Name    re_emitted_container_name_router
@@ -227,7 +228,7 @@ data:
     [FILTER]
         # Parse the log key and make it a json object again under $
         Name Parser
-        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller|mgmt-agent)\.logs
+        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller|kube-applier|mgmt-agent)\.logs
         Key_Name log
         Parser containerlogs
         Preserve_Key On
@@ -496,6 +497,24 @@ data:
         Table_Name fleetLogs
         ingestion_mapping_reference ingestionMapping
         azure_kusto_buffer_key fleetLogs
+        buffer_dir "{{ .Values.forwarder.kusto.buffer_dir }}"
+{{- if .Values.forwarder.kusto.buffering }}
+        {{- template "buffer_settings" . }}
+{{- end }}
+
+    [OUTPUT]
+        Match kube-applier.logs
+        Name azure_kusto
+        Retry_Limit 5
+        auth_type workload_identity
+        tenant_id {{ .Values.forwarder.tenantId }}
+        client_id {{ .Values.forwarder.msiClientId }}
+        workload_identity_token_file ${AZURE_FEDERATED_TOKEN_FILE}
+        Ingestion_Endpoint {{ .Values.forwarder.kusto.ingestionEndpoint }}
+        Database_Name {{ .Values.forwarder.kusto.serviceLogsDatabase }}
+        Table_Name kubeApplierLogs
+        ingestion_mapping_reference ingestionMapping
+        azure_kusto_buffer_key kubeApplierLogs
         buffer_dir "{{ .Values.forwarder.kusto.buffer_dir }}"
 {{- if .Values.forwarder.kusto.buffering }}
         {{- template "buffer_settings" . }}

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
@@ -212,6 +212,7 @@ data:
         Rule            $kubernetes['container_name'] ^aro-hcp-backend* aro-hcp-backend.logs false
         Rule            $kubernetes['container_name'] ^clusters-service* clusters-service.logs false
         Rule            $kubernetes['container_name'] ^fleet-controller* fleet-controller.logs false
+        Rule            $kubernetes['container_name'] ^kube-applier* kube-applier.logs false
         Rule            $kubernetes['container_name'] ^kube-events* kube-events.logs false
         Rule            $kubernetes['container_name'] ^mgmt-agent-controller* mgmt-agent.logs true
         Emitter_Name    re_emitted_container_name_router
@@ -221,7 +222,7 @@ data:
     [FILTER]
         # Parse the log key and make it a json object again under $
         Name Parser
-        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller|mgmt-agent)\.logs
+        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller|kube-applier|mgmt-agent)\.logs
         Key_Name log
         Parser containerlogs
         Preserve_Key On
@@ -309,6 +310,21 @@ data:
         Table_Name fleetLogs
         ingestion_mapping_reference ingestionMapping
         azure_kusto_buffer_key fleetLogs
+        buffer_dir "/var/kusto"
+
+    [OUTPUT]
+        Match kube-applier.logs
+        Name azure_kusto
+        Retry_Limit 5
+        auth_type workload_identity
+        tenant_id __tenantId__
+        client_id __msiClientId__
+        workload_identity_token_file ${AZURE_FEDERATED_TOKEN_FILE}
+        Ingestion_Endpoint __kustoDataIngestionUri__
+        Database_Name ServiceLogs
+        Table_Name kubeApplierLogs
+        ingestion_mapping_reference ingestionMapping
+        azure_kusto_buffer_key kubeApplierLogs
         buffer_dir "/var/kusto"
 
     [OUTPUT]
@@ -505,7 +521,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: c8896f5244aff6b874876352778c18fb853910aa2c0cc6eef09ae37c55c6af05
+        checksum/configmap: 33351d4bec76e2ea74c7f8a7bc2234103d39f2e5fa06ec35810e0b8d1e94f77f
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
@@ -211,6 +211,7 @@ data:
         Rule            $kubernetes['container_name'] ^aro-hcp-backend* aro-hcp-backend.logs false
         Rule            $kubernetes['container_name'] ^clusters-service* clusters-service.logs false
         Rule            $kubernetes['container_name'] ^fleet-controller* fleet-controller.logs false
+        Rule            $kubernetes['container_name'] ^kube-applier* kube-applier.logs false
         Rule            $kubernetes['container_name'] ^kube-events* kube-events.logs false
         Rule            $kubernetes['container_name'] ^mgmt-agent-controller* mgmt-agent.logs true
         Emitter_Name    re_emitted_container_name_router
@@ -220,7 +221,7 @@ data:
     [FILTER]
         # Parse the log key and make it a json object again under $
         Name Parser
-        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller|mgmt-agent)\.logs
+        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller|kube-applier|mgmt-agent)\.logs
         Key_Name log
         Parser containerlogs
         Preserve_Key On
@@ -329,6 +330,31 @@ data:
         Table_Name fleetLogs
         ingestion_mapping_reference ingestionMapping
         azure_kusto_buffer_key fleetLogs
+        buffer_dir "/var/kusto"
+        buffering_enabled           true 
+        upload_timeout              1m
+        upload_file_size            16M
+        buffer_file_delete_early    false
+        unify_tag                   true
+        store_dir_limit_size        1.8GB
+        blob_uri_length             128
+        scheduler_max_retries       9
+        delete_on_max_upload_error  true
+        io_timeout                  60s
+
+    [OUTPUT]
+        Match kube-applier.logs
+        Name azure_kusto
+        Retry_Limit 5
+        auth_type workload_identity
+        tenant_id __tenantId__
+        client_id __msiClientId__
+        workload_identity_token_file ${AZURE_FEDERATED_TOKEN_FILE}
+        Ingestion_Endpoint __kustoDataIngestionUri__
+        Database_Name ServiceLogs
+        Table_Name kubeApplierLogs
+        ingestion_mapping_reference ingestionMapping
+        azure_kusto_buffer_key kubeApplierLogs
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
@@ -595,7 +621,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 77b7704b58112c9442d23fdacc79baa5555b7f04c460c73e9fefcc47f8bdfc4a
+        checksum/configmap: 4e34bc964d65a4cbcf13cb50eb00f800219c28dbaa0c61059c99b832bf5e1baa
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
@@ -212,6 +212,7 @@ data:
         Rule            $kubernetes['container_name'] ^aro-hcp-backend* aro-hcp-backend.logs false
         Rule            $kubernetes['container_name'] ^clusters-service* clusters-service.logs false
         Rule            $kubernetes['container_name'] ^fleet-controller* fleet-controller.logs false
+        Rule            $kubernetes['container_name'] ^kube-applier* kube-applier.logs false
         Rule            $kubernetes['container_name'] ^kube-events* kube-events.logs false
         Rule            $kubernetes['container_name'] ^mgmt-agent-controller* mgmt-agent.logs true
         Emitter_Name    re_emitted_container_name_router
@@ -221,7 +222,7 @@ data:
     [FILTER]
         # Parse the log key and make it a json object again under $
         Name Parser
-        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller|mgmt-agent)\.logs
+        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller|kube-applier|mgmt-agent)\.logs
         Key_Name log
         Parser containerlogs
         Preserve_Key On
@@ -330,6 +331,31 @@ data:
         Table_Name fleetLogs
         ingestion_mapping_reference ingestionMapping
         azure_kusto_buffer_key fleetLogs
+        buffer_dir "/var/kusto"
+        buffering_enabled           true 
+        upload_timeout              1m
+        upload_file_size            16M
+        buffer_file_delete_early    false
+        unify_tag                   true
+        store_dir_limit_size        1.8GB
+        blob_uri_length             128
+        scheduler_max_retries       9
+        delete_on_max_upload_error  true
+        io_timeout                  60s
+
+    [OUTPUT]
+        Match kube-applier.logs
+        Name azure_kusto
+        Retry_Limit 5
+        auth_type workload_identity
+        tenant_id __tenantId__
+        client_id __msiClientId__
+        workload_identity_token_file ${AZURE_FEDERATED_TOKEN_FILE}
+        Ingestion_Endpoint __kustoDataIngestionUri__
+        Database_Name ServiceLogs
+        Table_Name kubeApplierLogs
+        ingestion_mapping_reference ingestionMapping
+        azure_kusto_buffer_key kubeApplierLogs
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
@@ -596,7 +622,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: bd696671f98d37a37359a7ee177a449adb9cfde28181262ff60647fde7458cff
+        checksum/configmap: 0c7a3657f6e2f00e6edd961d2cdc25e9a5a756b01eefe7458370c13bdf49a464
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -214,6 +214,7 @@ data:
         Rule            $kubernetes['container_name'] ^aro-hcp-backend* aro-hcp-backend.logs false
         Rule            $kubernetes['container_name'] ^clusters-service* clusters-service.logs false
         Rule            $kubernetes['container_name'] ^fleet-controller* fleet-controller.logs false
+        Rule            $kubernetes['container_name'] ^kube-applier* kube-applier.logs false
         Rule            $kubernetes['container_name'] ^kube-events* kube-events.logs false
         Rule            $kubernetes['container_name'] ^mgmt-agent-controller* mgmt-agent.logs true
         Emitter_Name    re_emitted_container_name_router
@@ -223,7 +224,7 @@ data:
     [FILTER]
         # Parse the log key and make it a json object again under $
         Name Parser
-        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller|mgmt-agent)\.logs
+        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller|kube-applier|mgmt-agent)\.logs
         Key_Name log
         Parser containerlogs
         Preserve_Key On
@@ -509,6 +510,31 @@ data:
         Table_Name fleetLogs
         ingestion_mapping_reference ingestionMapping
         azure_kusto_buffer_key fleetLogs
+        buffer_dir "/var/kusto"
+        buffering_enabled           true 
+        upload_timeout              1m
+        upload_file_size            16M
+        buffer_file_delete_early    false
+        unify_tag                   true
+        store_dir_limit_size        1.8GB
+        blob_uri_length             128
+        scheduler_max_retries       9
+        delete_on_max_upload_error  true
+        io_timeout                  60s
+
+    [OUTPUT]
+        Match kube-applier.logs
+        Name azure_kusto
+        Retry_Limit 5
+        auth_type workload_identity
+        tenant_id __tenantId__
+        client_id __msiClientId__
+        workload_identity_token_file ${AZURE_FEDERATED_TOKEN_FILE}
+        Ingestion_Endpoint __kustoDataIngestionUri__
+        Database_Name ServiceLogs
+        Table_Name kubeApplierLogs
+        ingestion_mapping_reference ingestionMapping
+        azure_kusto_buffer_key kubeApplierLogs
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
@@ -816,7 +842,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: f0311b4f9da7294ac2ee43d8778c426af65296e434d332622aa97a93b362c130
+        checksum/configmap: d614b8b281ec0724817c49a74c03810d573856fafad32fbd2391c18155baee48
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
@@ -212,6 +212,7 @@ data:
         Rule            $kubernetes['container_name'] ^aro-hcp-backend* aro-hcp-backend.logs false
         Rule            $kubernetes['container_name'] ^clusters-service* clusters-service.logs false
         Rule            $kubernetes['container_name'] ^fleet-controller* fleet-controller.logs false
+        Rule            $kubernetes['container_name'] ^kube-applier* kube-applier.logs false
         Rule            $kubernetes['container_name'] ^kube-events* kube-events.logs false
         Rule            $kubernetes['container_name'] ^mgmt-agent-controller* mgmt-agent.logs true
         Emitter_Name    re_emitted_container_name_router
@@ -221,7 +222,7 @@ data:
     [FILTER]
         # Parse the log key and make it a json object again under $
         Name Parser
-        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller|mgmt-agent)\.logs
+        Match_regex (aro-hcp-(frontend|backend)|kube-events|clusters-service|fleet-controller|kube-applier|mgmt-agent)\.logs
         Key_Name log
         Parser containerlogs
         Preserve_Key On
@@ -330,6 +331,31 @@ data:
         Table_Name fleetLogs
         ingestion_mapping_reference ingestionMapping
         azure_kusto_buffer_key fleetLogs
+        buffer_dir "/var/kusto"
+        buffering_enabled           true 
+        upload_timeout              1m
+        upload_file_size            16M
+        buffer_file_delete_early    false
+        unify_tag                   true
+        store_dir_limit_size        1.8GB
+        blob_uri_length             128
+        scheduler_max_retries       9
+        delete_on_max_upload_error  true
+        io_timeout                  60s
+
+    [OUTPUT]
+        Match kube-applier.logs
+        Name azure_kusto
+        Retry_Limit 5
+        auth_type workload_identity
+        tenant_id __tenantId__
+        client_id __msiClientId__
+        workload_identity_token_file ${AZURE_FEDERATED_TOKEN_FILE}
+        Ingestion_Endpoint __kustoDataIngestionUri__
+        Database_Name ServiceLogs
+        Table_Name kubeApplierLogs
+        ingestion_mapping_reference ingestionMapping
+        azure_kusto_buffer_key kubeApplierLogs
         buffer_dir "/var/kusto"
         buffering_enabled           true 
         upload_timeout              1m
@@ -596,7 +622,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 6a10e176a9d7712985710fe5db0595561ce2199571c4f8b46d122af797fab089
+        checksum/configmap: 28b2c4877eded93a36fb86b7118a531d9efa6fff14b15866a73eddb0a4402bfe
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'


### PR DESCRIPTION
AI generated for adding kubeApplierLogs to kusto with fields similar backendLogs. Adds a controller_name field, and adds the new table to snapshot and must-gather.