### PR TITLE
docs: harden stuck cluster deletion SOP with verified cleanup lessons

### DIFF
--- a/docs/ops/cleanup-stuck-cluster-deletion.md
+++ b/docs/ops/cleanup-stuck-cluster-deletion.md
@@ -181,7 +181,7 @@ kubectl get <kind> -n <namespace> -o json | \
   jq -r '.items[] | "\(.metadata.name)\tdel=\(.metadata.deletionTimestamp)"'
 
 # Check whether CAPI/CAPZ can still reconcile machine deletion
-kubectl get deployment capi-provider cluster-api -n <control-plane-namespace>
+kubectl get deployment capi-provider cluster-api -n <cp-namespace>
 
 # Check Hypershift operator logs
 kubectl logs -n hypershift deployment/operator --tail=50 | grep <cluster-name-or-id>
@@ -248,17 +248,17 @@ kubectl exec -n clusters-service deployment/clusters-service -- \
 #
 kubectl exec -n maestro deployment/maestro -c maestro-server -- sh -c \
   "curl -s 'http://localhost:8000/api/maestro/v1/resource-bundles?size=2900'" | \
-  jq --arg cid "${CLUSTER_ID}" '[.items[] | select(tostring | test($cid)) |
+  jq --arg cid "${CLUSTER_ID}" '[.items[] | select(tostring | index($cid)) |
   {id, name, created_at, consumer_name, deleted_at,
    labels: .metadata.labels}]'
 ```
 
-ResourceBundle names are UUIDs. Match the cluster ID against the whole object because it may appear in `manifests` or `metadata.labels`, then confirm the label inventory when needed:
+ResourceBundle names are UUIDs. Match the cluster ID against the whole object because it may appear in `manifests` or `metadata.labels`; a bundle missed here is one that Maestro can later use to recreate everything you just deleted. `index` is a literal substring match, so the ID is never interpreted as a regex. Confirm the label inventory when a match looks unexpected:
 
 ```bash
 kubectl exec -n maestro deployment/maestro -c maestro-server -- sh -c \
   "curl -s 'http://localhost:8000/api/maestro/v1/resource-bundles?size=2900'" | \
-  jq -r '[.items[].metadata.labels["api.openshift.com/id"]] | unique'
+  jq -r '[.items[].metadata.labels["api.openshift.com/id"] // empty] | unique'
 ```
 
 ### Phase 3: Resolution
@@ -411,7 +411,11 @@ for kind in machines.cluster.x-k8s.io machinesets.cluster.x-k8s.io machinedeploy
 done
 
 # Deployments with hypershift.openshift.io/component-finalizer
-for name in $(kubectl get deployment -n <cp-namespace> -o jsonpath='{.items[*].metadata.name}'); do
+# Only the Deployments actually holding that finalizer -- a CP namespace has dozens of
+# Deployments and stripping finalizers from all of them is far broader than intended.
+for name in $(kubectl get deployment -n <cp-namespace> -o json | \
+  jq -r '.items[] | select((.metadata.finalizers // []) |
+    index("hypershift.openshift.io/component-finalizer")) | .metadata.name'); do
   kubectl patch deployment $name -n <cp-namespace> \
     --type=merge -p='{"metadata":{"finalizers":null}}'
 done
@@ -461,7 +465,7 @@ kubectl exec -n clusters-service deployment/clusters-service -- \
 # On the Service Cluster - verify no orphaned Maestro bundles
 kubectl exec -n maestro deployment/maestro -c maestro-server -- sh -c \
   "curl -s 'http://localhost:8000/api/maestro/v1/resource-bundles?size=2900'" | \
-  jq --arg cid "${CLUSTER_ID}" '[.items[] | select(tostring | test($cid)) | {id, name, deleted_at}]'
+  jq --arg cid "${CLUSTER_ID}" '[.items[] | select(tostring | index($cid)) | {id, name, deleted_at}]'
 ```
 
 > **Note**: If CS still has the cluster record in `uninstalling` state after management cluster cleanup, re-issue the ARO-HCP `DELETE` (Strategy 1). With Maestro and the management cluster cleared, the CS controller can now complete the deletion and subsequent `GET`s will return `404`.
