### PR TITLE
feat(acr): enable diagnostic settings for OCP ACR in dev cloud

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -416,9 +416,9 @@
                 },
                 "retentionInDays": {
                   "type": "integer",
-                  "minimum": 0,
+                  "minimum": 30,
                   "maximum": 730,
-                  "description": "Data retention in days for the Log Analytics workspace"
+                  "description": "Data retention in days for the Log Analytics workspace. Azure requires 30-730 days."
                 }
               },
               "required": [

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -395,6 +395,45 @@
         "replicationState": {
           "type": "boolean",
           "description": "Whether this region's replica should have its regional data endpoint enabled. False for a canary/EUAP replica (e.g. eastus2euap) that must be kept disabled, see config.msft.clouds-overlay.yaml. Defaults to true (enabled)."
+        },
+        "diagnosticSettings": {
+          "type": "object",
+          "description": "ACR diagnostic settings (repository/login events + metrics) sent to a dedicated Log Analytics workspace.",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "logAnalyticsWorkspace": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the Log Analytics workspace to create for ACR diagnostic logs"
+                },
+                "sku": {
+                  "type": "string",
+                  "description": "SKU for the Log Analytics workspace"
+                },
+                "retentionInDays": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 730,
+                  "description": "Data retention in days for the Log Analytics workspace"
+                }
+              },
+              "required": [
+                "name",
+                "sku",
+                "retentionInDays"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "enabled",
+            "logAnalyticsWorkspace"
+          ],
+          "additionalProperties": false
         }
       },
       "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1430,8 +1430,16 @@ clouds:
         ocp:
           name: 'arohcpocpdev' # [globally-unique]
           zoneRedundantMode: Disabled
+          # All dev-cloud environments (ci00, ci01, cspr, dev, perf, pers) share
+          # this single arohcpocpdev registry. Azure caps diagnosticSettings at
+          # 5 per resource, so this MUST resolve to one static, shared
+          # workspace/diagnostic-settings name across every environment
+          # (not templated per-environment) so each environment's redeploy is
+          # an idempotent update of the same resource, not a new one.
           diagnosticSettings:
             enabled: true
+            logAnalyticsWorkspace:
+              name: 'arohcpocpdev-diag'
       # Metrics
       monitoring:
         alertsEnabled: true

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -112,6 +112,16 @@ defaults:
       # keeps eastus2euap's regional endpoint disabled so the manual mitigation
       # persists across rollouts; every other region defaults to enabled.
       replicationState: true
+      # ACR diagnostic settings (repository/login events + metrics) sent to a
+      # dedicated Log Analytics workspace. Disabled by default; enabled per-cloud
+      # below (see clouds.dev.defaults.acr.ocp). Added to help diagnose ACR
+      # throttling (429s) affecting E2E image pulls (AROSLSRE-1883).
+      diagnosticSettings:
+        enabled: false
+        logAnalyticsWorkspace:
+          name: 'arohcpocp{{ .ctx.environment }}-diag'
+          sku: PerGB2018
+          retentionInDays: 90
   # TRANSIENT — STG-global "V2" migration scaffolding. Every pipeline (including
   # the stg-only V2 copies) is preprocessed by helmtest against the dev render
   # and by EV2 manifest generation for all public envs, and the renderer uses
@@ -1420,6 +1430,8 @@ clouds:
         ocp:
           name: 'arohcpocpdev' # [globally-unique]
           zoneRedundantMode: Disabled
+          diagnosticSettings:
+            enabled: true
       # Metrics
       monitoring:
         alertsEnabled: true

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -14,7 +14,7 @@ acr:
     diagnosticSettings:
       enabled: true
       logAnalyticsWorkspace:
-        name: arohcpocpci00-diag
+        name: arohcpocpdev-diag
         retentionInDays: 90
         sku: PerGB2018
     name: arohcpocpdev

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -11,6 +11,12 @@ acm:
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
   ocp:
+    diagnosticSettings:
+      enabled: true
+      logAnalyticsWorkspace:
+        name: arohcpocpci00-diag
+        retentionInDays: 90
+        sku: PerGB2018
     name: arohcpocpdev
     replicationState: true
     untaggedImagesRetention:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -14,7 +14,7 @@ acr:
     diagnosticSettings:
       enabled: true
       logAnalyticsWorkspace:
