### PR TITLE
feat(nodehealth): add CNI plugin not initialized detector

### DIFF
--- a/docs/controllers/node-health.md
+++ b/docs/controllers/node-health.md
@@ -202,8 +202,23 @@ never a candidate. On those nodes it matches `FailedCreatePodSandBox` Events in 
 `route ip+net: no such network interface` family (plus the network-unreachable,
 mtpnc-not-ready, and dhcp-discover-timeout variants seen for this fault). It lives
 in its own file and contributes only its specifics; its signature, thresholds, and
-node-applicability label are constants in code, not config. A second fault family
-would be another detector reusing the shared primitives, shipped and tested as code.
+node-applicability label are constants in code, not config.
+
+The second detector, `cni-plugin-not-initialized`, covers a different Ready-but-
+broken failure. The kubelet repeatedly emits pod-scoped `NetworkNotReady` Events
+(`InvolvedObject.Kind: Pod`) whose message contains `cni plugin not initialized`,
+and newly scheduled pods cannot get sandboxes. In many episodes the node stays
+Ready throughout because kubelet's `NetworkReady` condition only gates the
+initial Ready transition; however, in some episodes the node does eventually go
+NotReady with reason `KubeletNotReady`. Because `Decide` gates every pod
+detector behind `isNodeReady`, the detector only fires while the node reports
+Ready — on episodes where the node flips NotReady and later recovers, the
+detector sees only the tail after kubelet marks it Ready again. It is
+scoped to SWIFT-v2 nodes and uses a three-pod floor, 20-minute dwell and
+window, and zero-success requirement (a wider dwell and window than
+`swift-vf-teardown`'s 10-minute values, chosen to clear the observed reimage
+ceiling; that detector's floor is 2). The exact Event
+message is pinned in the detector tests.
 
 The decision is **rate, continuity, and success-presence, never an absolute error
 count**. The measured evidence is explicit about why an absolute count misleads:

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/README.md
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/README.md
@@ -53,8 +53,8 @@ is adding code in its own file, never editing the engine:
   (windowed correlation of failure Events to stuck pods, condition-based dwell
   math, node-Ready and success helpers). Families that fit this shape reuse all
   of it.
-- **`swift_vf.go`**: one fault family's specifics only, the `swift-vf-teardown`
-  detector value plus its applicability predicate. No evaluation logic lives here.
+- **`swift_vf.go`** and **`cni_plugin_not_initialized.go`**: each fault family's
+  specifics only. No evaluation logic lives in these files.
 - **`never_ready.go`**: the `never-ready` detector, a `NodeDetector` whose whole
   evidence is the Node object.
 
@@ -87,7 +87,7 @@ constants, never config):
 | field                | meaning |
 |----------------------|---------|
 | `appliesTo`          | predicate limiting the detector to nodes that can physically exhibit the fault (nil = all nodes) |
-| `eventReason`        | the kubelet Event `reason` that marks a pod as failing sandbox creation |
+| `eventReason`        | the kubelet Event `reason` that signals a pod-level networking failure |
 | `signatures`         | regexes matched against the failure Event message; any match is a hit. The first one that matches classifies the pod, and the signature classifying most of the counted pods is reported in the `Snapshot` for triage (ties broken by declaration order, so it is stable) |
 | `failuresFloor`      | minimum number of stuck pods that have each individually been stuck past `dwell` (a floor so the storm is sustained, not the trigger) |
 | `window`             | rolling window over which failures and successes are counted |
@@ -143,19 +143,35 @@ Pods that the apiserver garbage-collects:
 
 ## The detectors today
 
-### `swift-vf-teardown`
+### Pod detectors
 
-Applies only to SWIFT-v2 delegated-NIC nodes (label
+Both current detectors apply only to SWIFT-v2 delegated-NIC nodes (label
 `kubernetes.azure.com/podnetwork-swiftv2-enabled=true`, exported as
 `SwiftV2LabelKey`/`SwiftV2LabelValue`): a node with no delegated secondary NIC
-cannot suffer a VF teardown, so it is never a candidate. On those nodes it matches
-`FailedCreatePodSandBox` Events in the `route ip+net: no such network interface`
-family (plus the `network is unreachable`, `mtpnc is not ready`, and
-`dhcp discover ... timed out` variants), with `failuresFloor: 3`, `window: 10m`,
-`dwell: 10m`, `requireZeroSuccess: true`.
+is outside the observed failure scope.
+
+- `swift-vf-teardown` matches `FailedCreatePodSandBox` Events in the
+  `route ip+net: no such network interface` family, plus the
+  `network is unreachable`, `mtpnc is not ready`, and
+  `dhcp discover ... timed out` variants.
+- `cni-plugin-not-initialized` matches `NetworkNotReady` Events carrying
+  `cni plugin not initialized`. In this modality the node
+  often remains `Ready`, but its CNI never initializes and newly scheduled pods
+  cannot get sandboxes. In many episodes the node stays Ready throughout because
+  the kubelet `NetworkReady` condition only gates the initial Ready transition;
+  in some episodes the node does eventually go NotReady. Because the detector
+  gates behind `isNodeReady`, it only fires while the node reports Ready.
+
+Both use `requireZeroSuccess: true`.
+`swift-vf-teardown` uses `window: 10m`, `dwell: 10m`, and `failuresFloor: 2`
+(a hard wedge presents with very few distinct pods);
+`cni-plugin-not-initialized` uses `window: 20m`, `dwell: 20m`, and
+`failuresFloor: 3` (a wider window chosen to clear the observed reimage
+ceiling — production data across five regions showed transient CNI bursts
+topping out around 14 minutes).
 
 `SwiftV2LabelKey`/`Value` are exported because the controller uses them to scope
-its periodic sweep to the nodes a detector can actually fire on, rather than
+its periodic sweep to the nodes these detectors can actually fire on, rather than
 sweeping every node in the cluster. The sweep is the union of that selector and
 the wedged-label selector, so a node that stops being a detection candidate while
 labeled is still swept and has its stale label retired

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/cni_plugin_not_initialized.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/cni_plugin_not_initialized.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package detectors
+
+import "time"
+
+// reasonNetworkNotReady is the kubelet Event reason emitted when the
+// container runtime network is not ready (e.g. CNI plugin not initialized).
+const reasonNetworkNotReady = "NetworkNotReady"
+
+// cniPluginNotInitialized detects a SWIFT-v2 node whose kubelet remains Ready
+// while its CNI plugin cannot initialize. This is distinct from delegated-NIC
+// teardown: kubelet emits pod-scoped NetworkNotReady Events (InvolvedObject.Kind
+// = Pod) rather than FailedCreatePodSandBox, but the durable symptom and
+// recovery discriminator are the same.
+var cniPluginNotInitialized = signatureDetector{
+	name:        "cni-plugin-not-initialized",
+	reason:      "CNI plugin not initialized: sustained NetworkNotReady failures with zero successful pod starts",
+	appliesTo:   isSwiftV2Node,
+	eventReason: reasonNetworkNotReady,
+	signatures: mustCompileSignatures(
+		`cni plugin not initialized`,
+	),
+	// failuresFloor is 3, not 2 as in swift-vf-teardown. A dead CNI affects every
+	// pod on the node, so observed bursts carry 7–8 distinct pods and 3 is
+	// comfortably reachable, unlike the delegated-NIC wedge where almost nothing
+	// new is placed once the NIC is gone.
+	failuresFloor:      3,
+	window:             20 * time.Minute,
+	dwell:              20 * time.Minute,
+	requireZeroSuccess: true,
+	// successScope is nil: a dead CNI breaks the node's only pod network, so
+	// every pod traverses the broken path and any success is real evidence of
+	// recovery. This differs from swift-vf-teardown, where only pods requesting
+	// a delegated NIC exercise the broken path.
+}

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/decide.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/decide.go
@@ -120,7 +120,7 @@ type NodeDetector interface {
 // its evidence, shipped and tested as code. The split is what keeps a detector
 // off the path it has nothing to say on, instead of a runtime check.
 var (
-	podRegistry  = []PodDetector{swiftVFTeardown}
+	podRegistry  = []PodDetector{swiftVFTeardown, cniPluginNotInitialized}
 	nodeRegistry = []NodeDetector{neverReady}
 )
 

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/decide_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/decide_test.go
@@ -58,10 +58,14 @@ func testNode(swift, ready bool) *corev1.Node {
 // node and whose involved object is the named pod (correlated by UID), matching
 // the SWIFT signature.
 func failEventFor(pod string, last time.Time, msg string) *corev1.Event {
+	return eventFor(pod, last, reasonFailedCreatePodSandBox, msg)
+}
+
+func eventFor(pod string, last time.Time, reason, msg string) *corev1.Event {
 	return &corev1.Event{
 		InvolvedObject: corev1.ObjectReference{Kind: "Pod", Namespace: "ns", Name: pod, UID: podUID(pod)},
 		Source:         corev1.EventSource{Host: nodeName, Component: "kubelet"},
-		Reason:         reasonFailedCreatePodSandBox,
+		Reason:         reason,
 		Message:        msg,
 		LastTimestamp:  metav1.NewTime(last),
 		FirstTimestamp: metav1.NewTime(last),
@@ -451,6 +455,47 @@ func TestSignatureVariantsMatch(t *testing.T) {
 	if _, ok := swiftVFTeardown.matchSignature("image pull backoff"); ok {
 		t.Error("unrelated message should not match")
 	}
+}
+
+func TestCNIPluginNotInitialized(t *testing.T) {
+	const message = "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized"
+
+	events := []*corev1.Event{
+		eventFor("p0", ago(20*time.Second), reasonNetworkNotReady, message),
+		eventFor("p1", ago(20*time.Second), reasonNetworkNotReady, message),
+		eventFor("p2", ago(20*time.Second), reasonNetworkNotReady, message),
+	}
+	pods := []*corev1.Pod{
+		stuckPod("p0", ago(25*time.Minute)),
+		stuckPod("p1", ago(25*time.Minute)),
+		stuckPod("p2", ago(25*time.Minute)),
+	}
+
+	t.Run("persistent failure wedges a Ready SWIFT node", func(t *testing.T) {
+		got, snap := Decide(testNode(true, true), events, pods, testNow)
+		if got != DecisionWedged {
+			t.Fatalf("Decide() = %v, want Wedged", got)
+		}
+		if snap.DetectorName != cniPluginNotInitialized.name {
+			t.Errorf("snapshot detector = %q, want %q", snap.DetectorName, cniPluginNotInitialized.name)
+		}
+		if snap.MatchedSignature != cniPluginNotInitialized.signatures[0].String() {
+			t.Errorf("matched signature = %q, want %q", snap.MatchedSignature, cniPluginNotInitialized.signatures[0].String())
+		}
+	})
+
+	t.Run("recent sandbox success suppresses the wedge", func(t *testing.T) {
+		withSuccess := append(append([]*corev1.Pod{}, pods...), startedPod("ok", ago(2*time.Minute), false))
+		if got, _ := Decide(testNode(true, true), events, withSuccess, testNow); got != DecisionHealthy {
+			t.Errorf("Decide() = %v, want Healthy", got)
+		}
+	})
+
+	t.Run("non-SWIFT node is outside the observed failure scope", func(t *testing.T) {
+		if got, _ := Decide(testNode(false, true), events, pods, testNow); got != DecisionNotApplicable {
+			t.Errorf("Decide() = %v, want NotApplicable", got)
+		}
+	})
 }
 
 func TestMatchedSignatureReportsDominantFailureMode(t *testing.T) {

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/production_evidence_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/production_evidence_test.go
@@ -77,6 +77,51 @@ func TestProductionSandboxMessagesMatchSignatures(t *testing.T) {
 	}
 }
 
+// TestCNIPluginNotInitializedEvidence pins the exact kubelet signal for a node
+// that stays Ready while several pods remain without sandboxes.
+// Message captured from australiaeast NetworkNotReady events (Kusto, 2026-08).
+func TestCNIPluginNotInitializedEvidence(t *testing.T) {
+	const message = "network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized"
+	now := time.Date(2026, 8, 19, 22, 30, 0, 0, time.UTC)
+
+	var events []*corev1.Event
+	var pods []*corev1.Pod
+	for _, name := range []string{"set-kubelet-parameters-for-scale", "system-pod-1", "system-pod-2"} {
+		uid := types.UID("uid-" + name)
+		pods = append(pods, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: name, UID: uid},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				Conditions: []corev1.PodCondition{{
+					Type:               corev1.PodReadyToStartContainers,
+					Status:             corev1.ConditionFalse,
+					LastTransitionTime: metav1.NewTime(now.Add(-24 * time.Hour)),
+				}},
+			},
+		})
+		events = append(events, &corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Namespace: "kube-system", Name: name + ".evt"},
+			Reason:         reasonNetworkNotReady,
+			Message:        message,
+			InvolvedObject: corev1.ObjectReference{Kind: "Pod", Namespace: "kube-system", Name: name, UID: uid},
+			Source:         corev1.EventSource{Host: "swift-node", Component: "kubelet"},
+			FirstTimestamp: metav1.NewTime(now.Add(-1 * time.Minute)),
+			LastTimestamp:  metav1.NewTime(now.Add(-1 * time.Minute)),
+		})
+	}
+
+	got, snap := Decide(productionWedgedNode(), events, pods, now)
+	if got != DecisionWedged {
+		t.Fatalf("Decide() = %v, want Wedged", got)
+	}
+	if snap.DetectorName != cniPluginNotInitialized.name {
+		t.Errorf("snapshot detector = %q, want %q", snap.DetectorName, cniPluginNotInitialized.name)
+	}
+	if snap.MatchedSignature != cniPluginNotInitialized.signatures[0].String() {
+		t.Errorf("matched signature = %q, want %q", snap.MatchedSignature, cniPluginNotInitialized.signatures[0].String())
+	}
+}
+
 // productionNodeLabels are the SWIFT-related labels carried by the captured
 // wedged node. The node was Ready throughout, which is the premise the whole
 // controller rests on: node lifecycle never sees these nodes as broken.
