### PR TITLE
fix: Add omitempty to externalAuthUpdateDispatchConfig fields

### DIFF
--- a/internal/ocm/external_auth_update_dispatch_config.go
+++ b/internal/ocm/external_auth_update_dispatch_config.go
@@ -109,17 +109,17 @@ import (
 //     and persistence onto HCPOpenShiftClusterExternalAuth. Internal-only fields still need
 //     whatever backend path writes the value Cosmos holds.
 type externalAuthUpdateDispatchConfig struct {
-	Issuer  externalAuthUpdateDispatchConfigIssuer   `json:"issuer"`
-	Clients []externalAuthUpdateDispatchConfigClient `json:"clients"`
-	Claim   externalAuthUpdateDispatchConfigClaim    `json:"claim"`
+	Issuer  externalAuthUpdateDispatchConfigIssuer   `json:"issuer,omitempty"`
+	Clients []externalAuthUpdateDispatchConfigClient `json:"clients,omitempty"`
+	Claim   externalAuthUpdateDispatchConfigClaim    `json:"claim,omitempty"`
 }
 
 // externalAuthUpdateDispatchConfigIssuer is the curated issuer subset used for dispatch hash and
 // sync. See externalAuthUpdateDispatchConfig: do not embed coreapi.TokenIssuerProfile.
 type externalAuthUpdateDispatchConfigIssuer struct {
-	URL       string   `json:"url"`
-	Audiences []string `json:"audiences"`
-	CA        string   `json:"ca"`
+	URL       string   `json:"url,omitempty"`
+	Audiences []string `json:"audiences,omitempty"`
+	CA        string   `json:"ca,omitempty"`
 }
 
 // externalAuthUpdateDispatchConfigClient is the curated client subset used for dispatch hash and
@@ -128,54 +128,54 @@ type externalAuthUpdateDispatchConfigIssuer struct {
 // through convertExternalAuthClientTypeCSToRP and convertExternalAuthClientTypeRPToCS because CS
 // uses lowercase values ("public", "confidential") while RP uses PascalCase ("Public", "Confidential").
 type externalAuthUpdateDispatchConfigClient struct {
-	ComponentName      string                             `json:"componentName"`
-	ComponentNamespace string                             `json:"componentNamespace"`
-	ClientID           string                             `json:"clientId"`
-	ExtraScopes        []string                           `json:"extraScopes"`
-	Type               metadataapi.ExternalAuthClientType `json:"type"`
+	ComponentName      string                             `json:"componentName,omitempty"`
+	ComponentNamespace string                             `json:"componentNamespace,omitempty"`
+	ClientID           string                             `json:"clientId,omitempty"`
+	ExtraScopes        []string                           `json:"extraScopes,omitempty"`
+	Type               metadataapi.ExternalAuthClientType `json:"type,omitempty"`
 }
 
 // externalAuthUpdateDispatchConfigClaim is the curated claim subset used for dispatch hash and
 // sync. See externalAuthUpdateDispatchConfig: do not embed coreapi.ExternalAuthClaimProfile.
 type externalAuthUpdateDispatchConfigClaim struct {
-	Mappings        externalAuthUpdateDispatchConfigClaimMappings    `json:"mappings"`
-	ValidationRules []externalAuthUpdateDispatchConfigValidationRule `json:"validationRules"`
+	Mappings        externalAuthUpdateDispatchConfigClaimMappings    `json:"mappings,omitempty"`
+	ValidationRules []externalAuthUpdateDispatchConfigValidationRule `json:"validationRules,omitempty"`
 }
 
 // externalAuthUpdateDispatchConfigClaimMappings is the curated claim mappings subset used for
 // dispatch hash and sync. See externalAuthUpdateDispatchConfig: do not embed coreapi.TokenClaimMappingsProfile.
 type externalAuthUpdateDispatchConfigClaimMappings struct {
-	Username externalAuthUpdateDispatchConfigUsernameClaim `json:"username"`
-	Groups   *externalAuthUpdateDispatchConfigGroupsClaim  `json:"groups"`
+	Username externalAuthUpdateDispatchConfigUsernameClaim `json:"username,omitempty"`
+	Groups   *externalAuthUpdateDispatchConfigGroupsClaim  `json:"groups,omitempty"`
 }
 
 // externalAuthUpdateDispatchConfigUsernameClaim is the curated username claim subset used for
 // dispatch hash and sync. See externalAuthUpdateDispatchConfig: do not embed coreapi.UsernameClaimProfile.
 type externalAuthUpdateDispatchConfigUsernameClaim struct {
-	Claim        string                                `json:"claim"`
-	Prefix       string                                `json:"prefix"`
-	PrefixPolicy metadataapi.UsernameClaimPrefixPolicy `json:"prefixPolicy"`
+	Claim        string                                `json:"claim,omitempty"`
+	Prefix       string                                `json:"prefix,omitempty"`
+	PrefixPolicy metadataapi.UsernameClaimPrefixPolicy `json:"prefixPolicy,omitempty"`
 }
 
 // externalAuthUpdateDispatchConfigGroupsClaim is the curated groups claim subset used for dispatch
 // hash and sync. See externalAuthUpdateDispatchConfig: do not embed coreapi.GroupClaimProfile.
 type externalAuthUpdateDispatchConfigGroupsClaim struct {
-	Claim  string `json:"claim"`
-	Prefix string `json:"prefix"`
+	Claim  string `json:"claim,omitempty"`
+	Prefix string `json:"prefix,omitempty"`
 }
 
 // externalAuthUpdateDispatchConfigValidationRule is the curated validation rule subset used for
 // dispatch hash and sync. See externalAuthUpdateDispatchConfig: do not embed coreapi.TokenClaimValidationRule.
 type externalAuthUpdateDispatchConfigValidationRule struct {
-	Type          metadataapi.TokenValidationRuleType           `json:"type"`
-	RequiredClaim externalAuthUpdateDispatchConfigRequiredClaim `json:"requiredClaim"`
+	Type          metadataapi.TokenValidationRuleType           `json:"type,omitempty"`
+	RequiredClaim externalAuthUpdateDispatchConfigRequiredClaim `json:"requiredClaim,omitempty"`
 }
 
 // externalAuthUpdateDispatchConfigRequiredClaim is the curated required-claim subset used for
 // dispatch hash and sync. See externalAuthUpdateDispatchConfig: do not embed coreapi.TokenRequiredClaim.
 type externalAuthUpdateDispatchConfigRequiredClaim struct {
-	Claim         string `json:"claim"`
-	RequiredValue string `json:"requiredValue"`
+	Claim         string `json:"claim,omitempty"`
+	RequiredValue string `json:"requiredValue,omitempty"`
 }
 
 // ExternalAuthUpdateDispatchConfigJSONFromRP returns the canonical JSON of the dispatch config

--- a/internal/ocm/external_auth_update_dispatch_config_test.go
+++ b/internal/ocm/external_auth_update_dispatch_config_test.go
@@ -620,6 +620,67 @@ func TestExternalAuthUpdateDispatchConfigApplyToCSBuilder(t *testing.T) {
 	}
 }
 
+// TestExternalAuthUpdateDispatchConfigExtraScopesEmptyRPMatchesAbsentCS is a regression test for
+// ARO-28899: Cluster Service omits a client's `extra_scopes` field entirely when the client has no
+// extra scopes, while RP's ARM-to-internal conversion always produces a non-nil (possibly empty)
+// slice. Before ExtraScopes had `omitempty`, canonical JSON rendered `"extraScopes":[]` on the RP
+// side but `"extraScopes":null` on the CS side, so the two never compared equal and the external
+// auth update operation stayed in Updating forever even though nothing had actually drifted.
+func TestExternalAuthUpdateDispatchConfigExtraScopesEmptyRPMatchesAbsentCS(t *testing.T) {
+	ea := newTestExternalAuth()
+	ea.Properties.Clients[0].ExtraScopes = []string{}
+
+	desiredConfig, err := externalAuthUpdateDispatchConfigFromRP(ea)
+	require.NoError(t, err)
+	require.NotNil(t, desiredConfig.Clients[0].ExtraScopes, "test setup: RP side must produce a non-nil empty slice to reproduce the bug")
+	require.Empty(t, desiredConfig.Clients[0].ExtraScopes)
+
+	csExternalAuth, err := arohcpv1alpha1.NewExternalAuth().
+		Issuer(arohcpv1alpha1.NewTokenIssuer().
+			URL(ea.Properties.Issuer.URL).
+			CA(ea.Properties.Issuer.CA).
+			Audiences(ea.Properties.Issuer.Audiences...)).
+		Clients(
+			arohcpv1alpha1.NewExternalAuthClientConfig().
+				ID(ea.Properties.Clients[0].ClientID).
+				Component(arohcpv1alpha1.NewClientComponent().
+					Name(ea.Properties.Clients[0].Component.Name).
+					Namespace(ea.Properties.Clients[0].Component.AuthClientNamespace)).
+				// Intentionally not calling ExtraScopes(...): reproduces Cluster Service
+				// omitting the field for a client with no extra scopes.
+				Type(arohcpv1alpha1.ExternalAuthClientTypePublic),
+		).
+		Claim(arohcpv1alpha1.NewExternalAuthClaim().
+			Mappings(arohcpv1alpha1.NewTokenClaimMappings().
+				UserName(arohcpv1alpha1.NewUsernameClaim().
+					Claim(ea.Properties.Claim.Mappings.Username.Claim).
+					PrefixPolicy("NoPrefix")).
+				Groups(arohcpv1alpha1.NewGroupsClaim().
+					Claim(ea.Properties.Claim.Mappings.Groups.Claim).
+					Prefix(ea.Properties.Claim.Mappings.Groups.Prefix))).
+			ValidationRules(
+				arohcpv1alpha1.NewTokenClaimValidationRule().
+					Claim(ea.Properties.Claim.ValidationRules[0].RequiredClaim.Claim).
+					RequiredValue(ea.Properties.Claim.ValidationRules[0].RequiredClaim.RequiredValue),
+			)).
+		Build()
+	require.NoError(t, err)
+
+	actualConfig, err := externalAuthUpdateDispatchConfigFromCS(csExternalAuth)
+	require.NoError(t, err)
+	require.Nil(t, actualConfig.Clients[0].ExtraScopes, "test setup: CS side must leave extraScopes unset to reproduce the bug")
+
+	desiredHash, err := desiredConfig.hash()
+	require.NoError(t, err)
+	actualHash, err := actualConfig.hash()
+	require.NoError(t, err)
+	assert.Equal(t, desiredHash, actualHash, "an empty extraScopes on the RP side must be considered equal to an absent extraScopes on the CS side")
+
+	desiredJSON, err := desiredConfig.canonicalJSON()
+	require.NoError(t, err)
+	assert.NotContains(t, string(desiredJSON), "extraScopes", "empty extraScopes should be omitted from canonical JSON rather than rendered as null or []")
+}
+
 func TestConvertExternalAuthClientTypeRPToCSAndCSToRP(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Link to Jira issue -->
https://redhat.atlassian.net/browse/ARO-28899

### What

Added `omitempty` to every json tag on externalAuthUpdateDispatchConfig and nested structs to align with cluster/node pool dispatch configs.

### Why

The external auth update dispatch config compares RP desired state vs. CS actual state using canonical JSON string equality. CS intentionally omits empty optional arrays (e.g. extra_scopes) on GET; RP was comparing that to a non-nil empty slice as "extraScopes":[] vs "extraScopes":null, causing perpetual false drift and external auth update operations stuck in Updating.

This matches existing cluster/nodepool dispatch config patterns, does not affect ARM/Cosmos/CS PATCH behavior, and does not remove any nil-vs-empty distinction that RP actually uses today.

The GET omission of empty optional arrays has been present since ExternalAuth was introduced and is not a regression in CS. The behavior is also present with the `audiences` field; however, that will not encounter the same bug because it is required to be populated.

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
