### PR TITLE
feat: set dataPlaneHAProxyImage to decouple worker HAProxy from management cluster

### DIFF
--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -38,6 +38,32 @@ resourceGroups:
       - "unauthorized: authentication required"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
+  - name: mirror-data-plane-haproxy-image
+    action: ImageMirror
+    targetACR:
+      configRef: 'acr.ocp.name'
+    sourceRegistry:
+      configRef: clustersService.dataPlaneHAProxyImage.registry
+    repository:
+      configRef: clustersService.dataPlaneHAProxyImage.repository
+    digest:
+      configRef: clustersService.dataPlaneHAProxyImage.digest
+    pullSecretKeyVault:
+      configRef: global.keyVault.name
+    pullSecretName:
+      configRef: imageSync.ondemandSync.pullSecretName
+    shellIdentity:
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    automatedRetry:
+      errorContainsAny:
+      - "unknown_storage_failure"
+      - "unexpected EOF"
+      - "unauthorized: authentication required"
+      maximumRetryCount: 5
+      durationBetweenRetries: 1m
 - name: kusto
   resourceGroup: '{{ .kusto.rg }}'
   subscription: '{{ .global.subscription.key }}'
@@ -135,6 +161,8 @@ resourceGroups:
       step: output
     - resourceGroup: global
       step: mirror-image
+    - resourceGroup: global
+      step: mirror-data-plane-haproxy-image
     automatedRetry:
       errorContainsAny:
       - "500 Internal Server Error"

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
@@ -8107,6 +8107,7 @@ spec:
         - --log-fields-from-baggage=aro.correlation_id=correlation_id,aro.client.request_id=client_request_id
         
         
+        - --data-plane-ha-proxy-image=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890
         livenessProbe:
           httpGet:
             path: /api/clusters_mgmt/v1

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
@@ -8208,6 +8208,7 @@ spec:
         - --log-fields-from-baggage=aro.correlation_id=correlation_id,aro.client.request_id=client_request_id
         
         
+        - --data-plane-ha-proxy-image=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890
         livenessProbe:
           httpGet:
             path: /api/clusters_mgmt/v1

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_distinct_arm_helper.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_distinct_arm_helper.yaml
@@ -8107,6 +8107,7 @@ spec:
         - --log-fields-from-baggage=aro.correlation_id=correlation_id,aro.client.request_id=client_request_id
         
         
+        - --data-plane-ha-proxy-image=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890
         livenessProbe:
           httpGet:
             path: /api/clusters_mgmt/v1

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_shared_arm_helper.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_shared_arm_helper.yaml
@@ -8107,6 +8107,7 @@ spec:
         - --log-fields-from-baggage=aro.correlation_id=correlation_id,aro.client.request_id=client_request_id
         
         
+        - --data-plane-ha-proxy-image=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890
         livenessProbe:
           httpGet:
             path: /api/clusters_mgmt/v1

--- a/cluster-service/values.yaml
+++ b/cluster-service/values.yaml
@@ -214,7 +214,7 @@ managedIdentitiesDataPlaneAudienceResource: "{{ .msiRp.dataPlaneAudienceResource
 # The image used to override the HAProxy image of the worker node API server proxy.
 # Assembled as an ACR reference so worker nodes pull from the environment-specific ACR, not quay.io.
 # When digest is empty, CS falls back to IMAGE_SHARED_INGRESS_HAPROXY (legacy behavior).
-dataPlaneHAProxyImage: "{{ if .clustersService.dataPlaneHAProxyImage.digest }}{{ .acr.ocp.name }}.azurecr.io/{{ .clustersService.dataPlaneHAProxyImage.repository }}@{{ .clustersService.dataPlaneHAProxyImage.digest }}{{ end }}"
+dataPlaneHAProxyImage: "{{ if .clustersService.dataPlaneHAProxyImage.digest }}{{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/{{ .clustersService.dataPlaneHAProxyImage.repository }}@{{ .clustersService.dataPlaneHAProxyImage.digest }}{{ end }}"
 # The Azure Operator Managed Identities.
 azureOperatorsMI:
   roleSetName: "{{ .clustersService.azureOperatorsManagedIdentities.roleSetName }}"

--- a/cluster-service/values.yaml
+++ b/cluster-service/values.yaml
@@ -212,9 +212,9 @@ databasePort: "5432"
 # The name of the managed identities data plane audience resource.
 managedIdentitiesDataPlaneAudienceResource: "{{ .msiRp.dataPlaneAudienceResource }}"
 # The image used to override the HAProxy image of the worker node API server proxy.
-# If set to an empty string, either the environment variable IMAGE_SHARED_INGRESS_HAPROXY or the default shared ingress image will be used.
-# If given a value, it must be a valid image reference.
-dataPlaneHAProxyImage: "{{ .clustersService.dataPlaneHAProxyImage }}"
+# Assembled as an ACR reference so worker nodes pull from the environment-specific ACR, not quay.io.
+# When digest is empty, CS falls back to IMAGE_SHARED_INGRESS_HAPROXY (legacy behavior).
+dataPlaneHAProxyImage: "{{ if .clustersService.dataPlaneHAProxyImage.digest }}{{ .acr.ocp.name }}.azurecr.io/{{ .clustersService.dataPlaneHAProxyImage.repository }}@{{ .clustersService.dataPlaneHAProxyImage.digest }}{{ end }}"
 # The Azure Operator Managed Identities.
 azureOperatorsMI:
   roleSetName: "{{ .clustersService.azureOperatorsManagedIdentities.roleSetName }}"

