### PR TITLE
[DEMO][DO NOT MERGE] test: nodepool delete-then-scale E2E test

### DIFF
--- a/nonlocal-e2e-specs.txt
+++ b/nonlocal-e2e-specs.txt
@@ -12,6 +12,7 @@
   "should be able to create an HCP cluster then delete it by deleting the customer resource group",
   "should be able to delete an HCP cluster whose managed identities were deleted first",
   "should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings",
+  "should be able to scale a remaining nodepool after a sibling nodepool is deleted",
   "should confirm the HCP cluster is deleted (not found)",
   "should create an HCP cluster and validate TLS certificates",
   "should deny pods with images from disallowed registries",

--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -716,7 +716,8 @@ func setupCli() *cobra.Command {
 	// 	specs = specs.AddLabel("SLOW")
 
 	// Specs can be globally filtered...
-	// specs = specs.MustFilter([]string{`name.contains("filter")`})
+	// DEMO ONLY: restricts CI to a single new test for demo purposes. Revert before merge.
+	specs = specs.MustFilter([]string{`name.contains("should be able to scale a remaining nodepool after a sibling nodepool is deleted")`})
 
 	// Or walked...
 	// specs = specs.Walk(func(spec *extensiontests.ExtensionTestSpec) {

--- a/test/e2e/nodepool_delete_then_scale_remaining.go
+++ b/test/e2e/nodepool_delete_then_scale_remaining.go
@@ -1,0 +1,170 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+
+	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+	"github.com/Azure/ARO-HCP/test/util/verifiers"
+)
+
+// DEMO: scoped down to reproduce reports of scaling failures after a sibling nodepool is deleted.
+// This test is not intended to merge.
+var _ = Describe("Customer", func() {
+	It("should be able to scale a remaining nodepool after a sibling nodepool is deleted",
+		labels.RequireNothing,
+		labels.High,
+		labels.Positive,
+		labels.MIContainers(1),
+		func(ctx context.Context) {
+			const (
+				customerClusterName = "np-del-scale-hcp-cluster"
+				firstNodePoolName   = "np-first"
+				secondNodePoolName  = "np-second"
+			)
+
+			tc := framework.NewTestContext()
+
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
+			}
+
+			By("creating a resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "nodepool-del-scale", tc.Location())
+			Expect(err).NotTo(HaveOccurred(), "failed to create resource group nodepool-del-scale")
+
+			By("creating cluster parameters")
+			clusterParams := framework.NewDefaultClusterParams20240610()
+			clusterParams.ClusterName = customerClusterName
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.ManagedResourceGroupName = managedResourceGroupName
+
+			By("creating customer resources")
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
+				resourceGroup,
+				clusterParams,
+				map[string]interface{}{},
+				TestArtifactsFS,
+				framework.RBACScopeResourceGroup,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources")
+
+			By("creating the HCP cluster")
+			err = tc.CreateHCPClusterFromParam20240610(ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				framework.ClusterCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %s", customerClusterName)
+
+			By("getting admin credentials for the cluster")
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
+				ctx,
+				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				*resourceGroup.Name,
+				customerClusterName,
+				framework.GetAdminRESTConfigTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for cluster %s", customerClusterName)
+
+			By("creating both single-node node pools in parallel")
+			firstNodePoolParams := framework.NewDefaultNodePoolParams20240610()
+			firstNodePoolParams.NodePoolName = firstNodePoolName
+			firstNodePoolParams.Replicas = int32(1)
+
+			secondNodePoolParams := framework.NewDefaultNodePoolParams20240610()
+			secondNodePoolParams.NodePoolName = secondNodePoolName
+			secondNodePoolParams.Replicas = int32(1)
+
+			errCh := make(chan error, 2)
+			group, groupCtx := errgroup.WithContext(ctx)
+			for _, nodePoolParams := range []framework.NodePoolParams20240610{firstNodePoolParams, secondNodePoolParams} {
+				group.Go(func() error {
+					createErr := tc.CreateNodePoolFromParam20240610(
+						groupCtx,
+						GinkgoLogr,
+						*resourceGroup.Name,
+						managedResourceGroupName,
+						customerClusterName,
+						nodePoolParams,
+						framework.NodePoolCreationTimeout,
+					)
+					if createErr != nil {
+						errCh <- createErr
+					}
+					return createErr
+				})
+			}
+			_ = group.Wait()
+			close(errCh)
+			var creationErrors []error
+			for createErr := range errCh {
+				creationErrors = append(creationErrors, createErr)
+			}
+			Expect(creationErrors).To(BeEmpty(), "nodepool creation errors: %v", creationErrors)
+
+			By("verifying both node pools came up healthy")
+			totalNodeCount := 2
+			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify initial node count of %d", totalNodeCount)
+			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify all nodes are ready after initial creation")
+
+			nodePoolsClient := tc.Get20240610ClientFactoryOrDie(ctx).NewNodePoolsClient()
+
+			By("deleting the first node pool")
+			Expect(framework.DeleteNodePool20240610(
+				ctx,
+				nodePoolsClient,
+				*resourceGroup.Name,
+				customerClusterName,
+				firstNodePoolName,
+				framework.NodePoolDeletionTimeout,
+			)).To(Succeed(), "failed to delete node pool %s", firstNodePoolName)
+
+			By("scaling the remaining node pool from 1 to 2 replicas")
+			update := hcpsdk20240610preview.NodePoolUpdate{
+				Properties: &hcpsdk20240610preview.NodePoolPropertiesUpdate{
+					Replicas: to.Ptr(int32(2)),
+				},
+			}
+			scaleResp, err := framework.UpdateNodePoolAndWait20240610(ctx,
+				nodePoolsClient,
+				*resourceGroup.Name,
+				customerClusterName,
+				secondNodePoolName,
+				update,
+				framework.NodePoolScalingTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to scale node pool %s from 1 to 2 replicas after deleting sibling node pool %s", secondNodePoolName, firstNodePoolName)
+			Expect(scaleResp.Properties).NotTo(BeNil(), "scale response Properties was nil")
+			Expect(scaleResp.Properties.Replicas).NotTo(BeNil(), "scale response Properties.Replicas was nil")
+			Expect(*scaleResp.Properties.Replicas).To(Equal(int32(2)), "expected scale response replicas to equal 2")
+
+			By("verifying the remaining node pool has 2 ready nodes")
+			Expect(verifiers.VerifyNodeCount(customerClusterName, 2).Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify node count of 2 after scale up")
+			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify all nodes are ready after scale up")
+		})
+})

--- a/tooling/hcpctl/README.md
+++ b/tooling/hcpctl/README.md
@@ -214,3 +214,4 @@ The timestamp fields define the time window for log queries. They are rendered a
 - tests for the `pkg/breakglass/minting` package
 - tests for the `pkg/breakglass/portforward` package (e.g. https://github.com/openshift/ci-tools/blob/05305124f711827983c0908af9020a41ad6afacf/pkg/testhelper/accessory.go#L261)
 - E2E tests for all breakglass commands
+


### PR DESCRIPTION
## Summary
- DEMO PR for testing the E2E flow only — not intended to be merged.
- Adds a new E2E test (`test/e2e/nodepool_delete_then_scale_remaining.go`) that: creates an HCP cluster, creates two single-node nodepools in parallel, waits for both to be ready, deletes the first, then scales the second from 1 to 2 replicas — reproducing reports of scaling failures in that scenario.
- For dev/demo purposes, CI is scoped to run **only** this new test via a `MustFilter` in `test/cmd/aro-hcp-tests/main.go` (per `test/AGENTS.md`, this is the sanctioned "only way to select tests for CI runs in higher environments" and must be reverted before any real merge).
- Registered the new spec in `nonlocal-e2e-specs.txt` via `make record-nonlocal-e2e`.

## Test plan
- [x] `go build ./test/...` passes
- [x] `make record-nonlocal-e2e` run, registry up to date
- [ ] `/test prod-e2e-parallel` (posted separately) to validate against Public/Prod per docs/ci/e2e-testing.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)