### PR TITLE
fix: enable kubelet reservations on CI management clusters

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1804,7 +1804,6 @@ clouds:
                 osDiskSizeGB: 64
             jaeger:
               deploy: false
-            applyKubeletFixes: false
           # SVC
           svc:
             rg: "hcp-underlay-{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
@@ -1911,7 +1910,6 @@ clouds:
                 osDiskSizeGB: 64
             jaeger:
               deploy: false
-            applyKubeletFixes: false
           # SVC
           svc:
             subscription:

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -682,7 +682,7 @@ mgmt:
       zoneRedundantMode: Auto
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14
-  applyKubeletFixes: false
+  applyKubeletFixes: true
   defaultStorageClassSkuName: PremiumV2_LRS
   hcpBackups:
     storageAccount:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -682,7 +682,7 @@ mgmt:
       zoneRedundantMode: Auto
       zones: ""
     vnetAddressPrefix: 10.128.0.0/14
-  applyKubeletFixes: false
+  applyKubeletFixes: true
   defaultStorageClassSkuName: PremiumV2_LRS
   hcpBackups:
     storageAccount:


### PR DESCRIPTION
## Summary
- Remove `applyKubeletFixes: false` overrides from CI environments (ci00, ci01) in `config/config.yaml`
- CI management clusters now inherit the default `true`, enabling kubelet resource reservations

## Why
CI management clusters have been hitting node NotReady conditions during heavy pod loads. Kubelet resource reservations prevent the kubelet from being starved of resources, keeping nodes healthy under pressure.

## Test plan
- [x] `config/rendered/` files updated via `make materialize` — ci00 and ci01 now show `applyKubeletFixes: true`
- [ ] CI pipelines apply the change after merge
- [ ] Monitor CI MC nodes for NotReady events