-        name: arohcpocpci01-diag
+        name: arohcpocpdev-diag
         retentionInDays: 90
         sku: PerGB2018
     name: arohcpocpdev

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -11,6 +11,12 @@ acm:
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
   ocp:
+    diagnosticSettings:
+      enabled: true
+      logAnalyticsWorkspace:
+        name: arohcpocpci01-diag
+        retentionInDays: 90
+        sku: PerGB2018
     name: arohcpocpdev
     replicationState: true
     untaggedImagesRetention:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -14,7 +14,7 @@ acr:
     diagnosticSettings:
       enabled: true
       logAnalyticsWorkspace:
-        name: arohcpocpcspr-diag
+        name: arohcpocpdev-diag
         retentionInDays: 90
         sku: PerGB2018
     name: arohcpocpdev

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -11,6 +11,12 @@ acm:
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
   ocp:
+    diagnosticSettings:
+      enabled: true
+      logAnalyticsWorkspace:
+        name: arohcpocpcspr-diag
+        retentionInDays: 90
+        sku: PerGB2018
     name: arohcpocpdev
     replicationState: true
     untaggedImagesRetention:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -11,6 +11,12 @@ acm:
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
   ocp:
+    diagnosticSettings:
+      enabled: true
+      logAnalyticsWorkspace:
+        name: arohcpocpdev-diag
+        retentionInDays: 90
+        sku: PerGB2018
     name: arohcpocpdev
     replicationState: true
     untaggedImagesRetention:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -11,6 +11,12 @@ acm:
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
   ocp:
+    diagnosticSettings:
+      enabled: true
+      logAnalyticsWorkspace:
+        name: arohcpocpperf-diag
+        retentionInDays: 90
+        sku: PerGB2018
     name: arohcpocpdev
     replicationState: true
     untaggedImagesRetention:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -14,7 +14,7 @@ acr:
     diagnosticSettings:
       enabled: true
       logAnalyticsWorkspace:
-        name: arohcpocpperf-diag
+        name: arohcpocpdev-diag
         retentionInDays: 90
         sku: PerGB2018
     name: arohcpocpdev

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -14,7 +14,7 @@ acr:
     diagnosticSettings:
       enabled: true
       logAnalyticsWorkspace:
-        name: arohcpocppers-diag
+        name: arohcpocpdev-diag
         retentionInDays: 90
         sku: PerGB2018
     name: arohcpocpdev

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -11,6 +11,12 @@ acm:
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
   ocp:
+    diagnosticSettings:
+      enabled: true
+      logAnalyticsWorkspace:
+        name: arohcpocppers-diag
+        retentionInDays: 90
+        sku: PerGB2018
     name: arohcpocpdev
     replicationState: true
     untaggedImagesRetention:

--- a/dev-infrastructure/configurations/global-acr.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-acr.tmpl.bicepparam
@@ -20,3 +20,8 @@ param ocpAcrZoneRedundantMode = '{{ .acr.ocp.zoneRedundantMode }}'
 param globalKeyVaultName = '{{ .global.keyVault.name}}'
 
 param deployMiseArtifactSync = {{ .mise.deploy }}
+
+param ocpAcrDiagnosticSettingsEnabled = {{ .acr.ocp.diagnosticSettings.enabled }}
+param ocpAcrLogAnalyticsWorkspaceName = '{{ .acr.ocp.diagnosticSettings.logAnalyticsWorkspace.name }}'
+param ocpAcrLogAnalyticsWorkspaceSku = '{{ .acr.ocp.diagnosticSettings.logAnalyticsWorkspace.sku }}'
+param ocpAcrLogAnalyticsWorkspaceRetentionInDays = {{ .acr.ocp.diagnosticSettings.logAnalyticsWorkspace.retentionInDays }}

