### PR TITLE
test: retry known KAS ingress convergence failures

### DIFF
--- a/test/e2e/cluster_create_feature_aggregation.go
+++ b/test/e2e/cluster_create_feature_aggregation.go
@@ -61,6 +61,7 @@ var _ = Describe("Customer", func() {
 		labels.Positive,
 		labels.AroRpApiCompatible,
 		labels.CreateCluster,
+		labels.AllowRetry, // owner: @mmazur, tracking: OCPBUGS-95614. KASLoadBalancerNotReachable is a known transient ingress-convergence failure; remove this label when the issue is fixed.
 		labels.MIContainers(1),
 		func(ctx context.Context) {
 			const (

--- a/test/e2e/cluster_create_private_ingress.go
+++ b/test/e2e/cluster_create_private_ingress.go
@@ -42,6 +42,7 @@ var _ = Describe("Customer", func() {
 		labels.Positive,
 		labels.AroRpApiCompatible,
 		labels.CreateCluster,
+		labels.AllowRetry, // owner: @mmazur, tracking: OCPBUGS-95614. KASLoadBalancerNotReachable is a known transient ingress-convergence failure; remove this label when the issue is fixed.
 		labels.MIContainers(1),
 		func(ctx context.Context) {
 			const (


### PR DESCRIPTION
Tracking: https://issues.redhat.com/browse/AROSLSRE-1870

## Why
`KASLoadBalancerNotReachable: APIServer external route not admitted` caused correlated ARO HCP EV2 E2E create failures while the management-cluster ingress path was unstable. The HyperShift status-reporting and router-unschedulability failure mode is tracked upstream by https://issues.redhat.com/browse/OCPBUGS-95614.

## What
Mark the aggregated-advanced-features and private-ingress create specs as temporarily safe for the existing one-time EV2 retry mechanism. The no-CNI/private-Key-Vault/Cilium spec was already allowlisted.

## Validation
- `go test ./test/cmd/aro-hcp-tests -run 'TestWriteEV2RetryMetadata|TestMainListSuitesForEachSuite' -count=1`