--- a/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
+++ b/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
@@ -8107,6 +8107,7 @@ spec:
         - --log-fields-from-baggage=aro.correlation_id=correlation_id,aro.client.request_id=client_request_id
         
         
+        - --data-plane-ha-proxy-image=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890
         livenessProbe:
           httpGet:
             path: /api/clusters_mgmt/v1

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1238,8 +1238,7 @@
           ]
         },
         "dataPlaneHAProxyImage": {
-          "type": "string",
-          "description": "A valid image reference used for overriding the HAProxy image of the worker node API server proxy. If set to an empty string, either the environment variable IMAGE_SHARED_INGRESS_HAPROXY or the default shared ingress image will be used."
+          "$ref": "#/definitions/containerImage"
         }
       },
       "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1097,7 +1097,12 @@ defaults:
     environment: "arohcp{{ .ctx.environment }}"
     denyAssignments: "disabled"
     # The image used to override the HAProxy image of the worker node API server proxy.
-    dataPlaneHAProxyImage: ""
+    # Defaults to matching sharedIngressImage so the decoupled image starts identical.
+    # Override only `digest` per-region in sdp-pipelines overlays when regions need pinning.
+    dataPlaneHAProxyImage:
+      registry: quay.io
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+      digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     postgres:
       name: "arohcp-{{ .ctx.environment }}-dbcs-{{ .ctx.regionShort }}" # [globally-unique]
       deploy: true

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -171,7 +171,10 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
-  dataPlaneHAProxyImage: ""
+  dataPlaneHAProxyImage:
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcpci00

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -171,7 +171,10 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
-  dataPlaneHAProxyImage: ""
+  dataPlaneHAProxyImage:
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcpci01

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -171,7 +171,10 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
-  dataPlaneHAProxyImage: ""
+  dataPlaneHAProxyImage:
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcpcspr

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -171,7 +171,10 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
-  dataPlaneHAProxyImage: ""
+  dataPlaneHAProxyImage:
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcpdev

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -171,7 +171,10 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
-  dataPlaneHAProxyImage: ""
+  dataPlaneHAProxyImage:
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcpperf

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -171,7 +171,10 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
-  dataPlaneHAProxyImage: ""
+  dataPlaneHAProxyImage:
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcppers


### PR DESCRIPTION
## Why

Bumping the management cluster HAProxy image (`IMAGE_SHARED_INGRESS_HAPROXY`) currently triggers unintended worker node rollouts across all hosted clusters because NodePools lack the `hypershift.openshift.io/haproxy-image` annotation. Without this annotation, worker nodes inherit the management cluster's HAProxy image, coupling data plane image versions to control plane upgrades (see incident [ARO-27681](https://redhat.atlassian.net/browse/ARO-27681) / [AROSLSRE-978](https://redhat.atlassian.net/browse/AROSLSRE-978)).

This PR enables Cluster Service to explicitly set the data plane HAProxy image on every NodePool, breaking that coupling. Once all environments have annotation coverage, [AROSLSRE-994](https://redhat.atlassian.net/browse/AROSLSRE-994) can safely unpin the prod region digest overrides.

## What

Restructures `dataPlaneHAProxyImage` from an empty string to a structured `containerImage` object (registry/repository/digest), matching the existing `sharedIngressImage` pattern:

- **Config schema**: `dataPlaneHAProxyImage` changed from `"type": "string"` to `"$ref": "#/definitions/containerImage"`
- **Config values**: Populated with the same image currently used by `sharedIngressImage` (safe: no image change, just enables annotation)
- **values.yaml**: Assembles ACR reference from structured fields (`<acr.ocp.name>.azurecr.io/<repo>@<digest>`)
- **pipeline.yaml**: Added `mirror-data-plane-haproxy-image` ImageMirror step to copy the image to the OCP ACR (where worker nodes pull from)
- **Materialized configs and helm fixtures**: Updated via `make materialize`

## Verification

- `make materialize`, `make validate-config-pipelines`, `make verify-schema` all pass
- Deployed to personal dev environment (`pers-usw3avol`)
- Confirmed all 3 CS pod replicas have the `--data-plane-ha-proxy-image=arohcpocpdev.azurecr.io/...@sha256:5e22710f...` flag
- NodePool annotation will be verified in DEV (CSPR) post-merge via test cluster creation

## Rollout Plan

1. **This PR** merges to ARO-HCP, DEV auto-deploys
2. INT/STG via sdp-pipelines config bump
3. PROD australiaeast + uksouth via sdp-pipelines with per-region digest override (`sha256:4eea8f36...`)
4. PROD remaining regions inherit global default
5. After full annotation coverage: [AROSLSRE-994](https://redhat.atlassian.net/browse/AROSLSRE-994) proceeds (unpin prod regions)

## Safety

The default digest (`sha256:5e22710f...`) matches the current `sharedIngressImage` digest in all non-overridden regions. Enabling the annotation does not change the actual image used — it only makes the assignment explicit, preventing future management cluster image bumps from cascading to worker nodes.

PROD uksouth and australiaeast have pinned overrides (`sha256:4eea8f36...`) that must be set via sdp-pipelines overlays before those regions are deployed (Phase 1.4-1.5 in the rollout plan).

Refs: ARO-27756, [AROSLSRE-994](https://redhat.atlassian.net/browse/AROSLSRE-994)