### PR TITLE
test/e2e: cap dev E2E slots at 2 per shard (20 -> 8 concurrent jobs)

### DIFF
--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -7,33 +7,36 @@ environments:
     pools:
     # Jobs choose the runtime region; `region` is only the default when no runtime override is provided.
     # Identity containers are provisioned in westus3.
-    # Each managed subscription keeps 300 containers split into five 60-container job slots.
+    # Each managed subscription keeps 300 containers split into 60-container job slots.
+    # slot_count is capped at 2 per shard to bound total concurrent dev E2E jobs
+    # to 8 (4 shards x 2). identity_container_count stays 60, so per-job HCP
+    # concurrency is unchanged; the extra provisioned containers are headroom.
     - subscription_name: "ARO HCP E2E Hosted Clusters (EA Subscription)"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard0-slot
-      slot_count: 5
+      slot_count: 2
       identity_container_prefix: aro-hcp-msi-container-dev-shard0
       identity_container_count: 60
     - subscription_name: "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard1-slot
-      slot_count: 5
+      slot_count: 2
       identity_container_prefix: aro-hcp-msi-container-dev-shard1
       identity_container_count: 60
     - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 02"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard2-slot
-      slot_count: 5
+      slot_count: 2
       identity_container_prefix: aro-hcp-msi-container-dev-shard2
       identity_container_count: 60
     - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 03"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard3-slot
-      slot_count: 5
+      slot_count: 2
       identity_container_prefix: aro-hcp-msi-container-dev-shard3
       identity_container_count: 60
     - subscription_name: "Hypershift Managed Azure"


### PR DESCRIPTION
## What

Reduce `slot_count` from **5 to 2** on each of the four managed dev shards (`aro-hcp-dev-shard0-slot` .. `shard3`) in `test/e2e-config/e2e-slots.yaml`.

This lowers the maximum number of concurrent dev `e2e-parallel` PR jobs from **20** (4 shards × 5) to **8** (4 shards × 2).

## Why this lever

The dev `e2e-parallel` presubmit has no effective `max_concurrency` (the release generator strips `max_concurrency` from presubmits), so concurrency is bound solely by the Boskos slot pool. `slot_count` is that pool.

## What is intentionally NOT changed

- `identity_container_count` stays at **60** → max HCP concurrency per job is unchanged.
- `ARO_HCP_SUITE_PARALLELISM` (55) is untouched.

Only the number of leasable slots (= concurrent jobs) drops. Extra provisioned identity containers become headroom.

## Coordination

This is a **shrink**, so per the slot-manager ordering the matching openshift/release Boskos reduction must merge **first**:

- openshift/release PR: https://github.com/openshift/release/pull/84078