### PR TITLE
Improve ARM error message when install deadline is exceeded

### DIFF
--- a/backend/pkg/controllers/cluster/operations/operation_cluster_create.go
+++ b/backend/pkg/controllers/cluster/operations/operation_cluster_create.go
@@ -176,10 +176,10 @@ func (c *operationClusterCreate) SynchronizeOperation(ctx context.Context, key c
 		cluster.ServiceProviderProperties.CreateOperationCompletionDeadline != nil &&
 		c.clock.Now().After(cluster.ServiceProviderProperties.CreateOperationCompletionDeadline.Time) {
 
-		message := "cluster creation did not complete before the deadline"
-		if len(operationalState.Message) > 0 {
-			message = operationalState.Message
-		}
+		message := operationbase.DeadlineExceededMessage(
+			"cluster creation did not complete before the deadline",
+			operationalState.Message,
+		)
 		logger.Info("create operation deadline exceeded, marking as failed",
 			"deadline", cluster.ServiceProviderProperties.CreateOperationCompletionDeadline.Time,
 			"message", message)
@@ -264,11 +264,7 @@ func (c *operationClusterCreate) clusterServiceCreateOperationState(ctx context.
 		return nil, utils.TrackError(err)
 	}
 	logger.Info("new status via cluster-service", "newStatus", newOperationStatus, "newOperationError", opError)
-	msg := ""
-	if opError != nil {
-		msg = opError.Message
-	}
-	return operationbase.NewOperationState(newOperationStatus, msg), nil
+	return operationbase.NewOperationState(newOperationStatus, operationbase.ClusterServiceOperationMessage(clusterStatus, opError)), nil
 }
 
 func (c *operationClusterCreate) clusterOperationStatus(ctx context.Context, operation *coreapi.Operation) (*operationbase.OperationState, error) {

--- a/backend/pkg/controllers/cluster/operations/operation_cluster_create_test.go
+++ b/backend/pkg/controllers/cluster/operations/operation_cluster_create_test.go
@@ -210,6 +210,8 @@ func TestOperationClusterCreate_SynchronizeOperation(t *testing.T) {
 				assert.Equal(t, coreapi.ProvisioningStateFailed, op.Status)
 				require.NotNil(t, op.Error)
 				assert.Equal(t, coreapi.CloudErrorCodeInternalServerError, op.Error.Code)
+				assert.Contains(t, op.Error.Message, "cluster creation did not complete before the deadline")
+				assert.Contains(t, op.Error.Message, "cluster service is installing")
 			},
 		},
 		{
@@ -240,6 +242,7 @@ func TestOperationClusterCreate_SynchronizeOperation(t *testing.T) {
 				assert.Equal(t, coreapi.ProvisioningStateFailed, op.Status)
 				require.NotNil(t, op.Error)
 				assert.Equal(t, coreapi.CloudErrorCodeInternalServerError, op.Error.Code)
+				assert.Contains(t, op.Error.Message, "cluster creation did not complete before the deadline")
 			},
 		},
 		{
@@ -724,7 +727,8 @@ func TestDetermineOperationState(t *testing.T) {
 					}),
 				},
 			},
-			expectedState: coreapi.ProvisioningStateProvisioning,
+			expectedState:     coreapi.ProvisioningStateProvisioning,
+			wantMessageSubstr: "cluster service is installing",
 		},
 	}
 