@@ -505,7 +509,7 @@ kubectl exec -n maestro deployment/maestro -c maestro-server -- sh -c \
 
 ### Scenario 5: CAPI Machine Deletion Cannot Finish
 
-**Symptoms**: The CP namespace remains `Terminating`; Machine conditions remain at `WaitingForInfrastructureDeletion`; and `kubectl get deployment capi-provider cluster-api -n <cp-ns>` shows one or both controllers at `0/N` replicas. Namespace conditions may reference infrastructure or machine kinds, or may only show the parent `Cluster`, `HostedControlPlane`, and Deployments that are waiting on them.
+**Symptoms**: The CP namespace remains `Terminating`; Machine conditions remain at `WaitingForInfrastructureDeletion`; and `kubectl get deployment capi-provider cluster-api -n <cp-namespace>` shows one or both controllers at `0/N` replicas. Namespace conditions may reference infrastructure or machine kinds, or may only show the parent `Cluster`, `HostedControlPlane`, and Deployments that are waiting on them.
 
 **Cause**: CAPI machine resources hold their own finalizers, but CAPI/CAPZ is no longer running to process them. The stale `WaitingForInfrastructureDeletion` condition cannot self-resolve. Common blockers in the CP namespace:
 
@@ -558,7 +562,7 @@ curl -s 'http://localhost:8002/api/maestro/v1/resource-bundles?size=2900' | \
 
 # Search for a specific cluster's bundles
 curl -s 'http://localhost:8002/api/maestro/v1/resource-bundles?size=2900' | \
-  jq --arg cid "${CLUSTER_ID}" '[.items[] | select(tostring | test($cid)) |
+  jq --arg cid "${CLUSTER_ID}" '[.items[] | select(tostring | index($cid)) |
   {id, name, deleted_at, labels: .metadata.labels}]'
 ```
 

--- a/docs/ops/cleanup-stuck-cluster-deletion.md
+++ b/docs/ops/cleanup-stuck-cluster-deletion.md
@@ -239,7 +239,8 @@ kubectl exec -n clusters-service deployment/clusters-service -- \
 #### Step 6: Check Maestro Resource Bundles
 
 ```bash
-# Search for resource bundles by cluster ID (search in manifest content)
+# Search for resource bundles by cluster ID (matches anywhere in the bundle,
+# including manifest content and metadata.labels)
 #
 # TIP: Use port-forward instead of kubectl exec for more reliable Maestro API
 # inspection -- kubectl exec can truncate responses or drop fields:

--- a/docs/ops/cleanup-stuck-cluster-deletion.md
+++ b/docs/ops/cleanup-stuck-cluster-deletion.md
@@ -176,6 +176,13 @@ kubectl get hostedcluster <name> -n <namespace> \
 # Check what's blocking a Terminating namespace
 kubectl get namespace <namespace> -o json | jq '.status'
 
+# Show deletion timestamps explicitly (the default kubectl table omits them)
+kubectl get <kind> -n <namespace> -o json | \
+  jq -r '.items[] | "\(.metadata.name)\tdel=\(.metadata.deletionTimestamp)"'
+
+# Check whether CAPI/CAPZ can still reconcile machine deletion
+kubectl get deployment capi-provider cluster-api -n <control-plane-namespace>
+
 # Check Hypershift operator logs
 kubectl logs -n hypershift deployment/operator --tail=50 | grep <cluster-name-or-id>
 
@@ -205,6 +212,8 @@ kubectl get managedclusteraddon -n ${CLUSTER_ID} -o json | \
 ### Phase 2: Check the Service Cluster
 
 Before removing resources on the management cluster, check if the source (CS/Maestro) will recreate them.
+
+> **Mandatory gate**: Complete Steps 5 and 6 before using any resolution strategy that patches or deletes management-cluster resources. If the cluster record or an active ResourceBundle still exists, removing downstream resources can cause them to be recreated.
 
 Connect to the service cluster:
 
@@ -239,9 +248,17 @@ kubectl exec -n clusters-service deployment/clusters-service -- \
 #
 kubectl exec -n maestro deployment/maestro -c maestro-server -- sh -c \
   "curl -s 'http://localhost:8000/api/maestro/v1/resource-bundles?size=2900'" | \
-  jq --arg cid "${CLUSTER_ID}" '[.items[] | select(.manifests | tostring | test($cid)) |
+  jq --arg cid "${CLUSTER_ID}" '[.items[] | select(tostring | test($cid)) |
   {id, name, created_at, consumer_name, deleted_at,
    labels: .metadata.labels}]'
+```
+
+ResourceBundle names are UUIDs. Match the cluster ID against the whole object because it may appear in `manifests` or `metadata.labels`, then confirm the label inventory when needed:
+
+```bash
+kubectl exec -n maestro deployment/maestro -c maestro-server -- sh -c \
+  "curl -s 'http://localhost:8000/api/maestro/v1/resource-bundles?size=2900'" | \
+  jq -r '[.items[].metadata.labels["api.openshift.com/id"]] | unique'
 ```
 
 ### Phase 3: Resolution
@@ -360,6 +377,8 @@ kubectl get manifestwork -n local-cluster | grep -F "${CLUSTER_ID}"
 
 Only after ensuring the source (CS/Maestro) won't recreate resources, remove finalizers **bottom-up** on the management cluster.
 
+> **Azure resource safety**: Before clearing an `AzureMachine` finalizer, verify that its Azure VM, NIC, disks, and other managed-resource-group dependencies are gone. Clearing the finalizer only removes Kubernetes bookkeeping; it does not delete Azure resources and can leave a costly resource leak. If access is blocked by a deny assignment, coordinate the Azure deletion with the subscription owner first.
+
 > **Note**: If Phase 1 Step 4 shows the `ManagedCluster` in `Detaching` state or `ManagedClusterAddon` resources with held finalizers, clear those **first** (step 0 below). The destruct chain stops at the `hypershift-managed-cluster-destructor` step when addon pre-delete hooks fail (commonly due to klusterlet auth loss during Detaching), and the CP namespace teardown is never even attempted.
 
 ```bash
@@ -374,11 +393,7 @@ done
 # 1. Check what's blocking the CP namespace (if Terminating):
 kubectl get namespace <cp-namespace> -o json | jq '.status.conditions[] | select(.type == "NamespaceContentRemaining")'
 
-# 2. Remove finalizers from CP namespace resources (bottom-up, leaf resources first):
-# Deployments with hypershift.openshift.io/component-finalizer
-kubectl patch deployment <name> -n <cp-namespace> \
-  --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
-
+# 2. Remove finalizers from CP namespace resources (bottom-up, leaf resources first).
 # AzureMachines (infrastructure.cluster.x-k8s.io)
 # Uses a merge patch so the command is idempotent even if .metadata.finalizers is absent
 # on some items (JSONPatch `replace` would fail on those).
@@ -395,13 +410,19 @@ for kind in machines.cluster.x-k8s.io machinesets.cluster.x-k8s.io machinedeploy
   done
 done
 
+# Deployments with hypershift.openshift.io/component-finalizer
+for name in $(kubectl get deployment -n <cp-namespace> -o jsonpath='{.items[*].metadata.name}'); do
+  kubectl patch deployment $name -n <cp-namespace> \
+    --type=merge -p='{"metadata":{"finalizers":null}}'
+done
+
 # Cluster CRD with cluster.cluster.x-k8s.io finalizer
 kubectl patch clusters.cluster.x-k8s.io <name> -n <cp-namespace> \
-  --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
+  --type=merge -p='{"metadata":{"finalizers":null}}'
 
 # HostedControlPlane with hypershift.openshift.io/finalizer
 kubectl patch hostedcontrolplanes.hypershift.openshift.io <name> -n <cp-namespace> \
