### PR TITLE
fix(hcpctl): guard kusto primary-result receive to prevent nil-pointer panic

### DIFF
--- a/tooling/hcpctl/pkg/kusto/client.go
+++ b/tooling/hcpctl/pkg/kusto/client.go
@@ -99,6 +99,24 @@ func NewClient(endpoint *url.URL, queryTimeout time.Duration) (*Client, error) {
 	}, nil
 }
 
+// PrimaryResultTable receives the primary result table from an IterativeDataset's
+// Tables() channel. Tables() yields query.TableResult (an interface); when the
+// channel closes without yielding a table (e.g. the query context is cancelled
+// or times out), the receive returns a nil TableResult whose Err() would panic
+// with a nil pointer dereference. PrimaryResultTable guards that case and returns
+// a clear error instead. The returned table may be nil for a zero-row result —
+// callers decide whether that is an error.
+func PrimaryResultTable(tables <-chan azkquery.TableResult) (azkquery.IterativeTable, error) {
+	result, ok := <-tables
+	if !ok || result == nil {
+		return nil, fmt.Errorf("no primary result table returned")
+	}
+	if err := result.Err(); err != nil {
+		return nil, fmt.Errorf("failed to get primary result: %w", err)
+	}
+	return result.Table(), nil
+}
+
 // ExecutePreconfiguredQuery executes a KQL query against the Azure Data Explorer cluster
 func (c *Client) ExecutePreconfiguredQuery(ctx context.Context, query Query, outputChannel chan<- TaggedRow) (*QueryResult, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, c.QueryTimeout)
@@ -123,19 +141,16 @@ func (c *Client) ExecutePreconfiguredQuery(ctx context.Context, query Query, out
 
 	// Process the first table (primary result)
 	logger.V(6).Info("Processing primary result")
-	primaryResult := <-dataset.Tables()
-
-	err = primaryResult.Err()
+	table, err := PrimaryResultTable(dataset.Tables())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get primary result: %w", err)
+		return nil, fmt.Errorf("%w for query %q on database %q", err, query.GetName(), query.GetDatabase())
 	}
-
-	if primaryResult.Table() == nil {
+	if table == nil {
 		return nil, fmt.Errorf("primary result is nil")
 	}
 
 	columnsSet := false
-	for row := range primaryResult.Table().Rows() {
+	for row := range table.Rows() {
 		logger.V(8).Info("Processing row", "rowNumber", totalRows)
 		row := row.Row()
 		if row == nil {

--- a/tooling/hcpctl/pkg/kusto/client_test.go
+++ b/tooling/hcpctl/pkg/kusto/client_test.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kusto
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	azkquery "github.com/Azure/azure-kusto-go/azkustodata/query"
+)
+
+// TestPrimaryResultTable_EmptyChannel guards against the SIGSEGV regression:
+// when the Tables() channel closes without yielding a table (e.g. the query
+// context is cancelled or times out), the receive returns a nil TableResult.
+// Calling .Err() on it used to panic with a nil pointer dereference; it must
+// now return a clear error instead.
+func TestPrimaryResultTable_EmptyChannel(t *testing.T) {
+	ch := make(chan azkquery.TableResult)
+	close(ch)
+
+	table, err := PrimaryResultTable(ch)
+
+	require.Error(t, err, "closed empty channel must return an error, not panic")
+	require.Nil(t, table, "no table expected when the channel closes empty")
+	require.Contains(t, err.Error(), "no primary result table", "error should identify the missing primary table")
+}
+
+// TestPrimaryResultTable_ResultError confirms the normal error path (a
+// TableResult carrying an error) is still surfaced.
+func TestPrimaryResultTable_ResultError(t *testing.T) {
+	ch := make(chan azkquery.TableResult, 1)
+	ch <- azkquery.TableResultError(errors.New("boom"))
+	close(ch)
+
+	table, err := PrimaryResultTable(ch)
+
+	require.Error(t, err, "a TableResult error must be surfaced")
+	require.Nil(t, table, "no table expected on primary result error")
+	require.Contains(t, err.Error(), "failed to get primary result", "error should wrap the primary result failure")
+}

--- a/tooling/hcpctl/pkg/snapshot/gatherer.go
+++ b/tooling/hcpctl/pkg/snapshot/gatherer.go
@@ -34,6 +34,8 @@ import (
 	"github.com/Azure/azure-kusto-go/azkustodata/kql"
 	azkquery "github.com/Azure/azure-kusto-go/azkustodata/query"
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/kusto"
 )
 
 // GatherInput provides the parameters needed to gather a diagnostic snapshot.
@@ -1195,18 +1197,18 @@ func (g *Gatherer) executeKQLOnce(ctx context.Context, kqlStr, database string, 
 	}
 
 	var rows []resultRow
-	primaryResult := <-dataset.Tables()
-	if err := primaryResult.Err(); err != nil {
-		return nil, fmt.Errorf("failed to get primary result: %w", err)
+	table, err := kusto.PrimaryResultTable(dataset.Tables())
+	if err != nil {
+		return nil, fmt.Errorf("%w on database %q", err, database)
 	}
-	if primaryResult.Table() == nil {
+	if table == nil {
 		return nil, nil
 	}
 
 	var columns []string
 	columnsSet := false
 
-	for rowResult := range primaryResult.Table().Rows() {
+	for rowResult := range table.Rows() {
 		row := rowResult.Row()
 		if row == nil {
 			continue


### PR DESCRIPTION
Fixes [ARO-29169](https://redhat.atlassian.net/browse/ARO-29169)

### What

Guards a nil-pointer panic in hcpctl's Kusto client. `kusto.Client.ExecutePreconfiguredQuery` and `snapshot.Gatherer.executeKQLOnce` both received a value from `dataset.Tables()` without a comma-ok check, then called `.Err()` on it. `Tables()` yields `query.TableResult` (an interface); when the channel closes without a table, the receive returns a nil interface and `.Err()` dereferences nil → SIGSEGV.

The receive is extracted into one `kusto.PrimaryResultTable` helper (comma-ok + nil + `Err()` check) used by both sites; each keeps its own nil-table policy.

### Why

The channel closes empty when the query context times out or is cancelled (a zero-row query still emits a table). The panic writes no output, so CI reports `exit status 2` / `no output from command` — the same signature CIHealth uses to bucket [ARO-25369](https://redhat.atlassian.net/browse/ARO-25369) (timeout deserialization), so this distinct panic was mis-attributed to that ticket.

### Testing

A table-driven unit test drives the helper's channel directly (empty-closed channel; error-carrying `TableResult`) — no fakes or interface seam needed. It reproduces the exact `SIGSEGV addr=0x18` without the guard and passes with it; both call sites are covered through the helper.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
