### PR TITLE
fix(test): add Standard_NC6s_v3 as GPU SKU preferred fallback

### DIFF
--- a/test/util/framework/vm_sku_selection.go
+++ b/test/util/framework/vm_sku_selection.go
@@ -567,6 +567,7 @@ func GPUNodePoolVMSizeSelector() VMSizeSelector {
 			"Standard_NC8as_T4_v3",
 			"Standard_NC16as_T4_v3",
 			"Standard_NC64as_T4_v3",
+			"Standard_NC6s_v3",
 		},
 		NamePattern: regexp.MustCompile(`^Standard_N`),
 		RequireGPU:  true,


### PR DESCRIPTION
## Why

When all T4 GPU SKUs (`Standard_NC4as_T4_v3` through `Standard_NC64as_T4_v3`) are restricted in the test subscription/region (westus3, `64f0619f-...`), the GPU VM size selector falls through to a deterministic alphabetical fallback that picks `Standard_NC24ads_A100_v4` — an expensive A100 SKU (~$3.67/hr, 24 vCPUs).

## What

Adds `Standard_NC6s_v3` (V100, 1 GPU, 6 vCPUs, ~$3/hr) as the last preferred entry in `GPUNodePoolVMSizeSelector`. This is the cheapest non-T4 GPU SKU in the RP allowlist and is tried before the alphabetical fallback can pick A100/H100 SKUs.

## Test plan

- [ ] Verify `go build ./test/util/framework/` passes
- [ ] Verify existing `vm_sku_selection_test.go` tests pass
- [ ] In a subscription where T4 SKUs are restricted in westus3, confirm `Standard_NC6s_v3` is selected instead of `Standard_NC24ads_A100_v4`