-  --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
+  --type=merge -p='{"metadata":{"finalizers":null}}'
 
 # 3. Remove NodePool finalizers in the HostedCluster namespace
 # Uses a merge patch (idempotent when .metadata.finalizers is absent).
@@ -412,11 +433,11 @@ done
 
 # 4. Remove HostedCluster finalizer (only after CP namespace resources and NodePools are cleared)
 kubectl patch hostedcluster <name> -n ocm-${CLUSTER_PREFIX}-${CLUSTER_ID} \
-  --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
+  --type=merge -p='{"metadata":{"finalizers":null}}'
 
 # 5. Remove ManifestWork finalizers
 kubectl patch manifestwork <name> -n local-cluster \
-  --type=json -p='[{"op": "replace", "path": "/metadata/finalizers", "value": []}]'
+  --type=merge -p='{"metadata":{"finalizers":null}}'
 
 # 6. Delete orphaned namespaces (only after all resources are cleared)
 kubectl delete namespace <namespace>
@@ -440,7 +461,7 @@ kubectl exec -n clusters-service deployment/clusters-service -- \
 # On the Service Cluster - verify no orphaned Maestro bundles
 kubectl exec -n maestro deployment/maestro -c maestro-server -- sh -c \
   "curl -s 'http://localhost:8000/api/maestro/v1/resource-bundles?size=2900'" | \
-  jq --arg cid "${CLUSTER_ID}" '[.items[] | select(.manifests | tostring | test($cid)) | {id, name}]'
+  jq --arg cid "${CLUSTER_ID}" '[.items[] | select(tostring | test($cid)) | {id, name, deleted_at}]'
 ```
 
 > **Note**: If CS still has the cluster record in `uninstalling` state after management cluster cleanup, re-issue the ARO-HCP `DELETE` (Strategy 1). With Maestro and the management cluster cleared, the CS controller can now complete the deletion and subsequent `GET`s will return `404`.
@@ -482,18 +503,18 @@ kubectl exec -n maestro deployment/maestro -c maestro-server -- sh -c \
 
 **Fix**: Check `kubectl get namespace <ns> -o json | jq '.status.conditions'` to identify blocking resources, then remove their finalizers (Strategy 4).
 
-### Scenario 5: CP Namespace Stuck After Cluster and HostedControlPlane Are Cleared
+### Scenario 5: CAPI Machine Deletion Cannot Finish
 
-**Symptoms**: After force-removing finalizers on the CAPI `Cluster`, the `HostedControlPlane`, and the Hypershift Deployments, the CP namespace is still `Terminating`. `kubectl get namespace <cp-ns> -o json | jq '.status.conditions'` references infrastructure or machine kinds.
+**Symptoms**: The CP namespace remains `Terminating`; Machine conditions remain at `WaitingForInfrastructureDeletion`; and `kubectl get deployment capi-provider cluster-api -n <cp-ns>` shows one or both controllers at `0/N` replicas. Namespace conditions may reference infrastructure or machine kinds, or may only show the parent `Cluster`, `HostedControlPlane`, and Deployments that are waiting on them.
 
-**Cause**: CAPI machine resources hold their own finalizers and are not removed when the parent `Cluster` is force-deleted (finalizer cleared). Common blockers in the CP namespace:
+**Cause**: CAPI machine resources hold their own finalizers, but CAPI/CAPZ is no longer running to process them. The stale `WaitingForInfrastructureDeletion` condition cannot self-resolve. Common blockers in the CP namespace:
 
 - `azuremachines.infrastructure.cluster.x-k8s.io` (`azuremachine.infrastructure.cluster.x-k8s.io`)
 - `machines.cluster.x-k8s.io` (`machine.cluster.x-k8s.io`)
 - `machinesets.cluster.x-k8s.io` (`cluster.x-k8s.io/machineset`)
 - `machinedeployments.cluster.x-k8s.io` (`cluster.x-k8s.io/machinedeployment`)
 
-**Fix**: Patch the finalizers on all four kinds in the CP namespace (see Strategy 4, step 2).
+**Fix**: First verify that the corresponding Azure resources are gone, then patch all four machine-resource kinds before clearing Deployment, CAPI `Cluster`, or `HostedControlPlane` finalizers (see Strategy 4, step 2). Clearing parent finalizers first can hide the actual blockers and leave cluster-scoped or cloud resources orphaned.
 
 ### Scenario 6: ManagedCluster Stuck Detaching - Addon Finalizers Held
 
@@ -537,7 +558,7 @@ curl -s 'http://localhost:8002/api/maestro/v1/resource-bundles?size=2900' | \
 
 # Search for a specific cluster's bundles
 curl -s 'http://localhost:8002/api/maestro/v1/resource-bundles?size=2900' | \
-  jq --arg cid "${CLUSTER_ID}" '[.items[] | select(.manifests | tostring | test($cid)) |
+  jq --arg cid "${CLUSTER_ID}" '[.items[] | select(tostring | test($cid)) |
   {id, name, deleted_at, labels: .metadata.labels}]'
 ```
 


