### PR TITLE
Add Velero backup monitoring alerts

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPPrometheusAlertingRules.bicep
@@ -142,3 +142,226 @@ resource mgmtCapacityRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023
     ]
   }
 }
+
+resource veleroBackupAlertRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'velero-backup-alert-rules'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'VeleroHourlyBackupStuckWarning'
+        enabled: true
+        labels: {
+          component: 'velero'
+          severity: '3'
+          team: 'hcp-sl'
+        }
+        annotations: {
+          correlationId: 'VeleroHourlyBackupStuckWarning/{{ $labels.cluster }}/{{ $labels.hosted_cluster }}'
+          description: 'No successful Velero hourly backup for HostedCluster {{ $labels.hosted_cluster }} on management cluster {{ $labels.cluster }} in over 2 hours (last success {{ $value | humanizeDuration }} ago). Hourly cadence is 1h; this is the primary restore-point freshness signal.'
+          info: 'No successful Velero hourly backup for HostedCluster {{ $labels.hosted_cluster }} on management cluster {{ $labels.cluster }} in over 2 hours (last success {{ $value | humanizeDuration }} ago). Hourly cadence is 1h; this is the primary restore-point freshness signal.'
+          owning_team: 'hcp-sl'
+          runbook_url: 'https://aka.ms/arohcp-tsg-velerobackup'
+          summary: 'Velero hourly backup stuck for HostedCluster {{ $labels.hosted_cluster }} on {{ $labels.cluster }}'
+          title: 'Velero hourly backup stuck for HostedCluster {{ $labels.hosted_cluster }} on {{ $labels.cluster }}'
+        }
+        expression: '(time() - max by (cluster, hosted_cluster) (max without (prometheus_replica) (label_replace(velero_backup_last_successful_timestamp{schedule=~".+-hourly"}, "hosted_cluster", "$1", "schedule", "(.+)-hourly")))) > 2 * 3600'
+        for: 'PT15M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'VeleroHourlyBackupStuckCritical'
+        enabled: true
+        labels: {
+          component: 'velero'
+          severity: '3'
+          team: 'hcp-sl'
+        }
+        annotations: {
+          correlationId: 'VeleroHourlyBackupStuckCritical/{{ $labels.cluster }}/{{ $labels.hosted_cluster }}'
+          description: 'No successful Velero hourly backup for HostedCluster {{ $labels.hosted_cluster }} on management cluster {{ $labels.cluster }} in over 6 hours (last success {{ $value | humanizeDuration }} ago). HCP has no recent restore point; immediate investigation required.'
+          info: 'No successful Velero hourly backup for HostedCluster {{ $labels.hosted_cluster }} on management cluster {{ $labels.cluster }} in over 6 hours (last success {{ $value | humanizeDuration }} ago). HCP has no recent restore point; immediate investigation required.'
+          owning_team: 'hcp-sl'
+          runbook_url: 'https://aka.ms/arohcp-tsg-velerobackup'
+          summary: 'Velero hourly backup critically stuck for HostedCluster {{ $labels.hosted_cluster }} on {{ $labels.cluster }}'
+          title: 'Velero hourly backup critically stuck for HostedCluster {{ $labels.hosted_cluster }} on {{ $labels.cluster }}'
+        }
+        expression: '(time() - max by (cluster, hosted_cluster) (max without (prometheus_replica) (label_replace(velero_backup_last_successful_timestamp{schedule=~".+-hourly"}, "hosted_cluster", "$1", "schedule", "(.+)-hourly")))) > 6 * 3600'
+        for: 'PT15M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'VeleroDailyBackupStuck'
+        enabled: true
+        labels: {
+          component: 'velero'
+          severity: '4'
+          team: 'hcp-sl'
+        }
+        annotations: {
+          correlationId: 'VeleroDailyBackupStuck/{{ $labels.cluster }}/{{ $labels.hosted_cluster }}'
+          description: 'No successful Velero daily backup for HostedCluster {{ $labels.hosted_cluster }} on management cluster {{ $labels.cluster }} in over 24 hours (last success {{ $value | humanizeDuration }} ago). Daily cadence is 24h. Restore is not necessarily at risk if hourly backups are healthy; this affects 30-day retention/compliance coverage.'
+          info: 'No successful Velero daily backup for HostedCluster {{ $labels.hosted_cluster }} on management cluster {{ $labels.cluster }} in over 24 hours (last success {{ $value | humanizeDuration }} ago). Daily cadence is 24h. Restore is not necessarily at risk if hourly backups are healthy; this affects 30-day retention/compliance coverage.'
+          owning_team: 'hcp-sl'
+          runbook_url: 'https://aka.ms/arohcp-tsg-velerobackup'
+          summary: 'Velero daily backup stuck for HostedCluster {{ $labels.hosted_cluster }} on {{ $labels.cluster }}'
+          title: 'Velero daily backup stuck for HostedCluster {{ $labels.hosted_cluster }} on {{ $labels.cluster }}'
+        }
+        expression: '(time() - max by (cluster, hosted_cluster) (max without (prometheus_replica) (label_replace(velero_backup_last_successful_timestamp{schedule=~".+-daily"}, "hosted_cluster", "$1", "schedule", "(.+)-daily")))) > 24 * 3600'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'VeleroWeeklyBackupStuck'
+        enabled: true
+        labels: {
+          component: 'velero'
+          severity: '4'
+          team: 'hcp-sl'
+        }
+        annotations: {
+          correlationId: 'VeleroWeeklyBackupStuck/{{ $labels.cluster }}/{{ $labels.hosted_cluster }}'
+          description: 'No successful Velero weekly backup for HostedCluster {{ $labels.hosted_cluster }} on management cluster {{ $labels.cluster }} in over 168 hours (last success {{ $value | humanizeDuration }} ago). Weekly cadence is 7d. Restore is not necessarily at risk if hourly backups are healthy; this affects 90-day retention/compliance coverage.'
+          info: 'No successful Velero weekly backup for HostedCluster {{ $labels.hosted_cluster }} on management cluster {{ $labels.cluster }} in over 168 hours (last success {{ $value | humanizeDuration }} ago). Weekly cadence is 7d. Restore is not necessarily at risk if hourly backups are healthy; this affects 90-day retention/compliance coverage.'
+          owning_team: 'hcp-sl'
+          runbook_url: 'https://aka.ms/arohcp-tsg-velerobackup'
+          summary: 'Velero weekly backup stuck for HostedCluster {{ $labels.hosted_cluster }} on {{ $labels.cluster }}'
+          title: 'Velero weekly backup stuck for HostedCluster {{ $labels.hosted_cluster }} on {{ $labels.cluster }}'
+        }
+        expression: '(time() - max by (cluster, hosted_cluster) (max without (prometheus_replica) (label_replace(velero_backup_last_successful_timestamp{schedule=~".+-weekly"}, "hosted_cluster", "$1", "schedule", "(.+)-weekly")))) > 168 * 3600'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'VeleroCSISnapshotFailureRateHigh'
+        enabled: true
+        labels: {
+          component: 'velero'
+          severity: '3'
+          team: 'hcp-sl'
+        }
+        annotations: {
+          correlationId: 'VeleroCSISnapshotFailureRateHigh/{{ $labels.cluster }}'
+          description: '{{ $value | humanizePercentage }} of Velero CSI snapshot attempts failed on management cluster {{ $labels.cluster }} over the last hour (threshold 10%). Volume snapshots backing HCP backups may be failing.'
+          info: '{{ $value | humanizePercentage }} of Velero CSI snapshot attempts failed on management cluster {{ $labels.cluster }} over the last hour (threshold 10%). Volume snapshots backing HCP backups may be failing.'
+          owning_team: 'hcp-sl'
+          runbook_url: 'https://aka.ms/arohcp-tsg-velerobackup'
+          summary: 'Elevated Velero CSI snapshot failure rate on {{ $labels.cluster }}'
+          title: 'Elevated Velero CSI snapshot failure rate on {{ $labels.cluster }}'
+        }
+        expression: 'velero:csi_snapshot:failure_ratio1h > 0.1 and velero:csi_snapshot_attempt:increase1h >= 2'
+        for: 'PT15M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'VeleroBackupDeletionFailureRateHigh'
+        enabled: true
+        labels: {
+          component: 'velero'
+          severity: '3'
+          team: 'hcp-sl'
+        }
+        annotations: {
+          correlationId: 'VeleroBackupDeletionFailureRateHigh/{{ $labels.cluster }}'
+          description: '{{ $value | humanizePercentage }} of Velero backup deletion attempts failed on management cluster {{ $labels.cluster }} over the last hour (threshold 10%). Expired backups may not be reclaimed.'
+          info: '{{ $value | humanizePercentage }} of Velero backup deletion attempts failed on management cluster {{ $labels.cluster }} over the last hour (threshold 10%). Expired backups may not be reclaimed.'
+          owning_team: 'hcp-sl'
+          runbook_url: 'https://aka.ms/arohcp-tsg-velerobackup'
+          summary: 'Elevated Velero backup deletion failure rate on {{ $labels.cluster }}'
+          title: 'Elevated Velero backup deletion failure rate on {{ $labels.cluster }}'
+        }
+        expression: 'velero:backup_deletion:failure_ratio1h > 0.1 and velero:backup_deletion_attempt:increase1h >= 2'
+        for: 'PT15M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'VeleroMetricsAbsent'
+        enabled: true
+        labels: {
+          component: 'velero'
+          severity: '3'
+          team: 'hcp-sl'
+        }
+        annotations: {
+          correlationId: 'VeleroMetricsAbsent/{{ $labels.cluster }}'
+          description: 'Velero backup metrics have been absent on management cluster {{ $labels.cluster }} for at least 15 minutes. Velero may be down or its PodMonitor scrape is broken; all other Velero backup alerts are blind on this cluster until this is resolved.'
+          info: 'Velero backup metrics have been absent on management cluster {{ $labels.cluster }} for at least 15 minutes. Velero may be down or its PodMonitor scrape is broken; all other Velero backup alerts are blind on this cluster until this is resolved.'
+          owning_team: 'hcp-sl'
+          runbook_url: 'https://aka.ms/arohcp-tsg-velerobackup'
+          summary: 'Velero metrics absent on {{ $labels.cluster }}'
+          title: 'Velero metrics absent on {{ $labels.cluster }}'
+        }
+        expression: 'group by (cluster) (underlay_clusters{cluster!~".*-svc-.*"}) unless on (cluster) group by (cluster) (velero_backup_attempt_total)'
+        for: 'PT15M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}

