### PR TITLE
test: cover private KAS version validation

### DIFF
--- a/test/e2e/simple_negative_cases.go
+++ b/test/e2e/simple_negative_cases.go
@@ -99,6 +99,26 @@ var _ = Describe("Customer", func() {
 			_, err = nodePoolPager.NextPage(ctx)
 			checkExpectedError(&errs, "node pool listing in non-existent resource group", err, "resource group not found")
 
+			// TEST CASE: ARO-29314. The admission validation is implemented in #6692.
+			for _, version := range []string{"4.20", "4.21"} {
+				By(fmt.Sprintf("attempting to create a private KAS cluster on OCP %s", version))
+				versionSuffix := strings.ReplaceAll(version, ".", "")
+				privateKASClusterParams := clusterParams
+				privateKASClusterParams.ClusterName = fmt.Sprintf("private-kas-%s", versionSuffix)
+				privateKASClusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, fmt.Sprintf("-private-kas-%s-managed", versionSuffix), 64)
+				privateKASClusterParams.APIVisibility = "Private"
+				privateKASClusterParams.OpenshiftVersionId = version
+				privateKASCluster := framework.BuildHCPClusterFromParams20240610(privateKASClusterParams, tc.Location())
+				_, err = clusterClient.BeginCreateOrUpdate(
+					ctx,
+					*resourceGroup.Name,
+					privateKASClusterParams.ClusterName,
+					privateKASCluster,
+					nil,
+				)
+				checkExpectedError(&errs, fmt.Sprintf("private KAS cluster creation on OCP %s", version), err, "private KAS visibility requires OpenShift version 4.22")
+			}
+
 			By("creating the HCP cluster")
 			err = tc.CreateHCPClusterFromParam20240610(
 				ctx,


### PR DESCRIPTION
## Why

A private KAS cluster request below OpenShift 4.22 is accepted by the RP even though private KAS requires OpenShift 4.22 or later. Without admission validation, the request reaches Clusters Service, which rejects it with HTTP 400; the backend then retries that terminal error indefinitely and leaves the ARM operation in `Accepted`.

Tracking: https://redhat.atlassian.net/browse/ARO-29314

## Fix

https://github.com/Azure/ARO-HCP/pull/6692 adds the admission validation that rejects private KAS requests below OpenShift 4.22.

## What

- Adds private-KAS/OCP-4.20 and OCP-4.21 negative cases to the existing `simple_negative_cases.go` E2E suite, matching #6692's rejection behavior for every version below 4.22.
- Verifies that each creation request is rejected with the validation message requiring OpenShift 4.22.

## Test plan

- `make record-nonlocal-e2e`

Session id: 3af1a365-be05-4d7c-bb82-2d5239a8d74a (ms)
