### PR TITLE
fix(legacycredentialrequest): Handle a strange failure case

### DIFF
--- a/backend/pkg/controllers/cluster/legacycredentialrequest/operation_request_credential.go
+++ b/backend/pkg/controllers/cluster/legacycredentialrequest/operation_request_credential.go
@@ -16,6 +16,7 @@ package legacycredentialrequest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -24,6 +25,7 @@ import (
 	utilsclock "k8s.io/utils/clock"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
 	operationbase "github.com/Azure/ARO-HCP/backend/pkg/utils/operationutils"
@@ -113,6 +115,29 @@ func (opsync *operationRequestCredential) SynchronizeOperation(ctx context.Conte
 	}
 
 	breakGlassCredential, err := opsync.clustersServiceClient.GetBreakGlassCredential(ctx, oldOperation.InternalID)
+
+	// This is for an observed case where a credential request was dispatched, but for
+	// some reason took a full day for the Cluster Service credential endpoint to show
+	// status "issued". By that time the backing certificate had already expired. Logs
+	// showed Cluster Service transitioning the credential status to "issued" and then
+	// immediately purging it, such that further polling returned a 404 Not Found. The
+	// backend controller never saw the state transition. If this happens again, catch
+	// it and fail the operation to avoid a hot loop.
+	var ocmError *ocmerrors.Error
+	if errors.As(err, &ocmError) && ocmError.Status() == http.StatusNotFound {
+		logger.Info("credential endpoint vanished, terminating operation")
+		err = operationbase.PatchOperation(ctx, opsync.clock, opsync.resourcesDBClient, oldOperation,
+			coreapi.ProvisioningStateFailed,
+			&coreapi.CloudErrorBody{
+				Code:    coreapi.CloudErrorCodeInternalServerError,
+				Message: "Failed to provision cluster credential",
+			},
+			operationbase.PostAsyncNotificationFn(opsync.notificationClient))
+		if err != nil {
+			return utils.TrackError(err)
+		}
+		return nil
+	}
 	if err != nil {
 		return utils.TrackError(err)
 	}

--- a/backend/pkg/controllers/cluster/legacycredentialrequest/operation_request_credential_test.go
+++ b/backend/pkg/controllers/cluster/legacycredentialrequest/operation_request_credential_test.go
@@ -16,7 +16,7 @@ package legacycredentialrequest
 
 import (
 	"context"
-	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/go-logr/logr/testr"
@@ -27,6 +27,7 @@ import (
 	utilsclock "k8s.io/utils/clock"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
 	operationtesting "github.com/Azure/ARO-HCP/backend/pkg/utils/operationutils/operationtesting"
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
@@ -94,7 +95,7 @@ func TestOperationRequestCredential_SynchronizeOperation(t *testing.T) {
 		name                       string
 		operationOverride          func(*coreapi.Operation)
 		breakGlassCredentialStatus cmv1.BreakGlassCredentialStatus
-		getBreakGlassCredentialErr error
+		getBreakGlassCredentialErr *ocmerrors.ErrorBuilder
 		expectError                bool
 		expectCSMockCalled         bool
 		verify                     func(t *testing.T, ctx context.Context, db *corecosmosstoragetesting.MockResourcesDBClient, fixture *operationtesting.ClusterTestFixture)
@@ -147,13 +148,28 @@ func TestOperationRequestCredential_SynchronizeOperation(t *testing.T) {
 		{
 			name:                       "GetBreakGlassCredential failure leads to error",
 			breakGlassCredentialStatus: cmv1.BreakGlassCredentialStatusIssued,
-			getBreakGlassCredentialErr: errors.New("something went wrong"),
+			getBreakGlassCredentialErr: ocmerrors.NewError().Reason("something went wrong"),
 			expectError:                true,
 			expectCSMockCalled:         true,
 			verify: func(t *testing.T, ctx context.Context, db *corecosmosstoragetesting.MockResourcesDBClient, fixture *operationtesting.ClusterTestFixture) {
 				op, err := db.Operations(operationtesting.TestSubscriptionID).Get(ctx, operationtesting.TestOperationName)
 				require.NoError(t, err)
 				assert.Equal(t, coreapi.ProvisioningStateAccepted, op.Status) // no state change
+			},
+		},
+		{
+			name:                       "credential endpoint not found updates operation status to failed",
+			breakGlassCredentialStatus: cmv1.BreakGlassCredentialStatusIssued,
+			getBreakGlassCredentialErr: ocmerrors.NewError().
+				Status(http.StatusNotFound).
+				Reason(http.StatusText(http.StatusNotFound)),
+			expectError:        false,
+			expectCSMockCalled: true,
+			verify: func(t *testing.T, ctx context.Context, db *corecosmosstoragetesting.MockResourcesDBClient, fixture *operationtesting.ClusterTestFixture) {
+				op, err := db.Operations(operationtesting.TestSubscriptionID).Get(ctx, operationtesting.TestOperationName)
+				require.NoError(t, err)
+				assert.Equal(t, coreapi.ProvisioningStateFailed, op.Status)
+				assert.Equal(t, coreapi.CloudErrorCodeInternalServerError, op.Error.Code)
 			},
 		},
 		{
@@ -189,14 +205,23 @@ func TestOperationRequestCredential_SynchronizeOperation(t *testing.T) {
 			mockCSClient := ocm.NewMockClusterServiceClientSpec(ctrl)
 
 			if tt.expectCSMockCalled {
-				breakGlassCredential, err := cmv1.NewBreakGlassCredential().
-					Status(tt.breakGlassCredentialStatus).
-					Build()
-				require.NoError(t, err)
+				if tt.getBreakGlassCredentialErr != nil {
+					ocmError, err := tt.getBreakGlassCredentialErr.Build()
+					require.NoError(t, err)
 
-				mockCSClient.EXPECT().
-					GetBreakGlassCredential(gomock.Any(), fixture.ClusterInternalID).
-					Return(breakGlassCredential, tt.getBreakGlassCredentialErr)
+					mockCSClient.EXPECT().
+						GetBreakGlassCredential(gomock.Any(), fixture.ClusterInternalID).
+						Return(nil, ocmError)
+				} else {
+					breakGlassCredential, err := cmv1.NewBreakGlassCredential().
+						Status(tt.breakGlassCredentialStatus).
+						Build()
+					require.NoError(t, err)
+
+					mockCSClient.EXPECT().
+						GetBreakGlassCredential(gomock.Any(), fixture.ClusterInternalID).
+						Return(breakGlassCredential, nil)
+				}
 			}
 
 			controller := &operationRequestCredential{


### PR DESCRIPTION
[ARO-29084 - Credential controller workqueue operationrequestcredential retry hot loop
](https://redhat.atlassian.net/browse/ARO-29084)

### What

This avoids a controller hot loop in case a previously observed failure scenario occurs again.

Details about the failure scenario are in a code comment.

### Why

It's causing IcM alerts to fire.

### Testing

Added a test case to the controller's existing unit tests.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge