### PR TITLE
fix: add missing RBAC role assignments for Data plane and Control plane E2E managed identities

### DIFF
--- a/docs/ci/identity-leasing.md
+++ b/docs/ci/identity-leasing.md
@@ -160,7 +160,7 @@ The key limiting factor for identity pool sizing is **Azure role assignments per
 
 Each HCP cluster created during E2E consumes role assignments in its identity container. The cost depends on the RBAC scope mode:
 
-- **`resourceGroupScope`**: 24 role assignments per HCP (11 from E2E test bicep + 13 from the RP-managed resource group)
+- **`resourceGroupScope`**: 26 role assignments per HCP (13 from E2E test bicep + 13 from the RP-managed resource group)
 - **`resourceScope`**: 41 role assignments per HCP (28 from E2E test bicep + 13 from the RP-managed resource group)
 
 The E2E suite runs all tests in `resourceGroupScope` mode except one test path that uses `resourceScope`.
@@ -177,7 +177,7 @@ Individual test specs may also create additional role assignments beyond this ba
 Given a target suite parallelism and a subscription's role-assignment quota, the maximum identity-pool size for the flat legacy model is:
 
 ```text
-RG_SCOPE_COST  = 24   (current resourceGroupScope cost per HCP)
+RG_SCOPE_COST  = 26   (current resourceGroupScope cost per HCP)
 RES_SCOPE_COST = 41   (current resourceScope cost per HCP)
 
 max-concurrency = floor((role-assignment-quota - 100) / (((suite-parallelism - 1) * RG_SCOPE_COST) + RES_SCOPE_COST))

--- a/test/e2e-setup/bicep/modules/non-msi-scoped-assignments.bicep
+++ b/test/e2e-setup/bicep/modules/non-msi-scoped-assignments.bicep
@@ -253,15 +253,17 @@ resource fileStorageOperatorRoleResourceGroupAssignment 'Microsoft.Authorization
   }
 }
 
-resource fileStorageOperatorRoleSubnetAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (rbacScope == 'resource') {
-  name: guid(resourceGroup().id, fileCsiDriverMi.id, fileStorageOperatorRoleId, subnet.id)
-  scope: subnet
+resource fileStorageOperatorRoleVnetAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (rbacScope == 'resource') {
+  name: guid(resourceGroup().id, fileCsiDriverMi.id, fileStorageOperatorRoleId, vnet.id)
+  scope: vnet
   properties: {
     principalId: fileCsiDriverMi.properties.principalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: fileStorageOperatorRoleId
   }
 }
+
+// No subnet-scoped assignment: the VNet-scoped grant above already covers the subnet via RBAC scope inheritance.
 
 resource fileStorageOperatorRoleNsgAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (rbacScope == 'resource') {
   name: guid(resourceGroup().id, fileCsiDriverMi.id, fileStorageOperatorRoleId, nsg.id)
@@ -282,6 +284,36 @@ resource imageRegistryMi 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-
   name: identities.imageRegistryMiName
   scope: resourceGroup(resourceGroupName)
 }
+
+// Azure Red Hat OpenShift Image Registry Operator: Manage the OpenShift image registry's use of Azure Storage.
+// Shared by the control plane and data plane image-registry identities below.
+// https://www.azadvertizer.net/azrolesadvertizer/8b32b316-c2f5-4ddf-b05b-83dacd2d08b5.html
+var imageRegistryOperatorRoleId = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  '8b32b316-c2f5-4ddf-b05b-83dacd2d08b5'
+)
+
+resource imageRegistryOperatorRoleResourceGroupAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (rbacScope == 'resourceGroup') {
+  name: guid(resourceGroup().id, imageRegistryMi.id, imageRegistryOperatorRoleId)
+  scope: resourceGroup()
+  properties: {
+    principalId: imageRegistryMi.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: imageRegistryOperatorRoleId
+  }
+}
+
+resource imageRegistryOperatorRoleVnetAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (rbacScope == 'resource') {
+  name: guid(resourceGroup().id, imageRegistryMi.id, imageRegistryOperatorRoleId, vnet.id)
+  scope: vnet
+  properties: {
+    principalId: imageRegistryMi.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: imageRegistryOperatorRoleId
+  }
+}
+
+// No subnet-scoped assignment: the VNet-scoped grant above already covers the subnet via RBAC scope inheritance.
 
 
 //
@@ -310,15 +342,7 @@ resource networkOperatorRoleResourceGroupAssignment 'Microsoft.Authorization/rol
   }
 }
 
-resource networkOperatorRoleSubnetAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (rbacScope == 'resource') {
-  name: guid(resourceGroup().id, cloudNetworkConfigMi.id, networkOperatorRoleId, subnet.id)
-  scope: subnet
-  properties: {
-    principalId: cloudNetworkConfigMi.properties.principalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: networkOperatorRoleId
-  }
-}
+// No subnet-scoped assignment: the VNet-scoped grant below already covers the subnet via RBAC scope inheritance.
 
 resource networkOperatorRoleVnetAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (rbacScope == 'resource') {
   name: guid(resourceGroup().id, cloudNetworkConfigMi.id, networkOperatorRoleId, vnet.id)
@@ -355,15 +379,17 @@ resource dpFileCsiDriverFileStorageOperatorRoleResourceGroupAssignment 'Microsof
   }
 }
 
-resource dpFileCsiDriverFileStorageOperatorRoleSubnetAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (rbacScope == 'resource') {
-  name: guid(resourceGroup().id, dpFileCsiDriverMi.id, fileStorageOperatorRoleId, subnet.id)
-  scope: subnet
+resource dpFileCsiDriverFileStorageOperatorRoleVnetAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (rbacScope == 'resource') {
+  name: guid(resourceGroup().id, dpFileCsiDriverMi.id, fileStorageOperatorRoleId, vnet.id)
+  scope: vnet
   properties: {
     principalId: dpFileCsiDriverMi.properties.principalId
     principalType: 'ServicePrincipal'
     roleDefinitionId: fileStorageOperatorRoleId
   }
 }
+
+// No subnet-scoped assignment: the VNet-scoped grant above already covers the subnet via RBAC scope inheritance.
 
 resource dpFileCsiDriverFileStorageOperatorRoleNsgAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (rbacScope == 'resource') {
   name: guid(resourceGroup().id, dpFileCsiDriverMi.id, fileStorageOperatorRoleId, nsg.id)
@@ -379,6 +405,28 @@ resource dpImageRegistryMi 'Microsoft.ManagedIdentity/userAssignedIdentities@202
   name: identities.dpImageRegistryMiName
   scope: resourceGroup(resourceGroupName)
 }
+
+resource dpImageRegistryOperatorRoleResourceGroupAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (rbacScope == 'resourceGroup') {
+  name: guid(resourceGroup().id, dpImageRegistryMi.id, imageRegistryOperatorRoleId)
+  scope: resourceGroup()
+  properties: {
+    principalId: dpImageRegistryMi.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: imageRegistryOperatorRoleId
+  }
+}
+
+resource dpImageRegistryOperatorRoleVnetAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (rbacScope == 'resource') {
+  name: guid(resourceGroup().id, dpImageRegistryMi.id, imageRegistryOperatorRoleId, vnet.id)
+  scope: vnet
+  properties: {
+    principalId: dpImageRegistryMi.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: imageRegistryOperatorRoleId
+  }
+}
+
+// No subnet-scoped assignment: the VNet-scoped grant above already covers the subnet via RBAC scope inheritance.
 
 //
 // S E R V I C E   M A N A G E D   I D E N T I T Y
@@ -417,16 +465,7 @@ resource serviceManagedIdentityRoleAssignmentVnet 'Microsoft.Authorization/roleA
   }
 }
 
-// grant service managed identity role to the service managed identity over the user provided subnet
-resource serviceManagedIdentityRoleAssignmentSubnet 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (rbacScope == 'resource') {
-  name: guid(resourceGroup().id, serviceManagedIdentity.id, hcpServiceManagedIdentityRoleId, subnet.id)
-  scope: subnet
-  properties: {
-    principalId: serviceManagedIdentity.properties.principalId
-    principalType: 'ServicePrincipal'
-    roleDefinitionId: hcpServiceManagedIdentityRoleId
-  }
-}
+// No subnet-scoped assignment: the VNet-scoped grant above already covers the subnet via RBAC scope inheritance.
 
 // grant service managed identity role to the service managed identity over the user provided NSG
 resource serviceManagedIdentityRoleAssignmentNSG 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (rbacScope == 'resource') {


### PR DESCRIPTION
<!-- Link to Jira issue -->
https://redhat.atlassian.net/browse/ARO-29082

### What

Added the missing role assignments in test/e2e-setup/bicep/modules/non-msi-scoped-assignments.bicep (current suite, gated by the existing rbacScope parameter), and removed redundant subnet-scoped assignments that duplicated VNet-scoped grants via Azure RBAC inheritance (to stay within E2E identity-container capacity limits).

- Control plane
file-csi-driver — added VNet-scoped Azure Red Hat OpenShift File Storage Operator (replaced the prior subnet-scoped assignment; subnet grant removed as redundant)
image-registry — added Resource Group + VNet-scoped Azure Red Hat OpenShift Image Registry Operator (this identity had no role assignment at all before; no separate subnet grant — VNet scope covers subnet via inheritance)

- Data plane
file-csi-driver — added VNet-scoped Azure Red Hat OpenShift File Storage Operator (replaced the prior subnet-scoped assignment; subnet grant removed as redundant)
image-registry — added Resource Group + VNet-scoped Azure Red Hat OpenShift Image Registry Operator (this identity had no role assignment at all before; no separate subnet grant — VNet scope covers subnet via inheritance)
Capacity workaround (pre-existing redundant grants, not new validation requirements)

- Removed 4 subnet-scoped role assignments where an equivalent VNet-scoped grant already exists (RBAC scope inheritance makes the subnet grant redundant):
CP file-csi-driver, CP cloud-network-config
DP file-csi-driver
serviceManagedIdentity

- Also updated docs/ci/identity-leasing.md per-HCP role-assignment cost figures:
resourceGroupScope: 24 → 26 (+2 from new CP/DP image-registry RG-scoped grants)
resourceScope: unchanged at 41 (new grants offset by removing redundant subnet-scoped assignments; net capacity cost matches pre-PR baseline)

### Why

After DataPlaneIdentitiesPermissionsValidation and ControlPlaneIdentitiesPermissionsClusterValidation
were added on the backend, E2E clusters started failing those validations even though the E2E suite
itself was green. Kusto analysis of validation failures showed that several control-plane and
data-plane operator identities were missing RBAC role assignments on the customer-provided VNet,
subnet, and/or resource group in the E2E setup Bicep — the identities were correctly created, but
never granted the permissions the new validators expect them to have.

### Testing

Added all the verification screenshots to the Jira ticket comments:
https://redhat.atlassian.net/browse/ARO-29082?focusedCommentId=18077935


### PR Checklist

- [X] PR is scoped to a single task (no mixed concerns)
- [X] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [X] Summary explains the "Why" behind the change
- [X] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [X] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [X] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
