### PR TITLE
fix: align service key vault output names

### DIFF
--- a/dev-infrastructure/modules/keyvault/keyvault.bicep
+++ b/dev-infrastructure/modules/keyvault/keyvault.bicep
@@ -87,3 +87,8 @@ output kvId string = keyVault.id
 output kvName string = keyVault.name
 
 output kvUrl string = keyVault.properties.vaultUri
+
+// Aliases for templates that reference keyVaultName/keyVaultUrl (e.g. svc-infra).
+output keyVaultName string = keyVault.name
+
+output keyVaultUrl string = keyVault.properties.vaultUri

--- a/dev-infrastructure/templates/svc-infra.bicep
+++ b/dev-infrastructure/templates/svc-infra.bicep
@@ -106,5 +106,5 @@ module serviceKeyVaultDevopsSecretsOfficer '../modules/keyvault/keyvault-secret-
   ]
 }
 
-output svcKeyVaultName string = serviceKeyVault.outputs.kvName
-output svcKeyVaultUrl string = serviceKeyVault.outputs.kvUrl
+output svcKeyVaultName string = serviceKeyVault.outputs.keyVaultName
+output svcKeyVaultUrl string = serviceKeyVault.outputs.keyVaultUrl


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1866

### What

Align service Key Vault Bicep output names by updating  svc-infra.bicep  to read  keyVaultName  and  keyVaultUrl  from the service Key Vault module.

Add  keyVaultName  and  keyVaultUrl  aliases to  modules/keyvault/keyvault.bicep  while keeping the existing  kvName  and  kvUrl  outputs for current consumers.

### Why

The int rollout failed in  Service.Infra.service.infra-westus3-1  while evaluating the  svcKeyVaultName  ARM template output.

DeploymentOutputEvaluationFailed: The template output 'svcKeyVaultName' is not valid: The language expression property 'kvName' doesn't exist, available properties are 'keyVaultName, keyVaultUrl'.

This was introduced by PR #2746 / commit  591f871f4cc3bf815280f1e136033a56457d654c , which added lookup-only Key Vault output modules using  keyVaultName  and  keyVaultUrl .  svc-infra.bicep  still referenced the older  kvName  and  kvUrl  output names, so output evaluation could fail when the lookup-style output contract was used.

### Testing

Testing is required for feature completion and tests should be part of the pull request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear justification.

• Unit tests: not run; this is a Bicep output contract fix and does not affect Go code.
• Integration tests: not run; no integration test coverage exists for this ARM deployment output path.
• E2E tests: not run; no HCP runtime behavior changed.
• Manual validation: verified  dev-infrastructure/templates/svc-infra.bicep  no longer references  serviceKeyVault.outputs.kvName  or  serviceKeyVault.outputs.kvUrl .
• Manual validation: verified  modules/keyvault/keyvault.bicep  still exposes  kvName  and  kvUrl , and now also exposes  keyVaultName  and  keyVaultUrl .
• Manual validation: verified no remaining  serviceKeyVault.outputs.kvName  or  serviceKeyVault.outputs.kvUrl  references exist under  dev-infrastructure .

### Special notes for your reviewer

The existing  kvName  and  kvUrl  outputs are intentionally kept because other templates still consume them. This PR adds aliases rather than removing or renaming the existing module contract.

### PR Checklist

• PR is scoped to a single task (no mixed concerns)
• Title follows Conventional Commits format
• Summary explains the "Why" behind the change
• Linked to relevant ticket/issue
• Screenshots included (if graph/UI/metrics changes)
• Self-reviewed the diff
• CI/CD checks are passing (ignore Tide)
• Draft PR used for WIP (if applicable)
• Commit history is clean (rebased/squashed)
• Tricky code blocks are commented
• Specific reviewers tagged
• All comment threads resolved before merge

If E2E tests are included:

• E2E tests follow Principles of Good E2E Test Case Design
• If new E2E use case is covered (via a new test or new check/verifier), demonstrate that the test is able to detect a defect/error and fail with proper error message and logs which communicates nature of the problem.