### PR TITLE
fix(e2e): work around OCP 4.22 DNS NetworkPolicy blocking Cilium

### DIFF
--- a/test/e2e/cluster_create_cni_cilium.go
+++ b/test/e2e/cluster_create_cni_cilium.go
@@ -96,6 +96,8 @@ var _ = Describe("Customer", func() {
 				framework.GetAdminRESTConfigTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for cluster %q", customerClusterName)
+			adminRESTConfig.QPS = 50
+			adminRESTConfig.Burst = 100
 			Expect(verifiers.VerifyHCPCluster(ctx, adminRESTConfig)).To(Succeed(), "failed to verify HCP cluster %q is available", customerClusterName)
 
 			By("getting kubeconfig content for Helm")
@@ -165,6 +167,10 @@ var _ = Describe("Customer", func() {
 			)
 			// We delay checking the error on purpose to get more details
 			// about the issue by running the verifiers.
+
+			By("allowing DNS pods to reach the kube-apiserver-proxy via CiliumNetworkPolicy (OCP >= 4.22 only)")
+			err = framework.EnsureDNSAllowHostAPIServerCiliumNetworkPolicy(ctx, adminRESTConfig, framework.NodePoolCreationTimeout)
+			Expect(err).NotTo(HaveOccurred(), "failed to create CiliumNetworkPolicy allowing DNS pods to reach the kube-apiserver-proxy")
 
 			By("checking that cilium is running and nodes are in Ready state")
 			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodesReady(), verifiers.VerifyCiliumOperational(ciliumNamespace, "k8s-app=cilium"))

--- a/test/e2e/cluster_create_complex_cilium_kv.go
+++ b/test/e2e/cluster_create_complex_cilium_kv.go
@@ -114,6 +114,8 @@ var _ = Describe("Customer", func() {
 				framework.GetAdminRESTConfigTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for cluster %q", customerClusterName)
+			adminRESTConfig.QPS = 50
+			adminRESTConfig.Burst = 100
 
 			By("disabling kube-proxy via networks.operator.openshift.io patch")
 			opClient, err := operatorclient.NewForConfig(adminRESTConfig)
@@ -186,6 +188,10 @@ var _ = Describe("Customer", func() {
 						tc.LogDirPath)
 				}
 			}
+
+			By("allowing DNS pods to reach the kube-apiserver-proxy via CiliumNetworkPolicy (OCP >= 4.22 only)")
+			cnpErr := framework.EnsureDNSAllowHostAPIServerCiliumNetworkPolicy(ctx, adminRESTConfig, framework.NodePoolCreationTimeout)
+			Expect(cnpErr).NotTo(HaveOccurred(), "failed to create CiliumNetworkPolicy allowing DNS pods to reach the kube-apiserver-proxy")
 
 			By("verifying nodes become Ready with Cilium CNI")
 			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodesReady(), verifiers.VerifyCiliumOperational("kube-system", "k8s-app=cilium"))

--- a/test/e2e/cluster_create_feature_aggregation.go
+++ b/test/e2e/cluster_create_feature_aggregation.go
@@ -327,6 +327,10 @@ var _ = Describe("Customer", func() {
 			// We delay checking the error on purpose to get more details
 			// about the issue by running the verifiers.
 
+			By("allowing DNS pods to reach the kube-apiserver-proxy via CiliumNetworkPolicy (OCP >= 4.22 only)")
+			err = framework.EnsureDNSAllowHostAPIServerCiliumNetworkPolicy(ctx, adminRESTConfig, framework.NodePoolCreationTimeout)
+			Expect(err).NotTo(HaveOccurred(), "failed to create CiliumNetworkPolicy allowing DNS pods to reach the kube-apiserver-proxy")
+
 			By("checking that cilium is running and nodes are in Ready state")
 			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig, verifiers.VerifyNodesReady(), verifiers.VerifyCiliumOperational(ciliumNamespace, "k8s-app=cilium"))
 			Expect(errors.Join(err, nodePoolErrA)).NotTo(HaveOccurred(), "failed to verify cilium is running and nodes are Ready for cluster %q", customerClusterName)

--- a/test/util/framework/cilium_helper.go
+++ b/test/util/framework/cilium_helper.go
@@ -18,14 +18,26 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
+	"github.com/blang/semver/v4"
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/chart/v2/loader"
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/kube"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
+
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 )
 
 // Install Cilium helm chart using the helm Go SDK. Cilium configuration is
@@ -88,4 +100,105 @@ func InstallCiliumChart(ctx context.Context, chartVersion string, values map[str
 	}
 
 	return nil
+}
+
+var ciliumDNSHostAPIServerPolicyMinVersion = semver.MustParse("4.22.0")
+
+func EnsureDNSAllowHostAPIServerCiliumNetworkPolicy(ctx context.Context, adminRESTConfig *rest.Config, nodePoolCreationTimeout time.Duration) error {
+	const (
+		dnsNamespace    = "openshift-dns"
+		policyName      = "dns-allow-host-apiserver"
+		apiServerPort   = "6443"
+		dnsDaemonSetKey = "dns.operator.openshift.io/daemonset-dns"
+	)
+
+	configClient, err := configv1client.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create config client to resolve cluster version: %w", err)
+	}
+
+	clusterVersion, err := configClient.ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get clusterversion to resolve cluster version: %w", err)
+	}
+
+	currentVersion, err := semver.ParseTolerant(clusterVersion.Status.Desired.Version)
+	if err != nil {
+		return fmt.Errorf("failed to parse cluster version %q: %w", clusterVersion.Status.Desired.Version, err)
+	}
+
+	if currentVersion.LT(ciliumDNSHostAPIServerPolicyMinVersion) {
+		// Below the NE-1476 boundary: the DNS operator does not create any
+		// NetworkPolicy in openshift-dns, so there is nothing to work around.
+		return nil
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create dynamic client for CiliumNetworkPolicy: %w", err)
+	}
+
+	cnpGVR := schema.GroupVersionResource{Group: "cilium.io", Version: "v2", Resource: "ciliumnetworkpolicies"}
+	desired := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "cilium.io/v2",
+			"kind":       "CiliumNetworkPolicy",
+			"metadata": map[string]any{
+				"name":      policyName,
+				"namespace": dnsNamespace,
+			},
+			"spec": map[string]any{
+				"endpointSelector": map[string]any{
+					"matchLabels": map[string]any{
+						dnsDaemonSetKey: "default",
+					},
+				},
+				"egress": []any{
+					map[string]any{
+						"toEntities": []any{"host", "remote-node"},
+						"toPorts": []any{
+							map[string]any{
+								"ports": []any{
+									map[string]any{
+										"port":     apiServerPort,
+										"protocol": "TCP",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// The CiliumNetworkPolicy CRD is registered by cilium-operator, which can
+	// only schedule once the node pool's worker nodes exist. Retry only the
+	// CRD/GVR-not-found race; AlreadyExists means a previous attempt succeeded.
+	var lastErr error
+	err = wait.PollUntilContextTimeout(ctx, 10*time.Second, nodePoolCreationTimeout, true, func(ctx context.Context) (bool, error) {
+		_, createErr := dynamicClient.Resource(cnpGVR).Namespace(dnsNamespace).Create(ctx, desired, metav1.CreateOptions{})
+		if createErr == nil || apierrors.IsAlreadyExists(createErr) {
+			return true, nil
+		}
+		if isRetryableCiliumNetworkPolicyCreateError(createErr) {
+			lastErr = createErr
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to create CiliumNetworkPolicy %s/%s: %w", dnsNamespace, policyName, createErr)
+	})
+	if err != nil {
+		if wait.Interrupted(err) && lastErr != nil {
+			return fmt.Errorf("timed out creating CiliumNetworkPolicy %s/%s: %w", dnsNamespace, policyName, lastErr)
+		}
+		return err
+	}
+	return nil
+}
+
+// isRetryableCiliumNetworkPolicyCreateError reports whether create failed
+// because the CiliumNetworkPolicy CRD/GVR is not served yet. Permanent errors
+// such as Forbidden or Invalid must not be retried.
+func isRetryableCiliumNetworkPolicyCreateError(err error) bool {
+	return apierrors.IsNotFound(err) || meta.IsNoMatchError(err)
 }

--- a/test/util/framework/cilium_helper_test.go
+++ b/test/util/framework/cilium_helper_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestIsRetryableCiliumNetworkPolicyCreateError(t *testing.T) {
+	t.Parallel()
+
+	cnpGVR := schema.GroupResource{Group: "cilium.io", Resource: "ciliumnetworkpolicies"}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "CRD not found is retryable",
+			err:  apierrors.NewNotFound(cnpGVR, "dns-allow-host-apiserver"),
+			want: true,
+		},
+		{
+			name: "GVR not in discovery is retryable",
+			err: &meta.NoKindMatchError{
+				GroupKind:        schema.GroupKind{Group: "cilium.io", Kind: "CiliumNetworkPolicy"},
+				SearchedVersions: []string{"v2"},
+			},
+			want: true,
+		},
+		{
+			name: "AlreadyExists is not retryable",
+			err:  apierrors.NewAlreadyExists(cnpGVR, "dns-allow-host-apiserver"),
+			want: false,
+		},
+		{
+			name: "Forbidden is not retryable",
+			err:  apierrors.NewForbidden(cnpGVR, "dns-allow-host-apiserver", nil),
+			want: false,
+		},
+		{
+			name: "Invalid spec is not retryable",
+			err:  apierrors.NewInvalid(schema.GroupKind{Group: "cilium.io", Kind: "CiliumNetworkPolicy"}, "dns-allow-host-apiserver", nil),
+			want: false,
+		},
+		{
+			name: "Unauthorized is not retryable",
+			err:  apierrors.NewUnauthorized("not authorized"),
+			want: false,
+		},
+		{
+			name: "BadRequest is not retryable",
+			err:  apierrors.NewBadRequest("invalid CiliumNetworkPolicy"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isRetryableCiliumNetworkPolicyCreateError(tt.err)
+			if got != tt.want {
+				t.Errorf("isRetryableCiliumNetworkPolicyCreateError() = %v, want %v (err=%v)", got, tt.want, tt.err)
+			}
+		})
+	}
+}
+
+func TestIsRetryableCiliumNetworkPolicyCreateError_nil(t *testing.T) {
+	t.Parallel()
+	if isRetryableCiliumNetworkPolicyCreateError(nil) {
+		t.Fatal("nil error must not be treated as retryable")
+	}
+}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-29177

### What

Starting in OCP 4.22 (NE-1476, cluster-dns-operator@60b42af5), the DNS operator creates NetworkPolicy objects in openshift-dns (a default-deny policy plus a CIDR-only egress allow rule). Cilium's CIDR-based policy selectors cannot match the "host"/"remote-node" identities that kube-proxy's iptables DNAT causes CoreDNS's apiserver traffic to resolve to (the kube-apiserver-proxy ClusterIP rewrite happens before Cilium's eBPF datapath evaluates policy). As a result, CoreDNS's egress to the apiserver is dropped and DNS pods never become fully Ready on 4.22, while 4.20/4.21 are unaffected since no such NetworkPolicy exists there.

Add EnsureDNSAllowHostAPIServerCiliumNetworkPolicy in test/util/framework/cilium_helper.go, which queries the guest cluster's OpenShift version and, only for OCP >= 4.22, creates a CiliumNetworkPolicy allowing openshift-dns pods egress to the host/remote-node entities on TCP 6443. The check is retried (wait.PollUntilContextTimeout) to tolerate the CiliumNetworkPolicy CRD only being registered once cilium-operator schedules on a node.

The fix is explicitly version-gated: applying it unconditionally on 4.20/4.21, where openshift-dns currently has no NetworkPolicy at all, would flip DNS pod egress to default-deny and could break other legitimate egress (e.g. upstream DNS resolution) not covered by this narrow allow rule.

Wire the helper into all three Cilium CNI e2e tests, called right after node pool creation and before the cilium/nodes-ready verification step:
- cluster_create_cni_cilium.go
- cluster_create_complex_cilium_kv.go
- cluster_create_feature_aggregation.go (after the first node pool)

Live-validated on OCP 4.22.10: DNS pods went from 1/2 Ready (stuck) to 2/2 Running within ~30s of the CiliumNetworkPolicy being created, with dns/network/ingress ClusterOperators becoming healthy. Also validated no regression on 4.20/4.22 clean re-runs of all three tests.

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
