### PR TITLE
refactor(backend): remove unused maestro env parameter from backup sc…

### DIFF
--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -644,7 +644,6 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.KubeApplierDBClients,
 		backendInformers,
 		unionKubeApplierInformers,
-		b.options.MaestroSourceEnvironmentIdentifier,
 		b.options.BackupConfig,
 	)
 

--- a/backend/pkg/controllers/cluster/backups/schedule_controller.go
+++ b/backend/pkg/controllers/cluster/backups/schedule_controller.go
@@ -49,8 +49,6 @@ type backupScheduleSyncer struct {
 	applyDesireLister    kubeapplierlisters.ApplyDesireLister
 	readDesireLister     kubeapplierlisters.ReadDesireLister
 
-	hostedClusterNamespaceEnvIdentifier string
-
 	backupConfig *BackupConfig
 }
 
@@ -63,7 +61,6 @@ func NewBackupScheduleController(
 	kubeApplierDBClients kubeappliercosmosstorage.KubeApplierDBClients,
 	informers coreinformers.BackendInformers,
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
-	hostedClusterNamespaceEnvIdentifier string,
 	backupConfig *BackupConfig,
 ) controllerutils.Controller {
 
@@ -73,14 +70,13 @@ func NewBackupScheduleController(
 	_, readDesireLister := kubeApplierInformers.ReadDesires()
 
 	syncer := &backupScheduleSyncer{
-		cosmosClient:                        cosmosClient,
-		clusterLister:                       clusterLister,
-		serviceProviderClusterLister:        serviceProviderClusterLister,
-		kubeApplierDBClients:                kubeApplierDBClients,
-		applyDesireLister:                   applyDesireLister,
-		readDesireLister:                    readDesireLister,
-		hostedClusterNamespaceEnvIdentifier: hostedClusterNamespaceEnvIdentifier,
-		backupConfig:                        backupConfig,
+		cosmosClient:                 cosmosClient,
+		clusterLister:                clusterLister,
+		serviceProviderClusterLister: serviceProviderClusterLister,
+		kubeApplierDBClients:         kubeApplierDBClients,
+		applyDesireLister:            applyDesireLister,
+		readDesireLister:             readDesireLister,
+		backupConfig:                 backupConfig,
 	}
 
 	controller := controllerutils.NewClusterWatchingController(

--- a/backend/pkg/controllers/cluster/backups/schedule_controller_test.go
+++ b/backend/pkg/controllers/cluster/backups/schedule_controller_test.go
@@ -1001,14 +1001,13 @@ func TestBackupScheduleSyncer_SyncOnce(t *testing.T) {
 			}
 
 			syncer := &backupScheduleSyncer{
-				cosmosClient:                        mockResourcesDBClient,
-				clusterLister:                       clusterLister,
-				serviceProviderClusterLister:        &corelistertesting.SliceServiceProviderClusterLister{ServiceProviderClusters: serviceProviderClusterList},
-				kubeApplierDBClients:                mockKubeApplierDBClients,
-				applyDesireLister:                   &kubeapplierlistertesting.DBApplyDesireLister{Clients: mockKubeApplierDBClients, Lister: mcLister},
-				readDesireLister:                    &kubeapplierlistertesting.DBReadDesireLister{Clients: mockKubeApplierDBClients, Lister: mcLister},
-				hostedClusterNamespaceEnvIdentifier: testEnvID,
-				backupConfig:                        cfg,
+				cosmosClient:                 mockResourcesDBClient,
+				clusterLister:                clusterLister,
+				serviceProviderClusterLister: &corelistertesting.SliceServiceProviderClusterLister{ServiceProviderClusters: serviceProviderClusterList},
+				kubeApplierDBClients:         mockKubeApplierDBClients,
+				applyDesireLister:            &kubeapplierlistertesting.DBApplyDesireLister{Clients: mockKubeApplierDBClients, Lister: mcLister},
+				readDesireLister:             &kubeapplierlistertesting.DBReadDesireLister{Clients: mockKubeApplierDBClients, Lister: mcLister},
+				backupConfig:                 cfg,
 			}
 
 			syncCount := max(tt.syncCount, 1)


### PR DESCRIPTION
…hedule controller

No jira

### What

Removes unused maestro env parameter from schedule controller

### Why

Missed removing this variable when cutting over from maestro -> kubeapplier

### Testing

Existing unit/e2e tests.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
