### PR TITLE
feat: add management-cluster-scoped desire support

### DIFF
--- a/backend/pkg/controllers/cluster/operations/operation_cluster_create_test.go
+++ b/backend/pkg/controllers/cluster/operations/operation_cluster_create_test.go
@@ -374,6 +374,9 @@ func (l *errorReadDesireLister) GetForSystemAdminCredentialRequest(_ context.Con
 func (l *errorReadDesireLister) GetForSystemAdminCredentialRevocation(_ context.Context, _, _, _, _, _ string) (*kubeapplierapi.ReadDesire, error) {
 	return nil, l.err
 }
+func (l *errorReadDesireLister) GetForManagementCluster(_ context.Context, _, _ string) (*kubeapplierapi.ReadDesire, error) {
+	return nil, l.err
+}
 func (l *errorReadDesireLister) ListForManagementCluster(_ context.Context, _ *azcorearm.ResourceID) ([]*kubeapplierapi.ReadDesire, error) {
 	return nil, l.err
 }

--- a/internal/api/kubeapplierapi/registry.go
+++ b/internal/api/kubeapplierapi/registry.go
@@ -20,6 +20,7 @@ import (
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/fleetapi"
 )
 
 const (
@@ -54,6 +55,11 @@ var (
 	SystemAdminCredentialRevocationScopedApplyDesireResourceType = nestedResourceType(coreapi.ClusterResourceTypeName, coreapi.SystemAdminCredentialRevocationResourceTypeName, ApplyDesireResourceTypeName)
 	// SystemAdminCredentialRevocationScopedReadDesireResourceType is readDesires nested under a SystemAdminCredentialRevocation under a Cluster.
 	SystemAdminCredentialRevocationScopedReadDesireResourceType = nestedResourceType(coreapi.ClusterResourceTypeName, coreapi.SystemAdminCredentialRevocationResourceTypeName, ReadDesireResourceTypeName)
+
+	// ManagementClusterScopedApplyDesireResourceType is applyDesires nested under a ManagementCluster under a Stamp.
+	ManagementClusterScopedApplyDesireResourceType = nestedResourceType(fleetapi.StampResourceTypeName, fleetapi.ManagementClusterResourceTypeName, ApplyDesireResourceTypeName)
+	// ManagementClusterScopedReadDesireResourceType is readDesires nested under a ManagementCluster under a Stamp.
+	ManagementClusterScopedReadDesireResourceType = nestedResourceType(fleetapi.StampResourceTypeName, fleetapi.ManagementClusterResourceTypeName, ReadDesireResourceTypeName)
 )
 
 // ApplyDesireResourceTypeForParent derives the nested ApplyDesire resource type for

--- a/internal/api/kubeapplierapi/types_cosmosdata.go
+++ b/internal/api/kubeapplierapi/types_cosmosdata.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/fleetapi"
 )
 
 // ToClusterScopedApplyDesireResourceIDString returns the resource ID string for an ApplyDesire
@@ -119,6 +120,24 @@ func ToSystemAdminCredentialRevocationScopedReadDesireResourceIDString(subscript
 		"resourceGroups", resourceGroupName,
 		"providers", coreapi.ClusterResourceType.String(), clusterName,
 		coreapi.SystemAdminCredentialRevocationResourceTypeName, revocationName,
+		ReadDesireResourceTypeName, readDesireName,
+	))
+}
+
+// ToManagementClusterScopedApplyDesireResourceIDString returns the resource ID string for an ApplyDesire
+// nested under a ManagementCluster under a Stamp.
+func ToManagementClusterScopedApplyDesireResourceIDString(stampIdentifier, applyDesireName string) string {
+	return strings.ToLower(path.Join(
+		fleetapi.ToManagementClusterResourceIDString(stampIdentifier),
+		ApplyDesireResourceTypeName, applyDesireName,
+	))
+}
+
+// ToManagementClusterScopedReadDesireResourceIDString returns the resource ID string for a ReadDesire
+// nested under a ManagementCluster under a Stamp.
+func ToManagementClusterScopedReadDesireResourceIDString(stampIdentifier, readDesireName string) string {
+	return strings.ToLower(path.Join(
+		fleetapi.ToManagementClusterResourceIDString(stampIdentifier),
 		ReadDesireResourceTypeName, readDesireName,
 	))
 }

