### PR TITLE
chore: consolidate backup config after moving prod config to sdp-pipelines

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -40,8 +40,6 @@ clouds:
                 resources:
                   requests:
                     memory: 2Gi
-          backend:
-            backupScheduleState: Enabled
       stg:
         # this is the MSFT STAGE environment
         regions:
@@ -133,8 +131,6 @@ clouds:
           mise:
             audit:
               connectSocket: true
-          backend:
-            backupScheduleState: Enabled
       prod:
         # this is the MSFT PRODUCTION environment
         defaults:
@@ -142,8 +138,6 @@ clouds:
           e2e:
             regionTest:
               prowJobName: branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel
-          backend:
-            backupScheduleState: Disabled
           # Cluster Service
           clustersService:
             deployDebugJobs: true
@@ -188,6 +182,3 @@ clouds:
           switzerlandnorth:
             kusto:
               kustoName: "hcp-prod-ch-2"
-          australiaeast:
-            backend:
-              backupScheduleState: Enabled


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-29247

### What

We want to have to prod specific backup config in sdp-pipelines

### Why

The move is done to be able to see the changes in the rendered configuration for verification. Also you're able to change the config a bit more quickly and independent from ARO-HCP.

This is just cleaning up leftovers.

### Testing

`make -C config materialize` and check results

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean (rebased/squashed)
- [ ] All comment threads resolved before merge