### PR TITLE
fix: filter E2E GPU SKU selection against RP allowlist

### DIFF
--- a/internal/validation/enabled_nodepool_vm_sizes.go
+++ b/internal/validation/enabled_nodepool_vm_sizes.go
@@ -16,14 +16,14 @@ package validation
 
 import "k8s.io/apimachinery/pkg/util/sets"
 
-// enabledNodePoolAzureVMSizes returns the set of VM sizes that are enabled in the ARO-HCP service for node pools.
+// EnabledNodePoolAzureVMSizes returns the set of VM sizes that are enabled in the ARO-HCP service for node pools.
 // It is a superset of the list of VM sizes that are supported across all Azure regions that the ARO-HCP service is
 // available in. This means that it is not a perfect check, but it is a good enough to detect many cases.
 // TODO at some point we might want to fully remove this restriction and allow any VM size at this level, so we can
 // automatically support all VM Sizes out of the box. For now we restrict it to the set here.
 // For now this list is also maintained on Cluster Service config files, but we will remove it from there in the
 // near future.
-func enabledNodePoolAzureVMSizes() sets.Set[string] {
+func EnabledNodePoolAzureVMSizes() sets.Set[string] {
 	return sets.New[string](
 		"Standard_D128s_v6",
 		"Standard_D16as_v4",

--- a/internal/validation/validate_nodepools.go
+++ b/internal/validation/validate_nodepools.go
@@ -308,7 +308,7 @@ func validateNodePoolPlatformProfile(ctx context.Context, op operation.Operation
 	//VMSize                 string        `json:"vmSize,omitempty"`
 	errs = append(errs, immutableByCompare(ctx, op, fldPath.Child("vmSize"), &newObj.VMSize, safe.Field(oldObj, toNodePoolPlatformProfileVMSize))...)
 	errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("vmSize"), &newObj.VMSize, safe.Field(oldObj, toNodePoolPlatformProfileVMSize))...)
-	errs = append(errs, validate.Enum(ctx, op, fldPath.Child("vmSize"), &newObj.VMSize, safe.Field(oldObj, toNodePoolPlatformProfileVMSize), enabledNodePoolAzureVMSizes(), nil)...)
+	errs = append(errs, validate.Enum(ctx, op, fldPath.Child("vmSize"), &newObj.VMSize, safe.Field(oldObj, toNodePoolPlatformProfileVMSize), EnabledNodePoolAzureVMSizes(), nil)...)
 
 	//EnableEncryptionAtHost bool          `json:"enableEncryptionAtHost"`
 	errs = append(errs, immutableByCompare(ctx, op, fldPath.Child("enableEncryptionAtHost"), &newObj.EnableEncryptionAtHost, safe.Field(oldObj, toNodePoolPlatformProfileEnableEncryptionAtHost))...)

--- a/test/util/framework/vm_sku_selection.go
+++ b/test/util/framework/vm_sku_selection.go
@@ -28,6 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+
+	"github.com/Azure/ARO-HCP/internal/validation"
 )
 
 // ErrNoUsableVMSize is returned by SelectVMSize when no VM size in the target
@@ -90,6 +92,11 @@ type VMSizeSelector struct {
 	// EphemeralOSDiskSupported capability ("True"). SKUs without local/cache
 	// storage (e.g. Dsv5) do not support ephemeral OS disks and are excluded.
 	RequireEphemeralOSDisk bool
+	// IgnoreRPAllowlist, when true, skips filtering candidates against the
+	// ARO-HCP RP's node pool VM size allowlist. Use for selectors that create
+	// VMs directly via Azure Compute (e.g. jumpbox) rather than through the
+	// ARO-HCP RP.
+	IgnoreRPAllowlist bool
 }
 
 // SelectVMSize queries the Azure Resource SKUs API for the test location and
@@ -129,11 +136,16 @@ type vmSizeSelectionTrace struct {
 	// viaFallback is true when selection used the deterministic fallback rather
 	// than a preferred candidate.
 	viaFallback bool
+	// filteredByRPAllowlist counts SKUs that passed Azure-side checks but were
+	// excluded by the RP allowlist. Helps distinguish Azure restriction issues
+	// from allowlist gaps when debugging CI failures.
+	filteredByRPAllowlist int
 }
 
 type vmSizePreferredAttempt struct {
-	name   string
-	usable bool
+	name             string
+	usable           bool
+	notInRPAllowlist bool
 }
 
 // logVMSizeSelection writes a human-readable decision trace to the Ginkgo
@@ -141,11 +153,17 @@ type vmSizePreferredAttempt struct {
 func logVMSizeSelection(selector VMSizeSelector, location string, trace vmSizeSelectionTrace, selErr error) {
 	fmt.Fprintf(ginkgo.GinkgoWriter, "VM size selection for selector %q in %s:\n", selector.Name, location)
 	for _, attempt := range trace.preferredAttempts {
-		if attempt.usable {
+		switch {
+		case attempt.usable:
 			fmt.Fprintf(ginkgo.GinkgoWriter, "  preferred candidate %q: available/usable\n", attempt.name)
-		} else {
+		case attempt.notInRPAllowlist:
+			fmt.Fprintf(ginkgo.GinkgoWriter, "  preferred candidate %q: NOT in RP allowlist (skipping)\n", attempt.name)
+		default:
 			fmt.Fprintf(ginkgo.GinkgoWriter, "  preferred candidate %q: NOT available/usable in this subscription/region (skipping)\n", attempt.name)
 		}
+	}
+	if trace.filteredByRPAllowlist > 0 {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "  %d SKU(s) passed Azure checks but excluded by RP allowlist\n", trace.filteredByRPAllowlist)
 	}
 	switch {
 	case selErr != nil:
@@ -207,9 +225,16 @@ func cloneResourceSKUSlice(skus []*armcompute.ResourceSKU) []*armcompute.Resourc
 	return append([]*armcompute.ResourceSKU(nil), skus...)
 }
 
-// selectVMSize is the pure selection logic over a list of Resource SKUs. It returns
+// selectVMSize is the selection logic over a list of Resource SKUs. It returns
 // the selected SKU together with a trace describing how the decision was reached.
 func selectVMSize(skus []*armcompute.ResourceSKU, location string, selector VMSizeSelector) (string, vmSizeSelectionTrace, error) {
+	var rpAllowlist sets.Set[string]
+	if !selector.IgnoreRPAllowlist {
+		rpAllowlist = validation.EnabledNodePoolAzureVMSizes()
+	}
+
+	var trace vmSizeSelectionTrace
+
 	usable := map[string]struct{}{}
 	for _, sku := range skus {
 		if sku == nil || sku.Name == nil {
@@ -218,16 +243,22 @@ func selectVMSize(skus []*armcompute.ResourceSKU, location string, selector VMSi
 		if !skuUsable(sku, location, selector) {
 			continue
 		}
+		if rpAllowlist != nil && !rpAllowlist.Has(*sku.Name) {
+			trace.filteredByRPAllowlist++
+			continue
+		}
 		usable[*sku.Name] = struct{}{}
 	}
-
-	var trace vmSizeSelectionTrace
 
 	// Preferred entries win when they survive restriction/capability filtering.
 	// Record every attempt (including misses) so the caller can log the path.
 	for _, name := range selector.Preferred {
 		_, ok := usable[name]
-		trace.preferredAttempts = append(trace.preferredAttempts, vmSizePreferredAttempt{name: name, usable: ok})
+		attempt := vmSizePreferredAttempt{name: name, usable: ok}
+		if !ok && rpAllowlist != nil && !rpAllowlist.Has(name) {
+			attempt.notInRPAllowlist = true
+		}
+		trace.preferredAttempts = append(trace.preferredAttempts, attempt)
 	}
 	for _, attempt := range trace.preferredAttempts {
 		if attempt.usable {
@@ -477,10 +508,11 @@ func SmallWorkerVMSizeSelector() VMSizeSelector {
 // low. The [^p] exclusion prevents matching Arm64 variants.
 func JumpboxVMSizeSelector() VMSizeSelector {
 	return VMSizeSelector{
-		Name:        "jumpbox",
-		Preferred:   []string{JumpboxVMSize, "Standard_D2s_v4", "Standard_D2ds_v5", "Standard_D2lds_v6"},
-		NamePattern: regexp.MustCompile(`^Standard_D[2-4][^p]*s_v[3456]$`),
-		MinVCPUs:    2,
+		Name:              "jumpbox",
+		Preferred:         []string{JumpboxVMSize, "Standard_D2s_v4", "Standard_D2ds_v5", "Standard_D2lds_v6"},
+		NamePattern:       regexp.MustCompile(`^Standard_D[2-4][^p]*s_v[3456]$`),
+		MinVCPUs:          2,
+		IgnoreRPAllowlist: true,
 	}
 }
 

--- a/test/util/framework/vm_sku_selection_test.go
+++ b/test/util/framework/vm_sku_selection_test.go
@@ -163,9 +163,10 @@ func TestSelectVMSize(t *testing.T) {
 				makeSKU("Standard_D2s_v3", testLocation, withCapability(capabilityVCPUs, "2")),
 			},
 			selector: VMSizeSelector{
-				Name:        "default-worker",
-				NamePattern: dPattern,
-				MinVCPUs:    8,
+				Name:              "default-worker",
+				NamePattern:       dPattern,
+				MinVCPUs:          8,
+				IgnoreRPAllowlist: true,
 			},
 			wantErr: ErrNoUsableVMSize,
 		},
@@ -259,15 +260,15 @@ func TestSelectVMSize(t *testing.T) {
 			name: "RequireEphemeralOSDisk selects SKU with EphemeralOSDiskSupported=True",
 			skus: []*armcompute.ResourceSKU{
 				makeSKU("Standard_D8s_v5", testLocation, withCapability(capabilityVCPUs, "8")),
-				makeSKU("Standard_D8ds_v5", testLocation, withCapability(capabilityVCPUs, "8"), withCapability(capabilityEphemeralOSDiskSupported, "True")),
+				makeSKU("Standard_D8as_v4", testLocation, withCapability(capabilityVCPUs, "8"), withCapability(capabilityEphemeralOSDiskSupported, "True")),
 			},
 			selector: VMSizeSelector{
 				Name:                   "ephemeral",
-				Preferred:              []string{"Standard_D8s_v5", "Standard_D8ds_v5"},
+				Preferred:              []string{"Standard_D8s_v5", "Standard_D8as_v4"},
 				MinVCPUs:               8,
 				RequireEphemeralOSDisk: true,
 			},
-			want: "Standard_D8ds_v5",
+			want: "Standard_D8as_v4",
 		},
 		{
 			name: "RequireEphemeralOSDisk excludes all SKUs when none support ephemeral",
@@ -286,11 +287,11 @@ func TestSelectVMSize(t *testing.T) {
 			name: "RequireEphemeralOSDisk preferred ordering is preserved",
 			skus: []*armcompute.ResourceSKU{
 				makeSKU("Standard_D8s_v3", testLocation, withCapability(capabilityVCPUs, "8"), withCapability(capabilityEphemeralOSDiskSupported, "True")),
-				makeSKU("Standard_D8ds_v5", testLocation, withCapability(capabilityVCPUs, "8"), withCapability(capabilityEphemeralOSDiskSupported, "True")),
+				makeSKU("Standard_D8as_v4", testLocation, withCapability(capabilityVCPUs, "8"), withCapability(capabilityEphemeralOSDiskSupported, "True")),
 			},
 			selector: VMSizeSelector{
 				Name:                   "ephemeral",
-				Preferred:              []string{"Standard_D8s_v3", "Standard_D8ds_v5"},
+				Preferred:              []string{"Standard_D8s_v3", "Standard_D8as_v4"},
 				RequireEphemeralOSDisk: true,
 			},
 			want: "Standard_D8s_v3",
@@ -337,9 +338,45 @@ func TestSelectVMSize(t *testing.T) {
 				),
 			},
 			selector: VMSizeSelector{
-				Name:      "gpu",
-				Preferred: []string{"Standard_NV12s_v3"},
-				MinVCPUs:  8,
+				Name:              "gpu",
+				Preferred:         []string{"Standard_NV12s_v3"},
+				MinVCPUs:          8,
+				IgnoreRPAllowlist: true,
+			},
+			wantErr: ErrNoUsableVMSize,
+		},
+		{
+			name: "RP allowlist filters non-allowlisted GPU SKUs on fallback",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_NC4as_T4_v3", testLocation, withCapability(capabilityGPUs, "1"), withLocationRestriction(testLocation)),
+				makeSKU("Standard_NC16ads_A10_v4", testLocation, withCapability(capabilityGPUs, "1")),
+				makeSKU("Standard_NC24ads_A100_v4", testLocation, withCapability(capabilityGPUs, "1")),
+			},
+			selector: GPUNodePoolVMSizeSelector(),
+			want:     "Standard_NC24ads_A100_v4",
+		},
+		{
+			name: "IgnoreRPAllowlist lets non-allowlisted preferred through",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_D2ds_v5", testLocation, withCapability(capabilityVCPUs, "2")),
+			},
+			selector: VMSizeSelector{
+				Name:              "jumpbox",
+				Preferred:         []string{"Standard_D2ds_v5"},
+				IgnoreRPAllowlist: true,
+			},
+			want: "Standard_D2ds_v5",
+		},
+		{
+			name: "all SKUs pass Azure checks but none in RP allowlist yields ErrNoUsableVMSize",
+			skus: []*armcompute.ResourceSKU{
+				makeSKU("Standard_NC16ads_A10_v4", testLocation, withCapability(capabilityGPUs, "1")),
+				makeSKU("Standard_NV6ads_A10_v5", testLocation, withCapability(capabilityGPUs, "1")),
+			},
+			selector: VMSizeSelector{
+				Name:        "gpu",
+				NamePattern: regexp.MustCompile(`^Standard_N`),
+				RequireGPU:  true,
 			},
 			wantErr: ErrNoUsableVMSize,
 		},
@@ -521,7 +558,7 @@ func TestEphemeralSelectorSelectsDifferentFamily(t *testing.T) {
 // entirely. Asserting that every Preferred entry also matches its own
 // NamePattern keeps the two lists in sync and prevents a non-allowlisted SKU
 // from being reintroduced via Preferred.
-func TestWorkerSelectorPreferredEntriesAreAllowlisted(t *testing.T) {
+func TestWorkerSelectorPreferredEntriesMatchNamePattern(t *testing.T) {
 	for _, sel := range productionWorkerSelectors() {
 		if sel.NamePattern == nil {
 			t.Fatalf("selector %q has no NamePattern; it is required as the allowlist boundary", sel.Name)


### PR DESCRIPTION
## Summary
- Add RP allowlist filtering to VM SKU selection so non-allowlisted GPU SKUs (e.g. A10) are excluded from both preferred and fallback paths
- Export `EnabledNodePoolAzureVMSizes` for cross-package use by the E2E test framework
- Add `IgnoreRPAllowlist` opt-out for selectors (Jumpbox) that intentionally use non-allowlisted sizes

Fixes the westus3 failure where all T4 preferred entries were restricted and fallback selected Standard_NC16ads_A10_v4, causing 400 InvalidRequestContent after ~16 min of cluster creation.

[ARO-29173](https://issues.redhat.com/browse/ARO-29173)

## Test plan
- [ ] `go test ./test/util/framework/ -count=1` passes
- [ ] New table test cases cover: allowlist filtering on fallback, IgnoreRPAllowlist opt-out, all-filtered-yields-error