--- a/dev-infrastructure/modules/acr/diagnostic-settings.bicep
+++ b/dev-infrastructure/modules/acr/diagnostic-settings.bicep
@@ -1,0 +1,39 @@
+@description('Name of the existing ACR to configure diagnostic settings for')
+param acrName string
+
+@description('Resource ID of the Log Analytics workspace to send diagnostic logs to')
+param logAnalyticsWorkspaceId string
+
+@description('Name for the diagnostic settings resource')
+param diagnosticSettingsName string = 'acr-diagnostic-logs'
+
+resource acr 'Microsoft.ContainerRegistry/registries@2023-11-01-preview' existing = {
+  name: acrName
+}
+
+// Sends ACR repository and login events (including 429 throttling events) to
+// Log Analytics so pull/push throughput issues can be diagnosed directly,
+// instead of inferring them from downstream Kubernetes events.
+resource acrDiagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  scope: acr
+  name: diagnosticSettingsName
+  properties: {
+    workspaceId: logAnalyticsWorkspaceId
+    logs: [
+      {
+        category: 'ContainerRegistryRepositoryEvents'
+        enabled: true
+      }
+      {
+        category: 'ContainerRegistryLoginEvents'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
+}

--- a/dev-infrastructure/modules/monitor/log-analytics-workspace.bicep
+++ b/dev-infrastructure/modules/monitor/log-analytics-workspace.bicep
@@ -7,7 +7,9 @@ param location string
 @description('SKU for the Log Analytics workspace')
 param sku string = 'PerGB2018'
 
-@description('Data retention in days')
+@description('Data retention in days. Azure requires 30-730 days.')
+@minValue(30)
+@maxValue(730)
 param retentionInDays int = 90
 
 resource workspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {

--- a/dev-infrastructure/modules/monitor/log-analytics-workspace.bicep
+++ b/dev-infrastructure/modules/monitor/log-analytics-workspace.bicep
@@ -1,0 +1,24 @@
+@description('Name of the Log Analytics workspace')
+param workspaceName string
+
+@description('Azure region for the workspace')
+param location string
+
+@description('SKU for the Log Analytics workspace')
+param sku string = 'PerGB2018'
+
+@description('Data retention in days')
+param retentionInDays int = 90
+
+resource workspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: workspaceName
+  location: location
+  properties: {
+    sku: {
+      name: sku
+    }
+    retentionInDays: retentionInDays
+  }
+}
+
+output workspaceId string = workspace.id

--- a/dev-infrastructure/templates/global-acr.bicep
+++ b/dev-infrastructure/templates/global-acr.bicep
@@ -28,6 +28,18 @@ param svcAcrZoneRedundantMode string
 @description('Deploy mise artifact sync, only valid in Microsoft Production and AME Tenants')
 param deployMiseArtifactSync bool = false
 
+@description('Enable diagnostic settings (repository/login events + metrics) for the OCP ACR')
+param ocpAcrDiagnosticSettingsEnabled bool = false
+
+@description('Name of the Log Analytics workspace to create for OCP ACR diagnostic logs')
+param ocpAcrLogAnalyticsWorkspaceName string = ''
+
+@description('SKU for the OCP ACR diagnostics Log Analytics workspace')
+param ocpAcrLogAnalyticsWorkspaceSku string = 'PerGB2018'
+
+@description('Retention in days for the OCP ACR diagnostics Log Analytics workspace')
+param ocpAcrLogAnalyticsWorkspaceRetentionInDays int = 90
+
 resource globalMSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
   name: globalMSIName
 }
@@ -236,6 +248,27 @@ module globalMSIOcpAcrAccess '../modules/acr/acr-permissions.bicep' = {
     grantPushAccess: true
     grantPullAccess: true
     acrName: ocpAcrName
+  }
+  dependsOn: [
+    ocpAcr
+  ]
+}
+
+module ocpAcrLogAnalyticsWorkspace '../modules/monitor/log-analytics-workspace.bicep' = if (ocpAcrDiagnosticSettingsEnabled) {
+  name: '${ocpAcrName}-diagnostics-workspace'
+  params: {
+    workspaceName: ocpAcrLogAnalyticsWorkspaceName
+    location: location
+    sku: ocpAcrLogAnalyticsWorkspaceSku
+    retentionInDays: ocpAcrLogAnalyticsWorkspaceRetentionInDays
+  }
+}
+
+module ocpAcrDiagnosticSettings '../modules/acr/diagnostic-settings.bicep' = if (ocpAcrDiagnosticSettingsEnabled) {
+  name: '${ocpAcrName}-diagnostic-settings'
+  params: {
+    acrName: ocpAcrName
+    logAnalyticsWorkspaceId: ocpAcrLogAnalyticsWorkspace!.outputs.workspaceId
   }
   dependsOn: [
     ocpAcr

--- a/dev-infrastructure/templates/global-acr.bicep
+++ b/dev-infrastructure/templates/global-acr.bicep
@@ -271,6 +271,11 @@ module ocpAcrDiagnosticSettings '../modules/acr/diagnostic-settings.bicep' = if 
   params: {
     acrName: ocpAcrName
     logAnalyticsWorkspaceId: ocpAcrLogAnalyticsWorkspace!.outputs.workspaceId
+    // The OCP ACR is shared across dev-cloud environments (they all point
+    // ocpAcrName at the same registry), so the diagnosticSettings resource
+    // name must be derived per-environment or each environment's deployment
+    // would overwrite the others' diagnostic settings on the shared ACR.
+    diagnosticSettingsName: '${ocpAcrLogAnalyticsWorkspaceName}-diagnostic-settings'
   }
   dependsOn: [
     ocpAcr

--- a/dev-infrastructure/templates/global-acr.bicep
+++ b/dev-infrastructure/templates/global-acr.bicep
@@ -257,7 +257,10 @@ module globalMSIOcpAcrAccess '../modules/acr/acr-permissions.bicep' = {
 }
 
 module ocpAcrLogAnalyticsWorkspace '../modules/monitor/log-analytics-workspace.bicep' = if (ocpAcrDiagnosticSettingsEnabled) {
-  name: '${ocpAcrName}-diagnostics-workspace'
+  // Named per-environment (not per-ACR) since ocpAcrName is shared across all
+  // dev-cloud environments; a shared deployment name risks ARM deployment
+  // name collisions when multiple environments deploy this template.
+  name: '${ocpAcrLogAnalyticsWorkspaceName}-diagnostics-workspace'
   params: {
     workspaceName: ocpAcrLogAnalyticsWorkspaceName
     location: location
@@ -267,7 +270,8 @@ module ocpAcrLogAnalyticsWorkspace '../modules/monitor/log-analytics-workspace.b
 }
 
 module ocpAcrDiagnosticSettings '../modules/acr/diagnostic-settings.bicep' = if (ocpAcrDiagnosticSettingsEnabled) {
-  name: '${ocpAcrName}-diagnostic-settings'
+  // Same rationale as ocpAcrLogAnalyticsWorkspace above.
+  name: '${ocpAcrLogAnalyticsWorkspaceName}-diagnostic-settings-deployment'
   params: {
     acrName: ocpAcrName
     logAnalyticsWorkspaceId: ocpAcrLogAnalyticsWorkspace!.outputs.workspaceId

--- a/dev-infrastructure/templates/global-acr.bicep
+++ b/dev-infrastructure/templates/global-acr.bicep
@@ -37,7 +37,9 @@ param ocpAcrLogAnalyticsWorkspaceName string = ''
 @description('SKU for the OCP ACR diagnostics Log Analytics workspace')
 param ocpAcrLogAnalyticsWorkspaceSku string = 'PerGB2018'
 
-@description('Retention in days for the OCP ACR diagnostics Log Analytics workspace')
+@description('Retention in days for the OCP ACR diagnostics Log Analytics workspace. Azure requires 30-730 days.')
+@minValue(30)
+@maxValue(730)
 param ocpAcrLogAnalyticsWorkspaceRetentionInDays int = 90
 
 resource globalMSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {

--- a/dev-infrastructure/templates/global-acr.bicep
+++ b/dev-infrastructure/templates/global-acr.bicep
@@ -257,10 +257,14 @@ module globalMSIOcpAcrAccess '../modules/acr/acr-permissions.bicep' = {
 }
 
 module ocpAcrLogAnalyticsWorkspace '../modules/monitor/log-analytics-workspace.bicep' = if (ocpAcrDiagnosticSettingsEnabled) {
-  // Named per-environment (not per-ACR) since ocpAcrName is shared across all
-  // dev-cloud environments; a shared deployment name risks ARM deployment
-  // name collisions when multiple environments deploy this template.
-  name: '${ocpAcrLogAnalyticsWorkspaceName}-diagnostics-workspace'
+  // The OCP ACR (ocpAcrName) is shared by every dev-cloud environment that
+  // enables this flag; ocpAcrLogAnalyticsWorkspaceName is configured to
+  // resolve to the same static value in every one of them (see config.yaml),
+  // so this module name resolves identically too and each environment's
+  // redeploy idempotently updates the same workspace instead of creating a
+  // new one (Azure caps diagnosticSettings at 5 per resource - a per-env
+  // workspace/name would blow past that with 6 dev-cloud environments).
+  name: '${ocpAcrName}-diagnostics-workspace'
   params: {
     workspaceName: ocpAcrLogAnalyticsWorkspaceName
     location: location
@@ -270,16 +274,14 @@ module ocpAcrLogAnalyticsWorkspace '../modules/monitor/log-analytics-workspace.b
 }
 
 module ocpAcrDiagnosticSettings '../modules/acr/diagnostic-settings.bicep' = if (ocpAcrDiagnosticSettingsEnabled) {
-  // Same rationale as ocpAcrLogAnalyticsWorkspace above.
-  name: '${ocpAcrLogAnalyticsWorkspaceName}-diagnostic-settings-deployment'
+  // Same rationale as ocpAcrLogAnalyticsWorkspace above: this resolves to one
+  // shared diagnosticSettings resource on the shared ACR, not one per
+  // environment.
+  name: '${ocpAcrName}-diagnostic-settings'
   params: {
     acrName: ocpAcrName
     logAnalyticsWorkspaceId: ocpAcrLogAnalyticsWorkspace!.outputs.workspaceId
-    // The OCP ACR is shared across dev-cloud environments (they all point
-    // ocpAcrName at the same registry), so the diagnosticSettings resource
-    // name must be derived per-environment or each environment's deployment
-    // would overwrite the others' diagnostic settings on the shared ACR.
-    diagnosticSettingsName: '${ocpAcrLogAnalyticsWorkspaceName}-diagnostic-settings'
+    diagnosticSettingsName: '${ocpAcrName}-diagnostic-logs'
   }
   dependsOn: [
     ocpAcr


### PR DESCRIPTION
## Why

`arohcpocpdev.azurecr.io` (OCP ACR) is being throttled with HTTP 429s during E2E test runs (~11% of pull attempts throttled per Kusto analysis of `kubernetesEvents`, corroborated by Azure Monitor's aggregate ACR metrics). We currently have no ACR diagnostic settings enabled on this registry, so we can't inspect per-request/per-client patterns, only aggregate Azure Monitor metrics.

Tracked in [AROSLSRE-1883](https://redhat.atlassian.net/browse/AROSLSRE-1883) / [AROSLSRE-1893](https://redhat.atlassian.net/browse/AROSLSRE-1893). A Microsoft support ticket has also been filed for a throughput increase (case `2608260050002092`).

## What

Enables ACR diagnostic settings (`ContainerRegistryRepositoryEvents`, `ContainerRegistryLoginEvents`, `AllMetrics`) for the OCP ACR. `arohcpocpdev` is one physical ACR shared by all 6 dev-cloud environments (ci00, ci01, cspr, dev, perf, pers), and Azure caps `diagnosticSettings` at 5 per resource, so all environments share a single, statically-named Log Analytics workspace and diagnostic-settings resource (`arohcpocpdev-diag`) instead of one per environment. Every environment's pipeline deploy is an idempotent update of that same shared resource.

- New module `modules/monitor/log-analytics-workspace.bicep`: generic, reusable Log Analytics workspace.
- New module `modules/acr/diagnostic-settings.bicep`: wires `Microsoft.Insights/diagnosticSettings` on an existing ACR resource to a Log Analytics workspace.
- `templates/global-acr.bicep`: new params (`ocpAcrDiagnosticSettingsEnabled`, `ocpAcrLogAnalyticsWorkspaceName`, `ocpAcrLogAnalyticsWorkspaceSku`, `ocpAcrLogAnalyticsWorkspaceRetentionInDays`) and two new conditional modules, scoped to the OCP ACR only (not SVC ACR).
- `config.yaml` / `config.schema.json`: new `acr.ocp.diagnosticSettings` block, disabled by default; enabled for the `dev` cloud only, with a static shared workspace name (`arohcpocpdev-diag`) since the underlying ACR is shared.
- Rendered configs and bicepparam template regenerated via `make materialize`.

## Scope

- Only wired for the OCP ACR (`arohcpocpdev` and other dev-cloud environments), since that's the registry being throttled.
- Disabled by default; only the `dev` cloud enables it, so int/stg/prod are unaffected.
- The "TRANSIENT STG-global V2" bicepparam template (`global-acr-stg.tmpl.bicepparam`) is left unmodified and relies on the bicep params' disabled defaults, to avoid Log Analytics workspace name collisions with the V2 migration stack.

## Validation

- `cd config && make materialize` — passes, rendered configs updated for all dev-cloud environments (ci00, ci01, cspr, dev, perf, pers), all resolving to the same shared workspace name (`arohcpocpdev-diag`).
- `bicep build` on both new modules and the modified `global-acr.bicep` — succeeds cleanly (no new warnings).


