### PR TITLE
Don't enforce upgrade edge for candidate or nightly

### DIFF
--- a/internal/admission/admit_cluster.go
+++ b/internal/admission/admit_cluster.go
@@ -685,6 +685,11 @@ func admitClusterVersionID(_ context.Context, admissionContext *ClusterAdmission
 	if len(newObj.ChannelGroup) == 0 {
 		return nil
 	}
+	// on nightlies and candidates, we don't wait for the target version to show up. We trust these people to
+	// know what they're doing.
+	if newObj.ChannelGroup == "nightly" || newObj.ChannelGroup == "candidate" {
+		return nil
+	}
 
 	// No channel data yet: fail open (see the doc comment above). A genuinely
 	// missing ServiceProviderCluster prefetch is still surfaced as an

--- a/internal/admission/admit_cluster_test.go
+++ b/internal/admission/admit_cluster_test.go
@@ -1341,7 +1341,9 @@ func TestAdmitCluster_PlatformResourceIDs(t *testing.T) {
 // associated HostedCluster's observed status.version.desired.channels, which the
 // backend mirrors onto ServiceProviderCluster.Status.DesiredVersionChannels. The
 // requested version's major.minor is derived from its ID, so patch, nightly and
-// pre-release IDs all resolve to their release-line channel.
+// pre-release IDs all resolve to their release-line channel. The check is skipped
+// entirely for the "nightly" and "candidate" channel groups, which we trust to
+// self-serve without waiting for the target channel to be mirrored.
 func TestAdmitClusterVersionID(t *testing.T) {
 	t.Parallel()
 
@@ -1407,23 +1409,46 @@ func TestAdmitClusterVersionID(t *testing.T) {
 			},
 		},
 		{
-			// Nightly pre-release: "5.0.0-0.nightly-..." must resolve to "5.0".
-			name:         "nightly version resolves to major.minor channel and passes",
+			// Nightly-build pre-release string ("5.0.0-0.nightly-...") must resolve to the "5.0"
+			// release line. Uses the "fast" channel group so the availability check actually runs
+			// (nightly/candidate short-circuit it).
+			name:         "nightly-build version string resolves to major.minor channel and passes",
 			op:           operation.Operation{Type: operation.Update},
-			oldVersion:   &coreapi.VersionProfile{ID: "4.19", ChannelGroup: "candidate"},
-			newVersion:   &coreapi.VersionProfile{ID: "5.0.0-0.nightly-2026-08-05-123456", ChannelGroup: "candidate"},
-			spc:          spcWithChannels("candidate-5.0"),
+			oldVersion:   &coreapi.VersionProfile{ID: "4.19", ChannelGroup: "fast"},
+			newVersion:   &coreapi.VersionProfile{ID: "5.0.0-0.nightly-2026-08-05-123456", ChannelGroup: "fast"},
+			spc:          spcWithChannels("fast-5.0"),
 			expectErrors: []utils.ExpectedError{},
 		},
 		{
-			name:       "nightly version with no matching major.minor channel is rejected",
+			// Same setup on "fast", but the target channel is absent: the availability check runs
+			// and rejects it (unlike nightly/candidate, which short-circuit — see below).
+			name:       "nightly-build version string with no matching channel is rejected on fast",
 			op:         operation.Operation{Type: operation.Update},
-			oldVersion: &coreapi.VersionProfile{ID: "4.19", ChannelGroup: "candidate"},
-			newVersion: &coreapi.VersionProfile{ID: "5.0.0-0.nightly-2026-08-05-123456", ChannelGroup: "candidate"},
-			spc:        spcWithChannels("candidate-4.19"),
+			oldVersion: &coreapi.VersionProfile{ID: "4.19", ChannelGroup: "fast"},
+			newVersion: &coreapi.VersionProfile{ID: "5.0.0-0.nightly-2026-08-05-123456", ChannelGroup: "fast"},
+			spc:        spcWithChannels("fast-4.19"),
 			expectErrors: []utils.ExpectedError{
-				{FieldPath: "properties.version.id", Message: `no upgrade path to update channel "candidate-5.0"`},
+				{FieldPath: "properties.version.id", Message: `no upgrade path to update channel "fast-5.0"`},
 			},
+		},
+		{
+			// candidate short-circuits the availability check: we trust candidate users, so a
+			// missing target channel is NOT rejected (contrast the "fast" case above).
+			name:         "candidate channel group skips the availability check",
+			op:           operation.Operation{Type: operation.Update},
+			oldVersion:   &coreapi.VersionProfile{ID: "4.19", ChannelGroup: "candidate"},
+			newVersion:   &coreapi.VersionProfile{ID: "5.0.0-0.nightly-2026-08-05-123456", ChannelGroup: "candidate"},
+			spc:          spcWithChannels("candidate-4.19"), // candidate-5.0 absent, but not enforced
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			// nightly likewise short-circuits the availability check.
+			name:         "nightly channel group skips the availability check",
+			op:           operation.Operation{Type: operation.Update},
+			oldVersion:   &coreapi.VersionProfile{ID: "4.19", ChannelGroup: "nightly"},
+			newVersion:   &coreapi.VersionProfile{ID: "4.20", ChannelGroup: "nightly"},
+			spc:          spcWithChannels("nightly-4.19"), // nightly-4.20 absent, but not enforced
+			expectErrors: []utils.ExpectedError{},
 		},
 		{
 			// Pre-release: "4.21.0-rc.1" must resolve to "4.21".

--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -25,7 +25,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/blang/semver/v4"
-	"github.com/google/uuid"
 
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes"
@@ -35,7 +34,6 @@ import (
 	clusterversion "github.com/Azure/ARO-HCP/backend/pkg/controllers/cluster/version"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controlplaneversion"
 	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
-	"github.com/Azure/ARO-HCP/internal/cincinnati"
 	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
@@ -69,7 +67,6 @@ var _ = Describe("Customer", func() {
 			// resolvable via the OpenShift update service at the channel's z-stream offset.
 			installVersionId := fmt.Sprintf("%d.%d", installVersion.Major, installVersion.Minor)
 			upgradeVersionId := fmt.Sprintf("%d.%d", upgradeVersion.Major, upgradeVersion.Minor)
-			var resolvedInstallVersion string
 			if channelGroup == "nightly" {
 				resolvedInstall, err := framework.GetLatestNightlyInstallVersion(ctx, channelGroup, installVersionId)
 				if framework.IsVersionNotFoundError(err) {
@@ -77,7 +74,6 @@ var _ = Describe("Customer", func() {
 				}
 				Expect(err).NotTo(HaveOccurred(), "failed to resolve nightly install version for %s", installVersionId)
 				installVersionId = resolvedInstall
-				resolvedInstallVersion = installVersionId
 
 				resolvedUpgrade, err := framework.GetLatestNightlyInstallVersion(ctx, channelGroup, upgradeVersionId)
 				if framework.IsVersionNotFoundError(err) {
@@ -95,10 +91,18 @@ var _ = Describe("Customer", func() {
 						Skip(fmt.Sprintf("no version resolved for channel %s-%s; skipping y-stream upgrade %s -> %s",
 							channelGroup, minorLine, installVersionId, upgradeVersionId))
 					}
-					if minorLine == installVersionId {
-						resolvedInstallVersion = desiredVersion.Version
-					}
 				}
+			}
+
+			// TIMEBOMB: upstream cincinnati-graph-data promoted 4.20.35 as a node in
+			// candidate-4.21 on 2026-08-21 but has not yet added outgoing 4.20.35 -> 4.21.z
+			// edges. Because the RP picks the channel tip (offset 0) for candidate/fast,
+			// every 4.20 -> 4.21 run lands on 4.20.35 and is rejected by frontend admission
+			// with "no upgrade path to update channel \"candidate-4.21\"". Skip until
+			// upstream publishes the edge or the deadline passes (revisit and remove).
+			if channelGroup != "nightly" && installVersionId == "4.20" && upgradeVersionId == "4.21" &&
+				time.Now().Before(time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC)) {
+				Skip("timebomb: upstream cincinnati-graph-data has no 4.20.35 -> 4.21.z edge yet; re-evaluate after 2026-08-31")
 			}
 
 			tc := framework.NewTestContext()
@@ -178,42 +182,6 @@ var _ = Describe("Customer", func() {
 				},
 			}
 			_, err = framework.UpdateHCPCluster20240610(ctx, hcpClient, *resourceGroup.Name, clusterName, update, framework.HCPClusterVersionUpgradeTimeout)
-			// Reactive: when the upgrade is rejected with "no upgrade path to update
-			// channel …", confirm via Cincinnati that the resolved install z-stream
-			// truly has no outgoing edges to the target minor. If so, the failure is
-			// a transient upstream graph-data gap — skip the test instead of failing.
-			// The timebomb (2026-09-30) ensures this grace window doesn't mask a real
-			// regression indefinitely.
-			if err != nil && channelGroup != "nightly" && strings.Contains(err.Error(), "no upgrade path to update channel") &&
-				time.Now().Before(time.Date(2026, 9, 30, 0, 0, 0, 0, time.UTC)) {
-				installSemver, parseErr := semver.ParseTolerant(resolvedInstallVersion)
-				if parseErr == nil {
-					upgradeChannel := fmt.Sprintf("%s-%s", channelGroup, upgradeVersionId)
-					cincinnatiURI, uriErr := cincinnati.GetCincinnatiURI(channelGroup)
-					if uriErr == nil {
-						cincinnatiClient := cincinnati.NewClientCache().GetOrCreateClient(uuid.Nil)
-						_, updates, _, edgeErr := cincinnatiClient.GetUpdates(ctx, cincinnatiURI, "multi", "multi", upgradeChannel, installSemver)
-						noEdges := cincinnati.IsCincinnatiVersionNotFoundError(edgeErr)
-						if edgeErr == nil {
-							noEdges = true
-							for _, u := range updates {
-								v, vErr := semver.ParseTolerant(u.Version)
-								if vErr != nil {
-									continue
-								}
-								if v.Major == upgradeVersion.Major && v.Minor == upgradeVersion.Minor {
-									noEdges = false
-									break
-								}
-							}
-						}
-						if noEdges {
-							Skip(fmt.Sprintf("reactive: upgrade of cluster %q failed with 'no upgrade path' and Cincinnati confirms no outgoing edges from %s to %s.z in channel %s — upstream graph data likely not yet published",
-								clusterName, resolvedInstallVersion, upgradeVersionId, upgradeChannel))
-						}
-					}
-				}
-			}
 			Expect(err).NotTo(HaveOccurred(), "failed to trigger y-stream upgrade of cluster %q to %s", clusterName, upgradeVersionId)
 
 			By("verifying control plane reached desired version and cluster remains viable")

--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -94,17 +94,6 @@ var _ = Describe("Customer", func() {
 				}
 			}
 
-			// TIMEBOMB: upstream cincinnati-graph-data promoted 4.20.35 as a node in
-			// candidate-4.21 on 2026-08-21 but has not yet added outgoing 4.20.35 -> 4.21.z
-			// edges. Because the RP picks the channel tip (offset 0) for candidate/fast,
-			// every 4.20 -> 4.21 run lands on 4.20.35 and is rejected by frontend admission
-			// with "no upgrade path to update channel \"candidate-4.21\"". Skip until
-			// upstream publishes the edge or the deadline passes (revisit and remove).
-			if channelGroup != "nightly" && installVersionId == "4.20" && upgradeVersionId == "4.21" &&
-				time.Now().Before(time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC)) {
-				Skip("timebomb: upstream cincinnati-graph-data has no 4.20.35 -> 4.21.z edge yet; re-evaluate after 2026-08-31")
-			}
-
 			tc := framework.NewTestContext()
 			if tc.UsePooledIdentities() {
 				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)


### PR DESCRIPTION
There may not be a path from a candidate build to the next release. That's ok, don't enforce one.

We may even be able to eliminate it for fast and stable, but we dont' have to do that now.

Reverts the short-term changes in https://github.com/Azure/ARO-HCP/pull/6642 and https://github.com/Azure/ARO-HCP/pull/6652