--- a/internal/api/kubeapplierapi/types_cosmosdata_test.go
+++ b/internal/api/kubeapplierapi/types_cosmosdata_test.go
@@ -21,11 +21,12 @@ import (
 )
 
 const (
-	testIDPrefix                  = "/subscriptions/00000000-0000-0000-0000-000000000001/resourcegroups/myrg"
-	testClusterIDPrefix           = testIDPrefix + "/providers/microsoft.redhatopenshift/hcpopenshiftclusters/mycluster"
-	testNodePoolIDPrefix          = testClusterIDPrefix + "/nodepools/mynodepool"
-	testCredentialRequestIDPrefix = testClusterIDPrefix + "/systemadmincredentialrequests/mycred"
-	testRevocationIDPrefix        = testClusterIDPrefix + "/systemadmincredentialrevocations/myrevocation"
+	testIDPrefix                        = "/subscriptions/00000000-0000-0000-0000-000000000001/resourcegroups/myrg"
+	testClusterIDPrefix                 = testIDPrefix + "/providers/microsoft.redhatopenshift/hcpopenshiftclusters/mycluster"
+	testNodePoolIDPrefix                = testClusterIDPrefix + "/nodepools/mynodepool"
+	testCredentialRequestIDPrefix       = testClusterIDPrefix + "/systemadmincredentialrequests/mycred"
+	testRevocationIDPrefix              = testClusterIDPrefix + "/systemadmincredentialrevocations/myrevocation"
+	testManagementClusterDesireIDPrefix = "/providers/microsoft.redhatopenshift/stamps/mystamp/managementclusters/default"
 )
 
 func TestResourceIDStrings(t *testing.T) {
@@ -36,6 +37,7 @@ func TestResourceIDStrings(t *testing.T) {
 		np         = "myNodePool"
 		cred       = "myCred"
 		revocation = "myRevocation"
+		stamp      = "myStamp"
 		name       = "myDesire"
 	)
 	tests := []struct {
@@ -83,6 +85,16 @@ func TestResourceIDStrings(t *testing.T) {
 			got:  ToSystemAdminCredentialRevocationScopedReadDesireResourceIDString(sub, rg, cluster, revocation, name),
 			want: testRevocationIDPrefix + "/readdesires/mydesire",
 		},
+		{
+			name: "ApplyDesire under management cluster",
+			got:  ToManagementClusterScopedApplyDesireResourceIDString(stamp, name),
+			want: testManagementClusterDesireIDPrefix + "/applydesires/mydesire",
+		},
+		{
+			name: "ReadDesire under management cluster",
+			got:  ToManagementClusterScopedReadDesireResourceIDString(stamp, name),
+			want: testManagementClusterDesireIDPrefix + "/readdesires/mydesire",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -104,6 +116,7 @@ func TestResourceIDsParseToExpectedTypes(t *testing.T) {
 		np         = "myNodePool"
 		cred       = "myCred"
 		revocation = "myRevocation"
+		stamp      = "myStamp"
 		name       = "myDesire"
 	)
 	cases := []struct {
@@ -150,6 +163,16 @@ func TestResourceIDsParseToExpectedTypes(t *testing.T) {
 			name:     "revocation-scoped ReadDesire",
 			idStr:    ToSystemAdminCredentialRevocationScopedReadDesireResourceIDString(sub, rg, cluster, revocation, name),
 			wantType: SystemAdminCredentialRevocationScopedReadDesireResourceType.String(),
+		},
+		{
+			name:     "management-cluster-scoped ApplyDesire",
+			idStr:    ToManagementClusterScopedApplyDesireResourceIDString(stamp, name),
+			wantType: ManagementClusterScopedApplyDesireResourceType.String(),
+		},
+		{
+			name:     "management-cluster-scoped ReadDesire",
+			idStr:    ToManagementClusterScopedReadDesireResourceIDString(stamp, name),
+			wantType: ManagementClusterScopedReadDesireResourceType.String(),
 		},
 	}
 	for _, tc := range cases {

--- a/internal/database/cosmosstorage/kubeappliercosmosstorage/desire_scope.go
+++ b/internal/database/cosmosstorage/kubeappliercosmosstorage/desire_scope.go
@@ -21,6 +21,7 @@ import (
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/fleetapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
 	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
 )
@@ -34,6 +35,9 @@ const (
 	// ClusterAncestry is subscription-rooted (…/hcpOpenShiftClusters/…).
 	// Built with ClusterNestedResourceIDBuilder.
 	ClusterAncestry Ancestry = "cluster"
+	// StampAncestry is provider-rooted (/providers/…/stamps/…/managementClusters/…).
+	// Built with FleetResourceIDBuilder.
+	StampAncestry Ancestry = "stamp"
 )
 
 // DesireScope is a validated parent resource that scopes a set of desires. Its
@@ -55,6 +59,8 @@ func (s DesireScope) ResourceIDBuilder() cosmosstorageutils.ResourceIDBuilder {
 	switch s.ancestry {
 	case ClusterAncestry:
 		return cosmosstorageutils.ClusterNestedResourceIDBuilder{}
+	case StampAncestry:
+		return cosmosstorageutils.FleetResourceIDBuilder{}
 	default:
 		panic(fmt.Errorf("coding error: unknown kube-applier ancestry %q", s.ancestry))
 	}
@@ -96,6 +102,15 @@ func CredentialRevocationScope(subscriptionID, resourceGroupName, clusterName, r
 	return ParseDesireScope(id)
 }
 
+// ManagementClusterScope returns a DesireScope for a management cluster parent.
+func ManagementClusterScope(stampIdentifier string) (DesireScope, error) {
+	id, err := fleetapi.ToManagementClusterResourceID(stampIdentifier)
+	if err != nil {
+		return DesireScope{}, err
+	}
+	return ParseDesireScope(id)
+}
+
 // ParseDesireScope categorizes a raw parent resource ID into a DesireScope,
 // rejecting any resource type that is not allowed to scope desires. The
 // kube-applier controllers pass their generic key's parent through here, so an
@@ -121,6 +136,8 @@ func ancestryForParentType(rt azcorearm.ResourceType) (Ancestry, bool) {
 		armhelpers.ResourceTypeEqual(rt, coreapi.SystemAdminCredentialRequestResourceType),
 		armhelpers.ResourceTypeEqual(rt, coreapi.SystemAdminCredentialRevocationResourceType):
 		return ClusterAncestry, true
+	case armhelpers.ResourceTypeEqual(rt, fleetapi.ManagementClusterResourceType):
+		return StampAncestry, true
 	default:
 		return "", false
 	}

--- a/internal/database/cosmosstorage/kubeappliercosmosstorage/desire_scope_test.go
+++ b/internal/database/cosmosstorage/kubeappliercosmosstorage/desire_scope_test.go
@@ -23,6 +23,7 @@ import (
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/fleetapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
 	"github.com/Azure/ARO-HCP/internal/utils/armhelpers"
 )
@@ -66,6 +67,12 @@ func TestParseDesireScope(t *testing.T) {
 			id:              mustParseResourceID("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster/systemAdminCredentialRevocations/rev"),
 			wantAncestry:    ClusterAncestry,
 			wantBuilderType: cosmosstorageutils.ClusterNestedResourceIDBuilder{},
+		},
+		{
+			name:            "management cluster parent",
+			id:              mustParseResourceID("/providers/Microsoft.RedHatOpenShift/stamps/eastus/managementClusters/default"),
+			wantAncestry:    StampAncestry,
+			wantBuilderType: cosmosstorageutils.FleetResourceIDBuilder{},
 		},
 		{
 			name:    "nil resource ID",
@@ -132,6 +139,12 @@ func TestDesireScopeConstructors(t *testing.T) {
 			},
 			wantType:     coreapi.SystemAdminCredentialRevocationResourceType,
 			wantAncestry: ClusterAncestry,
+		},
+		{
+			name:         "ManagementClusterScope",
+			constructor:  func() (DesireScope, error) { return ManagementClusterScope("eastus") },
+			wantType:     fleetapi.ManagementClusterResourceType,
+			wantAncestry: StampAncestry,
 		},
 	}
 

--- a/internal/database/cosmosstorage/kubeappliercosmosstorage/kube_applier_client.go
+++ b/internal/database/cosmosstorage/kubeappliercosmosstorage/kube_applier_client.go
@@ -93,6 +93,10 @@ type KubeApplierDBClient interface {
 	ReadDesiresForSystemAdminCredentialRequest(subscriptionID, resourceGroupName, clusterName, credentialRequestName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error)
 	// ReadDesiresForSystemAdminCredentialRevocation returns a CRUD scoped to a SystemAdminCredentialRevocation parent.
 	ReadDesiresForSystemAdminCredentialRevocation(subscriptionID, resourceGroupName, clusterName, revocationName string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error)
+	// ApplyDesiresForManagementCluster returns a CRUD scoped to a management cluster parent.
+	ApplyDesiresForManagementCluster(stampIdentifier string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error)
+	// ReadDesiresForManagementCluster returns a CRUD scoped to a management cluster parent.
+	ReadDesiresForManagementCluster(stampIdentifier string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error)
 
 	// ApplyDesiresFor returns an ApplyDesire CRUD scoped to the given parent.
 	ApplyDesiresFor(parent DesireScope) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error)
@@ -229,6 +233,22 @@ func (c *kubeApplierCosmosDBClient) ReadDesiresForSystemAdminCredentialRevocatio
 	return c.ReadDesiresFor(parent)
 }
 
+func (c *kubeApplierCosmosDBClient) ApplyDesiresForManagementCluster(stampIdentifier string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
+	parent, err := ManagementClusterScope(stampIdentifier)
+	if err != nil {
+		return nil, err
+	}
+	return c.ApplyDesiresFor(parent)
+}
+
+func (c *kubeApplierCosmosDBClient) ReadDesiresForManagementCluster(stampIdentifier string) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error) {
+	parent, err := ManagementClusterScope(stampIdentifier)
+	if err != nil {
+		return nil, err
+	}
+	return c.ReadDesiresFor(parent)
+}
+
 // ApplyDesiresFor returns an ApplyDesire CRUD scoped to the given parent.
 func (c *kubeApplierCosmosDBClient) ApplyDesiresFor(parent DesireScope) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
 	if parent.resourceID == nil {
@@ -293,6 +313,7 @@ func (g *cosmosKubeApplierListers) ApplyDesires() cosmosstorageutils.GlobalListe
 			kubeapplierapi.NodePoolScopedApplyDesireResourceType,
 			kubeapplierapi.SystemAdminCredentialRequestScopedApplyDesireResourceType,
 			kubeapplierapi.SystemAdminCredentialRevocationScopedApplyDesireResourceType,
+			kubeapplierapi.ManagementClusterScopedApplyDesireResourceType,
 		},
 	}
 }
