### PR TITLE
hcpctl: note frozen tag / stale source archives in release header

### DIFF
--- a/tooling/hcpctl/.goreleaser.yaml
+++ b/tooling/hcpctl/.goreleaser.yaml
@@ -35,6 +35,10 @@ release:
   name_template: "hcpctl (latest)"
   header: |
     Automatically-built `hcpctl` binaries from the current `main` branch. Not a versioned release.
+
+    > [!NOTE]
+    > - The `hcpctl-latest` git tag stays pinned to an older commit; the **binaries below are always built from the latest `main`**.
+    > - GitHub's auto-generated **"Source code" archives match that old tag, not the binaries**. Ignore them and use the binary assets below.
   prerelease: true
   mode: replace
   replace_existing_artifacts: true


### PR DESCRIPTION
## Summary

Follow-up to #6673. The `hcpctl-latest` tag is intentionally never moved, so it lags behind the binaries. This spells that out on the release page so consumers aren't misled.

Adds two lines to the release header:

- The `hcpctl-latest` git tag stays pinned to an older commit; the binaries are always built from the latest `main`.
- GitHub's auto-generated "Source code" archives match that old tag, not the binaries.

Only `tooling/hcpctl/.goreleaser.yaml` `release.header` changes.

---
*AI-generated. Review for accuracy.*