--- a/backend/pkg/controllers/nodepool/operations/operation_node_pool_create.go
+++ b/backend/pkg/controllers/nodepool/operations/operation_node_pool_create.go
@@ -158,10 +158,10 @@ func (c *operationNodePoolCreate) SynchronizeOperation(ctx context.Context, key 
 	if !operationalState.ProvisioningState.IsTerminal() &&
 		nodePool.ServiceProviderProperties.CreateOperationCompletionDeadline != nil &&
 		c.clock.Now().After(nodePool.ServiceProviderProperties.CreateOperationCompletionDeadline.Time) {
-		message := "node pool creation did not complete before the deadline"
-		if len(operationalState.Message) > 0 {
-			message = operationalState.Message
-		}
+		message := operationbase.DeadlineExceededMessage(
+			"node pool creation did not complete before the deadline",
+			operationalState.Message,
+		)
 		logger.Info("create operation deadline exceeded, marking as failed",
 			"deadline", nodePool.ServiceProviderProperties.CreateOperationCompletionDeadline.Time,
 			"message", message)
@@ -232,9 +232,5 @@ func (c *operationNodePoolCreate) nodePoolServiceCreateOperationState(ctx contex
 		return nil, utils.TrackError(err)
 	}
 	logger.Info("new status via cluster-service", "newStatus", newOperationStatus, "newOperationError", newOperationError)
-	msg := ""
-	if newOperationError != nil {
-		msg = newOperationError.Message
-	}
-	return operationbase.NewOperationState(newOperationStatus, msg), nil
+	return operationbase.NewOperationState(newOperationStatus, operationbase.NodePoolServiceOperationMessage(csNodePoolStatus, newOperationError)), nil
 }

--- a/backend/pkg/controllers/nodepool/operations/operation_node_pool_create_test.go
+++ b/backend/pkg/controllers/nodepool/operations/operation_node_pool_create_test.go
@@ -244,6 +244,8 @@ func TestOperationNodePoolCreate_SynchronizeOperation(t *testing.T) {
 				assert.Equal(t, coreapi.ProvisioningStateFailed, op.Status)
 				require.NotNil(t, op.Error)
 				assert.Equal(t, coreapi.CloudErrorCodeInternalServerError, op.Error.Code)
+				assert.Contains(t, op.Error.Message, "node pool creation did not complete before the deadline")
+				assert.Contains(t, op.Error.Message, "cluster service node pool is installing")
 			},
 		},
 		{

--- a/backend/pkg/utils/operationutils/operation_state.go
+++ b/backend/pkg/utils/operationutils/operation_state.go
@@ -78,6 +78,15 @@ func CompareOperationState(lhs, rhs *OperationState) int {
 	return strings.Compare(lhs.Message, rhs.Message)
 }
 
+// DeadlineExceededMessage returns deadlineSentence, appending remainingChecks
+// when it is non-empty.
+func DeadlineExceededMessage(deadlineSentence, remainingChecks string) string {
+	if remainingChecks == "" {
+		return deadlineSentence
+	}
+	return deadlineSentence + "; " + remainingChecks
+}
+
 // PickWorstOperationState expects states pre-sorted and returns the worst state with merged messages.
 func PickWorstOperationState(states []*OperationState) (*OperationState, error) {
 	if len(states) == 0 {

--- a/backend/pkg/utils/operationutils/operation_state_test.go
+++ b/backend/pkg/utils/operationutils/operation_state_test.go
@@ -71,6 +71,20 @@ func TestCompareOperationState(t *testing.T) {
 	}
 }
 
+func TestDeadlineExceededMessage(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "cluster creation did not complete before the deadline",
+		DeadlineExceededMessage("cluster creation did not complete before the deadline", ""))
+	assert.Equal(t,
+		"cluster creation did not complete before the deadline; [clusterServiceClusterStatus] cluster service is installing",
+		DeadlineExceededMessage(
+			"cluster creation did not complete before the deadline",
+			"[clusterServiceClusterStatus] cluster service is installing",
+		),
+	)
+}
+
 func TestPickWorstOperationState(t *testing.T) {
 	t.Parallel()
 

--- a/backend/pkg/utils/operationutils/utils.go
+++ b/backend/pkg/utils/operationutils/utils.go
@@ -503,6 +503,33 @@ func ConvertClusterStatus(ctx context.Context, clusterServiceClient ocm.ClusterS
 	return newOperationStatus, opError, err
 }
 
+// ClusterServiceInProgressMessage returns a short description of a non-terminal
+// Cluster Service cluster state, or empty for terminal states.
+func ClusterServiceInProgressMessage(state arohcpv1alpha1.ClusterState) string {
+	switch state {
+	case arohcpv1alpha1.ClusterStateInstalling,
+		arohcpv1alpha1.ClusterStatePending,
+		arohcpv1alpha1.ClusterStateValidating,
+		arohcpv1alpha1.ClusterStateUpdating,
+		arohcpv1alpha1.ClusterStateUninstalling:
+		return fmt.Sprintf("cluster service is %s", state)
+	default:
+		return ""
+	}
+}
+
+// ClusterServiceOperationMessage is the OperationState message for a converted
+// ClusterStatus: opError.Message if set, otherwise the in-progress CS state.
+func ClusterServiceOperationMessage(clusterStatus *arohcpv1alpha1.ClusterStatus, opError *coreapi.CloudErrorBody) string {
+	if opError != nil && opError.Message != "" {
+		return opError.Message
+	}
+	if clusterStatus == nil {
+		return ""
+	}
+	return ClusterServiceInProgressMessage(clusterStatus.State())
+}
+
 // ConvertNodePoolStatus attempts to translate a NodePoolStatus object
 // from Cluster Service into an ARM provisioning state and, if necessary,
 // a structured OData error.
@@ -549,6 +576,34 @@ func ConvertNodePoolStatus(operation *coreapi.Operation, nodePoolStatus *arohcpv
 	}
 
 	return newOperationStatus, opError, err
+}
+
+// NodePoolServiceInProgressMessage returns a short description of a non-terminal
+// Cluster Service node pool state, or empty for terminal states.
+func NodePoolServiceInProgressMessage(state NodePoolStateValue) string {
+	switch state {
+	case NodePoolStateValidating, NodePoolStatePending, NodePoolStateInstalling,
+		NodePoolStateUpdating, NodePoolStateValidatingUpdate, NodePoolStatePendingUpdate,
+		NodePoolStateUninstalling:
+		return fmt.Sprintf("cluster service node pool is %s", state)
+	default:
+		return ""
+	}
+}
+
+// NodePoolServiceOperationMessage is the OperationState message for a converted
+// NodePoolStatus: opError.Message if set, else the CS message, else the in-progress state.
+func NodePoolServiceOperationMessage(nodePoolStatus *arohcpv1alpha1.NodePoolStatus, opError *coreapi.CloudErrorBody) string {
+	if opError != nil && opError.Message != "" {
+		return opError.Message
+	}
+	if nodePoolStatus == nil {
+		return ""
+	}
+	if msg, ok := nodePoolStatus.GetMessage(); ok && msg != "" {
+		return msg
+	}
+	return NodePoolServiceInProgressMessage(NodePoolStateValue(nodePoolStatus.State().NodePoolStateValue()))
 }
 
 func ConvertExternalAuthStatus(operation *coreapi.Operation, externalAuthStatus *arohcpv1alpha1.ExternalAuthStatus) (coreapi.ProvisioningState, *coreapi.CloudErrorBody, error) {

--- a/backend/pkg/utils/operationutils/utils_test.go
+++ b/backend/pkg/utils/operationutils/utils_test.go
@@ -336,3 +336,29 @@ func TestConvertClusterStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestClusterServiceInProgressMessage(t *testing.T) {
+	assert.Equal(t, "cluster service is installing", ClusterServiceInProgressMessage(arohcpv1alpha1.ClusterStateInstalling))
+	assert.Equal(t, "cluster service is pending", ClusterServiceInProgressMessage(arohcpv1alpha1.ClusterStatePending))
+	assert.Equal(t, "cluster service is validating", ClusterServiceInProgressMessage(arohcpv1alpha1.ClusterStateValidating))
+	assert.Equal(t, "", ClusterServiceInProgressMessage(arohcpv1alpha1.ClusterStateReady))
+	assert.Equal(t, "", ClusterServiceInProgressMessage(arohcpv1alpha1.ClusterStateError))
+}
+
+func TestClusterServiceOperationMessage(t *testing.T) {
+	assert.Equal(t, "provision failed", ClusterServiceOperationMessage(nil, &coreapi.CloudErrorBody{Message: "provision failed"}))
+	assert.Equal(t, "", ClusterServiceOperationMessage(nil, nil))
+
+	clusterStatus, err := arohcpv1alpha1.NewClusterStatus().
+		State(arohcpv1alpha1.ClusterStateInstalling).
+		Build()
+	assert.NoError(t, err)
+	assert.Equal(t, "cluster service is installing", ClusterServiceOperationMessage(clusterStatus, nil))
+}
+
+func TestNodePoolServiceInProgressMessage(t *testing.T) {
+	assert.Equal(t, "cluster service node pool is installing", NodePoolServiceInProgressMessage(NodePoolStateInstalling))
+	assert.Equal(t, "cluster service node pool is pending", NodePoolServiceInProgressMessage(NodePoolStatePending))
+	assert.Equal(t, "", NodePoolServiceInProgressMessage(NodePoolStateReady))
+	assert.Equal(t, "", NodePoolServiceInProgressMessage(NodePoolStateError))
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-28984

### What

When cluster/node pool create hits the RP cluster provisioning deadline and the cluster is still installing, ARM returns an error that gives the impression of a CS InternalServerError.

```
ERROR CODE: InternalServerError
"message": "[clusterServiceClusterStatus] <no_message>"
```

This changes keeps the create deadline sentence as the ARM error cause, and give in-progress Cluster Service create checks a real OperationState message so PickWorst does not fill in `<no_message>`.

| | Message |
|---|---|
| Before | `[clusterServiceClusterStatus] <no_message>` |
| After | `cluster creation did not complete before the deadline; [clusterServiceClusterStatus] cluster service is installing` |


### Why

ConvertClusterStatus maps to Provisioning with an empty message. PickWorstOperationState then substitutes <no_message>. The deadline path replaced the timeout sentence whenever PickWorst had any message, so the only text customers and e2e saw was [clusterServiceClusterStatus] <no_message> with InternalServerError. That hid the actual cause (create deadline) and blamed Cluster Service for cases where CS was healthy and still installing.

### Testing

Unit tests for new functions

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
