### PR TITLE
fix(fleet): preserve SchedulingPolicy on MC re-registration, add admin PUT endpoint

### DIFF
--- a/admin/server/handlers/stamp/managementcluster_test.go
+++ b/admin/server/handlers/stamp/managementcluster_test.go
@@ -51,6 +51,13 @@ func mustNewInternalID(t *testing.T, path string) *metadataapi.InternalID {
 	return &id
 }
 
+func newManagementClusterWithPolicy(t *testing.T, stampIdentifier string, policy fleetapi.ManagementClusterSchedulingPolicy) *fleetapi.ManagementCluster {
+	t.Helper()
+	managementCluster := newManagementCluster(t, stampIdentifier)
+	managementCluster.Spec.SchedulingPolicy = policy
+	return managementCluster
+}
+
 func newManagementCluster(t *testing.T, stampIdentifier string) *fleetapi.ManagementCluster {
 	t.Helper()
 	managementClusterResourceID, err := fleetapi.ToManagementClusterResourceID(stampIdentifier)

--- a/admin/server/handlers/stamp/managementclusterschedulingpolicy.go
+++ b/admin/server/handlers/stamp/managementclusterschedulingpolicy.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stamp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/fleetapi"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/fleetcosmosstorage"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+type schedulingPolicyRequest struct {
+	SchedulingPolicy fleetapi.ManagementClusterSchedulingPolicy `json:"schedulingPolicy"`
+}
+
+// ManagementClusterSchedulingPolicyPutHandler handles PUT /admin/v1/stamps/{stampIdentifier}/managementclusters/{managementClusterName}/schedulingPolicy.
+type ManagementClusterSchedulingPolicyPutHandler struct {
+	fleetDBClient fleetcosmosstorage.FleetDBClient
+}
+
+func NewManagementClusterSchedulingPolicyPutHandler(fleetDBClient fleetcosmosstorage.FleetDBClient) *ManagementClusterSchedulingPolicyPutHandler {
+	return &ManagementClusterSchedulingPolicyPutHandler{
+		fleetDBClient: fleetDBClient,
+	}
+}
+
+func (h *ManagementClusterSchedulingPolicyPutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+	stampIdentifier := r.PathValue("stampIdentifier")
+	managementClusterName := r.PathValue("managementClusterName")
+
+	if err := validateStampIdentifier(stampIdentifier); err != nil {
+		return err
+	}
+
+	var body schedulingPolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return coreapi.NewCloudError(http.StatusBadRequest, coreapi.CloudErrorCodeInvalidRequestContent, "", "invalid JSON body: %v", err)
+	}
+
+	if !fleetapi.ValidManagementClusterSchedulingPolicies.Has(body.SchedulingPolicy) {
+		return coreapi.NewCloudError(http.StatusBadRequest, coreapi.CloudErrorCodeInvalidRequestContent, "",
+			"schedulingPolicy %q must be one of %v", body.SchedulingPolicy, fleetapi.ValidManagementClusterSchedulingPolicies.UnsortedList())
+	}
+
+	managementClustersCRUD := h.fleetDBClient.Stamps().ManagementClusters(stampIdentifier)
+
+	existing, err := managementClustersCRUD.Get(ctx, managementClusterName)
+	if err != nil {
+		if cosmosstorageutils.IsNotFoundError(err) {
+			return coreapi.NewCloudError(http.StatusNotFound, coreapi.CloudErrorCodeNotFound, "",
+				"Management cluster %q not found in stamp %q", managementClusterName, stampIdentifier)
+		}
+		return utils.TrackError(fmt.Errorf("failed to get management cluster: %w", err))
+	}
+
+	updated := existing.DeepCopy()
+	updated.Spec.SchedulingPolicy = body.SchedulingPolicy
+
+	if _, err := managementClustersCRUD.Replace(ctx, updated, existing, nil); err != nil {
+		return utils.TrackError(fmt.Errorf("failed to update management cluster scheduling policy: %w", err))
+	}
+
+	_, err = coreapi.WriteJSONResponse(w, http.StatusOK, schedulingPolicyRequest{SchedulingPolicy: body.SchedulingPolicy})
+	return utils.TrackError(err)
+}

--- a/admin/server/handlers/stamp/managementclusterschedulingpolicy.go
+++ b/admin/server/handlers/stamp/managementclusterschedulingpolicy.go
@@ -30,7 +30,7 @@ type schedulingPolicyRequest struct {
 	SchedulingPolicy fleetapi.ManagementClusterSchedulingPolicy `json:"schedulingPolicy"`
 }
 
-// ManagementClusterSchedulingPolicyPutHandler handles PUT /admin/v1/stamps/{stampIdentifier}/managementclusters/{managementClusterName}/schedulingPolicy.
+// ManagementClusterSchedulingPolicyPutHandler handles PUT /admin/v1/stamps/{stampIdentifier}/managementclusters/{managementClusterName}/schedulingpolicy.
 type ManagementClusterSchedulingPolicyPutHandler struct {
 	fleetDBClient fleetcosmosstorage.FleetDBClient
 }
@@ -75,6 +75,9 @@ func (h *ManagementClusterSchedulingPolicyPutHandler) ServeHTTP(w http.ResponseW
 	updated.Spec.SchedulingPolicy = body.SchedulingPolicy
 
 	if _, err := managementClustersCRUD.Replace(ctx, updated, existing, nil); err != nil {
+		if cosmosstorageutils.IsPreconditionFailedError(err) {
+			return coreapi.NewCloudError(http.StatusConflict, coreapi.CloudErrorCodeConflict, "", "ETag conflict, retry the operation")
+		}
 		return utils.TrackError(fmt.Errorf("failed to update management cluster scheduling policy: %w", err))
 	}
 

--- a/admin/server/handlers/stamp/managementclusterschedulingpolicy_test.go
+++ b/admin/server/handlers/stamp/managementclusterschedulingpolicy_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stamp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/fleetapi"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/fleetcosmosstoragetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+func TestManagementClusterSchedulingPolicyPutHandler(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                   string
+		stampIdentifier        string
+		managementClusterName  string
+		requestBody            string
+		setupResources         []any
+		expectedStatusCode     int
+		expectedError          string
+		expectedSchedulePolicy fleetapi.ManagementClusterSchedulingPolicy
+	}{
+		{
+			name:                   "update scheduling policy from schedulable to unschedulable",
+			stampIdentifier:        "a1",
+			managementClusterName:  fleetapi.ManagementClusterResourceName,
+			requestBody:            `{"schedulingPolicy": "Unschedulable"}`,
+			setupResources:         []any{newStamp("a1"), newManagementCluster(t, "a1")},
+			expectedStatusCode:     http.StatusOK,
+			expectedSchedulePolicy: fleetapi.ManagementClusterSchedulingPolicyUnschedulable,
+		},
+		{
+			name:                   "update scheduling policy from unschedulable to schedulable",
+			stampIdentifier:        "a1",
+			managementClusterName:  fleetapi.ManagementClusterResourceName,
+			requestBody:            `{"schedulingPolicy": "Schedulable"}`,
+			setupResources:         []any{newStamp("a1"), newManagementClusterWithPolicy(t, "a1", fleetapi.ManagementClusterSchedulingPolicyUnschedulable)},
+			expectedStatusCode:     http.StatusOK,
+			expectedSchedulePolicy: fleetapi.ManagementClusterSchedulingPolicySchedulable,
+		},
+		{
+			name:                  "invalid scheduling policy returns 400",
+			stampIdentifier:       "a1",
+			managementClusterName: fleetapi.ManagementClusterResourceName,
+			requestBody:           `{"schedulingPolicy": "Invalid"}`,
+			setupResources:        []any{newStamp("a1"), newManagementCluster(t, "a1")},
+			expectedStatusCode:    http.StatusBadRequest,
+			expectedError:         "schedulingPolicy",
+		},
+		{
+			name:                  "empty scheduling policy returns 400",
+			stampIdentifier:       "a1",
+			managementClusterName: fleetapi.ManagementClusterResourceName,
+			requestBody:           `{"schedulingPolicy": ""}`,
+			setupResources:        []any{newStamp("a1"), newManagementCluster(t, "a1")},
+			expectedStatusCode:    http.StatusBadRequest,
+			expectedError:         "schedulingPolicy",
+		},
+		{
+			name:                  "invalid JSON body returns 400",
+			stampIdentifier:       "a1",
+			managementClusterName: fleetapi.ManagementClusterResourceName,
+			requestBody:           `not json`,
+			setupResources:        []any{newStamp("a1"), newManagementCluster(t, "a1")},
+			expectedStatusCode:    http.StatusBadRequest,
+			expectedError:         "invalid JSON body",
+		},
+		{
+			name:                  "management cluster not found returns 404",
+			stampIdentifier:       "a1",
+			managementClusterName: fleetapi.ManagementClusterResourceName,
+			requestBody:           `{"schedulingPolicy": "Schedulable"}`,
+			setupResources:        []any{newStamp("a1")},
+			expectedStatusCode:    http.StatusNotFound,
+			expectedError:         "not found",
+		},
+		{
+			name:                  "invalid stamp identifier returns 400",
+			stampIdentifier:       "",
+			managementClusterName: fleetapi.ManagementClusterResourceName,
+			requestBody:           `{"schedulingPolicy": "Schedulable"}`,
+			expectedStatusCode:    http.StatusBadRequest,
+			expectedError:         "Invalid stamp identifier",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+			var mockFleetDB *fleetcosmosstoragetesting.MockFleetDBClient
+			var err error
+			if len(tt.setupResources) > 0 {
+				mockFleetDB, err = fleetcosmosstoragetesting.NewMockFleetDBClientWithResources(ctx, tt.setupResources)
+				require.NoError(t, err)
+			} else {
+				mockFleetDB = fleetcosmosstoragetesting.NewMockFleetDBClient()
+			}
+
+			handler := NewManagementClusterSchedulingPolicyPutHandler(mockFleetDB)
+
+			req := httptest.NewRequest(http.MethodPut, "/admin/v1/stamps/"+tt.stampIdentifier+"/managementclusters/"+tt.managementClusterName+"/schedulingPolicy", strings.NewReader(tt.requestBody))
+			req.SetPathValue("stampIdentifier", tt.stampIdentifier)
+			req.SetPathValue("managementClusterName", tt.managementClusterName)
+			req = req.WithContext(ctx)
+			recorder := httptest.NewRecorder()
+
+			handlerErr := handler.ServeHTTP(recorder, req)
+
+			if len(tt.expectedError) > 0 {
+				require.Error(t, handlerErr)
+				var cloudErr *coreapi.CloudError
+				require.True(t, errors.As(handlerErr, &cloudErr), "expected CloudError but got %T: %v", handlerErr, handlerErr)
+				require.Equal(t, tt.expectedStatusCode, cloudErr.StatusCode)
+				require.Contains(t, cloudErr.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, handlerErr)
+				require.Equal(t, tt.expectedStatusCode, recorder.Code)
+
+				var resp schedulingPolicyRequest
+				require.NoError(t, json.NewDecoder(recorder.Body).Decode(&resp))
+				require.Equal(t, tt.expectedSchedulePolicy, resp.SchedulingPolicy)
+
+				// Verify the policy was persisted
+				managementCluster, err := mockFleetDB.Stamps().ManagementClusters(tt.stampIdentifier).Get(ctx, tt.managementClusterName)
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedSchedulePolicy, managementCluster.Spec.SchedulingPolicy)
+			}
+		})
+	}
+}

