### PR TITLE
feat: add CosmosDB platform metrics to gather-observability

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-observability/artifacts/metricspanel.html.tmpl
+++ b/test/cmd/aro-hcp-tests/gather-observability/artifacts/metricspanel.html.tmpl
@@ -48,7 +48,7 @@
         {{if .Description}}<div class="chart-description">{{.Description}}</div>{{end}}
         <div class="query-footer">
             <details>
-                <summary>PromQL: {{.Title}}
+                <summary>Query: {{.Title}}
                     <button class="copy-btn" onclick="var t=this.closest('.query-footer').querySelector('pre').textContent;navigator.clipboard.writeText(t).then(function(){event.target.textContent='Copied!';setTimeout(function(){event.target.textContent='Copy'},1500)})">Copy</button>
                 </summary>
                 <pre>{{.Query}}</pre>

--- a/test/cmd/aro-hcp-tests/gather-observability/azuremetric.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/azuremetric.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatherobservability
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-echarts/go-echarts/v2/opts"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+)
+
+// fetchAzureMetrics queries Azure Monitor platform metrics for a resource.
+func fetchAzureMetrics(ctx context.Context, cred azcore.TokenCredential, subscriptionID, resourceURI string, query QuerySpec, start, end time.Time) (*armmonitor.Response, error) {
+	client, err := armmonitor.NewMetricsClient(subscriptionID, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metrics client: %w", err)
+	}
+
+	timespan := fmt.Sprintf("%s/%s", start.UTC().Format(time.RFC3339), end.UTC().Format(time.RFC3339))
+	listOptions := &armmonitor.MetricsClientListOptions{
+		Timespan:    &timespan,
+		Interval:    &query.Interval,
+		Metricnames: &query.MetricName,
+		Aggregation: &query.Aggregation,
+	}
+	if len(query.Filter) > 0 {
+		listOptions.Filter = &query.Filter
+	}
+
+	resp, err := client.List(ctx, resourceURI, listOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list metrics for %s: %w", query.MetricName, err)
+	}
+	return &resp.Response, nil
+}
+
+// azureMetricsToSeries converts an Azure Monitor metrics response into
+// parsedSeries for chart rendering. Each TimeSeriesElement becomes one series,
+// labeled by its dimension metadata values. The aggregation parameter selects
+// which value (Average, Maximum, etc.) to extract from each MetricValue.
+func azureMetricsToSeries(resp *armmonitor.Response, aggregation string) []parsedSeries {
+	if resp == nil {
+		return nil
+	}
+
+	var result []parsedSeries
+	for _, metric := range resp.Value {
+		if metric == nil {
+			continue
+		}
+		for _, ts := range metric.Timeseries {
+			if ts == nil || len(ts.Data) == 0 {
+				continue
+			}
+
+			labels := make(map[string]string)
+			for _, md := range ts.Metadatavalues {
+				if md != nil && md.Name != nil && md.Name.Value != nil && md.Value != nil {
+					labels[*md.Name.Value] = *md.Value
+				}
+			}
+
+			var data []opts.LineData
+			for _, point := range ts.Data {
+				if point == nil || point.TimeStamp == nil {
+					continue
+				}
+				value := extractAggregationValue(point, aggregation)
+				if value == nil {
+					continue
+				}
+				data = append(data, opts.LineData{
+					Value: []any{point.TimeStamp.UnixMilli(), *value},
+				})
+			}
+			if len(data) == 0 {
+				continue
+			}
+
+			result = append(result, parsedSeries{
+				metric: labels,
+				data:   data,
+			})
+		}
+	}
+	return result
+}
+
+func extractAggregationValue(point *armmonitor.MetricValue, aggregation string) *float64 {
+	switch strings.ToLower(aggregation) {
+	case "average":
+		return point.Average
+	case "maximum":
+		return point.Maximum
+	case "minimum":
+		return point.Minimum
+	case "total":
+		return point.Total
+	case "count":
+		return point.Count
+	default:
+		return nil
+	}
+}

