### PR TITLE
fix: use string type for prowInvalidJobsMaxPercentage in alerting.bicep

### DIFF
--- a/tooling/tenant-quota/alerting.bicep
+++ b/tooling/tenant-quota/alerting.bicep
@@ -26,7 +26,7 @@ var prowE2EParallelMinSuccessfulRuns = 20
 var prowE2EParallelP95MaxSeconds = 9000 // 2h30m
 var prowCollectionMaxAgeSeconds = 900 // 15 minutes
 var prowBatchMaxConsecutiveFailures = 4
-var prowInvalidJobsMaxPercentage = 0.10
+var prowInvalidJobsMaxPercentage = '0.10'
 
 var prowHighFrequencyRuns = 'sum by (job_name, job_type) (prow_ci_job_info{job_type=~"presubmit|batch"})'
 var prowHighFrequencyFailures = 'sum by (job_name, job_type) (prow_ci_job_info{job_type=~"presubmit|batch",result=~"failure|error"})'
@@ -531,7 +531,7 @@ resource prowCIAlerts 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-0
         }
         annotations: {
           summary: 'High rate of malformed completed Prow CI jobs detected'
-          description: 'Malformed completed Prow jobs exceeded ${prowInvalidJobsMaxPercentage * 100}% of all completed jobs in the last 24h.'
+          description: 'Malformed completed Prow jobs exceeded 10% of all completed jobs in the last 24h.'
           runbook_url: 'https://github.com/Azure/ARO-HCP/blob/main/docs/ci/dev-ci-monitoring.md#exporter-health-checks'
         }
         actions: [


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1846

## Summary
- Fixes Bicep compilation error in `tooling/tenant-quota/alerting.bicep` that has been breaking the [dev-ci-pipeline-postsubmit](https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-dev-ci-pipeline-postsubmit) since https://github.com/Azure/ARO-HCP/pull/6543 (Aug 14)
- Bicep has no floating-point type — `0.10` was parsed as integer `0` followed by invalid property access `.10`, producing 6 compile errors that aborted the pipeline
- Changed `prowInvalidJobsMaxPercentage` to a string (`'0.10'`), consistent with `prowHealthcheckMaxFailureRate = '0.40'` on the same page
- Inlined `10%` in the alert description since Bicep can't do arithmetic on strings

## Test plan
- [ ] Verify `dev-ci-pipeline-postsubmit` passes the TenantQuota alerting step
- [ ] Confirm the `ProwCIInvalidJobsDetected` alert rule renders correctly with the `> 0.10` threshold