@@ -305,6 +326,7 @@ func (g *cosmosKubeApplierListers) ReadDesires() cosmosstorageutils.GlobalLister
 			kubeapplierapi.NodePoolScopedReadDesireResourceType,
 			kubeapplierapi.SystemAdminCredentialRequestScopedReadDesireResourceType,
 			kubeapplierapi.SystemAdminCredentialRevocationScopedReadDesireResourceType,
+			kubeapplierapi.ManagementClusterScopedReadDesireResourceType,
 		},
 	}
 }

--- a/internal/database/cosmosstoragetesting/kubeappliercosmosstoragetesting/mock_kube_applier_client.go
+++ b/internal/database/cosmosstoragetesting/kubeappliercosmosstoragetesting/mock_kube_applier_client.go
@@ -217,14 +217,34 @@ func (m *MockKubeApplierDBClient) ReadDesiresForSystemAdminCredentialRevocation(
 	return m.ReadDesiresFor(parent)
 }
 
+func (m *MockKubeApplierDBClient) ApplyDesiresForManagementCluster(
+	stampIdentifier string,
+) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
+	parent, err := kubeappliercosmosstorage.ManagementClusterScope(stampIdentifier)
+	if err != nil {
+		return nil, err
+	}
+	return m.ApplyDesiresFor(parent)
+}
+
+func (m *MockKubeApplierDBClient) ReadDesiresForManagementCluster(
+	stampIdentifier string,
+) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error) {
+	parent, err := kubeappliercosmosstorage.ManagementClusterScope(stampIdentifier)
+	if err != nil {
+		return nil, err
+	}
+	return m.ReadDesiresFor(parent)
+}
+
 func (m *MockKubeApplierDBClient) ApplyDesiresFor(
 	parent kubeappliercosmosstorage.DesireScope,
 ) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
 	if parent.ResourceID() == nil {
 		return nil, errors.New("desire scope is not initialized")
 	}