--- a/dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep
@@ -241,3 +241,59 @@ resource userjourneyKubeapiserverAvailabilityRecordingRules 'Microsoft.AlertsMan
     ]
   }
 }
+
+resource veleroBackupRecordingRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'velero-backup-recording-rules'
+  location: location
+  properties: {
+    scopes: [
+      azureMonitoring
+    ]
+    enabled: true
+    interval: 'PT1M'
+    rules: [
+      {
+        record: 'velero:csi_snapshot_attempt:increase1h'
+        expression: 'sum by (cluster) (max without (prometheus_replica) (increase(velero_csi_snapshot_attempt_total[1h])))'
+        labels: {
+          component: 'velero'
+        }
+      }
+      {
+        record: 'velero:csi_snapshot_failure:increase1h'
+        expression: 'sum by (cluster) (max without (prometheus_replica) (increase(velero_csi_snapshot_failure_total[1h])))'
+        labels: {
+          component: 'velero'
+        }
+      }
+      {
+        record: 'velero:csi_snapshot:failure_ratio1h'
+        expression: '(velero:csi_snapshot_failure:increase1h or 0 * velero:csi_snapshot_attempt:increase1h) / (velero:csi_snapshot_attempt:increase1h > 0)'
+        labels: {
+          component: 'velero'
+        }
+      }
+      {
+        record: 'velero:backup_deletion_attempt:increase1h'
+        expression: 'sum by (cluster) (max without (prometheus_replica) (increase(velero_backup_deletion_attempt_total[1h])))'
+        labels: {
+          component: 'velero'
+        }
+      }
+      {
+        record: 'velero:backup_deletion_failure:increase1h'
+        expression: 'sum by (cluster) (max without (prometheus_replica) (increase(velero_backup_deletion_failure_total[1h])))'
+        labels: {
+          component: 'velero'
+        }
+      }
+      {
+        record: 'velero:backup_deletion:failure_ratio1h'
+        expression: '(velero:backup_deletion_failure:increase1h or 0 * velero:backup_deletion_attempt:increase1h) / (velero:backup_deletion_attempt:increase1h > 0)'
+        labels: {
+          component: 'velero'
+        }
+      }
+    ]
+  }
+}

--- a/observability/alerts-sre-hcps.yaml
+++ b/observability/alerts-sre-hcps.yaml
@@ -2,6 +2,7 @@ prometheusRules:
   rulesFolders:
   - alerts/mgmt-capacity-prometheusRule.yaml
   - alerts/HCPkasRecord-prometheusRule-KSM.yaml
+  - alerts/velero-prometheusRule.yaml
   untestedRules: []
   testDependencies:
   - recording-rules-hcps.yaml

--- a/observability/alerts/velero-prometheusRule.yaml
+++ b/observability/alerts/velero-prometheusRule.yaml
@@ -1,0 +1,183 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: velero-backup-monitoring-rules
+  namespace: monitoring
+spec:
+  groups:
+  - name: velero-backup-alert-rules
+    labels:
+      component: velero
+    rules:
+    # ============================================================
+    # Velero Backup Alerting Rules
+    # ============================================================
+    # Velero runs on management clusters and backs up Hosted Clusters,
+    # NodePools, and HCP etcd. Schedules are named
+    # "<hostedClusterNamespace>-<cadence>", so the `schedule` label carries
+    # both the HostedCluster identity and the cadence. Rules that need
+    # per-HostedCluster scoping use `label_replace` to extract a
+    # `hosted_cluster` label and aggregate `by (cluster, hosted_cluster)`
+    # (never bare `by (cluster)`, which would let one HostedCluster's healthy
+    # backup mask another's failure on the same management cluster).
+    #
+    # `max without(prometheus_replica)` deduplicates HA Prometheus replicas
+    # before aggregation, matching the Velero Grafana dashboard queries.
+    #
+    # Owner: Service Lifecycle team (hcp-sl)
+
+    # ---- Stuck hourly backups (restore-point signal, pages) ---------------
+    # Hourly cadence is 1h; a recent hourly backup is what determines whether
+    # a valid restore point exists. Warn at >2h, page at >6h.
+    - alert: VeleroHourlyBackupStuckWarning
+      annotations:
+        summary: Velero hourly backup stuck for HostedCluster {{ $labels.hosted_cluster }} on {{ $labels.cluster }}
+        description: No successful Velero hourly backup for HostedCluster {{ $labels.hosted_cluster }} on management cluster {{ $labels.cluster }} in over 2 hours (last success {{ $value | humanizeDuration }} ago). Hourly cadence is 1h; this is the primary restore-point freshness signal.
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+      expr: |
+        (
+          time()
+          - max by (cluster, hosted_cluster) (
+              max without (prometheus_replica) (
+                label_replace(
+                  velero_backup_last_successful_timestamp{schedule=~".+-hourly"},
+                  "hosted_cluster", "$1", "schedule", "(.+)-hourly"
+                )
+              )
+            )
+        ) > 2 * 3600
+      for: 15m
+      labels:
+        severity: "3"
+        team: hcp-sl
+    - alert: VeleroHourlyBackupStuckCritical
+      annotations:
+        summary: Velero hourly backup critically stuck for HostedCluster {{ $labels.hosted_cluster }} on {{ $labels.cluster }}
+        description: No successful Velero hourly backup for HostedCluster {{ $labels.hosted_cluster }} on management cluster {{ $labels.cluster }} in over 6 hours (last success {{ $value | humanizeDuration }} ago). HCP has no recent restore point; immediate investigation required.
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+      expr: |
+        (
+          time()
+          - max by (cluster, hosted_cluster) (
+              max without (prometheus_replica) (
+                label_replace(
+                  velero_backup_last_successful_timestamp{schedule=~".+-hourly"},
+                  "hosted_cluster", "$1", "schedule", "(.+)-hourly"
+                )
+              )
+            )
+        ) > 6 * 3600
+      for: 15m
+      labels:
+        severity: "3"
+        team: hcp-sl
+    # ---- Stuck daily/weekly backups (retention signal, ticket-only) -------
+    # Daily/weekly cover longer-horizon retention (30d/90d TTLs), not restore
+    # readiness once hourly is healthy, so each cadence gets a single
+    # lower-severity alert (no separate critical tier).
+    #
+    # Note: the Velero Grafana dashboard's "Hours Since Last Backup" panel
+    # queries a 46h threshold (PR #6618) rather than 48h; that's a tracked
+    # dashboard bug, not an intentional difference from this alert's 24h.
+    - alert: VeleroDailyBackupStuck
+      annotations:
+        summary: Velero daily backup stuck for HostedCluster {{ $labels.hosted_cluster }} on {{ $labels.cluster }}
+        description: No successful Velero daily backup for HostedCluster {{ $labels.hosted_cluster }} on management cluster {{ $labels.cluster }} in over 24 hours (last success {{ $value | humanizeDuration }} ago). Daily cadence is 24h. Restore is not necessarily at risk if hourly backups are healthy; this affects 30-day retention/compliance coverage.
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+      expr: |
+        (
+          time()
+          - max by (cluster, hosted_cluster) (
+              max without (prometheus_replica) (
+                label_replace(
+                  velero_backup_last_successful_timestamp{schedule=~".+-daily"},
+                  "hosted_cluster", "$1", "schedule", "(.+)-daily"
+                )
+              )
+            )
+        ) > 24 * 3600
+      for: 30m
+      labels:
+        severity: "4"
+        team: hcp-sl
+    - alert: VeleroWeeklyBackupStuck
+      annotations:
+        summary: Velero weekly backup stuck for HostedCluster {{ $labels.hosted_cluster }} on {{ $labels.cluster }}
+        description: No successful Velero weekly backup for HostedCluster {{ $labels.hosted_cluster }} on management cluster {{ $labels.cluster }} in over 168 hours (last success {{ $value | humanizeDuration }} ago). Weekly cadence is 7d. Restore is not necessarily at risk if hourly backups are healthy; this affects 90-day retention/compliance coverage.
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+      expr: |
+        (
+          time()
+          - max by (cluster, hosted_cluster) (
+              max without (prometheus_replica) (
+                label_replace(
+                  velero_backup_last_successful_timestamp{schedule=~".+-weekly"},
+                  "hosted_cluster", "$1", "schedule", "(.+)-weekly"
+                )
+              )
+            )
+        ) > 168 * 3600
+      for: 30m
+      labels:
+        severity: "4"
+        team: hcp-sl
+    # ---- Elevated CSI snapshot failure rate -------------------------------
+    # Uses recorded rules (velero-recording-prometheusRule.yaml). Fires when
+    # >10% of CSI snapshot attempts failed over the last hour, gated on a
+    # minimum attempt volume to avoid noise on idle clusters.
+    - alert: VeleroCSISnapshotFailureRateHigh
+      annotations:
+        summary: Elevated Velero CSI snapshot failure rate on {{ $labels.cluster }}
+        description: '{{ $value | humanizePercentage }} of Velero CSI snapshot attempts failed on management cluster {{ $labels.cluster }} over the last hour (threshold 10%). Volume snapshots backing HCP backups may be failing.'
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+      expr: |
+        velero:csi_snapshot:failure_ratio1h > 0.10
+        and
+        velero:csi_snapshot_attempt:increase1h >= 2
+      for: 15m
+      labels:
+        severity: "3"
+        team: hcp-sl
+    # ---- Elevated backup deletion failure rate ----------------------------
+    # Mirrors the CSI snapshot alert above: fires when >10% of deletion
+    # attempts failed over the last hour, gated on a minimum attempt volume.
+    # Sustained failures leak backup storage and TTL enforcement.
+    - alert: VeleroBackupDeletionFailureRateHigh
+      annotations:
+        summary: Elevated Velero backup deletion failure rate on {{ $labels.cluster }}
+        description: '{{ $value | humanizePercentage }} of Velero backup deletion attempts failed on management cluster {{ $labels.cluster }} over the last hour (threshold 10%). Expired backups may not be reclaimed.'
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+      expr: |
+        velero:backup_deletion:failure_ratio1h > 0.10
+        and
+        velero:backup_deletion_attempt:increase1h >= 2
+      for: 15m
+      labels:
+        severity: "3"
+        team: hcp-sl
+    # ---- Canary: Velero metrics absent ------------------------------------
+    # Any management cluster (from `underlay_clusters`, service clusters
+    # excluded) missing a `velero_backup_attempt_total` series for 15m+ means
+    # Velero is down or its PodMonitor scrape is broken, blinding every other
+    # Velero alert on that cluster. Both sides use `group by (cluster)` so
+    # `unless` doesn't leak `underlay_clusters`' extra `source` label.
+    - alert: VeleroMetricsAbsent
+      annotations:
+        summary: Velero metrics absent on {{ $labels.cluster }}
+        description: Velero backup metrics have been absent on management cluster {{ $labels.cluster }} for at least 15 minutes. Velero may be down or its PodMonitor scrape is broken; all other Velero backup alerts are blind on this cluster until this is resolved.
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+      expr: |
+        group by (cluster) (underlay_clusters{cluster!~".*-svc-.*"})
+        unless on (cluster)
+        group by (cluster) (velero_backup_attempt_total)
+      for: 15m
+      labels:
+        severity: "3"
+        team: hcp-sl

--- a/observability/alerts/velero-prometheusRule_test.yaml
+++ b/observability/alerts/velero-prometheusRule_test.yaml
@@ -1,0 +1,280 @@
+rule_files:
+- velero-recording-prometheusRule.yaml
+- velero-prometheusRule.yaml
+group_eval_order:
+- velero-backup-recording-rules
+- velero-backup-alert-rules
+evaluation_interval: 1m
+tests:
+# ---- Stuck hourly backup: last success 3h ago (warning, not critical) ----
+- interval: 1m
+  input_series:
+  - series: 'velero_backup_last_successful_timestamp{cluster="mgmt-1", schedule="ocm-a-hourly", prometheus_replica="a"}'
+    values: "0+0x420"
+  alert_rule_test:
+  - eval_time: 180m
+    alertname: VeleroHourlyBackupStuckWarning
+    exp_alerts:
+    - exp_labels:
+        cluster: mgmt-1
+        hosted_cluster: ocm-a
+        component: velero
+        severity: "3"
+        team: hcp-sl
+      exp_annotations:
+        summary: Velero hourly backup stuck for HostedCluster ocm-a on mgmt-1
+        description: No successful Velero hourly backup for HostedCluster ocm-a on management cluster mgmt-1 in over 2 hours (last success 3h 0m 0s ago). Hourly cadence is 1h; this is the primary restore-point freshness signal.
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+  - eval_time: 180m
+    alertname: VeleroHourlyBackupStuckCritical
+    exp_alerts: []
+    # ---- Stuck hourly backup: last success 7h ago (critical fires) ----
+  - eval_time: 420m
+    alertname: VeleroHourlyBackupStuckCritical
+    exp_alerts:
+    - exp_labels:
+        cluster: mgmt-1
+        hosted_cluster: ocm-a
+        component: velero
+        severity: "3"
+        team: hcp-sl
+      exp_annotations:
+        summary: Velero hourly backup critically stuck for HostedCluster ocm-a on mgmt-1
+        description: No successful Velero hourly backup for HostedCluster ocm-a on management cluster mgmt-1 in over 6 hours (last success 7h 0m 0s ago). HCP has no recent restore point; immediate investigation required.
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+# ---- Healthy hourly backup: timestamp keeps advancing (no alert) ----
+- interval: 10m
+  input_series:
+  - series: 'velero_backup_last_successful_timestamp{cluster="mgmt-2", schedule="ocm-b-hourly", prometheus_replica="a"}'
+    values: "0+600x60"
+  alert_rule_test:
+  - eval_time: 180m
+    alertname: VeleroHourlyBackupStuckWarning
+    exp_alerts: []
+  - eval_time: 180m
+    alertname: VeleroHourlyBackupStuckCritical
+    exp_alerts: []
+# ---- Multi-HostedCluster masking regression: one HC's healthy hourly
+# backup on a shared management cluster must NOT mask a different,
+# fully-stuck HC's hourly backup on that same management cluster. This is
+# the scoping bug flagged in PR #6664 review (schedule encodes HC identity,
+# not just cadence) -- `by (cluster, hosted_cluster)` must keep them
+# distinct. ----
+- interval: 1m
+  input_series:
+  - series: 'velero_backup_last_successful_timestamp{cluster="mgmt-shared", schedule="ocm-healthy-hourly", prometheus_replica="a"}'
+    values: "0+60x420"
+  - series: 'velero_backup_last_successful_timestamp{cluster="mgmt-shared", schedule="ocm-stuck-hourly", prometheus_replica="a"}'
+    values: "0+0x420"
+  alert_rule_test:
+  - eval_time: 420m
+    alertname: VeleroHourlyBackupStuckCritical
+    exp_alerts:
+    - exp_labels:
+        cluster: mgmt-shared
+        hosted_cluster: ocm-stuck
+        component: velero
+        severity: "3"
+        team: hcp-sl
+      exp_annotations:
+        summary: Velero hourly backup critically stuck for HostedCluster ocm-stuck on mgmt-shared
+        description: No successful Velero hourly backup for HostedCluster ocm-stuck on management cluster mgmt-shared in over 6 hours (last success 7h 0m 0s ago). HCP has no recent restore point; immediate investigation required.
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+# ---- Stuck daily backup: last success 25h ago (fires; single alert, no
+# separate critical -- daily is now a retention/compliance signal only) ----
+- interval: 1m
+  input_series:
+  - series: 'velero_backup_last_successful_timestamp{cluster="mgmt-3", schedule="ocm-c-daily", prometheus_replica="a"}'
+    values: "0+0x3000"
+  alert_rule_test:
+  - eval_time: 1500m
+    alertname: VeleroDailyBackupStuck
+    exp_alerts:
+    - exp_labels:
+        cluster: mgmt-3
+        hosted_cluster: ocm-c
+        component: velero
+        severity: "4"
+        team: hcp-sl
+      exp_annotations:
+        summary: Velero daily backup stuck for HostedCluster ocm-c on mgmt-3
+        description: No successful Velero daily backup for HostedCluster ocm-c on management cluster mgmt-3 in over 24 hours (last success 1d 1h 0m 0s ago). Daily cadence is 24h. Restore is not necessarily at risk if hourly backups are healthy; this affects 30-day retention/compliance coverage.
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+# ---- Healthy daily backup: timestamp keeps advancing (no alert) ----
+- interval: 10m
+  input_series:
+  - series: 'velero_backup_last_successful_timestamp{cluster="mgmt-4", schedule="ocm-d-daily", prometheus_replica="a"}'
+    values: "0+600x310"
+  alert_rule_test:
+  - eval_time: 1620m
+    alertname: VeleroDailyBackupStuck
+    exp_alerts: []
+# ---- Stuck weekly backup: last success 169h ago (fires; single alert, no
+# separate critical -- weekly is now a retention/compliance signal only) ----
+- interval: 1m
+  input_series:
+  - series: 'velero_backup_last_successful_timestamp{cluster="mgmt-5", schedule="ocm-e-weekly", prometheus_replica="a"}'
+    values: "0+0x20250"
+  alert_rule_test:
+  - eval_time: 10140m
+    alertname: VeleroWeeklyBackupStuck
+    exp_alerts:
+    - exp_labels:
+        cluster: mgmt-5
+        hosted_cluster: ocm-e
+        component: velero
+        severity: "4"
+        team: hcp-sl
+      exp_annotations:
+        summary: Velero weekly backup stuck for HostedCluster ocm-e on mgmt-5
+        description: No successful Velero weekly backup for HostedCluster ocm-e on management cluster mgmt-5 in over 168 hours (last success 7d 1h 0m 0s ago). Weekly cadence is 7d. Restore is not necessarily at risk if hourly backups are healthy; this affects 90-day retention/compliance coverage.
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+# ---- Healthy weekly backup: timestamp keeps advancing (no alert) ----
+- interval: 30m
+  input_series:
+  - series: 'velero_backup_last_successful_timestamp{cluster="mgmt-6", schedule="ocm-f-weekly", prometheus_replica="a"}'
+    values: "0+1800x338"
+  alert_rule_test:
+  - eval_time: 10140m
+    alertname: VeleroWeeklyBackupStuck
+    exp_alerts: []
+# ---- Elevated CSI snapshot failure rate (30% failing fires; 0% does not) ----
+- interval: 1m
+  input_series:
+  - series: 'velero_csi_snapshot_attempt_total{cluster="mgmt-fail", prometheus_replica="a"}'
+    values: "0+10x90"
+  - series: 'velero_csi_snapshot_failure_total{cluster="mgmt-fail", prometheus_replica="a"}'
+    values: "0+3x90"
+  - series: 'velero_csi_snapshot_attempt_total{cluster="mgmt-ok", prometheus_replica="a"}'
+    values: "0+10x90"
+  - series: 'velero_csi_snapshot_failure_total{cluster="mgmt-ok", prometheus_replica="a"}'
+    values: "0+0x90"
+  alert_rule_test:
+  - eval_time: 90m
+    alertname: VeleroCSISnapshotFailureRateHigh
+    exp_alerts:
+    - exp_labels:
+        cluster: mgmt-fail
+        component: velero
+        severity: "3"
+        team: hcp-sl
+      exp_annotations:
+        summary: Elevated Velero CSI snapshot failure rate on mgmt-fail
+        description: 30% of Velero CSI snapshot attempts failed on management cluster mgmt-fail over the last hour (threshold 10%). Volume snapshots backing HCP backups may be failing.
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+# ---- Elevated backup deletion failure rate (30% failing fires; 0% does not) ----
+- interval: 1m
+  input_series:
+  - series: 'velero_backup_deletion_attempt_total{cluster="mgmt-del", prometheus_replica="a"}'
+    values: "0+10x90"
+  - series: 'velero_backup_deletion_failure_total{cluster="mgmt-del", prometheus_replica="a"}'
+    values: "0+3x90"
+  - series: 'velero_backup_deletion_attempt_total{cluster="mgmt-delok", prometheus_replica="a"}'
+    values: "0+10x90"
+  - series: 'velero_backup_deletion_failure_total{cluster="mgmt-delok", prometheus_replica="a"}'
+    values: "0+0x90"
+  # mgmt-delnever: deletions attempted, but the failure counter has never
+  # incremented, so it has never emitted a series at all (cold-start case).
+  - series: 'velero_backup_deletion_attempt_total{cluster="mgmt-delnever", prometheus_replica="a"}'
+    values: "0+10x90"
+  alert_rule_test:
+  - eval_time: 90m
+    alertname: VeleroBackupDeletionFailureRateHigh
+    exp_alerts:
+    - exp_labels:
+        cluster: mgmt-del
+        component: velero
+        severity: "3"
+        team: hcp-sl
+      exp_annotations:
+        summary: Elevated Velero backup deletion failure rate on mgmt-del
+        description: 30% of Velero backup deletion attempts failed on management cluster mgmt-del over the last hour (threshold 10%). Expired backups may not be reclaimed.
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+# ---- Canary: Velero metrics absent (fires when the counter is missing) ----
+- interval: 1m
+  input_series:
+  - series: 'underlay_clusters{cluster="mgmt-1", source="bicep"}'
+    values: "1+0x30"
+  alert_rule_test:
+  - eval_time: 20m
+    alertname: VeleroMetricsAbsent
+    exp_alerts:
+    - exp_labels:
+        cluster: mgmt-1
+        component: velero
+        severity: "3"
+        team: hcp-sl
+      exp_annotations:
+        summary: Velero metrics absent on mgmt-1
+        description: Velero backup metrics have been absent on management cluster mgmt-1 for at least 15 minutes. Velero may be down or its PodMonitor scrape is broken; all other Velero backup alerts are blind on this cluster until this is resolved.
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+# ---- Canary: Velero metrics present (no alert) ----
+- interval: 1m
+  input_series:
+  - series: 'underlay_clusters{cluster="mgmt-1", source="bicep"}'
+    values: "1+0x30"
+  - series: 'velero_backup_attempt_total{cluster="mgmt-1", prometheus_replica="a"}'
+    values: "0+1x30"
+  alert_rule_test:
+  - eval_time: 20m
+    alertname: VeleroMetricsAbsent
+    exp_alerts: []
+# ---- Canary: single-cluster failure is not masked by a healthy cluster ----
+- interval: 1m
+  input_series:
+  - series: 'underlay_clusters{cluster="mgmt-broken", source="bicep"}'
+    values: "1+0x30"
+  - series: 'underlay_clusters{cluster="mgmt-healthy", source="bicep"}'
+    values: "1+0x30"
+  - series: 'velero_backup_attempt_total{cluster="mgmt-healthy", prometheus_replica="a"}'
+    values: "0+1x30"
+  alert_rule_test:
+  - eval_time: 20m
+    alertname: VeleroMetricsAbsent
+    exp_alerts:
+    - exp_labels:
+        cluster: mgmt-broken
+        component: velero
+        severity: "3"
+        team: hcp-sl
+      exp_annotations:
+        summary: Velero metrics absent on mgmt-broken
+        description: Velero backup metrics have been absent on management cluster mgmt-broken for at least 15 minutes. Velero may be down or its PodMonitor scrape is broken; all other Velero backup alerts are blind on this cluster until this is resolved.
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+# ---- Canary: vanished scrape target (underlay exists, no metrics at all) ----
+- interval: 1m
+  input_series:
+  - series: 'underlay_clusters{cluster="mgmt-vanished", source="bicep"}'
+    values: "1+0x30"
+  alert_rule_test:
+  - eval_time: 20m
+    alertname: VeleroMetricsAbsent
+    exp_alerts:
+    - exp_labels:
+        cluster: mgmt-vanished
+        component: velero
+        severity: "3"
+        team: hcp-sl
+      exp_annotations:
+        summary: Velero metrics absent on mgmt-vanished
+        description: Velero backup metrics have been absent on management cluster mgmt-vanished for at least 15 minutes. Velero may be down or its PodMonitor scrape is broken; all other Velero backup alerts are blind on this cluster until this is resolved.
+        runbook_url: https://aka.ms/arohcp-tsg-velerobackup
+        owning_team: hcp-sl
+# ---- Canary: service clusters must never false-fire (Velero doesn't run there) ----
+- interval: 1m
+  input_series:
+  - series: 'underlay_clusters{cluster="uksouth-svc-1", source="bicep"}'
+    values: "1+0x30"
+  alert_rule_test:
+  - eval_time: 20m
+    alertname: VeleroMetricsAbsent
+    exp_alerts: []

--- a/observability/alerts/velero-recording-prometheusRule.yaml
+++ b/observability/alerts/velero-recording-prometheusRule.yaml
@@ -1,0 +1,85 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: k8s
+    role: recording-rules
+  name: velero-backup-recording-rules
+  namespace: monitoring
+spec:
+  groups:
+  # ============================================================
+  # Velero Backup Recording Rules
+  # ============================================================
+  # Pre-aggregates Velero backup signals used by the Velero backup
+  # alerting rules (alerts/velero-prometheusRule.yaml). Velero runs on the
+  # management clusters and is scraped via the `velero` PodMonitor.
+  #
+  # `max without(prometheus_replica)` deduplicates the HA Prometheus replicas
+  # before aggregation, matching the Velero Grafana dashboard queries.
+  #
+  # Owner: Service Lifecycle team (hcp-sl)
+  - name: velero-backup-recording-rules
+    interval: 1m
+    labels:
+      component: velero
+    rules:
+    # CSI snapshot attempts observed per management cluster over the last hour.
+    - record: velero:csi_snapshot_attempt:increase1h
+      expr: |
+        sum by (cluster) (
+          max without (prometheus_replica) (
+            increase(velero_csi_snapshot_attempt_total[1h])
+          )
+        )
+    # CSI snapshot failures observed per management cluster over the last hour.
+    - record: velero:csi_snapshot_failure:increase1h
+      expr: |
+        sum by (cluster) (
+          max without (prometheus_replica) (
+            increase(velero_csi_snapshot_failure_total[1h])
+          )
+        )
+    # Fraction of CSI snapshot attempts that failed per management cluster.
+    # `(attempts > 0)` gates the denominator so a cluster with zero attempts
+    # yields no series ("no data") instead of clamp_min's misleading 0%.
+    - record: velero:csi_snapshot:failure_ratio1h
+      expr: |
+        (
+          velero:csi_snapshot_failure:increase1h
+          or
+          0 * velero:csi_snapshot_attempt:increase1h
+        )
+        /
+        (velero:csi_snapshot_attempt:increase1h > 0)
+    # Backup deletion attempts observed per management cluster over the last
+    # hour. Mirrors the CSI snapshot rules above.
+    - record: velero:backup_deletion_attempt:increase1h
+      expr: |
+        sum by (cluster) (
+          max without (prometheus_replica) (
+            increase(velero_backup_deletion_attempt_total[1h])
+          )
+        )
+    # Backup deletion failures observed per management cluster over the last
+    # hour.
+    - record: velero:backup_deletion_failure:increase1h
+      expr: |
+        sum by (cluster) (
+          max without (prometheus_replica) (
+            increase(velero_backup_deletion_failure_total[1h])
+          )
+        )
+    # Fraction of Velero backup deletion attempts that failed per management
+    # cluster. Same `(attempts > 0)` gating as the CSI snapshot ratio.
+    - record: velero:backup_deletion:failure_ratio1h
+      expr: |
+        (
+          velero:backup_deletion_failure:increase1h
+          or
+          0 * velero:backup_deletion_attempt:increase1h
+        )
+        /
+        (velero:backup_deletion_attempt:increase1h > 0)

