### PR TITLE
fix(mgmt-agent): watch acn.azure.com CRDs and Nodes (MTPNC, NNC)

### DIFF
--- a/mgmt-agent/pkg/controller/resourcewatcher.go
+++ b/mgmt-agent/pkg/controller/resourcewatcher.go
@@ -40,7 +40,7 @@ var watchedGroupSuffixes = []string{
 	"hypershift.openshift.io",
 	"agent-install.openshift.io",
 	"multicluster.openshift.io",
-	"multitenancy.acn.azure.com",
+	"acn.azure.com",
 	"velero.io",
 }
 

--- a/mgmt-agent/pkg/controller/resourcewatcher_test.go
+++ b/mgmt-agent/pkg/controller/resourcewatcher_test.go
@@ -36,6 +36,7 @@ func TestMatchesGroupSuffix(t *testing.T) {
 		{"agent-install.openshift.io", true},
 		{"capi-provider.agent-install.openshift.io", true},
 		{"multicluster.openshift.io", true},
+		{"acn.azure.com", true},
 		{"multitenancy.acn.azure.com", true},
 		{"velero.io", true},
 		{"", false},


### PR DESCRIPTION
## What

Expands `watchedGroupSuffixes` from `multitenancy.acn.azure.com` to the entire `acn.azure.com` group, to pick up MultiTenantPodNetworkConfig and NodeNetworkConfig. Also adds `core/v1/nodes` to the hardcoded resources watched alongside `core/v1/namespaces`.

## Why

The SWIFT networking TSG ([ARO-25382](https://redhat.atlassian.net/browse/ARO-25382)) needs MTPNC, NNC, and Node state for triage, but none of it was being snapshotted into `kubernetesResourceSnapshots`.