@@ -153,6 +198,7 @@ func TestProductionCompletedPodsDoNotCount(t *testing.T) {
 			Message:        productionSandboxMessages[0].message,
 			InvolvedObject: corev1.ObjectReference{Kind: "Pod", Namespace: ns, Name: c.name, UID: uid},
 			Source:         corev1.EventSource{Host: "aks-userswift0-00000000-vmss000000"},
+			FirstTimestamp: metav1.NewTime(now.Add(-1 * time.Minute)),
 			LastTimestamp:  metav1.NewTime(now.Add(-1 * time.Minute)),
 		})
 	}
@@ -199,6 +245,7 @@ func productionWedgeEvidence(now time.Time) ([]*corev1.Event, []*corev1.Pod) {
 			Message:        productionSandboxMessages[i%len(productionSandboxMessages)].message,
 			InvolvedObject: corev1.ObjectReference{Kind: "Pod", Namespace: ns, Name: name, UID: uid},
 			Source:         corev1.EventSource{Host: host},
+			FirstTimestamp: metav1.NewTime(now.Add(-1 * time.Minute)),
 			LastTimestamp:  metav1.NewTime(now.Add(-1 * time.Minute)),
 		})
 	}


### PR DESCRIPTION
[AROSLSRE-1849](https://redhat.atlassian.net/browse/AROSLSRE-1849)

### What

Add a `cni-plugin-not-initialized` detector to the node-health controller that identifies SWIFT-v2 nodes remaining Ready while their CNI plugin persistently fails to initialize.

### Why

Nodes in this state emit `NetworkNotReady` events with `NetworkPluginNotReady: cni plugin not initialized` but never go `NotReady`, so the scheduler keeps placing pods that can never get sandboxes. The existing `swift-vf-teardown` detector did not cover this signature.

### Testing

- Unit tests: `TestCNIPluginNotInitialized` covers wedge detection, success
  suppression, and non-SWIFT applicability.
- Production evidence test: `TestCNIPluginNotInitializedEvidence` pins the
  exact kubelet signal against realistic fixtures.
- All existing node-health detector tests continue to pass (20 tests, 0.003s).
- No e2e tests required — labeling is non-disruptive and the detector reuses
  the established `signatureDetector` base without new I/O paths.

### Special notes for your reviewer

This follows the documented pattern for adding a fault family: a new `signatureDetector` value in its own file, registered in `decide.go`, with no changes to the detection engine or shared primitives.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge