### PR TITLE
fix: removing PrometheusMetricsAbsentPerCluster alert from msft queue

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedMsftPrometheusAlertingRules.bicep
@@ -720,53 +720,6 @@ resource msftKubernetesStorage 'Microsoft.AlertsManagement/prometheusRuleGroups@
   }
 }
 
-resource msftPrometheusWipRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
-  name: 'msft-prometheus-wip-rules'
-  location: location
-  properties: {
-    interval: 'PT1M'
-    rules: [
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'PrometheusMetricsAbsentPerCluster'
-        enabled: true
-        labels: {
-          component: 'monitoring-infrastructure'
-          severity: 'critical'
-        }
-        annotations: {
-          correlationId: 'PrometheusMetricsAbsentPerCluster/{{ $labels.cluster }}'
-          description: '''Prometheus on cluster {{ $labels.cluster }} has not reported any up metrics in the last 10 minutes, but was reporting within the last 7 days.
-This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
-Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
-'''
-          info: '''Prometheus on cluster {{ $labels.cluster }} has not reported any up metrics in the last 10 minutes, but was reporting within the last 7 days.
-This indicates the Prometheus agent on this specific cluster is dead or its remote write pipeline is broken.
-Check the PrometheusAgent pod status and remote write configuration on the affected cluster.
-'''
-          runbook_url: 'https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/Prometheus.md'
-          summary: 'Prometheus metrics absent for cluster {{ $labels.cluster }}.'
-          title: 'Prometheus metrics absent for cluster {{ $labels.cluster }}.'
-        }
-        expression: 'count by (cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[1w])) unless count by (cluster) (count_over_time(up{job="prometheus/prometheus",namespace="prometheus"}[10m]))'
-        for: 'PT10M'
-        severity: severityCeiling > 0 ? max(2, severityCeiling) : 2
-      }
-    ]
-    scopes: [
-      azureMonitoring
-    ]
-  }
-}
-
 resource msftMise 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
   name: 'msft-mise'
   location: location

--- a/observability/alerts-msft-services.yaml
+++ b/observability/alerts-msft-services.yaml
@@ -57,9 +57,6 @@ prometheusRules:
   - groupName: mise
     alerts:
     - MiseEnvoyScrapeDown
-  - groupName: prometheus-wip-rules
-    alerts:
-    - PrometheusMetricsAbsentPerCluster
   labelsToExtract:
   - persistentvolumeclaim
   - persistentvolume


### PR DESCRIPTION
[ARO-29227](https://redhat.atlassian.net/browse/ARO-29227)

### What

Removes PrometheusMetricsAbsentPerCluster alert from the alerts going to microsoft

### Why

This is a duplicate alert. We have one that already goes to the Red Hat SLSRE queue.

### Testing

Tested by e2e parallel

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge

If E2E tests are included:

- [x] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [x] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
