### PR TITLE
chore: remove image-sync/oc-mirror from image-updater bumper

### DIFF
--- a/docs/ops/bump-image-digests.md
+++ b/docs/ops/bump-image-digests.md
@@ -14,7 +14,6 @@ Each service component defines its image digest in the [configuration](../config
 | Maestro                       | `maestro.image.digest`                            |
 | Hypershift Operator           | `hypershift.image.digest`                         |
 | ACR Pull                      | `acrPull.image.digest`                            |
-| Image Sync (oc-mirror)        | `imageSync.ocMirror.image.digest`                 |
 | Prometheus Operator (SVC)     | `svc.prometheus.prometheusOperator.image.digest`  |
 | Prometheus Operator (MGMT)    | `mgmt.prometheus.prometheusOperator.image.digest` |
 | Prometheus Server (SVC)       | `svc.prometheus.prometheusSpec.image.digest`      |

--- a/tooling/image-updater/README.md
+++ b/tooling/image-updater/README.md
@@ -164,7 +164,7 @@ make update GROUPS=hypershift-stack,velero
 make update GROUPS=hypershift-stack EXCLUDE_COMPONENTS=maestro-agent-sidecar
 ```
 
-Example groups include `cs`, `aro-deps`, `hypershift-stack`, `prom-stack`, `obs-agents`, `velero`, and `platform-utils`. For the complete, current set of supported groups, refer to `config.yaml`.
+Example groups include `cs`, `hypershift-stack`, `prom-stack`, `obs-agents`, `velero`, and `platform-utils`. For the complete, current set of supported groups, refer to `config.yaml`.
 
 ### Output to File
 
@@ -202,13 +202,16 @@ To pin an image to a specific digest and prevent automatic updates:
 2. **Update `config.yaml`** to use a specific `tag` instead of `tagPattern`:
 
 ```yaml
-imageSync:
+clusters-service:
   source:
-    image: arohcpsvcdev.azurecr.io/image-sync/oc-mirror
-    tag: "8755133"  # Pin to a specific tag instead of tagPattern
+    image: quay.io/app-sre/aro-hcp-clusters-service
+    tag: "abc1234"  # Pin to a specific tag instead of tagPattern
     useAuth: true
+    keyVault:
+      url: "https://arohcpdev-global.vault.azure.net/"
+      secretName: "component-sync-pull-secret"
   targets:
-  - jsonPath: defaults.imageSync.ocMirror.image.digest
+  - jsonPath: defaults.clustersService.image.digest
     filePath: ../../config/config.yaml
 ```
 
@@ -222,7 +225,7 @@ az login
 
 ```bash
 # Update specific component
-make update COMPONENTS=imageSync
+make update COMPONENTS=clusters-service
 ```
 
 5. **Run materialize** to update rendered configs:
@@ -300,12 +303,15 @@ clusters-service:
 
 **Azure Container Registry (Private)**:
 ```yaml
-imageSync:
+clusters-service:
   source:
-    image: arohcpsvcdev.azurecr.io/image-sync/oc-mirror
-    useAuth: true  # Uses DefaultAzureCredential
+    image: quay.io/app-sre/aro-hcp-clusters-service
+    useAuth: true  # Uses Key Vault credentials
+    keyVault:
+      url: "https://arohcpdev-global.vault.azure.net/"
+      secretName: "component-sync-pull-secret"
   targets:
-  - jsonPath: defaults.imageSync.ocMirror.image.digest
+  - jsonPath: defaults.clustersService.image.digest
     filePath: ../../config/config.yaml
 ```
 

--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -144,16 +144,6 @@ images:
     targets:
     - jsonPath: defaults.secretSyncController.providerImage.digest
       filePath: ../../config/config.yaml
-  # Image Sync
-  imageSync:
-    group: aro-deps
-    source:
-      image: arohcpsvcdev.azurecr.io/image-sync/oc-mirror
-      tagPattern: "^[a-f0-9]{7}$"
-      useAuth: true
-    targets:
-    - jsonPath: defaults.imageSync.ocMirror.image.digest
-      filePath: ../../config/config.yaml
   # Tenant Quota Collector image
   tenant-quota:
     group: aro-ci-images


### PR DESCRIPTION
## Summary

- Remove the `imageSync` (image-sync/oc-mirror) entry from `tooling/image-updater/config.yaml`
- This is a first-party image whose digests are already managed by the sdp-pipelines release flow
- The image-updater entry is redundant since we already bump them via [sdp-pipelines](https://dev.azure.com/msazure/AzureRedHatOpenShift/_git/sdp-pipelines?path=/tooling/pkg/release/candidate/bump/options.go&version=GBmain&line=568&lineEnd=569&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents) 

## Context

Follows the same pattern as:
- [AROSLSRE-778](https://redhat.atlassian.net/browse/AROSLSRE-778) / #5400 — removed `frontend`, `backend`, `admin-api`, `sessiongate`
- [AROSLSRE-1173](https://redhat.atlassian.net/browse/AROSLSRE-1173) — removed `aro-hcp-exporter`

Ref: [AROSLSRE-1829](https://redhat.atlassian.net/browse/AROSLSRE-1829)

## Test plan

- [x] Verify `imageSync` no longer appears in a dry-run of the bumper
- [x] Verify `defaults.imageSync.ocMirror.image.digest` in `config/config.yaml` is unchanged