-	return corecosmosstoragetesting.NewMockResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ApplyDesire]](
-		m, parent.ResourceID(), kubeapplierapi.ApplyDesireResourceTypeForParent(parent.ResourceID()),
+	return newMockDesireCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire](
+		m, parent, kubeapplierapi.ApplyDesireResourceTypeForParent(parent.ResourceID()),
 	), nil
 }
 
@@ -234,9 +254,37 @@ func (m *MockKubeApplierDBClient) ReadDesiresFor(
 	if parent.ResourceID() == nil {
 		return nil, errors.New("desire scope is not initialized")
 	}
-	return corecosmosstoragetesting.NewMockResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire, cosmosstorageutils.GenericDocument[kubeapplierapi.ReadDesire]](
-		m, parent.ResourceID(), kubeapplierapi.ReadDesireResourceTypeForParent(parent.ResourceID()),
+	return newMockDesireCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire](
+		m, parent, kubeapplierapi.ReadDesireResourceTypeForParent(parent.ResourceID()),
 	), nil
+}
+
+// newMockDesireCRUD creates a MockResourceCRUD whose path builder delegates to
+// the scope's ResourceIDBuilder — the same builder production uses. This keeps
+// the mock's ID construction in sync with production for every ancestry family
+// (cluster-scoped uses ClusterNestedResourceIDBuilder, stamp-scoped uses
+// FleetResourceIDBuilder) without the mock having to know about ancestry at all.
+func newMockDesireCRUD[T any, PT coreapi.CosmosMetadataAccessorPtr[T]](
+	store corecosmosstoragetesting.MockDocumentStore,
+	parent kubeappliercosmosstorage.DesireScope,
+	resourceType azcorearm.ResourceType,
+) *corecosmosstoragetesting.MockResourceCRUD[T, PT, cosmosstorageutils.GenericDocument[T]] {
+	crud := corecosmosstoragetesting.NewMockResourceCRUD[T, PT, cosmosstorageutils.GenericDocument[T]](
+		store, parent.ResourceID(), resourceType,
+	)
+	builder := parent.ResourceIDBuilder()
+	parentID := parent.ResourceID()
+	crud.MakeResourceIDPath = func(resourceName string) (*azcorearm.ResourceID, error) {
+		return builder.BuildResourceID(parentID, resourceType, resourceName)
+	}
+	crud.GetListPrefix = func() (string, error) {
+		id, err := builder.BuildResourceID(parentID, resourceType, "")
+		if err != nil {
+			return "", err
+		}
+		return id.String() + "/", nil
+	}
+	return crud
 }
 
 func (m *MockKubeApplierDBClient) Listers() kubeappliercosmosstorage.KubeApplierListers {
@@ -276,6 +324,7 @@ func (g *mockKubeApplierListers) ApplyDesires() cosmosstorageutils.GlobalLister[
 			kubeapplierapi.NodePoolScopedApplyDesireResourceType,
 			kubeapplierapi.SystemAdminCredentialRequestScopedApplyDesireResourceType,
 			kubeapplierapi.SystemAdminCredentialRevocationScopedApplyDesireResourceType,
+			kubeapplierapi.ManagementClusterScopedApplyDesireResourceType,
 		},
 	)
 }
