### PR TITLE
test: add sliding-5m frontend request-count chart and document gather-observability artifacts

### DIFF
--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -1,1 +1,55 @@
 Load AGENTS.md for context
+
+## Finding the e2e "gather-observability" Spyglass artifacts
+
+The metrics/alert pages shown inline on a Prow job's Spyglass page (and browsable
+under gcsweb at `.../artifacts/e2e-parallel/aro-hcp-gather-observability/artifacts/`)
+are produced by the `gather-observability` subcommand, **not** by a Grafana
+dashboard. Source lives in `test/cmd/aro-hcp-tests/gather-observability/`.
+
+The CI step `aro-hcp-gather-observability` runs `aro-hcp-tests gather-observability`
+(`cmd.go`, `Use: "gather-observability"`) and writes every artifact into the
+`--output` dir, which Prow uploads to that GCS path.
+
+### Artifact → producer map
+
+| Spyglass file | What it is | Produced by |
+|---|---|---|
+| `panel-<slug>-summary.html` | one page per metrics **panel** (charts) | `queries.yaml` panels, rendered by `runQueries` → `renderPanel` (`options.go`, `render.go`, `chart.go`); filename is `panel-%s-summary.html` with `sanitizeTitle(panel.Title)` (`render.go`) |
+| `alerts-summary.html` + `alerts.json` | Azure Monitor alerts that fired | `options.go` (`Run`) + `alerts.go` + `render.go` template |
+| `junit_alerts.xml` | alerts as JUnit (fails the step) | `junit.go` (`alertsToJUnit`) |
+
+The `-summary.html` suffix is **required**: Prow's Spyglass HTML lens only renders
+files matching `.*-summary.*\.html` inline (see the comment in `options.go` near
+`fmt.Sprintf("panel-%s-summary.html", ...)`).
+
+Panel-title → filename examples (slug = lowercase, non-alphanumerics → `-`):
+- "Frontend Metrics" → `panel-frontend-metrics-summary.html`
+- "Backend Metrics" → `panel-backend-metrics-summary.html`
+- "Fleet Controller Metrics" → `panel-fleet-controller-metrics-summary.html`
+- "Maestro Metrics" → `panel-maestro-metrics-summary.html`
+
+### Adding or changing a chart
+
+Edit `test/cmd/aro-hcp-tests/gather-observability/queries.yaml`. Each entry under
+`panels[].queries[]` has: `title`, `description`, `query` (PromQL run via
+`query_range` against the Azure Monitor Prometheus workspace), `unit` (free-form
+label), `workspace` (`svc` or `hcp`), `step` (default `60s`), and optional
+`chartType` (`line` default, or `faceted-stacked-area` with `facetBy`/`stackBy`/`colors`)
+and `minPeakThreshold`. The schema is `QuerySpec` in `promql.go`;
+`TestLoadQueriesConfigEmbedded` (`chart_test.go`) validates the embedded file parses.
+
+**HA-replica dedup (counters/gauges):** the managed Prometheus may scrape each
+target from multiple HA replicas (label `prometheus_replica`). Collapse that
+dimension with `max without (prometheus_replica) ( ... )` *inside* your
+aggregation before `sum`, or totals are counted once per replica and inflated —
+e.g. `sum by (cluster) ( max without (prometheus_replica) ( increase(foo_total[5m]) ) )`.
+The header comment in `queries.yaml` and the workqueue queries show the pattern.
+
+### The metrics the charts query
+
+Service metric names come from the services themselves, e.g. the frontend HTTP
+metrics are defined in `frontend/pkg/frontend/metrics.go` (names in
+`frontend/pkg/frontend/const.go`): `frontend_http_requests_total` (counter) and
+`frontend_http_requests_duration_seconds` (histogram). The Azure Monitor managed
+Prometheus adds a `cluster` external label, which the queries group by.

--- a/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
@@ -1,3 +1,12 @@
+# HA-replica dedup convention:
+# The Azure Monitor managed Prometheus can run in HA, scraping each target from
+# multiple replicas (label `prometheus_replica`). Counter/gauge queries must
+# collapse that replica dimension BEFORE aggregating, or every series is counted
+# once per replica and totals are inflated. Wrap the per-series function in
+# `max without (prometheus_replica) ( ... )` inside your `sum`/aggregation, e.g.
+#   sum by (cluster) ( max without (prometheus_replica) ( increase(foo_total[5m]) ) )
+# (`max` because both replicas observe ~the same value). See the workqueue and
+# request-count queries below for the pattern.
 panels:
 - title: "Frontend Metrics"
   queries:
@@ -10,6 +19,17 @@ panels:
         )
       )
     unit: seconds
+    workspace: svc
+    step: "60s"
+  - title: "Frontend Request Count (5m sliding)"
+    description: "Frontend HTTP requests served in the trailing five-minute window, broken down by method and route per svc cluster (same breakdown as Frontend Request Latency, but counting every route including hcpoperationresults). Uses increase() over frontend_http_requests_total, deduplicating HA Prometheus replicas with max without(prometheus_replica) before summing. At each point the value is the request count for the preceding five minutes (a sliding block)."
+    query: |
+      sum by (route, method, cluster) (
+        max without (prometheus_replica) (
+          increase(frontend_http_requests_total[5m])
+        )
+      )
+    unit: requests
     workspace: svc
     step: "60s"
 - title: "Backend Metrics"


### PR DESCRIPTION
Adds a "Frontend Request Count (5m sliding)" chart to the Frontend Metrics panel of the e2e gather-observability report: sum by (cluster) of increase(frontend_http_requests_total[5m]), i.e. the total requests served in the trailing five-minute window. It renders next to Frontend Request Latency on panel-frontend-metrics-summary.html in the Prow Spyglass view.

Also documents, in test/CLAUDE.md, how the gather-observability Spyglass artifacts are produced (artifact -> producer map, the panel-title slug rule, the -summary.html Spyglass-lens requirement, and how to add/change a chart via queries.yaml) so these pages are easy to find and modify later.

Adding these to try to make debugging frontend latency alerting failures.