### PR TITLE
feat(byok): pass diskEncryptionSet ID to CS if AFEC is registered

### DIFF
--- a/internal/admission/admit_nodepool.go
+++ b/internal/admission/admit_nodepool.go
@@ -93,6 +93,11 @@ func mutateNodePoolServiceProviderProperties(ctx context.Context, admissionConte
 	errs = append(errs, mutateNodePoolExperimentalTags(ctx, admissionContext, op)...)
 	errs = append(errs, mutateNodePoolCreateOperationCompletionDeadline(ctx, admissionContext, op, fldPath.Child("createOperationCompletionDeadline"), &newObj.CreateOperationCompletionDeadline)...)
 
+	if op.Type == operation.Create {
+		subscription := admissionContext.Subscription
+		newObj.ExperimentalFeaturesEnabled = subscription != nil && subscription.HasRegisteredFeature(metadataapi.FeatureExperimentalReleaseFeatures)
+	}
+
 	return errs
 }
 

--- a/internal/admission/admit_nodepool_test.go
+++ b/internal/admission/admit_nodepool_test.go
@@ -347,6 +347,68 @@ func TestMutateNodePoolCreateOperationCompletionDeadline(t *testing.T) {
 	}
 }
 
+func TestMutateNodePoolExperimentalFeaturesEnabled(t *testing.T) {
+	afecRegistered := &coreapi.Subscription{
+		Properties: &coreapi.SubscriptionProperties{
+			RegisteredFeatures: &[]coreapi.Feature{
+				{
+					Name:  ptr.To(metadataapi.FeatureExperimentalReleaseFeatures),
+					State: ptr.To("Registered"),
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name         string
+		op           operation.Type
+		subscription *coreapi.Subscription
+		expected     bool
+	}{
+		{
+			name:         "create: AFEC registered sets ExperimentalFeaturesEnabled=true",
+			op:           operation.Create,
+			subscription: afecRegistered,
+			expected:     true,
+		},
+		{
+			name:         "create: no AFEC leaves ExperimentalFeaturesEnabled=false",
+			op:           operation.Create,
+			subscription: &coreapi.Subscription{Properties: &coreapi.SubscriptionProperties{}},
+			expected:     false,
+		},
+		{
+			name:         "create: nil subscription leaves ExperimentalFeaturesEnabled=false",
+			op:           operation.Create,
+			subscription: nil,
+			expected:     false,
+		},
+		{
+			name:         "update: AFEC registered does not set ExperimentalFeaturesEnabled",
+			op:           operation.Update,
+			subscription: afecRegistered,
+			expected:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodePool := &coreapi.HCPOpenShiftClusterNodePool{}
+			admissionContext := &NodePoolAdmissionContext{
+				Clock:        utilsclock.RealClock{},
+				Subscription: tt.subscription,
+				Cluster:      &coreapi.HCPOpenShiftCluster{},
+			}
+			if tt.op == operation.Update {
+				admissionContext.OriginalNodePool = &coreapi.HCPOpenShiftClusterNodePool{}
+			}
+			errs := MutateNodePool(context.Background(), admissionContext, operation.Operation{Type: tt.op}, nodePool, admissionContext.OriginalNodePool)
+			require.Empty(t, errs)
+			assert.Equal(t, tt.expected, nodePool.ServiceProviderProperties.ExperimentalFeaturesEnabled)
+		})
+	}
+}
+
 func TestAdmitNodePool_SubnetVNet(t *testing.T) {
 	const (
 		clusterSubnet       = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/cluster-vnet/subnets/cluster-subnet"

--- a/internal/api/coreapi/types_nodepool.go
+++ b/internal/api/coreapi/types_nodepool.go
@@ -124,6 +124,13 @@ type HCPOpenShiftClusterNodePoolServiceProviderProperties struct {
 	// The operation node pool create controller uses this value to decide about marking the install as failed.
 	// The e2e tests set this value to one minute less than the default timeout.
 	CreateOperationCompletionDeadline *metav1.Time `json:"createOperationCompletionDeadline,omitempty"`
+
+	// ExperimentalFeaturesEnabled records whether the FeatureExperimentalReleaseFeatures AFEC was
+	// registered on the subscription at node pool creation time. Used by internal/ocm/convert.go
+	// to gate experimental CS fields (e.g. SseEncryptionSetResourceId on the OS disk) that are
+	// only sent to Cluster Service when the AFEC is registered.
+	// Written by: Frontend PUT NodePool (Create)
+	ExperimentalFeaturesEnabled bool `json:"experimentalFeaturesEnabled,omitempty"`
 }
 
 // NodePoolVersionProfile represents the worker node pool version.

--- a/internal/apitesting/coreapitesting/fuzz.go
+++ b/internal/apitesting/coreapitesting/fuzz.go
@@ -196,6 +196,7 @@ func CommonRoundTripFuzzFuncs() []interface{} {
 			j.ActiveOperationID = ""
 			j.ClusterServiceID = nil
 			j.UsesNewNodePoolDeletionApproach = false
+			j.ExperimentalFeaturesEnabled = false
 		},
 		func(j *coreapi.HCPOpenShiftClusterExternalAuthServiceProviderProperties, c randfill.Continue) {
 			c.FillNoCustom(j)

--- a/internal/ocm/convert.go
+++ b/internal/ocm/convert.go
@@ -224,6 +224,17 @@ func convertEnableEncryptionAtHostToCSBuilder(in coreapi.NodePoolPlatformProfile
 	return arohcpv1alpha1.NewAzureNodePoolEncryptionAtHost().State(state)
 }
 
+func buildCSOsDisk(osDisk coreapi.OSDiskProfile, storageAccountType, persistence string) *arohcpv1alpha1.AzureNodePoolOsDiskBuilder {
+	builder := arohcpv1alpha1.NewAzureNodePoolOsDisk().
+		SizeGibibytes(int(*osDisk.SizeGiB)).
+		StorageAccountType(storageAccountType).
+		Persistence(persistence)
+	if osDisk.EncryptionSetID != nil {
+		builder.SseEncryptionSetResourceId(osDisk.EncryptionSetID.String())
+	}
+	return builder
+}
+
 func convertClusterImageRegistryStateRPToCS(in coreapi.ClusterImageRegistryProfile) (string, error) {
 	switch in.State {
 	case metadataapi.ClusterImageRegistryStateDisabled:
@@ -629,10 +640,7 @@ func BuildCSNodePool(ctx context.Context, nodePool *coreapi.HCPOpenShiftClusterN
 				ResourceName(strings.ToLower(nodePool.Name)).
 				VMSize(nodePool.Properties.Platform.VMSize).
 				EncryptionAtHost(convertEnableEncryptionAtHostToCSBuilder(nodePool.Properties.Platform)).
-				OsDisk(arohcpv1alpha1.NewAzureNodePoolOsDisk().
-					SizeGibibytes(int(*nodePool.Properties.Platform.OSDisk.SizeGiB)).
-					StorageAccountType(csDiskStorageAccountType).
-					Persistence(csPersistence))).
+				OsDisk(buildCSOsDisk(nodePool.Properties.Platform.OSDisk, csDiskStorageAccountType, csPersistence))).
 			AvailabilityZone(nodePool.Properties.Platform.AvailabilityZone).
 			AutoRepair(nodePool.Properties.AutoRepair)
 	}

--- a/internal/ocm/convert.go
+++ b/internal/ocm/convert.go
@@ -224,12 +224,12 @@ func convertEnableEncryptionAtHostToCSBuilder(in coreapi.NodePoolPlatformProfile
 	return arohcpv1alpha1.NewAzureNodePoolEncryptionAtHost().State(state)
 }
 
-func buildCSOsDisk(osDisk coreapi.OSDiskProfile, storageAccountType, persistence string) *arohcpv1alpha1.AzureNodePoolOsDiskBuilder {
+func buildCSOsDisk(osDisk coreapi.OSDiskProfile, storageAccountType, persistence string, experimentalFeaturesEnabled bool) *arohcpv1alpha1.AzureNodePoolOsDiskBuilder {
 	builder := arohcpv1alpha1.NewAzureNodePoolOsDisk().
 		SizeGibibytes(int(*osDisk.SizeGiB)).
 		StorageAccountType(storageAccountType).
 		Persistence(persistence)
-	if osDisk.EncryptionSetID != nil {
+	if experimentalFeaturesEnabled && osDisk.EncryptionSetID != nil {
 		builder.SseEncryptionSetResourceId(osDisk.EncryptionSetID.String())
 	}
 	return builder
@@ -640,7 +640,7 @@ func BuildCSNodePool(ctx context.Context, nodePool *coreapi.HCPOpenShiftClusterN
 				ResourceName(strings.ToLower(nodePool.Name)).
 				VMSize(nodePool.Properties.Platform.VMSize).
 				EncryptionAtHost(convertEnableEncryptionAtHostToCSBuilder(nodePool.Properties.Platform)).
-				OsDisk(buildCSOsDisk(nodePool.Properties.Platform.OSDisk, csDiskStorageAccountType, csPersistence))).
+				OsDisk(buildCSOsDisk(nodePool.Properties.Platform.OSDisk, csDiskStorageAccountType, csPersistence, nodePool.ServiceProviderProperties.ExperimentalFeaturesEnabled))).
 			AvailabilityZone(nodePool.Properties.Platform.AvailabilityZone).
 			AutoRepair(nodePool.Properties.AutoRepair)
 	}

--- a/internal/ocm/convert_test.go
+++ b/internal/ocm/convert_test.go
@@ -440,6 +440,35 @@ func TestBuildCSNodePool(t *testing.T) {
 					),
 				),
 		},
+		{
+			name: "passes disk encryption set ID to CS",
+			hcpNodePool: getHCPNodePoolResource(
+				func(hsc *coreapi.HCPOpenShiftClusterNodePool) {
+					hsc.Properties.Platform.OSDisk.EncryptionSetID = metadataapi.Must(azcorearm.ParseResourceID(
+						"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/diskEncryptionSets/test-des"))
+				},
+			),
+			expectedCSNodePool: getBaseCSNodePoolBuilder().
+				AzureNodePool(arohcpv1alpha1.NewAzureNodePool().
+					ResourceName("").
+					VMSize("").
+					EncryptionAtHost(
+						arohcpv1alpha1.NewAzureNodePoolEncryptionAtHost().
+							State(csEncryptionAtHostStateDisabled),
+					).
+					OsDisk(arohcpv1alpha1.NewAzureNodePoolOsDisk().
+						SizeGibibytes(64).
+						StorageAccountType(string(metadataapi.DiskStorageAccountTypePremium_LRS)).
+						Persistence("persistent").
+						SseEncryptionSetResourceId("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/diskEncryptionSets/test-des"),
+					),
+				),
+		},
+		{
+			name:               "nil disk encryption set ID does not set SSE field",
+			hcpNodePool:        getHCPNodePoolResource(),
+			expectedCSNodePool: getBaseCSNodePoolBuilder(),
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/ocm/convert_test.go
+++ b/internal/ocm/convert_test.go
@@ -441,11 +441,12 @@ func TestBuildCSNodePool(t *testing.T) {
 				),
 		},
 		{
-			name: "passes disk encryption set ID to CS",
+			name: "passes disk encryption set ID to CS when AFEC is enabled",
 			hcpNodePool: getHCPNodePoolResource(
 				func(hsc *coreapi.HCPOpenShiftClusterNodePool) {
 					hsc.Properties.Platform.OSDisk.EncryptionSetID = metadataapi.Must(azcorearm.ParseResourceID(
 						"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/diskEncryptionSets/test-des"))
+					hsc.ServiceProviderProperties.ExperimentalFeaturesEnabled = true
 				},
 			),
 			expectedCSNodePool: getBaseCSNodePoolBuilder().
@@ -463,6 +464,16 @@ func TestBuildCSNodePool(t *testing.T) {
 						SseEncryptionSetResourceId("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/diskEncryptionSets/test-des"),
 					),
 				),
+		},
+		{
+			name: "disk encryption set ID not passed to CS when AFEC is disabled",
+			hcpNodePool: getHCPNodePoolResource(
+				func(hsc *coreapi.HCPOpenShiftClusterNodePool) {
+					hsc.Properties.Platform.OSDisk.EncryptionSetID = metadataapi.Must(azcorearm.ParseResourceID(
+						"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/diskEncryptionSets/test-des"))
+				},
+			),
+			expectedCSNodePool: getBaseCSNodePoolBuilder(),
 		},
 		{
 			name:               "nil disk encryption set ID does not set SSE field",


### PR DESCRIPTION
<!-- Link to Jira issue -->

https://redhat.atlassian.net/browse/ARO-27738

### What

- This is the same as https://github.com/Azure/ARO-HCP/pull/6647 but without the e2e test, and behind the experimental features AFEC flag which is only registered in CI subscriptions.
- This change allows BYOK for nodePool OS disk encryption. Currently, since we don't pass the diskEncryptionSet ID to cluster service, all nodePool OS disks fall back to platform-managed keys, even if the intent was to configure it with a diskEncryptionSet. This also unblocks mHSM support for nodePool OS Disk encryption, which functions in the same way.
- The goal is to merge this PR and release it to stage and prod, change https://github.com/Azure/ARO-HCP/pull/6647 to only be the e2e test + AFEC flag check removal, and then run `/test stage-e2e-parallel prod-e2e-parallel` in that PR to confirm that e2e works in prod and stage environments (we already know it works in lower environments). Merging this feature this way is required because workload identities in dev, CI, and INT are mocked with a custom role, such that the role assignment scopes in the e2e test are not fully testable (workload identities are over-privileged). This is the cleanest way to ensure that e2e functions everywhere before release.
<!-- Briefly describe what this PR does -->

### Why

This is required to get BYOK for nodePool OS Disk encryption working, both for regular keyvaults, and mHSM keyvaults. Today the HCP API will accept a disk encryption set but won't use it for the actual encryption, which is unexpected behavior.

<!-- Briefly explain why this change is needed -->

### Testing

<!--
    Testing is required for feature completion and tests should 
    be part of the pull request along with the feature changes. 
    Describe the testing provided (unit, integration, e2e).

    If you did not add tests, provide a clear justification.
-->

### Special notes for your reviewer

<!-- optional -->

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge
