### PR TITLE
feat: allow disabling Postgres HA to enable SameZone↔ZoneRedundant migration

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -959,6 +959,17 @@
         "zoneRedundantMode": {
           "$ref": "#/definitions/zoneRedundantMode"
         },
+        "highAvailabilityMode": {
+          "type": "string",
+          "description": "Overrides the PostgreSQL highAvailability mode. Empty string defers to zoneRedundantMode (default). When non-empty it takes precedence; 'Auto' is region-aware (ZoneRedundant where availability zones exist, otherwise SameZone).",
+          "enum": [
+            "",
+            "Auto",
+            "Disabled",
+            "SameZone",
+            "ZoneRedundant"
+          ]
+        },
         "backupRetentionDays": {
           "type": "integer",
           "description": "Number of days to retain backups for the PostgreSQL server."

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1064,6 +1064,7 @@ defaults:
       minTLSVersion: 'TLSV1.2'
       databaseName: maestro
       zoneRedundantMode: 'Auto'
+      highAvailabilityMode: ''
       backupRetentionDays: 7
       geoRedundantBackup: false
       enhancedMetricsEnabled: false
@@ -1119,6 +1120,7 @@ defaults:
       serverStorageSizeGB: 128
       databaseName: clusters-service
       zoneRedundantMode: 'Auto'
+      highAvailabilityMode: ''
       backupRetentionDays: 7
       geoRedundantBackup: false
       enhancedMetricsEnabled: false

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -209,6 +209,7 @@ clustersService:
     deploy: false
     enhancedMetricsEnabled: true
     geoRedundantBackup: false
+    highAvailabilityMode: ""
     minTLSVersion: TLSV1.2
     name: arohcp-ci00-dbcs-j7654321
     password: TheBlurstOfTimes
@@ -612,6 +613,7 @@ maestro:
     deploy: false
     enhancedMetricsEnabled: true
     geoRedundantBackup: false
+    highAvailabilityMode: ""
     minTLSVersion: TLSV1.2
     name: arohcp-ci00-dbmaestro-j7654321
     password: TheBlurstOfTimes

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -209,6 +209,7 @@ clustersService:
     deploy: false
     enhancedMetricsEnabled: true
     geoRedundantBackup: false
+    highAvailabilityMode: ""
     minTLSVersion: TLSV1.2
     name: arohcp-ci01-dbcs-j7654321
     password: TheBlurstOfTimes
@@ -612,6 +613,7 @@ maestro:
     deploy: false
     enhancedMetricsEnabled: true
     geoRedundantBackup: false
+    highAvailabilityMode: ""
     minTLSVersion: TLSV1.2
     name: arohcp-ci01-dbmaestro-j7654321
     password: TheBlurstOfTimes

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -209,6 +209,7 @@ clustersService:
     deploy: true
     enhancedMetricsEnabled: true
     geoRedundantBackup: false
+    highAvailabilityMode: ""
     minTLSVersion: TLSV1.2
     name: arohcp-cspr-dbcs-usw3
     password: ""
@@ -612,6 +613,7 @@ maestro:
     deploy: true
     enhancedMetricsEnabled: true
     geoRedundantBackup: false
+    highAvailabilityMode: ""
     minTLSVersion: TLSV1.2
     name: arohcp-cspr-dbmaestro-usw3
     password: ""

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -209,6 +209,7 @@ clustersService:
     deploy: true
     enhancedMetricsEnabled: true
     geoRedundantBackup: false
+    highAvailabilityMode: ""
     minTLSVersion: TLSV1.2
     name: arohcp-dev-dbcs-usw3
     password: ""
@@ -612,6 +613,7 @@ maestro:
     deploy: true
     enhancedMetricsEnabled: true
     geoRedundantBackup: false
+    highAvailabilityMode: ""
     minTLSVersion: TLSV1.2
     name: arohcp-dev-dbmaestro-usw3
     password: ""

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -209,6 +209,7 @@ clustersService:
     deploy: true
     enhancedMetricsEnabled: true
     geoRedundantBackup: false
+    highAvailabilityMode: ""
     minTLSVersion: TLSV1.2
     name: arohcp-perf-dbcs-usw3ptest
     password: ""
@@ -612,6 +613,7 @@ maestro:
     deploy: true
     enhancedMetricsEnabled: true
     geoRedundantBackup: false
+    highAvailabilityMode: ""
     minTLSVersion: TLSV1.2
     name: arohcp-perf-dbmaestro-usw3ptest
     password: ""

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -209,6 +209,7 @@ clustersService:
     deploy: false
     enhancedMetricsEnabled: true
     geoRedundantBackup: false
+    highAvailabilityMode: ""
     minTLSVersion: TLSV1.2
     name: arohcp-pers-dbcs-usw3test
     password: TheBlurstOfTimes
@@ -612,6 +613,7 @@ maestro:
     deploy: false
     enhancedMetricsEnabled: true
     geoRedundantBackup: false
+    highAvailabilityMode: ""
     minTLSVersion: TLSV1.2
     name: arohcp-pers-dbmaestro-usw3test
     password: TheBlurstOfTimes

--- a/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/svc-cluster.tmpl.bicepparam
@@ -79,6 +79,7 @@ param maestroPostgresServerSku = '{{ .maestro.postgres.serverSku }}'
 param maestroPostgresDatabaseName = '{{ .maestro.postgres.databaseName }}'
 param deployMaestroPostgres = {{ .maestro.postgres.deploy }}
 param maestroPostgresZoneRedundantMode = '{{ .maestro.postgres.zoneRedundantMode }}'
+param maestroPostgresHAMode = '{{ .maestro.postgres.highAvailabilityMode }}'
 param maestroPostgresBackupRetentionDays = {{ .maestro.postgres.backupRetentionDays }}
 param maestroPostgresGeoRedundantBackup = {{ .maestro.postgres.geoRedundantBackup }}
 param maestroPostgresPrivate = {{ .maestro.postgres.private }}
@@ -86,6 +87,7 @@ param maestroPostgresEnhancedMetricsEnabled = {{ .maestro.postgres.enhancedMetri
 
 param csPostgresDeploy = {{ .clustersService.postgres.deploy }}
 param csPostgresZoneRedundantMode = '{{ .clustersService.postgres.zoneRedundantMode }}'
+param csPostgresHAMode = '{{ .clustersService.postgres.highAvailabilityMode }}'
 param csPostgresBackupRetentionDays = {{ .clustersService.postgres.backupRetentionDays }}
 param csPostgresGeoRedundantBackup = {{ .clustersService.postgres.geoRedundantBackup }}
 param csPostgresServerName = '{{ .clustersService.postgres.name }}'

--- a/dev-infrastructure/modules/common.bicep
+++ b/dev-infrastructure/modules/common.bicep
@@ -432,6 +432,15 @@ func determineZoneRedundancyForRegion(region string, mode string) bool =>
 func determineZoneRedundancy(availabilityZones array, mode string) bool =>
   mode == 'Auto' ? length(availabilityZones) > 0 : mode == 'Enabled' && length(availabilityZones) > 0
 
+// Resolves a Postgres Flexible Server highAvailability.mode. 'Auto' picks
+// 'ZoneRedundant' where the region has availability zones and 'SameZone'
+// otherwise; the explicit modes ('Disabled', 'SameZone', 'ZoneRedundant') pass
+// through unchanged so callers can pin a mode (e.g. 'Disabled' as the required
+// intermediate step when migrating between 'SameZone' and 'ZoneRedundant').
+@export()
+func determinePostgresHAMode(region string, mode string) string =>
+  mode == 'Auto' ? (length(getLocationAvailabilityZones(region)) > 0 ? 'ZoneRedundant' : 'SameZone') : mode
+
 @export()
 func generateZoneList(count int) array => count > 0 ? map(range(1, count), i => string(i)) : []
 

--- a/dev-infrastructure/modules/postgres/postgres.bicep
+++ b/dev-infrastructure/modules/postgres/postgres.bicep
@@ -36,6 +36,11 @@ type DatabaseProperties = {
 param databases DatabaseProperties[] = []
 
 @description('The zone redundant mode of the Postgres Database')
+@allowed([
+  'Disabled'
+  'SameZone'
+  'ZoneRedundant'
+])
 param postgresZoneRedundantMode string
 
 type MaintenanceWindow = {

--- a/dev-infrastructure/templates/svc-cluster.bicep
+++ b/dev-infrastructure/templates/svc-cluster.bicep
@@ -2,6 +2,7 @@ import {
   csvToArray
   determineZoneRedundancy
   determineZoneRedundancyForRegion
+  determinePostgresHAMode
   getLocationAvailabilityZonesCSV
 } from '../modules/common.bicep'
 import * as res from '../modules/resource.bicep'
@@ -174,6 +175,9 @@ param csPostgresDeploy bool
 @description('The zone redundant mode of the Maestro Postgres Database')
 param csPostgresZoneRedundantMode string
 
+@description('Overrides the CS Postgres highAvailability mode when set (Auto, Disabled, SameZone, ZoneRedundant); empty falls back to csPostgresZoneRedundantMode')
+param csPostgresHAMode string = ''
+
 @description('The number of days to retain backups for the CS Postgres server')
 param csPostgresBackupRetentionDays int
 
@@ -210,6 +214,9 @@ param deployMaestroPostgres bool = true
 
 @description('The zone redundant mode of the Maestro Postgres Database')
 param maestroPostgresZoneRedundantMode string
+
+@description('Overrides the Maestro Postgres highAvailability mode when set (Auto, Disabled, SameZone, ZoneRedundant); empty falls back to maestroPostgresZoneRedundantMode')
+param maestroPostgresHAMode string = ''
 
 @description('The number of days to retain backups for the Maestro Postgres server')
 param maestroPostgresBackupRetentionDays int
@@ -813,9 +820,9 @@ module maestroServer '../modules/maestro/maestro-server.bicep' = {
     postgresServerMinTLSVersion: maestroPostgresServerMinTLSVersion
     postgresServerStorageSizeGB: maestroPostgresServerStorageSizeGB
     postgresServerSku: maestroPostgresServerSku
-    postgresZoneRedundantMode: determineZoneRedundancyForRegion(location, maestroPostgresZoneRedundantMode)
-      ? 'ZoneRedundant'
-      : 'SameZone'
+    postgresZoneRedundantMode: maestroPostgresHAMode == ''
+      ? (determineZoneRedundancyForRegion(location, maestroPostgresZoneRedundantMode) ? 'ZoneRedundant' : 'SameZone')
+      : determinePostgresHAMode(location, maestroPostgresHAMode)
     postgresBackupRetentionDays: maestroPostgresBackupRetentionDays
     postgresGeoRedundantBackup: maestroPostgresGeoRedundantBackup
     privateEndpointSubnetId: nodeSubnetCreation.outputs.subnetId
@@ -855,9 +862,9 @@ module cs '../modules/cluster-service.bicep' = {
     privateEndpointVnetId: vnetCreation.outputs.vnetId
     privateEndpointResourceGroup: resourceGroup().name
     deployPostgres: csPostgresDeploy
-    postgresZoneRedundantMode: determineZoneRedundancyForRegion(location, csPostgresZoneRedundantMode)
-      ? 'ZoneRedundant'
-      : 'SameZone'
+    postgresZoneRedundantMode: csPostgresHAMode == ''
+      ? (determineZoneRedundancyForRegion(location, csPostgresZoneRedundantMode) ? 'ZoneRedundant' : 'SameZone')
+      : determinePostgresHAMode(location, csPostgresHAMode)
     postgresBackupRetentionDays: csPostgresBackupRetentionDays
     postgresGeoRedundantBackup: csPostgresGeoRedundantBackup
     postgresServerPrivate: clusterServicePostgresPrivate


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-29038

### What

Adds an optional highAvailabilityMode setting for the Maestro and Cluster-Service Postgres flexible servers. When non-empty it takes precedence over the existing zoneRedundantMode and maps directly to the Azure highAvailability.mode field, supporting all three real values — Disabled, SameZone, ZoneRedundant — plus Auto (region-aware, same as today). An empty string (the default) defers to the existing zoneRedundantMode derivation.

• config/config.yaml — new highAvailabilityMode: '' on both postgres blocks.
• config/config.schema.json — new highAvailabilityMode enum ("" | Auto | Disabled | SameZone | ZoneRedundant) on the shared postgres definition; "" is the "defer to zoneRedundantMode" sentinel.
• svc-cluster.tmpl.bicepparam — passes maestroPostgresHAMode / csPostgresHAMode through (plain field access).
• svc-cluster.bicep — two new params (default ''). Each derivation is: if empty, use today's zoneRedundantMode logic; otherwise resolve via the new helper.
• common.bicep — determinePostgresHAMode(region, mode): Auto → region-aware (ZoneRedundant where AZs exist, else SameZone); explicit modes pass through.
• postgres.bicep — @/allowed(['Disabled','SameZone','ZoneRedundant']) guardrail on the leaf param.
• config/rendered/dev/* — regenerated (highAvailabilityMode: "" added, two lines per env).

### Why

Today the templates can only ever emit SameZone or ZoneRedundant for highAvailability.mode — there is no path to Disabled. Azure Postgres Flexible Server does not allow switching HA directly between SameZone and ZoneRedundant; you must go through Disabled first. That transition is currently impossible via IaC.

This is step 1 of an expand/contract migration, deliberately additive and behavior-preserving (empty-string default → identical resolved HA mode), so the sdp-pipelines sync window is safe regardless of merge order: the existing overlay that pins zoneRedundantMode (incl. Disabled for INT/stage/3 prod regions) stays valid and renders unchanged. A follow-up sdp-pipelines PR will set highAvailabilityMode to drive the actual Disabled → ZoneRedundant rollout (two sequential EV2 deployments). A later ARO-HCP PR can contract — remove zoneRedundantMode for Postgres once nothing references it.

### Testing

• az bicep build on svc-cluster.bicep succeeds (full module chain typechecks).
• az bicep format on all changed bicep is idempotent (bicep-lint clean).
• make validate-config-pipelines passes (bicepparam uses only permitted {{ .field }} access).
• cd config && make materialize succeeds; rendered diff is exactly highAvailabilityMode: "" ×2 per env — confirms behavior-preserving.
• Traced the value path: with the setting empty, config zoneRedundantMode: Disabled still resolves to SameZone (unchanged); the leaf @/allowed only ever receives resolved Azure HA modes.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