@@ -288,6 +337,7 @@ func (g *mockKubeApplierListers) ReadDesires() cosmosstorageutils.GlobalLister[k
 			kubeapplierapi.NodePoolScopedReadDesireResourceType,
 			kubeapplierapi.SystemAdminCredentialRequestScopedReadDesireResourceType,
 			kubeapplierapi.SystemAdminCredentialRevocationScopedReadDesireResourceType,
+			kubeapplierapi.ManagementClusterScopedReadDesireResourceType,
 		},
 	)
 }

--- a/internal/database/informers/kubeapplierinformers/informers.go
+++ b/internal/database/informers/kubeapplierinformers/informers.go
@@ -95,6 +95,7 @@ func NewReadDesireInformerWithRelistDuration(
 			kubeapplierapi.NodePoolScopedReadDesireResourceType,
 			kubeapplierapi.SystemAdminCredentialRequestScopedReadDesireResourceType,
 			kubeapplierapi.SystemAdminCredentialRevocationScopedReadDesireResourceType,
+			kubeapplierapi.ManagementClusterScopedReadDesireResourceType,
 		},
 		utilsclock.RealClock{},
 		lister,

--- a/internal/database/listers/kubeapplierlisters/apply_desire_lister.go
+++ b/internal/database/listers/kubeapplierlisters/apply_desire_lister.go
@@ -47,6 +47,10 @@ type ApplyDesireLister interface {
 	// SystemAdminCredentialRevocation by the revocation's identity and the desire's name.
 	GetForSystemAdminCredentialRevocation(ctx context.Context, subscriptionID, resourceGroupName, clusterName, revocationName, name string) (*kubeapplierapi.ApplyDesire, error)
 
+	// GetForManagementCluster fetches a single management-cluster-scoped ApplyDesire
+	// by its stamp identifier and the desire's name.
+	GetForManagementCluster(ctx context.Context, stampIdentifier, name string) (*kubeapplierapi.ApplyDesire, error)
+
 	// ListForManagementCluster returns every ApplyDesire whose
 	// spec.managementCluster matches (case-insensitively). A nil
 	// managementClusterResourceID returns no results.
@@ -105,6 +109,13 @@ func (l *applyDesireLister) GetForSystemAdminCredentialRevocation(
 	key := kubeapplierapi.ToSystemAdminCredentialRevocationScopedApplyDesireResourceIDString(
 		subscriptionID, resourceGroupName, clusterName, revocationName, name,
 	)
+	return listerutils.GetByKey[kubeapplierapi.ApplyDesire](l.indexer, key)
+}
+
+func (l *applyDesireLister) GetForManagementCluster(
+	ctx context.Context, stampIdentifier, name string,
+) (*kubeapplierapi.ApplyDesire, error) {
+	key := kubeapplierapi.ToManagementClusterScopedApplyDesireResourceIDString(stampIdentifier, name)
 	return listerutils.GetByKey[kubeapplierapi.ApplyDesire](l.indexer, key)
 }
 

--- a/internal/database/listers/kubeapplierlisters/read_desire_lister.go
+++ b/internal/database/listers/kubeapplierlisters/read_desire_lister.go
@@ -33,6 +33,7 @@ type ReadDesireLister interface {
 	GetForNodePool(ctx context.Context, subscriptionID, resourceGroupName, clusterName, nodePoolName, name string) (*kubeapplierapi.ReadDesire, error)
 	GetForSystemAdminCredentialRequest(ctx context.Context, subscriptionID, resourceGroupName, clusterName, credentialRequestName, name string) (*kubeapplierapi.ReadDesire, error)
 	GetForSystemAdminCredentialRevocation(ctx context.Context, subscriptionID, resourceGroupName, clusterName, revocationName, name string) (*kubeapplierapi.ReadDesire, error)
+	GetForManagementCluster(ctx context.Context, stampIdentifier, name string) (*kubeapplierapi.ReadDesire, error)
 	ListForManagementCluster(ctx context.Context, managementClusterResourceID *azcorearm.ResourceID) ([]*kubeapplierapi.ReadDesire, error)
 	ListForCluster(ctx context.Context, subscriptionID, resourceGroupName, clusterName string) ([]*kubeapplierapi.ReadDesire, error)
 	ListForNodePool(ctx context.Context, subscriptionID, resourceGroupName, clusterName, nodePoolName string) ([]*kubeapplierapi.ReadDesire, error)
@@ -82,6 +83,13 @@ func (l *readDesireLister) GetForSystemAdminCredentialRevocation(
 	key := kubeapplierapi.ToSystemAdminCredentialRevocationScopedReadDesireResourceIDString(
 		subscriptionID, resourceGroupName, clusterName, revocationName, name,
 	)
+	return listerutils.GetByKey[kubeapplierapi.ReadDesire](l.indexer, key)
+}
+
+func (l *readDesireLister) GetForManagementCluster(
+	ctx context.Context, stampIdentifier, name string,
+) (*kubeapplierapi.ReadDesire, error) {
+	key := kubeapplierapi.ToManagementClusterScopedReadDesireResourceIDString(stampIdentifier, name)
 	return listerutils.GetByKey[kubeapplierapi.ReadDesire](l.indexer, key)
 }
 

--- a/internal/database/listertesting/kubeapplierlistertesting/db_listers.go
+++ b/internal/database/listertesting/kubeapplierlistertesting/db_listers.go
@@ -120,6 +120,15 @@ func (l *DBApplyDesireLister) GetForSystemAdminCredentialRevocation(
 		})
 }
 
+func (l *DBApplyDesireLister) GetForManagementCluster(
+	ctx context.Context, stampIdentifier, name string,
+) (*kubeapplierapi.ApplyDesire, error) {
+	return findClusterDesireInAnyClient(ctx, l.Clients, l.Lister, name,
+		func(c kubeappliercosmosstorage.KubeApplierDBClient) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire], error) {
+			return c.ApplyDesiresForManagementCluster(stampIdentifier)
+		})
+}
+
 func (l *DBApplyDesireLister) ListForManagementCluster(
 	ctx context.Context, managementClusterResourceID *azcorearm.ResourceID,
 ) ([]*kubeapplierapi.ApplyDesire, error) {
@@ -263,6 +272,15 @@ func (l *DBReadDesireLister) GetForSystemAdminCredentialRevocation(
 	return findClusterDesireInAnyClient(ctx, l.Clients, l.Lister, name,
 		func(c kubeappliercosmosstorage.KubeApplierDBClient) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error) {
 			return c.ReadDesiresForSystemAdminCredentialRevocation(subscriptionID, resourceGroupName, clusterName, revocationName)
+		})
+}
+
+func (l *DBReadDesireLister) GetForManagementCluster(
+	ctx context.Context, stampIdentifier, name string,
+) (*kubeapplierapi.ReadDesire, error) {
+	return findClusterDesireInAnyClient(ctx, l.Clients, l.Lister, name,
+		func(c kubeappliercosmosstorage.KubeApplierDBClient) (cosmosstorageutils.ResourceCRUD[kubeapplierapi.ReadDesire, *kubeapplierapi.ReadDesire], error) {
+			return c.ReadDesiresForManagementCluster(stampIdentifier)
 		})
 }
 

--- a/internal/database/listertesting/kubeapplierlistertesting/slice_listers.go
+++ b/internal/database/listertesting/kubeapplierlistertesting/slice_listers.go
@@ -96,6 +96,19 @@ func (l *SliceApplyDesireLister) GetForSystemAdminCredentialRevocation(
 	return nil, cosmosstorageutils.NewNotFoundError()
 }
 
