### PR TITLE
feat(observability): Add SLO alert annotations and status panel to cluster provisioning dashboard

### DIFF
--- a/observability/grafana-dashboards/sre/user-journey/cluster-provisioning-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/cluster-provisioning-slo.json
@@ -12,6 +12,19 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "enable": true,
+        "expr": "ALERTS{alertname=~\"UJClusterProvision.*\", alertstate=\"firing\"}",
+        "iconColor": "red",
+        "name": "Cluster Provision SLO Alerts",
+        "titleFormat": "{{alertname}}",
+        "textFormat": "{{alertname}} firing on {{cluster}}",
+        "step": "60s"
       }
     ]
   },
@@ -1877,6 +1890,140 @@
         }
       ],
       "type": "histogram"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 89
+      },
+      "id": 31,
+      "panels": [],
+      "title": "SLO Alert Status",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Current state of cluster provisioning SLO burn-rate alerts. Green = OK, Red = FIRING. Alerts are defined in cluster-provision-slo-prometheusRule.yaml.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "OK"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "FIRING"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 90
+      },
+      "id": 32,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.9",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max(ALERTS{alertname=\"UJClusterProvisionErrors1h5m\", alertstate=\"firing\"}) or vector(0)",
+          "instant": true,
+          "legendFormat": "Fast Burn (1h/5m)",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max(ALERTS{alertname=\"UJClusterProvisionErrors6h30m\", alertstate=\"firing\"}) or vector(0)",
+          "instant": true,
+          "legendFormat": "Medium Burn (6h/30m)",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max(ALERTS{alertname=\"UJClusterProvisionErrors3d\", alertstate=\"firing\"}) or vector(0)",
+          "instant": true,
+          "legendFormat": "Slow Burn (3d/6h)",
+          "range": false,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max(ALERTS{alertname=\"UJClusterProvisionErrorsDegradation\", alertstate=\"firing\"}) or vector(0)",
+          "instant": true,
+          "legendFormat": "Degradation (15%/30m)",
+          "range": false,
+          "refId": "D"
+        }
+      ],
+      "title": "SLO Alert Status",
+      "type": "stat"
     }
   ],
   "preload": false,

--- a/observability/grafana-dashboards/sre/user-journey/cluster-provisioning-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/cluster-provisioning-slo.json
@@ -2022,6 +2022,48 @@
           "refId": "D"
         }
       ],
+      "transformations": [
+        {
+          "id": "seriesToRows",
+          "options": {}
+        },
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Metric": {
+                "operation": "groupby",
+                "aggregations": []
+              },
+              "Value": {
+                "operation": "aggregate",
+                "aggregations": [
+                  "max"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "rowsToFields",
+          "options": {
+            "mappings": [
+              {
+                "fieldName": "Metric",
+                "handlerKey": "field.name"
+              },
+              {
+                "fieldName": "Value (max)",
+                "handlerKey": "field.value"
+              }
+            ]
+          }
+        }
+      ],
       "title": "SLO Alert Status",
       "type": "stat"
     }


### PR DESCRIPTION


[ARO-26196](https://redhat.atlassian.net/browse/ARO-26196)

### What

Add SLO alert annotations and an alert status panel to the cluster provisioning dashboard.

### Why
This change adds:
  1. Alert annotations — red vertical markers on all time-series panels when any cluster provision SLO alert fires, enabling visual correlation with metrics.
  2. SLO Alert Status panel — a dedicated stat panel showing OK/FIRING state for each of the 4 burn-rate alerts at a glance.
  
### Testing

Explore panels on prod (australiaeast prod-australiaeast-svc-1)

### Special notes for your reviewer

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge


<img width="3819" height="1513" alt="Screenshot From 2026-08-18 12-24-07" src="https://github.com/user-attachments/assets/c22f2097-b2bd-413f-9c38-a2ddfe2cbce0" />
<img width="3819" height="1513" alt="Screenshot From 2026-08-18 12-23-44" src="https://github.com/user-attachments/assets/1f2c4838-82e6-4e01-bcaa-9c494d6aa84d" />
<img width="3819" height="1513" alt="Screenshot From 2026-08-18 12-22-23" src="https://github.com/user-attachments/assets/98784fcc-7034-43ed-bdd8-6ba33a12950b" />
<img width="3819" height="1513" alt="Screenshot From 2026-08-18 12-21-34" src="https://github.com/user-attachments/assets/473ef03d-c2c7-45db-805e-65a88248d4d5" />
<img width="3819" height="1513" alt="Screenshot From 2026-08-18 12-21-04" src="https://github.com/user-attachments/assets/9f832015-9bc5-4620-83cd-40eea419085f" />
<img width="3819" height="1513" alt="Screenshot From 2026-08-18 12-20-38" src="https://github.com/user-attachments/assets/6919b348-f4e7-490c-b17f-9498243c1d2a" />
<img width="3819" height="1513" alt="Screenshot From 2026-08-18 12-20-06" src="https://github.com/user-attachments/assets/aafc7da9-88d4-4183-8c42-b3e709233f81" />
