### PR TITLE
test(e2e): timebomb 4.20->4.21 minor upgrade until Cincinnati publishes edges

### DIFF
--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -94,6 +94,17 @@ var _ = Describe("Customer", func() {
 				}
 			}
 
+			// TIMEBOMB: upstream cincinnati-graph-data promoted 4.20.35 as a node in
+			// candidate-4.21 on 2026-08-21 but has not yet added outgoing 4.20.35 -> 4.21.z
+			// edges. Because the RP picks the channel tip (offset 0) for candidate/fast,
+			// every 4.20 -> 4.21 run lands on 4.20.35 and is rejected by frontend admission
+			// with "no upgrade path to update channel \"candidate-4.21\"". Skip until
+			// upstream publishes the edge or the deadline passes (revisit and remove).
+			if channelGroup != "nightly" && installVersionId == "4.20" && upgradeVersionId == "4.21" &&
+				time.Now().Before(time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC)) {
+				Skip("timebomb: upstream cincinnati-graph-data has no 4.20.35 -> 4.21.z edge yet; re-evaluate after 2026-08-31")
+			}
+
 			tc := framework.NewTestContext()
 			if tc.UsePooledIdentities() {
 				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)


### PR DESCRIPTION
## Summary

- Scoped `Skip` in `test/e2e/control_plane_minor_upgrade.go` for the `candidate`/`fast` **4.20 → 4.21** case, expiring **2026-08-31**.
- Nightly and other minor jumps are unaffected.

## Why

All of the dev CI is failing on the test "Customer should be able to successfully upgrade control plane minor version from 4.20 minor to 4.21 minor"

Upstream `openshift/cincinnati-graph-data` promoted **4.20.35** as a node in `candidate-4.21` on 2026-08-21 (commit [12b0b5a5](https://github.com/openshift/cincinnati-graph-data/commit/12b0b5a5)), but has not yet added outgoing `4.20.35 → 4.21.z` edges. Because the RP picks the channel tip (offset 0) for `candidate`/`fast` (`GetZStreamOffset` in `backend/pkg/controllers/cluster/version/control_plane_desired_version_controller.go`), every 4.20 → 4.21 run lands on 4.20.35 and is rejected by frontend admission (`internal/admission/admit_cluster.go:670-723`) with:

> `no upgrade path to update channel "candidate-4.21" is currently available for this cluster`

Confirmed via graph query:

```
curl -s 'https://api.openshift.com/api/upgrades_info/graph?channel=candidate-4.21&arch=amd64' \
  | jq -r '.nodes as $n | .edges[] | select($n[.[0]].version=="4.20.35") | $n[.[1]].version' \
  | grep '^4\.21' || echo "no 4.20.35 -> 4.21.x edge yet"
```

Runtime evidence (int-uksouth, 2026-08-21 04:11Z): `serviceproviderclusters` snapshot for the failing cluster shows `desiredVersionChannels = ["candidate-4.20"]`, `activeVersions = [{"version":"4.20.35","state":"Completed"}]`.

Jira: [AROSLSRE-1853](https://redhat.atlassian.net/browse/AROSLSRE-1853)

## Follow-up

Replace the timebomb with a preflight that queries the Cincinnati graph for an outgoing edge from the resolved install version to the target minor and `Skip`s if absent — removes the race for good and self-heals across future z-stream promotions.

## Test plan

- [ ] CI green on this branch
- [ ] Verify the 4.20 → 4.21 entry reports `SKIP` (not fail) in E2E output while the timebomb is active
- [ ] Verify the 4.21 → 4.22 entry still runs