### PR TITLE
fix: switch CI svc cluster agent pools to AMD v7 VMs for better zonal availability

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1792,15 +1792,15 @@ clouds:
               systemAgentPool:
                 maxCount: 4
                 osDiskSizeGB: 32
-                vmSize: Standard_D8ds_v6
+                vmSize: Standard_D8ads_v7
               userAgentPool:
                 maxCount: 14
                 minCount: 4
                 osDiskSizeGB: 100
-                vmSize: Standard_E16ds_v6
+                vmSize: Standard_E16ads_v7
                 secondaryNicCount: 7
               infraAgentPool:
-                vmSize: Standard_D8ds_v6
+                vmSize: Standard_D8ads_v7
                 osDiskSizeGB: 64
             jaeger:
               deploy: false
@@ -1899,15 +1899,15 @@ clouds:
               systemAgentPool:
                 maxCount: 4
                 osDiskSizeGB: 32
-                vmSize: Standard_D8ds_v6
+                vmSize: Standard_D8ads_v7
               userAgentPool:
                 maxCount: 14
                 minCount: 4
                 osDiskSizeGB: 100
-                vmSize: Standard_E16ds_v6
+                vmSize: Standard_E16ads_v7
                 secondaryNicCount: 7
               infraAgentPool:
-                vmSize: Standard_D8ds_v6
+                vmSize: Standard_D8ads_v7
                 osDiskSizeGB: 64
             jaeger:
               deploy: false

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1811,13 +1811,13 @@ clouds:
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
               systemAgentPool:
-                vmSize: Standard_D4ds_v6
+                vmSize: Standard_D4ads_v7
               userAgentPool:
-                name: 'u64d8dsv6'
-                vmSize: Standard_D8ds_v6
+                name: 'u64d8adsv7'
+                vmSize: Standard_D8ads_v7
                 osDiskSizeGB: 64
               infraAgentPool:
-                vmSize: Standard_D4ds_v6
+                vmSize: Standard_D4ads_v7
             jaeger:
               deploy: true
       ci01:
@@ -1920,12 +1920,12 @@ clouds:
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
               systemAgentPool:
-                vmSize: Standard_D4ds_v6
+                vmSize: Standard_D4ads_v7
               userAgentPool:
-                name: 'u64d8dsv6'
-                vmSize: Standard_D8ds_v6
+                name: 'u64d8adsv7'
+                vmSize: Standard_D8ads_v7
                 osDiskSizeGB: 64
               infraAgentPool:
-                vmSize: Standard_D4ds_v6
+                vmSize: Standard_D4ads_v7
             jaeger:
               deploy: true

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -1012,7 +1012,7 @@ svc:
       name: infra
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D4ds_v6
+      vmSize: Standard_D4ads_v7
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: "1.35"
@@ -1027,7 +1027,7 @@ svc:
       name: system
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D4ds_v6
+      vmSize: Standard_D4ads_v7
       zoneRedundantMode: Auto
       zones: ""
     tags: clusterType=svc-cluster,persist=true
@@ -1037,10 +1037,10 @@ svc:
     userAgentPool:
       maxCount: 3
       minCount: 1
-      name: u64d8dsv6
+      name: u64d8adsv7
       osDiskSizeGB: 64
       poolCount: 3
-      vmSize: Standard_D8ds_v6
+      vmSize: Standard_D8ads_v7
       zoneRedundantMode: Auto
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -649,7 +649,7 @@ mgmt:
       name: infra
       osDiskSizeGB: 64
       poolCount: 2
-      vmSize: Standard_D8ds_v6
+      vmSize: Standard_D8ads_v7
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: "1.35"
@@ -664,7 +664,7 @@ mgmt:
       name: system
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D8ds_v6
+      vmSize: Standard_D8ads_v7
       zoneRedundantMode: Auto
       zones: ""
     tags: clusterType=mgmt-cluster,persist=true
@@ -678,7 +678,7 @@ mgmt:
       osDiskSizeGB: 100
       poolCount: 3
       secondaryNicCount: 7
-      vmSize: Standard_E16ds_v6
+      vmSize: Standard_E16ads_v7
       zoneRedundantMode: Auto
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -1012,7 +1012,7 @@ svc:
       name: infra
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D4ds_v6
+      vmSize: Standard_D4ads_v7
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: "1.35"
@@ -1027,7 +1027,7 @@ svc:
       name: system
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D4ds_v6
+      vmSize: Standard_D4ads_v7
       zoneRedundantMode: Auto
       zones: ""
     tags: clusterType=svc-cluster,persist=true
@@ -1037,10 +1037,10 @@ svc:
     userAgentPool:
       maxCount: 3
       minCount: 1
-      name: u64d8dsv6
+      name: u64d8adsv7
       osDiskSizeGB: 64
       poolCount: 3
-      vmSize: Standard_D8ds_v6
+      vmSize: Standard_D8ads_v7
       zoneRedundantMode: Auto
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -649,7 +649,7 @@ mgmt:
       name: infra
       osDiskSizeGB: 64
       poolCount: 2
-      vmSize: Standard_D8ds_v6
+      vmSize: Standard_D8ads_v7
       zoneRedundantMode: Auto
       zones: ""
     kubernetesVersion: "1.35"
@@ -664,7 +664,7 @@ mgmt:
       name: system
       osDiskSizeGB: 32
       poolCount: 1
-      vmSize: Standard_D8ds_v6
+      vmSize: Standard_D8ads_v7
       zoneRedundantMode: Auto
       zones: ""
     tags: clusterType=mgmt-cluster,persist=true
@@ -678,7 +678,7 @@ mgmt:
       osDiskSizeGB: 100
       poolCount: 3
       secondaryNicCount: 7
-      vmSize: Standard_E16ds_v6
+      vmSize: Standard_E16ads_v7
       zoneRedundantMode: Auto
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1977

## Summary

- Switch all CI svc and mgmt cluster agent pools (system, user, infra) in ci00 and ci01 from Intel v6 to AMD v7 VM SKUs
- Addresses `OverconstrainedZonalAllocationRequest` failures across multiple regions (`westus3`, `westus2`) where Azure lacked capacity for the v6 Intel SKUs in specific availability zones
- The v7 AMD family is newer generation with equivalent or better specs (same vCPUs, RAM, ephemeral disk support) and broader zonal availability

### SVC cluster changes

| Pool | Old SKU | New SKU |
|------|---------|---------|
| systemAgentPool | `Standard_D4ds_v6` | `Standard_D4ads_v7` |
| userAgentPool | `Standard_D8ds_v6` | `Standard_D8ads_v7` |
| infraAgentPool | `Standard_D4ds_v6` | `Standard_D4ads_v7` |

### MGMT cluster changes

| Pool | Old SKU | New SKU |
|------|---------|---------|
| systemAgentPool | `Standard_D8ds_v6` | `Standard_D8ads_v7` |
| userAgentPool | `Standard_E16ds_v6` | `Standard_E16ads_v7` |
| infraAgentPool | `Standard_D8ds_v6` | `Standard_D8ads_v7` |

### Failing jobs

- SVC failure: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/6583/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2091747201922371584
- MGMT failure: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/6447/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2091793135989428224

## Test plan

- [x] `cd config && make materialize` passes
- [x] Helm fixture tests pass
- [x] No v6 Intel SKUs remain in ci00/ci01 rendered configs
- [ ] e2e-parallel CI job succeeds with new SKUs