--- a/observability/alerts/velero-recording-prometheusRule_test.yaml
+++ b/observability/alerts/velero-recording-prometheusRule_test.yaml
@@ -1,0 +1,99 @@
+rule_files:
+- velero-recording-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+# CSI snapshot failure ratio: extrapolation factors in numerator and
+# denominator are identical, so the recorded ratio is exact.
+- interval: 1m
+  input_series:
+  # mgmt-fail: 3 of every 10 CSI snapshot attempts fail -> ratio 0.3
+  - series: 'velero_csi_snapshot_attempt_total{cluster="mgmt-fail", prometheus_replica="a"}'
+    values: "0+10x90"
+  - series: 'velero_csi_snapshot_failure_total{cluster="mgmt-fail", prometheus_replica="a"}'
+    values: "0+3x90"
+  # mgmt-ok: attempts but no failures -> ratio 0
+  - series: 'velero_csi_snapshot_attempt_total{cluster="mgmt-ok", prometheus_replica="a"}'
+    values: "0+10x90"
+  - series: 'velero_csi_snapshot_failure_total{cluster="mgmt-ok", prometheus_replica="a"}'
+    values: "0+0x90"
+  promql_expr_test:
+  - expr: "velero:csi_snapshot:failure_ratio1h"
+    eval_time: 75m
+    exp_samples:
+    - labels: 'velero:csi_snapshot:failure_ratio1h{cluster="mgmt-fail", component="velero"}'
+      value: 0.3
+    - labels: 'velero:csi_snapshot:failure_ratio1h{cluster="mgmt-ok", component="velero"}'
+      value: 0
+# mgmt-quiet: zero CSI snapshot attempts -> `(attempts > 0)` gate produces no
+# series ("no data"), instead of a misleading 0% or NaN.
+- interval: 1m
+  input_series:
+  - series: 'velero_csi_snapshot_attempt_total{cluster="mgmt-quiet", prometheus_replica="a"}'
+    values: "0+0x90"
+  promql_expr_test:
+  - expr: "velero:csi_snapshot:failure_ratio1h"
+    eval_time: 75m
+    exp_samples: []
+# HA Prometheus replica dedup: two replicas scrape the same cluster and both
+# report the same counter values (mirrored, as real HA replicas would). If
+# `max without(prometheus_replica)` were ever changed to `sum without(...)`,
+# this would double the effective attempt/failure counts and the recorded
+# ratio would silently change even though nothing about Velero did.
+- interval: 1m
+  input_series:
+  - series: 'velero_csi_snapshot_attempt_total{cluster="mgmt-ha", prometheus_replica="a"}'
+    values: "0+10x90"
+  - series: 'velero_csi_snapshot_attempt_total{cluster="mgmt-ha", prometheus_replica="b"}'
+    values: "0+10x90"
+  - series: 'velero_csi_snapshot_failure_total{cluster="mgmt-ha", prometheus_replica="a"}'
+    values: "0+3x90"
+  - series: 'velero_csi_snapshot_failure_total{cluster="mgmt-ha", prometheus_replica="b"}'
+    values: "0+3x90"
+  promql_expr_test:
+  - expr: "velero:csi_snapshot_attempt:increase1h"
+    eval_time: 75m
+    exp_samples:
+    - labels: 'velero:csi_snapshot_attempt:increase1h{cluster="mgmt-ha", component="velero"}'
+      value: 600
+  - expr: "velero:csi_snapshot:failure_ratio1h"
+    eval_time: 75m
+    exp_samples:
+    - labels: 'velero:csi_snapshot:failure_ratio1h{cluster="mgmt-ha", component="velero"}'
+      value: 0.3
+# Backup deletion failure ratio: same shape and gating as the CSI snapshot
+# ratio above.
+- interval: 1m
+  input_series:
+  # mgmt-delfail: 3 of every 10 deletion attempts fail -> ratio 0.3
+  - series: 'velero_backup_deletion_attempt_total{cluster="mgmt-delfail", prometheus_replica="a"}'
+    values: "0+10x90"
+  - series: 'velero_backup_deletion_failure_total{cluster="mgmt-delfail", prometheus_replica="a"}'
+    values: "0+3x90"
+  # mgmt-delok: attempts but no failures -> ratio 0
+  - series: 'velero_backup_deletion_attempt_total{cluster="mgmt-delok", prometheus_replica="a"}'
+    values: "0+10x90"
+  - series: 'velero_backup_deletion_failure_total{cluster="mgmt-delok", prometheus_replica="a"}'
+    values: "0+0x90"
+  # mgmt-delnever: deletions attempted, but the failure counter has never
+  # incremented, so it has never emitted a series at all (cold-start case).
+  - series: 'velero_backup_deletion_attempt_total{cluster="mgmt-delnever", prometheus_replica="a"}'
+    values: "0+10x90"
+  promql_expr_test:
+  - expr: "velero:backup_deletion:failure_ratio1h"
+    eval_time: 75m
+    exp_samples:
+    - labels: 'velero:backup_deletion:failure_ratio1h{cluster="mgmt-delfail", component="velero"}'
+      value: 0.3
+    - labels: 'velero:backup_deletion:failure_ratio1h{cluster="mgmt-delok", component="velero"}'
+      value: 0
+    - labels: 'velero:backup_deletion:failure_ratio1h{cluster="mgmt-delnever", component="velero"}'
+      value: 0
+# mgmt-delquiet: zero deletion attempts -> no series ("no data").
+- interval: 1m
+  input_series:
+  - series: 'velero_backup_deletion_attempt_total{cluster="mgmt-delquiet", prometheus_replica="a"}'
+    values: "0+0x90"
+  promql_expr_test:
+  - expr: "velero:backup_deletion:failure_ratio1h"
+    eval_time: 75m
+    exp_samples: []

--- a/observability/recording-rules-hcps.yaml
+++ b/observability/recording-rules-hcps.yaml
@@ -4,5 +4,6 @@ prometheusRules:
   - alerts/HCPkasRecord-prometheusRule-apiserver-requests.yaml
   - alerts/HCPkasRecord-prometheusRule-latency.yaml
   - alerts/UserJourneyKubeApiserverAvailabilityRecord-prometheusRule-KSM.yaml
+  - alerts/velero-recording-prometheusRule.yaml
   untestedRules: []
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep


### PR DESCRIPTION
<!-- Link to Jira issue -->
https://redhat.atlassian.net/browse/ARO-27405

### What

Adds Prometheus alerting and recording rules for Velero backup monitoring on management clusters:

- Stuck-backup alerts for hourly/daily/weekly cadences, scoped per HostedCluster (`observability/alerts/velero-prometheusRule.yaml`).
- Alerts for elevated CSI snapshot and backup-deletion failure rates, plus a canary for absent Velero metrics.
- Recording rules pre-aggregating CSI snapshot/deletion attempt and failure counts (`observability/alerts/velero-recording-prometheusRule.yaml`).
- Generated Bicep for both rule groups, registered in `observability/observability.yaml`.

Hourly stuck-backup alerts page (severity `"3"`, SRE queue). Daily/weekly are single, ticket-only alerts (severity `"4"`) — a failed daily/weekly run isn't paging-worthy as long as hourly is healthy and a recent restore point exists.

