### PR TITLE
fix(dev-infrastructure): fix svc KV nested-deployment collision on Service.Infra

### DIFF
--- a/dev-infrastructure/templates/svc-infra-lookup.bicep
+++ b/dev-infrastructure/templates/svc-infra-lookup.bicep
@@ -7,14 +7,12 @@ param serviceKeyVaultResourceGroup string = resourceGroup().name
 @description('The subscription ID where the service keyvault resource group lives. Defaults to the current subscription. Set when the keyvault is shared across subscriptions.')
 param serviceKeyVaultSubscription string = subscription().subscriptionId
 
-// this is mostly a situation where multiple svc-infra pipelines run towards
-// a shared svc keyvault resource group ${serviceKeyVaultResourceGroup}. while
-// the individual modules will not conflict with each other, the existence
-// of same-named deployments fails one pipeline.
-var deploymentNameSuffix = uniqueString(resourceGroup().id)
-
+// Nested deployment name is keyed on serviceKeyVaultName so multiple parents
+// looking up the same KV in a shared resource group collapse to one slot
+// (identical templates → safe Read), and do not collide with svc-infra.bicep's
+// create-side nested deployment which is keyed on the resource group id.
 module serviceKeyVault '../modules/keyvault/lookup.bicep' = {
-  name: 'svc-kv-${deploymentNameSuffix}'
+  name: 'svc-kv-${uniqueString(serviceKeyVaultName)}'
   scope: resourceGroup(serviceKeyVaultSubscription, serviceKeyVaultResourceGroup)
   params: {
     keyVaultName: serviceKeyVaultName

--- a/dev-infrastructure/templates/svc-infra.bicep
+++ b/dev-infrastructure/templates/svc-infra.bicep
@@ -105,6 +105,3 @@ module serviceKeyVaultDevopsSecretsOfficer '../modules/keyvault/keyvault-secret-
     serviceKeyVault
   ]
 }
-
-output svcKeyVaultName string = serviceKeyVault.outputs.kvName
-output svcKeyVaultUrl string = serviceKeyVault.outputs.kvUrl


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1879
 
## Summary
Two related fixes in `dev-infrastructure/templates/`:

1. **Rekey** the nested lookup deployment in `svc-infra-lookup.bicep` from `svc-kv-${uniqueString(resourceGroup().id)}` to `svc-kv-${uniqueString(serviceKeyVaultName)}` — matching the convention already used by `mgmt-infra-lookup.bicep`. This gives every parent looking up the same KV a shared, safe-Read slot, and keeps them off the create-side slot in `svc-infra.bicep`.

2. **Delete** the dead `svcKeyVaultName` / `svcKeyVaultUrl` outputs on `svc-infra.bicep`. They are unused — every downstream consumer in `svc-pipeline.yaml` reads `svcKeyVaultUrl` from `step: infra-output` (the lookup), never from `step: infra`, and `svcKeyVaultName` has no readers at all.

## Root cause
ARM allows only one active PUT per `{scope, deployment-name}`. Three templates (this repo's `svc-infra.bicep` + `svc-infra-lookup.bicep`, plus sdp-pipelines' `hcp/genevahealthfunction/Templates/svc-infra-lookup.bicep`) all wrote to `svc-kv-${uniqueString(rg().id)}` in the shared `westus3-shared-resources` RG. That produced two symptoms on int/westus3 rollouts:

- **`DeploymentActive`** — when a parallel service group (Geneva) won the millisecond race to the shared slot, Service.Infra's PUT was rejected as an in-flight overwrite.
- **`DeploymentOutputEvaluationFailed`** — when the lookup wrote last, `svc-infra.bicep`'s output eval hit `.outputs.kvName` on a record that only exposed `keyVaultName` / `keyVaultUrl`.

## Why key on `serviceKeyVaultName` instead of RG?
`mgmt-infra-lookup.bicep` already uses this pattern. Keying on what's being wrapped means:

- **Same KV, multiple parents** → same slot → identical templates → safe Read.
- **Different KV names** → different slots → no collision.
- **Never collides with create-side** (which stays on `uniqueString(rg().id)` because `keyvault.bicep` is a template of its own with a different output schema).

`uniqueString(rg().id)` was the worst possible key: every parent in the same RG resolves to the same string, guaranteeing max collision — and specifically colliding across templates with different output schemas.

## Why now
Latent since [PR #2746](https://github.com/Azure/ARO-HCP/pull/2746) (Sept 2025) introduced `svc-infra-lookup.bicep`. Detonated on the initial `Service.Infra` rollout into **int/westus3** (region added in `sdp-pipelines@267079ae78`), the first region where multiple service groups in the same RG raced the shared nested name.

## Follow-up
sdp-pipelines' `hcp/genevahealthfunction/Templates/svc-infra-lookup.bicep` needs a matching rekey to `svc-kv-${uniqueString(serviceKeyVaultName)}` in an ADO PR.

## Test plan
- [ ] `bicep build dev-infrastructure/templates/svc-infra.bicep` and `svc-infra-lookup.bicep` succeed
- [ ] Re-run `Service.Infra.service.infra-westus3-1` in int → passes without output-eval failure and without `DeploymentActive`
- [ ] Grep confirms no other pipeline references the removed outputs by `step: infra`

🤖 Generated with [Claude Code](https://claude.com/claude-code)