### PR TITLE
fix: label resource-cleaner namespace with Istio tag instead of static revision

### DIFF
--- a/cluster-service/Env.mk
+++ b/cluster-service/Env.mk
@@ -4,6 +4,7 @@ AKS_NAME ?= {{ .svc.aks.name }}
 SERVICE_KV ?= {{ .serviceKeyVault.name }}
 NAMESPACE ?= {{ .clustersService.k8s.namespace }}
 ACR_NAME ?= {{ .acr.svc.name }}
+SVC_ISTIO_TAG ?= {{ .svc.istio.tag }}
 OCP_ACR_NAME ?= {{ .acr.ocp.name }}
 REGIONAL_RESOURCEGROUP ?= {{ .regionRG }}
 MGMT_RESOURCEGROUP ?= {{ .mgmt.rg }}

--- a/cluster-service/Makefile
+++ b/cluster-service/Makefile
@@ -46,7 +46,8 @@ deploy-pr-env-deps:
 		--resource-group "${RESOURCEGROUP}" \
 		--cx-keyvault "${CX_SECRETS_KV_NAME}" \
 		--mi-keyvault "${CX_MI_KV_NAME}" \
-		--acr-name "${OCP_ACR_NAME}"
+		--acr-name "${OCP_ACR_NAME}" \
+		--istio-tag "${SVC_ISTIO_TAG}"
 
 cspr-jenkins-kubeconfig:
 	./cspr-kubeconfig.sh cluster-service-admin cluster-service-mgmt ./cspr.kubeconfig

--- a/cluster-service/cspr/deploy-resource-cleaner.sh
+++ b/cluster-service/cspr/deploy-resource-cleaner.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 #   --acr-name <name>          Azure Container Registry name (required)
 #   --maestro-url <url>        Maestro API URL (default: http://maestro.maestro.svc.cluster.local:8000)
 #   --retention-hours <hours>  Retention period in hours (default: 3)
+#   --istio-tag <tag>          Istio revision tag to label the namespace with (default: prod-stable)
 #   --help                     Show this help message
 ###############################################################################
 
@@ -33,6 +34,7 @@ MAESTRO_URL="http://maestro.maestro.svc.cluster.local:8000"
 RETENTION_HOURS="3"
 NAMESPACE="resource-cleaner"
 MI_NAME="cspr-cleaner-mi"
+ISTIO_REVISION_TAG="prod-stable"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -59,6 +61,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --retention-hours)
             RETENTION_HOURS="$2"
+            shift 2
+            ;;
+        --istio-tag)
+            ISTIO_REVISION_TAG="$2"
             shift 2
             ;;
         --help)
@@ -261,6 +267,7 @@ echo "  MI Key Vault: ${MI_KEYVAULT}"
 echo "  ACR Name: ${ACR_NAME}"
 echo "  Maestro URL: ${MAESTRO_URL}"
 echo "  Retention Hours: ${RETENTION_HOURS}"
+echo "  Istio Revision Tag: ${ISTIO_REVISION_TAG}"
 echo "  Namespace: ${NAMESPACE}"
 echo ""
 
@@ -273,19 +280,12 @@ kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply
 # Step 1.5: Label namespace for Istio injection
 echo "Step 1.5: Labeling namespace for Istio sidecar injection..."
 
-# Get Istio version from aks-istio-system
-ISTIO_VERSION=$(kubectl get deploy -n aks-istio-system -o name 2>/dev/null | \
-    grep -oE 'istiod-(asm-[0-9]+-[0-9]+)' | \
-    sed 's/istiod-//' | \
-    head -n1)
-
-if [[ -z "${ISTIO_VERSION}" ]]; then
-    echo "  ⚠️  WARNING: Could not find Istio version in aks-istio-system namespace"
-    echo "  Skipping Istio namespace labeling. Pods will not have Istio sidecars."
+if kubectl get deploy -n aks-istio-system -o name 2>/dev/null | grep -q '^deployment.apps/istiod'; then
+    kubectl label namespace "${NAMESPACE}" "istio.io/rev=${ISTIO_REVISION_TAG}" --overwrite
+    echo "  ✓ Namespace labeled with istio.io/rev=${ISTIO_REVISION_TAG}"
 else
-    echo "  Found Istio version: ${ISTIO_VERSION}"
-    kubectl label namespace "${NAMESPACE}" "istio.io/rev=${ISTIO_VERSION}" --overwrite
-    echo "  ✓ Namespace labeled with istio.io/rev=${ISTIO_VERSION}"
+    echo "  ⚠️  WARNING: Istio deployment not found in aks-istio-system namespace"
+    echo "  Skipping Istio namespace labeling. Pods will not have Istio sidecars."
 fi
 
 # Delete existing ConfigMap if it exists


### PR DESCRIPTION
### What

- `cluster-service/cspr/deploy-resource-cleaner.sh`: labels the`resource-cleaner` namespace with the `prod-stable` Istio revision tag instead of dynamically discovering and hardcoding the currently-installed istiod revision. The tag value is now configurable via a new `--istio-tag` flag (defaults to `prod-stable`).
- `cluster-service/Env.mk`: add `SVC_ISTIO_TAG`, templated from`svc.istio.tag` in `config.yaml`.
- `cluster-service/Makefile`: pass `SVC_ISTIO_TAG` through to`deploy-resource-cleaner.sh` via the new `--istio-tag` flag.

### Why

`cspr-pipeline-postsubmit` failed at the final verification step of`IstioUpgrade` ("9/9: cleanup job") with:

post-upgrade verification failed: [namespace resource-cleaner has label asm-1-28, expected asm-1-29 or prod-stable]


https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-cspr-pipeline-postsubmit/2089239860865929216

The upgrade itself succeeded (cluster moved to asm-1-29) — this was a post-migration verification failure only.

Root cause: `deploy-resource-cleaner.sh` labeled the `resource-cleaner` namespace with a dynamically-discovered static istiod revision instead of the `prod-stable` tag every other ARO-HCP namespace uses (see `cluster-service namespace.yaml`). `IstioUpgrade`'s migration model only ever flips the tag-based webhook and intentionally leaves statically-labeled namespaces untouched, so a statically-labeled namespace falls out of sync on every future revision bump.

### Testing

- No unit/integration/E2E tests added — this is a config/script fix for CSPR-only tooling with no existing automated test coverage.
- `bash -n` syntax-checked the updated script.
- `make -n deploy-pr-env-deps` dry-run verified `SVC_ISTIO_TAG` resolves correctly and is passed through as `--istio-tag prod-stable`.

### Special notes for your reviewer

- The live `resource-cleaner` namespace on `cspr-westus3-svc-1` has been manually corrected to unblock the environment, which then was relabeled to asm-1-29 after the cluster was upgraded; this PR prevents the same drift from recurring on future upgrades.
- Scoped to CSPR only.
- Related: #6236