+func (l *SliceApplyDesireLister) GetForManagementCluster(
+	ctx context.Context, stampIdentifier, name string,
+) (*kubeapplierapi.ApplyDesire, error) {
+	want := kubeapplierapi.ToManagementClusterScopedApplyDesireResourceIDString(stampIdentifier, name)
+	for _, d := range l.Desires {
+		id := listertestingutils.ResourceIDOf(d)
+		if id != nil && strings.EqualFold(id.String(), want) {
+			return d, nil
+		}
+	}
+	return nil, cosmosstorageutils.NewNotFoundError()
+}
+
 func (l *SliceApplyDesireLister) ListForManagementCluster(
 	ctx context.Context, managementClusterResourceID *azcorearm.ResourceID,
 ) ([]*kubeapplierapi.ApplyDesire, error) {
@@ -196,6 +209,19 @@ func (l *SliceReadDesireLister) GetForSystemAdminCredentialRevocation(
 	want := kubeapplierapi.ToSystemAdminCredentialRevocationScopedReadDesireResourceIDString(
 		subscriptionID, resourceGroupName, clusterName, revocationName, name,
 	)
+	for _, d := range l.Desires {
+		id := listertestingutils.ResourceIDOf(d)
+		if id != nil && strings.EqualFold(id.String(), want) {
+			return d, nil
+		}
+	}
+	return nil, cosmosstorageutils.NewNotFoundError()
+}
+
+func (l *SliceReadDesireLister) GetForManagementCluster(
+	ctx context.Context, stampIdentifier, name string,
+) (*kubeapplierapi.ReadDesire, error) {
+	want := kubeapplierapi.ToManagementClusterScopedReadDesireResourceIDString(stampIdentifier, name)
 	for _, d := range l.Desires {
 		id := listertestingutils.ResourceIDOf(d)
 		if id != nil && strings.EqualFold(id.String(), want) {

--- a/internal/database/unionlisters/kubeapplier/union_desire_lister.go
+++ b/internal/database/unionlisters/kubeapplier/union_desire_lister.go
@@ -48,6 +48,7 @@ type DesireLister[T any] interface {
 	GetForNodePool(ctx context.Context, subscriptionID, resourceGroupName, clusterName, nodePoolName, name string) (*T, error)
 	GetForSystemAdminCredentialRequest(ctx context.Context, subscriptionID, resourceGroupName, clusterName, credentialRequestName, name string) (*T, error)
 	GetForSystemAdminCredentialRevocation(ctx context.Context, subscriptionID, resourceGroupName, clusterName, revocationName, name string) (*T, error)
+	GetForManagementCluster(ctx context.Context, stampIdentifier, name string) (*T, error)
 	ListForManagementCluster(ctx context.Context, managementClusterResourceID *azcorearm.ResourceID) ([]*T, error)
 	ListForCluster(ctx context.Context, subscriptionID, resourceGroupName, clusterName string) ([]*T, error)
 	ListForNodePool(ctx context.Context, subscriptionID, resourceGroupName, clusterName, nodePoolName string) ([]*T, error)
@@ -192,6 +193,22 @@ func (u *UnionDesireLister[T]) GetForSystemAdminCredentialRevocation(
 ) (*T, error) {
 	for _, sub := range u.snapshot() {
 		d, err := sub.GetForSystemAdminCredentialRevocation(ctx, subscriptionID, resourceGroupName, clusterName, revocationName, name)
+		if err == nil {
+			return d, nil
+		}
+		if !cosmosstorageutils.IsNotFoundError(err) {
+			return nil, err
+		}
+	}
+	return nil, cosmosstorageutils.NewNotFoundError()
+}
+
+// GetForManagementCluster tries each sublister in turn. First hit wins.
+func (u *UnionDesireLister[T]) GetForManagementCluster(
+	ctx context.Context, stampIdentifier, name string,
+) (*T, error) {
+	for _, sub := range u.snapshot() {
+		d, err := sub.GetForManagementCluster(ctx, stampIdentifier, name)
 		if err == nil {
 			return d, nil
 		}

--- a/internal/database/unionlisters/kubeapplier/union_listers_test.go
+++ b/internal/database/unionlisters/kubeapplier/union_listers_test.go
@@ -447,6 +447,9 @@ func (e *erroringApplyLister) GetForSystemAdminCredentialRequest(ctx context.Con
 func (e *erroringApplyLister) GetForSystemAdminCredentialRevocation(ctx context.Context, _, _, _, _, _ string) (*kubeapplierapi.ApplyDesire, error) {
 	return nil, e.err
 }
+func (e *erroringApplyLister) GetForManagementCluster(ctx context.Context, _, _ string) (*kubeapplierapi.ApplyDesire, error) {
+	return nil, e.err
+}
 func (e *erroringApplyLister) ListForManagementCluster(ctx context.Context, _ *azcorearm.ResourceID) ([]*kubeapplierapi.ApplyDesire, error) {
 	return nil, e.err
 }

--- a/test-integration/kube-applier/artifacts/apply_creates_configmap_mgmt_scoped/01-loadApplyDesire-hello/desire.json
+++ b/test-integration/kube-applier/artifacts/apply_creates_configmap_mgmt_scoped/01-loadApplyDesire-hello/desire.json
@@ -1,0 +1,29 @@
+{
+	"cosmosMetadata": {
+		"partitionKey": "/providers/microsoft.redhatopenshift/stamps/test/managementclusters/mgmt-1",
+		"resourceID": "/providers/microsoft.redhatopenshift/stamps/test/managementclusters/default/applydesires/hello"
+	},
+	"spec": {
+		"managementCluster": "/providers/microsoft.redhatopenshift/stamps/test/managementclusters/mgmt-1",
+		"serverSideApply": {
+			"kubeContent": {
+				"apiVersion": "v1",
+				"data": {
+					"key": "value"
+				},
+				"kind": "ConfigMap",
+				"metadata": {
+					"name": "hello",
+					"namespace": "apply-creates-configmap-mgmt-scoped"
+				}
+			}
+		},
+		"targetItem": {
+			"name": "hello",
+			"namespace": "apply-creates-configmap-mgmt-scoped",
+			"resource": "configmaps",
+			"version": "v1"
+		},
+		"type": "ServerSideApply"
+	}
+}

--- a/test-integration/kube-applier/artifacts/apply_creates_configmap_mgmt_scoped/02-kubernetesEventually-cm-created/00-key.json
+++ b/test-integration/kube-applier/artifacts/apply_creates_configmap_mgmt_scoped/02-kubernetesEventually-cm-created/00-key.json
@@ -1,0 +1,6 @@
+{
+	"apiVersion": "v1",
+	"kind": "ConfigMap",
+	"name": "hello",
+	"namespace": "apply-creates-configmap-mgmt-scoped"
+}

--- a/test-integration/kube-applier/artifacts/apply_creates_configmap_mgmt_scoped/02-kubernetesEventually-cm-created/expected.json
+++ b/test-integration/kube-applier/artifacts/apply_creates_configmap_mgmt_scoped/02-kubernetesEventually-cm-created/expected.json
@@ -1,0 +1,10 @@
+{
+	"data": {
+		"key": "value"
+	},
+	"kind": "ConfigMap",
+	"metadata": {
+		"name": "hello",
+		"namespace": "apply-creates-configmap-mgmt-scoped"
+	}
+}

--- a/test-integration/kube-applier/artifacts/apply_creates_configmap_mgmt_scoped/03-desireEventually-status-successful/00-key.json
+++ b/test-integration/kube-applier/artifacts/apply_creates_configmap_mgmt_scoped/03-desireEventually-status-successful/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/providers/microsoft.redhatopenshift/stamps/test/managementclusters/default/applydesires/hello"
+}

--- a/test-integration/kube-applier/artifacts/apply_creates_configmap_mgmt_scoped/03-desireEventually-status-successful/expected.json
+++ b/test-integration/kube-applier/artifacts/apply_creates_configmap_mgmt_scoped/03-desireEventually-status-successful/expected.json
@@ -1,0 +1,10 @@
+{
+	"status": {
+		"conditions": [
+			{
+				"status": "True",
+				"type": "Successful"
+			}
+		]
+	}
+}

--- a/test-integration/kube-applier/artifacts/read_mirrors_configmap_mgmt_scoped/01-kubernetesLoad-watched-v1/configmap.json
+++ b/test-integration/kube-applier/artifacts/read_mirrors_configmap_mgmt_scoped/01-kubernetesLoad-watched-v1/configmap.json
@@ -1,0 +1,11 @@
+{
+	"apiVersion": "v1",
+	"data": {
+		"version": "1"
+	},
+	"kind": "ConfigMap",
+	"metadata": {
+		"name": "watched",
+		"namespace": "read-mirrors-configmap-mgmt-scoped"
+	}
+}

--- a/test-integration/kube-applier/artifacts/read_mirrors_configmap_mgmt_scoped/02-loadReadDesire-watched/desire.json
+++ b/test-integration/kube-applier/artifacts/read_mirrors_configmap_mgmt_scoped/02-loadReadDesire-watched/desire.json
@@ -1,0 +1,15 @@
+{
+	"cosmosMetadata": {
+		"partitionKey": "/providers/microsoft.redhatopenshift/stamps/test/managementclusters/mgmt-1",
+		"resourceID": "/providers/microsoft.redhatopenshift/stamps/test/managementclusters/default/readdesires/watched"
+	},
+	"spec": {
+		"managementCluster": "/providers/microsoft.redhatopenshift/stamps/test/managementclusters/mgmt-1",
+		"targetItem": {
+			"name": "watched",
+			"namespace": "read-mirrors-configmap-mgmt-scoped",
+			"resource": "configmaps",
+			"version": "v1"
+		}
+	}
+}

--- a/test-integration/kube-applier/artifacts/read_mirrors_configmap_mgmt_scoped/03-desireEventually-status-version-1/00-key.json
+++ b/test-integration/kube-applier/artifacts/read_mirrors_configmap_mgmt_scoped/03-desireEventually-status-version-1/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/providers/microsoft.redhatopenshift/stamps/test/managementclusters/default/readdesires/watched"
+}

--- a/test-integration/kube-applier/artifacts/read_mirrors_configmap_mgmt_scoped/03-desireEventually-status-version-1/expected.json
+++ b/test-integration/kube-applier/artifacts/read_mirrors_configmap_mgmt_scoped/03-desireEventually-status-version-1/expected.json
@@ -1,0 +1,9 @@
+{
+	"status": {
+		"kubeContent": {
+			"data": {
+				"version": "1"
+			}
+		}
+	}
+}

--- a/test-integration/kube-applier/artifacts/read_mirrors_configmap_mgmt_scoped/04-kubernetesApply-watched-v2/configmap.json
+++ b/test-integration/kube-applier/artifacts/read_mirrors_configmap_mgmt_scoped/04-kubernetesApply-watched-v2/configmap.json
@@ -1,0 +1,11 @@
+{
+	"apiVersion": "v1",
+	"data": {
+		"version": "2"
+	},
+	"kind": "ConfigMap",
+	"metadata": {
+		"name": "watched",
+		"namespace": "read-mirrors-configmap-mgmt-scoped"
+	}
+}

--- a/test-integration/kube-applier/artifacts/read_mirrors_configmap_mgmt_scoped/05-desireEventually-status-version-2/00-key.json
+++ b/test-integration/kube-applier/artifacts/read_mirrors_configmap_mgmt_scoped/05-desireEventually-status-version-2/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/providers/microsoft.redhatopenshift/stamps/test/managementclusters/default/readdesires/watched"
+}

--- a/test-integration/kube-applier/artifacts/read_mirrors_configmap_mgmt_scoped/05-desireEventually-status-version-2/expected.json
+++ b/test-integration/kube-applier/artifacts/read_mirrors_configmap_mgmt_scoped/05-desireEventually-status-version-2/expected.json
@@ -1,0 +1,9 @@
+{
+	"status": {
+		"kubeContent": {
+			"data": {
+				"version": "2"
+			}
+		}
+	}
+}


### PR DESCRIPTION
### What

Management clusters need their own desires (not nested under a customer cluster) to store MC-level state in Cosmos that is relevant for fleet and backend operations. Wire ManagementCluster as a valid desire parent through the full stack: DesireScope, resource types, resource ID builders, DB client CRUD, listers, and all test doubles.

follows up on https://github.com/Azure/ARO-HCP/pull/6549

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