Alerts are scoped `by (cluster, hosted_cluster)` — `hosted_cluster` derived via `label_replace` on `schedule` — so one HostedCluster's healthy backup can't mask a different, failing HostedCluster on the same management cluster.

### Why

Velero backs up Hosted Clusters, NodePools, and HCP etcd, but nothing alerted on stuck backups, elevated failure rates, or silent metric loss. A degraded DR posture could go unnoticed until a restore is actually needed.

Note: with CSI data-movement backups, a `DataUpload` finalizer can stall namespace GC if deletion races an in-flight backup. This is bounded (≤15m via `ItemOperationTimeout`, ≤1h worst case) and would surface via the hourly stuck-backup alert. Documented in the TSG (separate PR).

### Testing

- `promtool` rule tests for every alert/recording rule: firing and non-firing cases per cadence, failure-ratio thresholds, HA-replica dedup, multi-HostedCluster isolation, and metrics-absent canary. Run via `make -C observability alerts` and `make -C observability recording-rules`.
- Live-data validation against real INT Prometheus ([`atest`](https://github.com/Azure/ARO-HCP/blob/main/docs/alert-verification.md), 31-day window): hourly warning (93) and critical (85) firings are distinct and correctly ordered, confirming per-HostedCluster scoping works. CSI/deletion and weekly alerts had no live data to validate against (no such activity/schedules in INT) — covered by promtool instead.
- Integration/E2E: not applicable (no service code changes).

#### Velero Backup Live Validation

**Method:** Live validation against real INT data using the `alert-tester` (`atest`)
tool, run against the `services-westus3` Grafana datasource over a 31-day window
(2026-07-25 → 2026-08-25), matching each alert's exact PromQL, thresholds, and
`for:` duration as shipped in `observability/alerts/velero-prometheusRule.yaml`.

| Alert | Result | Verdict |
|---|---|---|
| `VeleroHourlyBackupStuckWarning` (>2h) | 93 series, 93 firings / 93 grouped incidents | ✅ Working |
| `VeleroHourlyBackupStuckCritical` (>6h) | 85 firings / 85 grouped incidents | ✅ Working — critical count ≤ warning count, exactly the expected relationship |
| `VeleroDailyBackupStuck` (>24h) | 6 series, 6 firings / 6 grouped incidents | ✅ Working |
| `VeleroWeeklyBackupStuck` (>168h) | 0 series | ✅ Expected — no weekly-cadence schedules configured in INT |
| `VeleroCSISnapshotFailureRateHigh` (>10%) | 0 series (raw counters confirmed empty) | ✅ Expected — no CSI snapshot activity occurred in INT during this window; validated via `promtool` synthetic tests instead |
| `VeleroBackupDeletionFailureRateHigh` (>10%) | 0 series (raw counters confirmed empty) | ✅ Expected — no backup deletions occurred in INT during this window; validated via `promtool` synthetic tests instead |
| `VeleroMetricsAbsent` (canary) | 2 series, 6 samples crossed threshold, "for 15m: never" fired | ✅ Working — correctly suppressed transient scrape gaps shorter than the 15m sustain window (no false positives) |

All 9 Velero backup alerts (hourly/daily/weekly stuck-backup pairs, CSI snapshot ratio, deletion ratio, metrics-absent canary) behave correctly against real INT Prometheus data. Where live data was unavailable (CSI snapshots, deletions, weekly schedules), this reflects the current INT environment's activity, not a defect in the alert rules — those paths remain covered by `promtool` unit tests (`observability/alerts/velero-prometheusRule_test.yaml`).


### Special notes for your reviewer

- `VeleroMetricsAbsent` uses `underlay_clusters` (per `docs/alerts.md`) instead of a bare `absent()`, so one cluster losing its scrape target is still detected.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier), demonstrate that the test is able to detect a defect/error and fail with proper error message and logs which communicates nature of the problem.
