### PR TITLE
Remove the ARO-25230 Skip that gated the 4.y->5.0 major upgrade

### DIFF
--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -46,12 +46,6 @@ var _ = Describe("Customer", func() {
 	DescribeTable("should be able to successfully upgrade control plane minor version",
 		labels.MIContainers(1),
 		func(ctx context.Context, targetMinor string) {
-			// The 4.22 -> 5.0 minor upgrade is not yet supported by Cluster Service, so skip it
-			// until CS gains support. This entry is the only one whose target minor is "5.0".
-			if targetMinor == "5.0" {
-				Skip(`cluster service doesn't support this yet: VerifyHostedControlPlaneYStreamUpgrade(previousMinor=4.22, targetMinor=5.0) failed: clusterversion status.history has no version in target minor "5.0"`)
-			}
-
 			channelGroup := framework.DefaultOpenshiftChannelGroup()
 			upgradeVersion := metadataapi.Must(semver.ParseTolerant(targetMinor))
 


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Removing skip for Release 4->5 upgrade

### Why

upgrade flow is verified for CP / node pools. test can be enabled also

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
