### PR TITLE
chore: update maestro image digest

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1064,7 +1064,7 @@ defaults:
     image:
       registry: quay.io
       repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
-      digest: sha256:e2dc5d8fa38b7320b384e46e86b6ce53bacd2432d16081e8a1208b0961abc985 # f634fb1af517d85e59ee6c5d3341de5b4624f34f (2026-08-18 21:17)
+      digest: sha256:46e44a9a9cfbd4e157110a6dcc88abdfd569b49315b4ad5088eb42fb69b45b60 # 36cd08663b9c1542c5d42477fd86589d298f5f2e (2026-08-19 07:33)
   # ACM
   acm:
     operator:

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -594,7 +594,7 @@ maestro:
     name: arohcp-ci00-maestro-j7654321
     private: false
   image:
-    digest: sha256:e2dc5d8fa38b7320b384e46e86b6ce53bacd2432d16081e8a1208b0961abc985
+    digest: sha256:46e44a9a9cfbd4e157110a6dcc88abdfd569b49315b4ad5088eb42fb69b45b60
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -594,7 +594,7 @@ maestro:
     name: arohcp-ci01-maestro-j7654321
     private: false
   image:
-    digest: sha256:e2dc5d8fa38b7320b384e46e86b6ce53bacd2432d16081e8a1208b0961abc985
+    digest: sha256:46e44a9a9cfbd4e157110a6dcc88abdfd569b49315b4ad5088eb42fb69b45b60
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -594,7 +594,7 @@ maestro:
     name: arohcp-cspr-maestro-usw3
     private: false
   image:
-    digest: sha256:e2dc5d8fa38b7320b384e46e86b6ce53bacd2432d16081e8a1208b0961abc985
+    digest: sha256:46e44a9a9cfbd4e157110a6dcc88abdfd569b49315b4ad5088eb42fb69b45b60
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -594,7 +594,7 @@ maestro:
     name: arohcp-dev-maestro-usw3
     private: false
   image:
-    digest: sha256:e2dc5d8fa38b7320b384e46e86b6ce53bacd2432d16081e8a1208b0961abc985
+    digest: sha256:46e44a9a9cfbd4e157110a6dcc88abdfd569b49315b4ad5088eb42fb69b45b60
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -594,7 +594,7 @@ maestro:
     name: arohcp-perf-maestro-usw3ptest
     private: false
   image:
-    digest: sha256:e2dc5d8fa38b7320b384e46e86b6ce53bacd2432d16081e8a1208b0961abc985
+    digest: sha256:46e44a9a9cfbd4e157110a6dcc88abdfd569b49315b4ad5088eb42fb69b45b60
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -594,7 +594,7 @@ maestro:
     name: arohcp-pers-maestro-usw3test
     private: false
   image:
-    digest: sha256:e2dc5d8fa38b7320b384e46e86b6ce53bacd2432d16081e8a1208b0961abc985
+    digest: sha256:46e44a9a9cfbd4e157110a6dcc88abdfd569b49315b4ad5088eb42fb69b45b60
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:


### PR DESCRIPTION
## Summary
- Bump maestro image digest to include the fix from [openshift-online/maestro#576](https://github.com/openshift-online/maestro/pull/576)
- New digest: `sha256:46e44a9a9cfbd4e157110a6dcc88abdfd569b49315b4ad5088eb42fb69b45b60` (commit `36cd08663b9c1542c5d42477fd86589d298f5f2e`, built 2026-08-19 07:33)

## Why
Maestro's soft-delete was silently no-op'ing repeated delete requests for resources already marked as deleting (`resource.go:293-296`), with zero logging. When the OCM SDK's in-memory store hit a race condition ([sdk-go#232](https://github.com/open-cluster-management-io/sdk-go/issues/232)), ManifestWork resources got stuck — the agent never reported `Deleted=true`, and maestro-server never triggered a hard-delete. This caused CS destructor chains to hang indefinitely during cluster cleanup.

The fix ([maestro#576](https://github.com/openshift-online/maestro/pull/576)) re-enqueues delete events for resources stuck in soft-deleted state (throttled with a hard cap), restoring the healing behavior that existed before the soft-delete change.

This was blocking CI (multiple e2e-parallel runs failing) and causing cruft accumulation across environments. Tracked in [ARO-28958](https://redhat.atlassian.net/browse/ARO-28958).