### PR DESCRIPTION
Resolves [AROSLSRE-1892](https://redhat.atlassian.net/browse/AROSLSRE-1892)

### What

Updates `docs/ops/cleanup-stuck-cluster-deletion.md` with lessons verified while manually recovering a stage HCP cluster whose deletion had been stuck for several days.

- Adds a **mandatory gate** requiring Clusters Service and Maestro verification before any resolution strategy patches or deletes management-cluster resources.
- Matches the cluster ID against the **whole Maestro ResourceBundle object** instead of only `.manifests`, and adds a label-inventory query for `api.openshift.com/id`.
- Adds two diagnostics: explicit deletion timestamps (the default `kubectl` table omits them) and `kubectl get deployment capi-provider cluster-api`.
- Reorders Strategy 4 so machine resources are cleared **before** their parents (AzureMachine → Machine/MachineSet/MachineDeployment → Deployments → CAPI `Cluster` → `HostedControlPlane` → NodePool → HostedCluster → ManifestWork).
- Converts the remaining finalizer patches to idempotent merge patches, consistent with the rationale already stated in the doc.
- Adds an **Azure resource safety** warning that clearing an `AzureMachine` finalizer removes Kubernetes bookkeeping only and can leak Azure resources.
- Rewrites Scenario 5 around the real failure mode: CAPI machine deletion that cannot finish.

### Why

A cleanup script deleted a cluster-scoped `AppliedManifestWork`, which propagated HostedCluster deletion while `capi-provider` and `cluster-api` were scaled to zero before machine teardown completed. CAPI/CAPZ finalizers were left stranded with Machines pinned at `WaitingForInfrastructureDeletion`, and the controllers sat at `0/1` for more than five days, so nothing could self-resolve.

Following the SOP as written was not sufficient in two ways that mattered:

1. The Maestro lookup filtered only on `.manifests`. ResourceBundle names are UUIDs and the cluster ID can appear in `metadata.labels`, so a matching bundle could be missed and downstream resources would be recreated after cleanup.
2. Strategy 4 cleared Deployment, CAPI `Cluster`, and `HostedControlPlane` finalizers before the machine resources, which hides the actual blockers and can leave cloud resources orphaned.

The reordering and the Azure warning came directly from the recovery: clearing `AzureMachine` finalizers unblocked Kubernetes but does **not** delete the underlying VM, NICs, or disks, so the managed resource group still needs an explicit leak check.

### Testing

Documentation-only change; no unit, integration, or E2E tests apply.

The updated commands were exercised during the live recovery of the affected stage cluster. After cleanup, Clusters Service and Maestro queries returned `[]`, both the HostedCluster and control-plane namespaces returned `NotFound`, no HostedCluster / NodePool / CAPI `Cluster` / Machine / AzureMachine / ManifestWork / AppliedManifestWork remained, and nothing was recreated on a follow-up check.

### Special notes for your reviewer

The reordering in Strategy 4 is the behavioral change worth the closest look — the previous ordering is what made the blockers hard to identify during the incident.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes) — N/A
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable) — N/A
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge
