### PR TITLE
fix(cosmosmigration): skip TTL-governed docs to stop resetting their TTL

### DIFF
--- a/backend/pkg/controllers/cosmosmigration/cosmos_migration.go
+++ b/backend/pkg/controllers/cosmosmigration/cosmos_migration.go
@@ -579,6 +579,13 @@ func replaceWithRetry[T any, TPointer coreapi.CosmosMetadataAccessorPtr[T]](ctx 
 		if err != nil {
 			return fmt.Errorf("failed to get %s %q: %w", resourceDesc, name, err)
 		}
+		// Skip TTL-governed documents (e.g. operations). Re-serializing them
+		// would issue a write that bumps the document's _ts, which resets the
+		// Cosmos TTL clock (expiry is _ts + ttl). Rewriting them on every
+		// process restart would therefore prevent them from ever expiring.
+		if cosmosstorageutils.TimeToLiveForInternal(curr) > 0 {
+			return nil
+		}
 		_, err = crud.Replace(ctx, curr, nil)
 		if err == nil {
 			return nil

--- a/backend/pkg/controllers/cosmosmigration/cosmos_migration_test.go
+++ b/backend/pkg/controllers/cosmosmigration/cosmos_migration_test.go
@@ -231,6 +231,69 @@ func TestReplaceWithRetry(t *testing.T) {
 	}
 }
 
+// opStubCRUD implements cosmosstorageutils.ResourceCRUD[coreapi.Operation, *coreapi.Operation]
+// just enough for the TTL-skip test. Only Get and Replace are exercised.
+type opStubCRUD struct {
+	getFunc     func(ctx context.Context, resourceID string) (*coreapi.Operation, error)
+	replaceFunc func(ctx context.Context, newObj *coreapi.Operation, options *azcosmos.ItemOptions) (*coreapi.Operation, error)
+}
+
+func (s *opStubCRUD) Get(ctx context.Context, resourceID string) (*coreapi.Operation, error) {
+	return s.getFunc(ctx, resourceID)
+}
+
+func (s *opStubCRUD) Replace(ctx context.Context, newObj *coreapi.Operation, options *azcosmos.ItemOptions) (*coreapi.Operation, error) {
+	return s.replaceFunc(ctx, newObj, options)
+}
+
+func (s *opStubCRUD) GetByID(context.Context, string) (*coreapi.Operation, error) {
+	panic("not implemented")
+}
+
+func (s *opStubCRUD) List(context.Context, *cosmosstorageutils.DBClientListResourceDocsOptions) (cosmosstorageutils.DBClientIterator[coreapi.Operation], error) {
+	panic("not implemented")
+}
+
+func (s *opStubCRUD) Create(context.Context, *coreapi.Operation, *azcosmos.ItemOptions) (*coreapi.Operation, error) {
+	panic("not implemented")
+}
+
+func (s *opStubCRUD) Delete(context.Context, string) error {
+	panic("not implemented")
+}
+
+func (s *opStubCRUD) AddCreateToTransaction(context.Context, cosmosstorageutils.DBTransaction, *coreapi.Operation, *azcosmos.TransactionalBatchItemOptions) (string, error) {
+	panic("not implemented")
+}
+
+func (s *opStubCRUD) AddReplaceToTransaction(context.Context, cosmosstorageutils.DBTransaction, *coreapi.Operation, *azcosmos.TransactionalBatchItemOptions) (string, error) {
+	panic("not implemented")
+}
+
+// TestReplaceWithRetrySkipsTTLDocuments verifies that replaceWithRetry does not
+// re-write TTL-governed documents (e.g. operations). Rewriting them would bump
+// the document's _ts and reset the Cosmos TTL clock, preventing expiry.
+func TestReplaceWithRetrySkipsTTLDocuments(t *testing.T) {
+	ctx := context.Background()
+	logger := testr.New(t)
+
+	getCalled := false
+	crud := &opStubCRUD{
+		getFunc: func(_ context.Context, _ string) (*coreapi.Operation, error) {
+			getCalled = true
+			return &coreapi.Operation{}, nil
+		},
+		replaceFunc: func(_ context.Context, _ *coreapi.Operation, _ *azcosmos.ItemOptions) (*coreapi.Operation, error) {
+			t.Fatal("Replace must not be called for TTL-governed documents; doing so resets their TTL clock")
+			return nil, nil
+		},
+	}
+
+	err := replaceWithRetry(ctx, logger, crud, "test-operation", "operation")
+	require.NoError(t, err)
+	assert.True(t, getCalled, "expected Get to be called before deciding to skip")
+}
+
 func TestSyncOnceSkipsAlreadyCompletedSubscription(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/database/cosmosstorage/cosmosstorageutils/convert_generic.go
+++ b/internal/database/cosmosstorage/cosmosstorageutils/convert_generic.go
@@ -23,6 +23,20 @@ import (
 
 const operationTimeToLive = 604800 // 7 days
 
+// TimeToLiveForInternal returns the Cosmos DB TTL (in seconds) that a given
+// internal object should be stored with, or 0 for "no TTL". This is the single
+// source of truth for which document types are TTL-governed: it is used both
+// when serializing documents (to stamp the ttl field) and by the Cosmos
+// migration controller (to avoid re-writing ephemeral, TTL-governed documents,
+// which would reset their _ts and therefore their TTL clock).
+func TimeToLiveForInternal(internalObj any) int {
+	switch internalObj.(type) {
+	case *coreapi.Operation:
+		return operationTimeToLive
+	}
+	return 0
+}
+
 func InternalToCosmosGeneric[InternalAPIType any](internalObj *InternalAPIType) (*GenericDocument[InternalAPIType], error) {
 	if internalObj == nil {
 		return nil, nil
@@ -59,11 +73,10 @@ func InternalToCosmosGeneric[InternalAPIType any](internalObj *InternalAPIType) 
 	}
 
 	// this isn't pretty, but on balance it's a better choice so that we can share all the rest.
-	switch any(internalObj).(type) {
-	case *coreapi.Operation:
-		// TODO Add TTL to cosmosMetadata
-		cosmosObj.TimeToLive = operationTimeToLive
-	}
+	// TimeToLiveForInternal is the single source of truth for which document
+	// types are TTL-governed (see also the Cosmos migration controller).
+	// TODO Add TTL to cosmosMetadata
+	cosmosObj.TimeToLive = TimeToLiveForInternal(any(internalObj))
 
 	return cosmosObj, nil
 }

--- a/internal/database/cosmosstorage/cosmosstorageutils/convert_generic.go
+++ b/internal/database/cosmosstorage/cosmosstorageutils/convert_generic.go
@@ -30,8 +30,13 @@ const operationTimeToLive = 604800 // 7 days
 // migration controller (to avoid re-writing ephemeral, TTL-governed documents,
 // which would reset their _ts and therefore their TTL clock).
 func TimeToLiveForInternal(internalObj any) int {
-	switch internalObj.(type) {
+	switch v := internalObj.(type) {
 	case *coreapi.Operation:
+		// A typed nil pointer still matches this case; honor the documented
+		// "nil => no TTL" contract rather than returning a TTL for it.
+		if v == nil {
+			return 0
+		}
 		return operationTimeToLive
 	}
 	return 0

--- a/internal/database/cosmosstorage/cosmosstorageutils/convert_generic_test.go
+++ b/internal/database/cosmosstorage/cosmosstorageutils/convert_generic_test.go
@@ -51,6 +51,11 @@ func TestTimeToLiveForInternal(t *testing.T) {
 			obj:  nil,
 			want: 0,
 		},
+		{
+			name: "typed nil operation pointer has no TTL",
+			obj:  (*coreapi.Operation)(nil),
+			want: 0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/database/cosmosstorage/cosmosstorageutils/convert_generic_test.go
+++ b/internal/database/cosmosstorage/cosmosstorageutils/convert_generic_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cosmosstorageutils
+
+import (
+	"testing"
+
+	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+)
+
+func TestTimeToLiveForInternal(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  any
+		want int
+	}{
+		{
+			name: "operations are TTL-governed",
+			obj:  &coreapi.Operation{},
+			want: operationTimeToLive,
+		},
+		{
+			name: "clusters have no TTL",
+			obj:  &coreapi.HCPOpenShiftCluster{},
+			want: 0,
+		},
+		{
+			name: "node pools have no TTL",
+			obj:  &coreapi.HCPOpenShiftClusterNodePool{},
+			want: 0,
+		},
+		{
+			name: "subscriptions have no TTL",
+			obj:  &coreapi.Subscription{},
+			want: 0,
+		},
+		{
+			name: "nil has no TTL",
+			obj:  nil,
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TimeToLiveForInternal(tt.obj); got != tt.want {
+				t.Errorf("TimeToLiveForInternal(%T) = %d, want %d", tt.obj, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The migration re-serializes every document on each backend restart. Rewriting operation docs bumped _ts, resetting the Cosmos TTL clock (expiry = _ts + ttl), so operations never expired and accumulated indefinitely. Skip any TTL-governed document via a shared TimeToLiveForInternal helper.
