### PR TITLE
chore: halve DEV e2e-parallel concurrent PR slot capacity

### DIFF
--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -7,33 +7,34 @@ environments:
     pools:
     # Jobs choose the runtime region; `region` is only the default when no runtime override is provided.
     # Identity containers are provisioned in westus3.
-    # Each managed subscription keeps 300 containers split into five 60-container job slots.
+    # Each managed subscription keeps 300 containers; slot_count is reduced to 2 per
+    # subscription (60-container job slots) to halve concurrent PR e2e-parallel jobs.
     - subscription_name: "ARO HCP E2E Hosted Clusters (EA Subscription)"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard0-slot
-      slot_count: 5
+      slot_count: 2
       identity_container_prefix: aro-hcp-msi-container-dev-shard0
       identity_container_count: 60
     - subscription_name: "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard1-slot
-      slot_count: 5
+      slot_count: 2
       identity_container_prefix: aro-hcp-msi-container-dev-shard1
       identity_container_count: 60
     - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 02"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard2-slot
-      slot_count: 5
+      slot_count: 2
       identity_container_prefix: aro-hcp-msi-container-dev-shard2
       identity_container_count: 60
     - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 03"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard3-slot
-      slot_count: 5
+      slot_count: 2
       identity_container_prefix: aro-hcp-msi-container-dev-shard3
       identity_container_count: 60
     - subscription_name: "Hypershift Managed Azure"

--- a/tooling/hcpctl/README.md
+++ b/tooling/hcpctl/README.md
@@ -214,3 +214,4 @@ The timestamp fields define the time window for log queries. They are rendered a
 - tests for the `pkg/breakglass/minting` package
 - tests for the `pkg/breakglass/portforward` package (e.g. https://github.com/openshift/ci-tools/blob/05305124f711827983c0908af9020a41ad6afacf/pkg/testhelper/accessory.go#L261)
 - E2E tests for all breakglass commands
+


### PR DESCRIPTION
## Summary
- Reduce `slot_count` from 5 to 2 for each of the four DEV shard pools in `test/e2e-config/e2e-slots.yaml`, cutting the maximum number of PRs that can run `pull-ci-Azure-ARO-HCP-main-e2e-parallel` concurrently from 20 to 8.
- `identity_container_count` (per-run HCP concurrency, currently 60 per pool) is unchanged — a single job run still provisions as many HCPs concurrently as before; this only limits how many PRs can run the job at the same time.

## Test plan
- [x] `go test ./cmd/aro-hcp-tests/slot-manager/...` passes against the updated catalog
- [ ] After merge: sync `openshift/release` Boskos inventory (`slot-manager sync-boskos-config` / `validate-boskos-config`) and confirm reduced slot counts are reflected there, per the shrink ordering in `docs/ci/identity-leasing.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)