--- a/test/cmd/aro-hcp-tests/gather-observability/azuremetric_test.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/azuremetric_test.go
@@ -1,0 +1,342 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatherobservability
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/utils/ptr"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+)
+
+func TestAzureMetricsToSeries(t *testing.T) {
+	t.Parallel()
+
+	ts1 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	ts2 := time.Date(2025, 1, 1, 0, 1, 0, 0, time.UTC)
+	ts3 := time.Date(2025, 1, 1, 0, 2, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		resp        *armmonitor.Response
+		aggregation string
+		wantLen     int
+		checkFirst  func(t *testing.T, series parsedSeries)
+	}{
+		{
+			name:        "nil response",
+			resp:        nil,
+			aggregation: "Maximum",
+			wantLen:     0,
+		},
+		{
+			name: "empty value slice",
+			resp: &armmonitor.Response{
+				Value: []*armmonitor.Metric{},
+			},
+			aggregation: "Maximum",
+			wantLen:     0,
+		},
+		{
+			name: "single timeseries with maximum aggregation",
+			resp: &armmonitor.Response{
+				Value: []*armmonitor.Metric{
+					{
+						Timeseries: []*armmonitor.TimeSeriesElement{
+							{
+								Metadatavalues: []*armmonitor.MetadataValue{
+									{
+										Name:  &armmonitor.LocalizableString{Value: ptr.To("CollectionName")},
+										Value: ptr.To("Resources"),
+									},
+								},
+								Data: []*armmonitor.MetricValue{
+									{TimeStamp: &ts1, Maximum: ptr.To(42.5)},
+									{TimeStamp: &ts2, Maximum: ptr.To(55.0)},
+									{TimeStamp: &ts3, Maximum: ptr.To(30.0)},
+								},
+							},
+						},
+					},
+				},
+			},
+			aggregation: "Maximum",
+			wantLen:     1,
+			checkFirst: func(t *testing.T, series parsedSeries) {
+				if series.metric["CollectionName"] != "Resources" {
+					t.Errorf("label CollectionName = %q, want %q", series.metric["CollectionName"], "Resources")
+				}
+				if len(series.data) != 3 {
+					t.Fatalf("data points = %d, want 3", len(series.data))
+				}
+				arr, ok := series.data[1].Value.([]any)
+				if !ok || len(arr) != 2 {
+					t.Fatalf("data[1].Value not []any of len 2")
+				}
+				if v, ok := arr[1].(float64); !ok || v != 55.0 {
+					t.Errorf("data[1] value = %v, want 55.0", arr[1])
+				}
+			},
+		},
+		{
+			name: "average aggregation",
+			resp: &armmonitor.Response{
+				Value: []*armmonitor.Metric{
+					{
+						Timeseries: []*armmonitor.TimeSeriesElement{
+							{
+								Data: []*armmonitor.MetricValue{
+									{TimeStamp: &ts1, Average: ptr.To(10.0), Maximum: ptr.To(20.0)},
+								},
+							},
+						},
+					},
+				},
+			},
+			aggregation: "Average",
+			wantLen:     1,
+			checkFirst: func(t *testing.T, series parsedSeries) {
+				arr := series.data[0].Value.([]any)
+				if v := arr[1].(float64); v != 10.0 {
+					t.Errorf("value = %v, want 10.0 (average, not maximum)", v)
+				}
+			},
+		},
+		{
+			name: "count aggregation",
+			resp: &armmonitor.Response{
+				Value: []*armmonitor.Metric{
+					{
+						Timeseries: []*armmonitor.TimeSeriesElement{
+							{
+								Data: []*armmonitor.MetricValue{
+									{TimeStamp: &ts1, Count: ptr.To(100.0)},
+								},
+							},
+						},
+					},
+				},
+			},
+			aggregation: "Count",
+			wantLen:     1,
+			checkFirst: func(t *testing.T, series parsedSeries) {
+				arr := series.data[0].Value.([]any)
+				if v := arr[1].(float64); v != 100.0 {
+					t.Errorf("value = %v, want 100.0", v)
+				}
+			},
+		},
+		{
+			name: "multiple timeseries",
+			resp: &armmonitor.Response{
+				Value: []*armmonitor.Metric{
+					{
+						Timeseries: []*armmonitor.TimeSeriesElement{
+							{
+								Metadatavalues: []*armmonitor.MetadataValue{
+									{
+										Name:  &armmonitor.LocalizableString{Value: ptr.To("CollectionName")},
+										Value: ptr.To("Resources"),
+									},
+								},
+								Data: []*armmonitor.MetricValue{
+									{TimeStamp: &ts1, Maximum: ptr.To(10.0)},
+								},
+							},
+							{
+								Metadatavalues: []*armmonitor.MetadataValue{
+									{
+										Name:  &armmonitor.LocalizableString{Value: ptr.To("CollectionName")},
+										Value: ptr.To("Billing"),
+									},
+								},
+								Data: []*armmonitor.MetricValue{
+									{TimeStamp: &ts1, Maximum: ptr.To(20.0)},
+								},
+							},
+						},
+					},
+				},
+			},
+			aggregation: "Maximum",
+			wantLen:     2,
+		},
+		{
+			name: "nil data points skipped",
+			resp: &armmonitor.Response{
+				Value: []*armmonitor.Metric{
+					{
+						Timeseries: []*armmonitor.TimeSeriesElement{
+							{
+								Data: []*armmonitor.MetricValue{
+									{TimeStamp: &ts1, Maximum: ptr.To(10.0)},
+									nil,
+									{TimeStamp: &ts2, Maximum: ptr.To(20.0)},
+								},
+							},
+						},
+					},
+				},
+			},
+			aggregation: "Maximum",
+			wantLen:     1,
+			checkFirst: func(t *testing.T, series parsedSeries) {
+				if len(series.data) != 2 {
+					t.Errorf("data points = %d, want 2 (nil skipped)", len(series.data))
+				}
+			},
+		},
+		{
+			name: "missing aggregation value skipped",
+			resp: &armmonitor.Response{
+				Value: []*armmonitor.Metric{
+					{
+						Timeseries: []*armmonitor.TimeSeriesElement{
+							{
+								Data: []*armmonitor.MetricValue{
+									{TimeStamp: &ts1, Average: ptr.To(10.0)},
+								},
+							},
+						},
+					},
+				},
+			},
+			aggregation: "Maximum",
+			wantLen:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			series := azureMetricsToSeries(tt.resp, tt.aggregation)
+			if len(series) != tt.wantLen {
+				t.Fatalf("series count = %d, want %d", len(series), tt.wantLen)
+			}
+			if tt.checkFirst != nil && len(series) > 0 {
+				tt.checkFirst(t, series[0])
+			}
+		})
+	}
+}
+
+func TestExtractAggregationValue(t *testing.T) {
+	t.Parallel()
+
+	point := &armmonitor.MetricValue{
+		Average: ptr.To(10.0),
+		Maximum: ptr.To(20.0),
+		Minimum: ptr.To(5.0),
+		Total:   ptr.To(100.0),
+		Count:   ptr.To(50.0),
+	}
+
+	tests := []struct {
+		name        string
+		aggregation string
+		want        float64
+	}{
+		{name: "average", aggregation: "Average", want: 10.0},
+		{name: "maximum", aggregation: "Maximum", want: 20.0},
+		{name: "minimum", aggregation: "Minimum", want: 5.0},
+		{name: "total", aggregation: "Total", want: 100.0},
+		{name: "count", aggregation: "Count", want: 50.0},
+		{name: "case insensitive", aggregation: "maximum", want: 20.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractAggregationValue(point, tt.aggregation)
+			if got == nil {
+				t.Fatal("got nil, want non-nil")
+			}
+			if *got != tt.want {
+				t.Errorf("got %v, want %v", *got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractAggregationValueNil(t *testing.T) {
+	t.Parallel()
+
+	point := &armmonitor.MetricValue{}
+
+	tests := []struct {
+		name        string
+		aggregation string
+	}{
+		{name: "nil average", aggregation: "Average"},
+		{name: "nil maximum", aggregation: "Maximum"},
+		{name: "nil minimum", aggregation: "Minimum"},
+		{name: "nil total", aggregation: "Total"},
+		{name: "nil count", aggregation: "Count"},
+		{name: "unknown type returns nil", aggregation: "Unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractAggregationValue(point, tt.aggregation)
+			if got != nil {
+				t.Errorf("got %v, want nil", *got)
+			}
+		})
+	}
+}
+
+func TestQueryDisplay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		query QuerySpec
+		want  string
+	}{
+		{
+			name:  "promql query",
+			query: QuerySpec{Type: queryTypePromQL, Query: "rate(foo[5m])"},
+			want:  "rate(foo[5m])",
+		},
+		{
+			name:  "azure metric without filter",
+			query: QuerySpec{Type: queryTypeAzureMetric, MetricName: "NormalizedRuConsumption", Aggregation: "Maximum"},
+			want:  "Maximum(NormalizedRuConsumption)",
+		},
+		{
+			name:  "azure metric with filter",
+			query: QuerySpec{Type: queryTypeAzureMetric, MetricName: "TotalRequests", Aggregation: "Count", Filter: "StatusCode eq '429'"},
+			want:  "Count(TotalRequests) | StatusCode eq '429'",
+		},
+		{
+			name:  "default type treated as promql",
+			query: QuerySpec{Query: "up"},
+			want:  "up",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.query.queryDisplay()
+			if got != tt.want {
+				t.Errorf("queryDisplay() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/cmd/aro-hcp-tests/gather-observability/chart.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/chart.go
@@ -132,13 +132,11 @@ func estimateLegendHeight(labels []string, chartWidth int) int {
 	return max(minLegendHeight, rows*legendRowHeight)
 }
 
-// buildChartData builds the chart HTML for a single PromQL query result.
-// Each PrometheusResult becomes a separate series, labeled by its metric
-// labels.
-func buildChartData(q QuerySpec, queryErr string, results []PrometheusResult, tw timing.TimeWindow) chartData {
-	series := parseResultsToSeries(results)
+// buildChartDataFromSeries builds chart HTML from pre-parsed series. Used by
+// both PromQL (via parseResultsToSeries) and Azure Monitor metric paths.
+func buildChartDataFromSeries(q QuerySpec, queryErr string, series []parsedSeries, tw timing.TimeWindow) chartData {
 	if len(series) == 0 {
-		return chartData{Title: q.Title, Description: q.Description, Query: q.Query, Error: queryErr, MinPeakThreshold: q.MinPeakThreshold}
+		return chartData{Title: q.Title, Description: q.Description, Query: q.queryDisplay(), Error: queryErr, MinPeakThreshold: q.MinPeakThreshold}
 	}
 	switch q.ChartType {
 	case chartTypeFacetedStackedArea:
@@ -146,8 +144,15 @@ func buildChartData(q QuerySpec, queryErr string, results []PrometheusResult, tw
 	case chartTypeLine:
 		return buildLineChartData(q, series, tw)
 	default:
-		return chartData{Title: q.Title, Description: q.Description, Query: q.Query, Error: fmt.Sprintf("unknown chartType: %q", q.ChartType)}
+		return chartData{Title: q.Title, Description: q.Description, Query: q.queryDisplay(), Error: fmt.Sprintf("unknown chartType: %q", q.ChartType)}
 	}
+}
+
+// buildChartData builds the chart HTML for a single PromQL query result.
+// Each PrometheusResult becomes a separate series, labeled by its metric
+// labels.
+func buildChartData(q QuerySpec, queryErr string, results []PrometheusResult, tw timing.TimeWindow) chartData {
+	return buildChartDataFromSeries(q, queryErr, parseResultsToSeries(results), tw)
 }
 
 func buildLineChartData(q QuerySpec, series []parsedSeries, tw timing.TimeWindow) chartData {
@@ -232,7 +237,7 @@ func buildLineChartData(q QuerySpec, series []parsedSeries, tw timing.TimeWindow
 	return chartData{
 		Title:            q.Title,
 		Description:      q.Description,
-		Query:            q.Query,
+		Query:            q.queryDisplay(),
 		HasData:          true,
 		ChartHTML:        template.HTML(html), //nolint:gosec // trusted go-echarts output
 		MinPeakThreshold: q.MinPeakThreshold,
@@ -371,7 +376,7 @@ func buildFacetedStackedAreaChartData(q QuerySpec, series []parsedSeries, tw tim
 	return chartData{
 		Title:       q.Title,
 		Description: q.Description,
-		Query:       q.Query,
+		Query:       q.queryDisplay(),
 		HasData:     true,
 		ChartHTML:   template.HTML(html), //nolint:gosec // trusted go-echarts output
 		ChartType:   q.ChartType,

--- a/test/cmd/aro-hcp-tests/gather-observability/chart_test.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/chart_test.go
@@ -19,8 +19,11 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-echarts/go-echarts/v2/opts"
+
+	"github.com/Azure/ARO-HCP/test/util/timing"
 )
 
 func TestParsePrometheusValue(t *testing.T) {
@@ -363,6 +366,86 @@ func TestSanitizeTitle(t *testing.T) {
 	}
 }
 
+func TestBuildChartDataFromSeries(t *testing.T) {
+	t.Parallel()
+
+	tw := timing.TimeWindow{
+		Start: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		End:   time.Date(2025, 1, 1, 1, 0, 0, 0, time.UTC),
+	}
+
+	newSampleSeries := func() []parsedSeries {
+		return []parsedSeries{
+			{
+				metric: map[string]string{"instance": "a"},
+				data: []opts.LineData{
+					{Value: []any{float64(1735689600000), 42.0}},
+					{Value: []any{float64(1735689660000), 43.0}},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		query    QuerySpec
+		queryErr string
+		series   func() []parsedSeries
+		wantData bool
+		wantErr  string
+	}{
+		{
+			name:     "empty series returns no data with query error",
+			query:    QuerySpec{Title: "T", ChartType: chartTypeLine},
+			queryErr: "timeout",
+			series:   func() []parsedSeries { return nil },
+			wantData: false,
+			wantErr:  "timeout",
+		},
+		{
+			name:     "empty series returns no data without error",
+			query:    QuerySpec{Title: "T", ChartType: chartTypeLine},
+			series:   func() []parsedSeries { return nil },
+			wantData: false,
+		},
+		{
+			name:     "line chart produces data",
+			query:    QuerySpec{Title: "T", ChartType: chartTypeLine},
+			series:   newSampleSeries,
+			wantData: true,
+		},
+		{
+			name:     "faceted-stacked-area chart produces data",
+			query:    QuerySpec{Title: "T", ChartType: chartTypeFacetedStackedArea, FacetBy: "instance", StackBy: "instance"},
+			series:   newSampleSeries,
+			wantData: true,
+		},
+		{
+			name:     "unknown chart type returns error",
+			query:    QuerySpec{Title: "T", ChartType: "pie"},
+			series:   newSampleSeries,
+			wantData: false,
+			wantErr:  `unknown chartType: "pie"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cd := buildChartDataFromSeries(tt.query, tt.queryErr, tt.series(), tw)
+			if cd.HasData != tt.wantData {
+				t.Errorf("HasData = %v, want %v", cd.HasData, tt.wantData)
+			}
+			if tt.wantErr != "" && !strings.Contains(cd.Error, tt.wantErr) {
+				t.Errorf("Error = %q, want to contain %q", cd.Error, tt.wantErr)
+			}
+			if tt.wantErr == "" && cd.Error != "" {
+				t.Errorf("unexpected Error = %q", cd.Error)
+			}
+		})
+	}
+}
+
 func TestLoadQueriesConfig(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -609,6 +692,142 @@ func TestLoadQueriesConfig(t *testing.T) {
       facetBy: cluster
 `,
 			wantErr: "facetBy is only valid with chartType",
+		},
+		{
+			name: "valid azureMetric query",
+			yaml: `panels:
+  - title: "CosmosDB"
+    queries:
+    - title: "NormalizedRU"
+      type: azureMetric
+      resource: cosmosdb
+      metricName: NormalizedRuConsumption
+      aggregation: Maximum
+`,
+			check: func(t *testing.T, cfg *QueriesConfig) {
+				q := cfg.Panels[0].Queries[0]
+				if q.Type != "azureMetric" {
+					t.Errorf("Type = %q, want %q", q.Type, "azureMetric")
+				}
+				if q.Resource != "cosmosdb" {
+					t.Errorf("Resource = %q, want %q", q.Resource, "cosmosdb")
+				}
+				if q.MetricName != "NormalizedRuConsumption" {
+					t.Errorf("MetricName = %q, want %q", q.MetricName, "NormalizedRuConsumption")
+				}
+				if q.Aggregation != "Maximum" {
+					t.Errorf("Aggregation = %q, want %q", q.Aggregation, "Maximum")
+				}
+				if q.Interval != "PT1M" {
+					t.Errorf("Interval = %q, want default %q", q.Interval, "PT1M")
+				}
+			},
+		},
+		{
+			name: "azureMetric interval preserved when set",
+			yaml: `panels:
+  - title: "CosmosDB"
+    queries:
+    - title: "NormalizedRU"
+      type: azureMetric
+      resource: cosmosdb
+      metricName: NormalizedRuConsumption
+      aggregation: Maximum
+      interval: PT5M
+`,
+			check: func(t *testing.T, cfg *QueriesConfig) {
+				if cfg.Panels[0].Queries[0].Interval != "PT5M" {
+					t.Errorf("Interval = %q, want %q", cfg.Panels[0].Queries[0].Interval, "PT5M")
+				}
+			},
+		},
+		{
+			name: "azureMetric missing resource returns error",
+			yaml: `panels:
+  - title: "CosmosDB"
+    queries:
+    - title: "NormalizedRU"
+      type: azureMetric
+      metricName: NormalizedRuConsumption
+      aggregation: Maximum
+`,
+			wantErr: "resource is required for azureMetric queries",
+		},
+		{
+			name: "azureMetric missing metricName returns error",
+			yaml: `panels:
+  - title: "CosmosDB"
+    queries:
+    - title: "NormalizedRU"
+      type: azureMetric
+      resource: cosmosdb
+      aggregation: Maximum
+`,
+			wantErr: "metricName is required for azureMetric queries",
+		},
+		{
+			name: "azureMetric missing aggregation returns error",
+			yaml: `panels:
+  - title: "CosmosDB"
+    queries:
+    - title: "NormalizedRU"
+      type: azureMetric
+      resource: cosmosdb
+      metricName: NormalizedRuConsumption
+`,
+			wantErr: "aggregation is required for azureMetric queries",
+		},
+		{
+			name: "invalid query type returns error",
+			yaml: `panels:
+  - title: "Panel"
+    queries:
+    - title: "Bad"
+      type: graphql
+      query: "{ foo }"
+`,
+			wantErr: `type must be "promql" or "azureMetric"`,
+		},
+		{
+			name: "type defaults to promql when omitted",
+			yaml: `panels:
+  - title: "Panel"
+    queries:
+    - title: "CPU"
+      query: "up"
+      workspace: svc
+`,
+			check: func(t *testing.T, cfg *QueriesConfig) {
+				if cfg.Panels[0].Queries[0].Type != "promql" {
+					t.Errorf("Type = %q, want %q", cfg.Panels[0].Queries[0].Type, "promql")
+				}
+			},
+		},
+		{
+			name: "mixed promql and azureMetric in same panel",
+			yaml: `panels:
+  - title: "Mixed"
+    queries:
+    - title: "PromQL Query"
+      query: "up"
+      workspace: svc
+    - title: "Azure Metric"
+      type: azureMetric
+      resource: cosmosdb
+      metricName: NormalizedRuConsumption
+      aggregation: Maximum
+`,
+			check: func(t *testing.T, cfg *QueriesConfig) {
+				if len(cfg.Panels[0].Queries) != 2 {
+					t.Fatalf("queries = %d, want 2", len(cfg.Panels[0].Queries))
+				}
+				if cfg.Panels[0].Queries[0].Type != "promql" {
+					t.Errorf("first query Type = %q, want %q", cfg.Panels[0].Queries[0].Type, "promql")
+				}
+				if cfg.Panels[0].Queries[1].Type != "azureMetric" {
+					t.Errorf("second query Type = %q, want %q", cfg.Panels[0].Queries[1].Type, "azureMetric")
+				}
+			},
 		},
 	}
 

--- a/test/cmd/aro-hcp-tests/gather-observability/options.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/options.go
@@ -77,6 +77,7 @@ type ValidatedOptions struct {
 type completedOptions struct {
 	OutputDir         string
 	Workspaces        map[string]azcorearm.ResourceID
+	Resources         map[string]azcorearm.ResourceID
 	TimeWindow        timing.TimeWindow
 	Queries           *QueriesConfig
 	SeverityThreshold int // -1 means no filter; 0=Sev0 .. 4=Sev4
@@ -173,6 +174,15 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 		workspaceHcp: *metadataapi.Must(azcorearm.ParseResourceID(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Monitor/accounts/%s", o.SubscriptionID, regionRG, hcpWorkspace))),
 	}
 
+	cosmosDBName, err := testutil.ConfigGetString(cfg, "frontend.cosmosDB.name")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get frontend.cosmosDB.name from config: %w", err)
+	}
+	resources := map[string]azcorearm.ResourceID{
+		"cosmosdb": *metadataapi.Must(azcorearm.ParseResourceID(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DocumentDB/databaseAccounts/%s", o.SubscriptionID, regionRG, cosmosDBName))),
+	}
+	logger.Info("resolved Azure resources for metric queries", "resources", len(resources))
+
 	queries, err := loadQueriesConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load queries config: %w", err)
@@ -192,6 +202,7 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*Options, error) {
 	return &Options{completedOptions: &completedOptions{
 		OutputDir:         o.OutputDir,
 		Workspaces:        workspaces,
+		Resources:         resources,
 		TimeWindow:        tw,
 		Queries:           queries,
 		SeverityThreshold: o.severityThreshold,
@@ -307,10 +318,10 @@ func (o Options) Run(ctx context.Context) error {
 	}
 	logger.Info("wrote alert JUnit artifact", "path", junitPath)
 
-	// Execute PromQL queries and render timeseries charts
+	// Execute queries and render timeseries charts
 	if o.Queries != nil {
 		if err := o.runQueries(ctx, workspaces); err != nil {
-			return utils.TrackError(fmt.Errorf("PromQL query execution failed: %w", err))
+			return utils.TrackError(fmt.Errorf("query execution failed: %w", err))
 		}
 	}
 
@@ -338,25 +349,14 @@ func (o Options) runQueries(ctx context.Context, workspaces map[string]*workspac
 
 		var panelCharts []chartData
 		for _, q := range panel.Queries {
-			ws, ok := workspaces[q.Workspace]
-			if !ok {
-				return fmt.Errorf("unknown workspace %q for query %q", q.Workspace, q.Title)
+			var cd chartData
+			switch q.Type {
+			case queryTypeAzureMetric:
+				cd = o.executeAzureMetricQuery(ctx, logger, q)
+			default:
+				cd = o.executePromQLQuery(ctx, httpClient, logger, q, workspaces)
 			}
-			endpoint := ws.PromEndpoint
-
-			logger.Info("executing PromQL query", "panel", panel.Title, "title", q.Title, "workspace", q.Workspace)
-
-			var results []PrometheusResult
-			var queryErr string
-			resp, err := queryRange(ctx, httpClient, o.cred, endpoint, q.Query, o.TimeWindow.Start, o.TimeWindow.End, q.Step)
-			if err != nil {
-				logger.Error(err, "PromQL query failed", "title", q.Title)
-				queryErr = err.Error()
-			} else {
-				results = resp.Data.Result
-			}
-
-			panelCharts = append(panelCharts, buildChartData(q, queryErr, results, o.TimeWindow))
+			panelCharts = append(panelCharts, cd)
 		}
 
 		// filename must match the Spyglass HTML lens regex .*-summary.*\.html
@@ -375,4 +375,42 @@ func (o Options) runQueries(ctx context.Context, workspaces map[string]*workspac
 		logger.Info("wrote panel", "path", panelPath, "charts", len(panelCharts))
 	}
 	return nil
+}
+
+func (o Options) executePromQLQuery(ctx context.Context, httpClient *http.Client, logger logr.Logger, q QuerySpec, workspaces map[string]*workspaceData) chartData {
+	ws, ok := workspaces[q.Workspace]
+	if !ok {
+		return chartData{Title: q.Title, Description: q.Description, Query: q.queryDisplay(), Error: fmt.Sprintf("unknown workspace %q", q.Workspace), MinPeakThreshold: q.MinPeakThreshold}
+	}
+	logger.Info("executing PromQL query", "title", q.Title, "workspace", q.Workspace)
+
+	var results []PrometheusResult
+	var queryErr string
+	resp, err := queryRange(ctx, httpClient, o.cred, ws.PromEndpoint, q.Query, o.TimeWindow.Start, o.TimeWindow.End, q.Step)
+	if err != nil {
+		logger.Error(err, "PromQL query failed", "title", q.Title)
+		queryErr = err.Error()
+	} else {
+		results = resp.Data.Result
+	}
+	return buildChartData(q, queryErr, results, o.TimeWindow)
+}
+
+func (o Options) executeAzureMetricQuery(ctx context.Context, logger logr.Logger, q QuerySpec) chartData {
+	resourceID, ok := o.Resources[q.Resource]
+	if !ok {
+		return chartData{Title: q.Title, Description: q.Description, Query: q.queryDisplay(), Error: fmt.Sprintf("unknown resource %q", q.Resource), MinPeakThreshold: q.MinPeakThreshold}
+	}
+	logger.Info("executing Azure metric query", "title", q.Title, "resource", q.Resource, "metric", q.MetricName)
+
+	var series []parsedSeries
+	var queryErr string
+	resp, err := fetchAzureMetrics(ctx, o.cred, resourceID.SubscriptionID, resourceID.String(), q, o.TimeWindow.Start, o.TimeWindow.End)
+	if err != nil {
+		logger.Error(err, "Azure metric query failed", "title", q.Title)
+		queryErr = err.Error()
+	} else {
+		series = azureMetricsToSeries(resp, q.Aggregation)
+	}
+	return buildChartDataFromSeries(q, queryErr, series, o.TimeWindow)
 }

--- a/test/cmd/aro-hcp-tests/gather-observability/promql.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/promql.go
@@ -26,48 +26,10 @@ import (
 	"strings"
 	"time"
 
-	_ "embed"
-
-	"sigs.k8s.io/yaml"
-
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
 )
-
-// QueriesConfig holds panels of grouped PromQL queries to run against Azure
-// Monitor Prometheus workspaces. Each panel produces one HTML page with
-// multiple charts.
-type QueriesConfig struct {
-	Panels []PanelSpec `json:"panels" yaml:"panels"`
-}
-
-// PanelSpec groups related queries that should be rendered together on a
-// single HTML page.
-type PanelSpec struct {
-	Title   string      `json:"title" yaml:"title"`
-	Queries []QuerySpec `json:"queries" yaml:"queries"`
-}
-
-const (
-	chartTypeLine               = "line"
-	chartTypeFacetedStackedArea = "faceted-stacked-area"
-)
-
-// QuerySpec describes a single PromQL query to execute and chart.
-type QuerySpec struct {
-	Title            string            `json:"title" yaml:"title"`
-	Description      string            `json:"description,omitempty" yaml:"description,omitempty"`
-	Query            string            `json:"query" yaml:"query"`
-	Unit             string            `json:"unit,omitempty" yaml:"unit,omitempty"`
-	Workspace        string            `json:"workspace" yaml:"workspace"` // "svc" or "hcp"
-	Step             string            `json:"step,omitempty" yaml:"step,omitempty"`
-	MinPeakThreshold float64           `json:"minPeakThreshold,omitempty" yaml:"minPeakThreshold,omitempty"`
-	ChartType        string            `json:"chartType,omitempty" yaml:"chartType,omitempty"`
-	FacetBy          string            `json:"facetBy,omitempty" yaml:"facetBy,omitempty"`
-	StackBy          string            `json:"stackBy,omitempty" yaml:"stackBy,omitempty"`
-	Colors           map[string]string `json:"colors,omitempty" yaml:"colors,omitempty"`
-}
 
 // PrometheusResponse is the top-level Prometheus HTTP API response.
 type PrometheusResponse struct {
@@ -87,55 +49,6 @@ type PrometheusData struct {
 type PrometheusResult struct {
 	Metric map[string]string `json:"metric"`
 	Values [][]any           `json:"values"` // each element is [unix_timestamp_float, "string_value"]
-}
-
-//go:embed queries.yaml
-var defaultQueriesYAML []byte
-
-func loadQueriesConfig() (*QueriesConfig, error) {
-	return parseQueriesConfig(defaultQueriesYAML)
-}
-
-func parseQueriesConfig(data []byte) (*QueriesConfig, error) {
-	var cfg QueriesConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("failed to parse queries config: %w", err)
-	}
-	for pi, p := range cfg.Panels {
-		if p.Title == "" {
-			return nil, fmt.Errorf("panel %d: title is required", pi)
-		}
-		if len(p.Queries) == 0 {
-			return nil, fmt.Errorf("panel %d (%s): at least one query is required", pi, p.Title)
-		}
-		for qi, q := range p.Queries {
-			if q.Title == "" {
-				return nil, fmt.Errorf("panel %d (%s), query %d: title is required", pi, p.Title, qi)
-			}
-			if q.Query == "" {
-				return nil, fmt.Errorf("panel %d (%s), query %d (%s): query is required", pi, p.Title, qi, q.Title)
-			}
-			if q.Workspace != workspaceSvc && q.Workspace != workspaceHcp {
-				return nil, fmt.Errorf("panel %d (%s), query %d (%s): workspace must be \"svc\" or \"hcp\", got %q", pi, p.Title, qi, q.Title, q.Workspace)
-			}
-			if q.Step == "" {
-				cfg.Panels[pi].Queries[qi].Step = "60s"
-			}
-			if q.ChartType == "" {
-				cfg.Panels[pi].Queries[qi].ChartType = chartTypeLine
-			}
-			if cfg.Panels[pi].Queries[qi].ChartType != chartTypeLine && cfg.Panels[pi].Queries[qi].ChartType != chartTypeFacetedStackedArea {
-				return nil, fmt.Errorf("panel %d (%s), query %d (%s): chartType must be %q or %q, got %q", pi, p.Title, qi, q.Title, chartTypeLine, chartTypeFacetedStackedArea, cfg.Panels[pi].Queries[qi].ChartType)
-			}
-			if cfg.Panels[pi].Queries[qi].ChartType == chartTypeFacetedStackedArea && q.FacetBy == "" {
-				return nil, fmt.Errorf("panel %d (%s), query %d (%s): facetBy is required when chartType is %q", pi, p.Title, qi, q.Title, chartTypeFacetedStackedArea)
-			}
-			if cfg.Panels[pi].Queries[qi].ChartType != chartTypeFacetedStackedArea && q.FacetBy != "" {
-				return nil, fmt.Errorf("panel %d (%s), query %d (%s): facetBy is only valid with chartType %q", pi, p.Title, qi, q.Title, chartTypeFacetedStackedArea)
-			}
-		}
-	}
-	return &cfg, nil
 }
 
 // lookupPrometheusEndpoint retrieves the Prometheus query endpoint for an

--- a/test/cmd/aro-hcp-tests/gather-observability/queries.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/queries.go
@@ -1,0 +1,160 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatherobservability
+
+import (
+	"fmt"
+
+	_ "embed"
+
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	chartTypeLine               = "line"
+	chartTypeFacetedStackedArea = "faceted-stacked-area"
+
+	queryTypePromQL      = "promql"
+	queryTypeAzureMetric = "azureMetric"
+)
+
+// QueriesConfig holds panels of grouped queries to run against Azure Monitor
+// workspaces and platform metrics. Each panel produces one HTML page with
+// multiple charts.
+type QueriesConfig struct {
+	Panels []PanelSpec `json:"panels" yaml:"panels"`
+}
+
+// PanelSpec groups related queries that should be rendered together on a
+// single HTML page.
+type PanelSpec struct {
+	Title   string      `json:"title" yaml:"title"`
+	Queries []QuerySpec `json:"queries" yaml:"queries"`
+}
+
+// QuerySpec describes a single query to execute and chart. The Type field
+// discriminates between PromQL queries (default) and Azure Monitor platform
+// metric queries.
+type QuerySpec struct {
+	Title            string            `json:"title" yaml:"title"`
+	Description      string            `json:"description,omitempty" yaml:"description,omitempty"`
+	Type             string            `json:"type,omitempty" yaml:"type,omitempty"`
+	Unit             string            `json:"unit,omitempty" yaml:"unit,omitempty"`
+	MinPeakThreshold float64           `json:"minPeakThreshold,omitempty" yaml:"minPeakThreshold,omitempty"`
+	ChartType        string            `json:"chartType,omitempty" yaml:"chartType,omitempty"`
+	FacetBy          string            `json:"facetBy,omitempty" yaml:"facetBy,omitempty"`
+	StackBy          string            `json:"stackBy,omitempty" yaml:"stackBy,omitempty"`
+	Colors           map[string]string `json:"colors,omitempty" yaml:"colors,omitempty"`
+
+	// PromQL fields
+	Query     string `json:"query,omitempty" yaml:"query,omitempty"`
+	Workspace string `json:"workspace,omitempty" yaml:"workspace,omitempty"`
+	Step      string `json:"step,omitempty" yaml:"step,omitempty"`
+
+	// Azure Monitor metric fields
+	Resource    string `json:"resource,omitempty" yaml:"resource,omitempty"`
+	MetricName  string `json:"metricName,omitempty" yaml:"metricName,omitempty"`
+	Aggregation string `json:"aggregation,omitempty" yaml:"aggregation,omitempty"`
+	Interval    string `json:"interval,omitempty" yaml:"interval,omitempty"`
+	Filter      string `json:"filter,omitempty" yaml:"filter,omitempty"`
+}
+
+// queryDisplay returns a human-readable string for the query, used in chart
+// metadata. For PromQL it's the query string; for Azure metrics it describes
+// the metric and aggregation.
+func (q QuerySpec) queryDisplay() string {
+	if q.Type == queryTypeAzureMetric {
+		display := fmt.Sprintf("%s(%s)", q.Aggregation, q.MetricName)
+		if len(q.Filter) > 0 {
+			display += fmt.Sprintf(" | %s", q.Filter)
+		}
+		return display
+	}
+	return q.Query
+}
+
+//go:embed queries.yaml
+var defaultQueriesYAML []byte
+
+func loadQueriesConfig() (*QueriesConfig, error) {
+	return parseQueriesConfig(defaultQueriesYAML)
+}
+
+func parseQueriesConfig(data []byte) (*QueriesConfig, error) {
+	var cfg QueriesConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse queries config: %w", err)
+	}
+	for pi, p := range cfg.Panels {
+		if p.Title == "" {
+			return nil, fmt.Errorf("panel %d: title is required", pi)
+		}
+		if len(p.Queries) == 0 {
+			return nil, fmt.Errorf("panel %d (%s): at least one query is required", pi, p.Title)
+		}
+		for qi, q := range p.Queries {
+			if q.Title == "" {
+				return nil, fmt.Errorf("panel %d (%s), query %d: title is required", pi, p.Title, qi)
+			}
+
+			if q.Type == "" {
+				cfg.Panels[pi].Queries[qi].Type = queryTypePromQL
+			}
+			qType := cfg.Panels[pi].Queries[qi].Type
+
+			switch qType {
+			case queryTypePromQL:
+				if q.Query == "" {
+					return nil, fmt.Errorf("panel %d (%s), query %d (%s): query is required", pi, p.Title, qi, q.Title)
+				}
+				if q.Workspace != workspaceSvc && q.Workspace != workspaceHcp {
+					return nil, fmt.Errorf("panel %d (%s), query %d (%s): workspace must be \"svc\" or \"hcp\", got %q", pi, p.Title, qi, q.Title, q.Workspace)
+				}
+				if q.Step == "" {
+					cfg.Panels[pi].Queries[qi].Step = "60s"
+				}
+			case queryTypeAzureMetric:
+				if q.Resource == "" {
+					return nil, fmt.Errorf("panel %d (%s), query %d (%s): resource is required for azureMetric queries", pi, p.Title, qi, q.Title)
+				}
+				if q.MetricName == "" {
+					return nil, fmt.Errorf("panel %d (%s), query %d (%s): metricName is required for azureMetric queries", pi, p.Title, qi, q.Title)
+				}
+				if q.Aggregation == "" {
+					return nil, fmt.Errorf("panel %d (%s), query %d (%s): aggregation is required for azureMetric queries", pi, p.Title, qi, q.Title)
+				}
+				if q.Interval == "" {
+					cfg.Panels[pi].Queries[qi].Interval = "PT1M"
+				}
+			default:
+				return nil, fmt.Errorf("panel %d (%s), query %d (%s): type must be %q or %q, got %q", pi, p.Title, qi, q.Title, queryTypePromQL, queryTypeAzureMetric, qType)
+			}
+
+			if q.ChartType == "" {
+				cfg.Panels[pi].Queries[qi].ChartType = chartTypeLine
+			}
+			if cfg.Panels[pi].Queries[qi].ChartType != chartTypeLine && cfg.Panels[pi].Queries[qi].ChartType != chartTypeFacetedStackedArea {
+				return nil, fmt.Errorf("panel %d (%s), query %d (%s): chartType must be %q or %q, got %q", pi, p.Title, qi, q.Title, chartTypeLine, chartTypeFacetedStackedArea, cfg.Panels[pi].Queries[qi].ChartType)
+			}
+			if cfg.Panels[pi].Queries[qi].ChartType == chartTypeFacetedStackedArea && q.FacetBy == "" {
+				return nil, fmt.Errorf("panel %d (%s), query %d (%s): facetBy is required when chartType is %q", pi, p.Title, qi, q.Title, chartTypeFacetedStackedArea)
+			}
+			if cfg.Panels[pi].Queries[qi].ChartType != chartTypeFacetedStackedArea && q.FacetBy != "" {
+				return nil, fmt.Errorf("panel %d (%s), query %d (%s): facetBy is only valid with chartType %q", pi, p.Title, qi, q.Title, chartTypeFacetedStackedArea)
+			}
+		}
+	}
+	return &cfg, nil
+}

--- a/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
@@ -251,3 +251,23 @@ panels:
     unit: /s
     workspace: svc
     step: "60s"
+- title: "CosmosDB Metrics"
+  queries:
+  - title: "Normalized RU Consumption"
+    description: "Maximum normalized RU consumption per collection. Values above 70% indicate the collection is approaching its provisioned throughput limit. Sustained values near 100% cause request throttling (HTTP 429)."
+    type: azureMetric
+    resource: cosmosdb
+    metricName: NormalizedRuConsumption
+    aggregation: Maximum
+    interval: PT1M
+    filter: "CollectionName eq '*'"
+    unit: percent
+  - title: "Throttled Requests (429s)"
+    description: "Count of requests throttled by CosmosDB (HTTP 429 status code) per collection. Non-zero values indicate the collection has exceeded its provisioned throughput and clients are being rate-limited."
+    type: azureMetric
+    resource: cosmosdb
+    metricName: TotalRequests
+    aggregation: Count
+    interval: PT1M
+    filter: "StatusCode eq '429'"
+    unit: requests


### PR DESCRIPTION
## Summary

- Extend `gather-observability` to query Azure Monitor platform metrics (CosmosDB NormalizedRU consumption, throttled requests) alongside existing PromQL queries
- Add `type` discriminator to `queries.yaml` (`promql` default vs `azureMetric`) with logical resource name resolution from rendered config
- Split shared query types into `queries.go`, keep `promql.go` for Prometheus-specific code, add `azuremetric.go` for platform metric fetcher

## Why

CosmosDB and AMW are ephemeral — destroyed after E2E tests. Platform metrics (RU consumption, 429 throttling) live in Azure Monitor's native metrics API, not in Prometheus/AMW, so they're invisible in CI artifacts today. This captures them before teardown.

## Open item

RBAC verification: confirm CI identity has `Monitoring Reader` (or equivalent) scoped to read platform metrics on the CosmosDB account.

## Test plan

- [x] Unit tests for Azure metric response → parsedSeries adapter
- [x] Unit tests for aggregation value extraction (Average/Maximum/Minimum/Total/Count)
- [x] Unit tests for queryDisplay() across query types
- [x] Tabular tests for parseQueriesConfig with azureMetric type validation
- [x] Embedded queries.yaml parse test passes
- [x] Lint clean
- [ ] Manual run against personal dev environment

[ARO-29198](https://issues.redhat.com/browse/ARO-29198)