### PR TITLE
fix: handle 409 DeploymentActive race in parallel ARM deployments

### DIFF
--- a/tooling/templatize/pkg/pipeline/arm.go
+++ b/tooling/templatize/pkg/pipeline/arm.go
@@ -226,6 +226,21 @@ func doWaitForDeployment(ctx context.Context, bicepClient *bicep.LSPClient, clie
 		// Hardcode until schema is adapted
 		deployment.Location = to.Ptr("eastus2")
 		poller, err := client.BeginCreateOrUpdateAtSubscriptionScope(ctx, deploymentName, deployment, nil)
+		// The deployment name is a content hash of the inputs — a 409 DeploymentActive means
+		// an identical deployment is already running (e.g. a sibling service group racing us).
+		// Safe to wait for it and reuse the output.
+		if isDeploymentActiveError(err) {
+			logger.V(1).Info("Deployment already active, waiting for it to complete", "deployment", deploymentName)
+			var exists bool
+			exists, output, details, err = pollAndGetOutputFromExistingDeployment(ctx, client, getOperationsClient, subscriptionID, timeoutSeconds, step.DeploymentLevel, rgName, deploymentName)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to poll concurrent deployment: %w", err)
+			}
+			if !exists {
+				return nil, nil, fmt.Errorf("concurrent deployment %q not found after 409 DeploymentActive", deploymentName)
+			}
+			return output, details, commit(output)
+		}
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create deployment: %w", err)
 		}
@@ -235,6 +250,21 @@ func doWaitForDeployment(ctx context.Context, bicepClient *bicep.LSPClient, clie
 	} else {
 		details = DetermineOperationsForResourceGroupDeployment(getOperationsClient, subscriptionID, rgName, deploymentName)
 		poller, err := client.BeginCreateOrUpdate(ctx, rgName, deploymentName, deployment, nil)
+		// The deployment name is a content hash of the inputs — a 409 DeploymentActive means
+		// an identical deployment is already running (e.g. a sibling service group racing us).
+		// Safe to wait for it and reuse the output.
+		if isDeploymentActiveError(err) {
+			logger.V(1).Info("Deployment already active, waiting for it to complete", "deployment", deploymentName)
+			var exists bool
+			exists, output, details, err = pollAndGetOutputFromExistingDeployment(ctx, client, getOperationsClient, subscriptionID, timeoutSeconds, step.DeploymentLevel, rgName, deploymentName)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to poll concurrent deployment: %w", err)
+			}
+			if !exists {
+				return nil, nil, fmt.Errorf("concurrent deployment %q not found after 409 DeploymentActive", deploymentName)
+			}
+			return output, details, commit(output)
+		}
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create deployment: %w", err)
 		}
@@ -309,6 +339,13 @@ func pollAndGetOutputFromExistingDeployment(ctx context.Context, client *armreso
 		output, err = get(ctx)
 	}
 	return false, nil, nil, errors.New("timed out waiting for pre-existing deployment to finish")
+}
+
+func isDeploymentActiveError(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) &&
+		respErr.StatusCode == http.StatusConflict &&
+		strings.EqualFold(respErr.ErrorCode, "DeploymentActive")
 }
 
 type deploymentInputs struct {

--- a/tooling/templatize/pkg/pipeline/arm_test.go
+++ b/tooling/templatize/pkg/pipeline/arm_test.go
@@ -15,12 +15,63 @@
 package pipeline
 
 import (
+	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 )
+
+func TestIsDeploymentActiveError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "unrelated error",
+			err:      errors.New("something else"),
+			expected: false,
+		},
+		{
+			name: "409 DeploymentActive",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusConflict,
+				ErrorCode:  "DeploymentActive",
+			},
+			expected: true,
+		},
+		{
+			name: "409 different error code",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusConflict,
+				ErrorCode:  "SomethingElse",
+			},
+			expected: false,
+		},
+		{
+			name: "404 DeploymentNotFound",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusNotFound,
+				ErrorCode:  "DeploymentNotFound",
+			},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isDeploymentActiveError(tt.err))
+		})
+	}
+}
 
 func TestComputeResourceGroupTags(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Sibling service groups (`Fleet.Registration` and `Velero`) both deploy `output-mgmt.bicep` to the same stamped management resource group. The deployment name is a SHA-256 content hash of the inputs, so both produce the same name and race to create it. The loser gets `409 DeploymentActive`.

Fix: detect the 409 and fall back to polling the existing deployment. Same hash = same inputs = safe to reuse output.

Example failure: [e2e-parallel #6588](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/6588/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2089884673239945216)

```
time=2026-08-19T01:54:28.068Z level=ERROR msg="Step errored."
  serviceGroup=Microsoft.Azure.ARO.HCP.Fleet.Registration resourceGroup=management step=output stamp=1
  err="stamp 1: failed to run ARM step: failed to create deployment: ... RESPONSE 409: 409 Conflict ERROR CODE: DeploymentActive"
```

Ref: [ARO-29172](https://issues.redhat.com/browse/ARO-29172)

## Test plan

- [ ] Existing pipeline tests pass
- [ ] `TestIsDeploymentActiveError` covers error classification
- [ ] e2e-parallel no longer flakes on DeploymentActive race