--- a/admin/server/handlers/stamp/managementclusterschedulingpolicy_test.go
+++ b/admin/server/handlers/stamp/managementclusterschedulingpolicy_test.go
@@ -124,7 +124,7 @@ func TestManagementClusterSchedulingPolicyPutHandler(t *testing.T) {
 
 			handler := NewManagementClusterSchedulingPolicyPutHandler(mockFleetDB)
 
-			req := httptest.NewRequest(http.MethodPut, "/admin/v1/stamps/"+tt.stampIdentifier+"/managementclusters/"+tt.managementClusterName+"/schedulingPolicy", strings.NewReader(tt.requestBody))
+			req := httptest.NewRequest(http.MethodPut, "/admin/v1/stamps/"+tt.stampIdentifier+"/managementclusters/"+tt.managementClusterName+"/schedulingpolicy", strings.NewReader(tt.requestBody))
 			req.SetPathValue("stampIdentifier", tt.stampIdentifier)
 			req.SetPathValue("managementClusterName", tt.managementClusterName)
 			req = req.WithContext(ctx)

--- a/admin/server/server/admin.go
+++ b/admin/server/server/admin.go
@@ -152,7 +152,7 @@ func NewAdminAPI(
 		errorutils.ReportError(stamphandlers.NewManagementClusterGetHandler(fleetDBClient).ServeHTTP))
 	middlewareMux.Handle("GET /admin/v1/stamps/{stampIdentifier}/managementclusters/{managementClusterName}/scheduling",
 		errorutils.ReportError(stamphandlers.NewManagementClusterSchedulingGetHandler(fleetDBClient).ServeHTTP))
-	middlewareMux.Handle("PUT /admin/v1/stamps/{stampIdentifier}/managementclusters/{managementClusterName}/schedulingPolicy",
+	middlewareMux.Handle("PUT /admin/v1/stamps/{stampIdentifier}/managementclusters/{managementClusterName}/schedulingpolicy",
 		errorutils.ReportError(stamphandlers.NewManagementClusterSchedulingPolicyPutHandler(fleetDBClient).ServeHTTP))
 	middlewareMux.Handle("POST /admin/v1/stamps/{stampIdentifier}/approval",
 		errorutils.ReportError(stamphandlers.NewStampApprovalHandler(fleetDBClient).ServeHTTP))

--- a/admin/server/server/admin.go
+++ b/admin/server/server/admin.go
@@ -152,6 +152,8 @@ func NewAdminAPI(
 		errorutils.ReportError(stamphandlers.NewManagementClusterGetHandler(fleetDBClient).ServeHTTP))
 	middlewareMux.Handle("GET /admin/v1/stamps/{stampIdentifier}/managementclusters/{managementClusterName}/scheduling",
 		errorutils.ReportError(stamphandlers.NewManagementClusterSchedulingGetHandler(fleetDBClient).ServeHTTP))
+	middlewareMux.Handle("PUT /admin/v1/stamps/{stampIdentifier}/managementclusters/{managementClusterName}/schedulingPolicy",
+		errorutils.ReportError(stamphandlers.NewManagementClusterSchedulingPolicyPutHandler(fleetDBClient).ServeHTTP))
 	middlewareMux.Handle("POST /admin/v1/stamps/{stampIdentifier}/approval",
 		errorutils.ReportError(stamphandlers.NewStampApprovalHandler(fleetDBClient).ServeHTTP))
 	middlewareMux.Handle("GET /admin/v1/hcpresourcerequirements/{name}",

--- a/fleet/cmd/register/cmd.go
+++ b/fleet/cmd/register/cmd.go
@@ -158,7 +158,7 @@ func (o *RegisterOptions) registerManagementCluster(ctx context.Context) error {
 	}
 
 	updated := existing.DeepCopy()
-	o.applyToManagementCluster(updated)
+	o.applyStatusToManagementCluster(updated)
 
 	logger.Info("Updating existing management cluster")
 	if _, err := managementClusterCRUD.Replace(ctx, updated, existing, nil); err != nil {
@@ -170,6 +170,10 @@ func (o *RegisterOptions) registerManagementCluster(ctx context.Context) error {
 
 func (o *RegisterOptions) applyToManagementCluster(managementCluster *fleetapi.ManagementCluster) {
 	managementCluster.Spec.SchedulingPolicy = o.schedulingPolicy
+	o.applyStatusToManagementCluster(managementCluster)
+}
+
+func (o *RegisterOptions) applyStatusToManagementCluster(managementCluster *fleetapi.ManagementCluster) {
 	managementCluster.Status.AKSResourceID = o.aksResourceID
 	managementCluster.Status.PublicDNSZoneResourceID = o.publicDNSZoneResourceID
 	managementCluster.Status.HostedClustersSecretsKeyVaultURL = o.hostedClustersSecretsKeyVaultURL

--- a/fleet/cmd/register/cmd_test.go
+++ b/fleet/cmd/register/cmd_test.go
@@ -217,7 +217,7 @@ func TestRun(t *testing.T) {
 			expectErr: "replace validation failed",
 		},
 		{
-			name: "update existing management cluster allows scheduling policy change",
+			name: "update existing management cluster preserves scheduling policy",
 			seed: func(t *testing.T) []any {
 				stamp := &fleetapi.Stamp{
 					CosmosMetadata: coreapi.CosmosMetadata{ResourceID: metadataapi.Must(fleetapi.ToStampResourceID(testStampIdentifier)), PartitionKey: strings.ToLower(testStampIdentifier)},
@@ -227,7 +227,7 @@ func TestRun(t *testing.T) {
 					CosmosMetadata: coreapi.CosmosMetadata{ResourceID: metadataapi.Must(fleetapi.ToManagementClusterResourceID(testStampIdentifier)), PartitionKey: strings.ToLower(testStampIdentifier)},
 					ResourceID:     metadataapi.Must(fleetapi.ToManagementClusterResourceID(testStampIdentifier)),
 					Spec: fleetapi.ManagementClusterSpec{
-						SchedulingPolicy: fleetapi.ManagementClusterSchedulingPolicySchedulable,
+						SchedulingPolicy: fleetapi.ManagementClusterSchedulingPolicyUnschedulable,
 					},
 					Status: fleetapi.ManagementClusterStatus{
 						AKSResourceID:                                        metadataapi.Must(azcorearm.ParseResourceID("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/aks-1")),
@@ -245,7 +245,7 @@ func TestRun(t *testing.T) {
 				return []any{stamp, managementCluster}
 			},
 			modify: func(t *testing.T, opts *RegisterOptions) {
-				opts.schedulingPolicy = fleetapi.ManagementClusterSchedulingPolicyUnschedulable
+				opts.schedulingPolicy = fleetapi.ManagementClusterSchedulingPolicySchedulable
 			},
 			verify: func(t *testing.T, client *fleetcosmosstoragetesting.MockFleetDBClient) {
 				ctx := testContext(t)


### PR DESCRIPTION
## Summary

- **Stop overwriting `SchedulingPolicy` on management cluster re-registration.** The register command was calling `applyToManagementCluster` on both create and update paths, resetting `Spec.SchedulingPolicy` to whatever the pipeline passes on every re-registration. Now the update path calls `applyStatusToManagementCluster` which only touches status fields, preserving the existing scheduling policy.
- **Add `PUT /admin/v1/stamps/{stampIdentifier}/managementclusters/{managementClusterName}/schedulingPolicy` admin endpoint.** Since the register command no longer manages the scheduling policy on updates, a dedicated admin API endpoint is needed to change it post-creation. The handler validates the request body, performs a read-modify-write on the management cluster document, and returns the updated policy.

## Test plan

- [ ] `fleet/cmd/register` tests pass — verify scheduling policy is preserved on re-registration
- [ ] `admin/server/handlers/stamp` tests pass — 7 test cases cover both policy transitions, invalid values, not-found, and bad input
- [ ] `go build ./...` and `go vet ./...` pass for both modules