### PR TITLE
feat(acr): add ACR overview/throttling dashboard for OCP ACR

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -434,6 +434,24 @@
             "logAnalyticsWorkspace"
           ],
           "additionalProperties": false
+        },
+        "overviewDashboard": {
+          "type": "object",
+          "description": "Azure portal dashboard visualizing ACR request volume, result codes, top repositories, latency, and 429 throttling from the diagnosticSettings Log Analytics workspace. Requires diagnosticSettings.enabled.",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string",
+              "description": "Name of the Microsoft.Portal/dashboards resource"
+            }
+          },
+          "required": [
+            "enabled",
+            "name"
+          ],
+          "additionalProperties": false
         }
       },
       "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -122,6 +122,12 @@ defaults:
           name: 'arohcpocp{{ .ctx.environment }}-diag'
           sku: PerGB2018
           retentionInDays: 90
+      # Azure portal dashboard visualizing the diagnosticSettings workspace
+      # above (request volume, result codes, 429 throttling). Disabled by
+      # default; enabled per-cloud below (see clouds.dev.defaults.acr.ocp).
+      overviewDashboard:
+        enabled: false
+        name: 'arohcpocp{{ .ctx.environment }}-overview'
   # TRANSIENT — STG-global "V2" migration scaffolding. Every pipeline (including
   # the stg-only V2 copies) is preprocessed by helmtest against the dev render
   # and by EV2 manifest generation for all public envs, and the renderer uses
@@ -1440,6 +1446,11 @@ clouds:
             enabled: true
             logAnalyticsWorkspace:
               name: 'arohcpocpdev-diag'
+          # Same rationale as diagnosticSettings above: one shared, statically
+          # named dashboard for the shared arohcpocpdev registry.
+          overviewDashboard:
+            enabled: true
+            name: 'arohcpocpdev-overview'
       # Metrics
       monitoring:
         alertsEnabled: true

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -18,6 +18,9 @@ acr:
         retentionInDays: 90
         sku: PerGB2018
     name: arohcpocpdev
+    overviewDashboard:
+      enabled: true
+      name: arohcpocpdev-overview
     replicationState: true
     untaggedImagesRetention:
       days: 90

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -18,6 +18,9 @@ acr:
         retentionInDays: 90
         sku: PerGB2018
     name: arohcpocpdev
+    overviewDashboard:
+      enabled: true
+      name: arohcpocpdev-overview
     replicationState: true
     untaggedImagesRetention:
       days: 90

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -18,6 +18,9 @@ acr:
         retentionInDays: 90
         sku: PerGB2018
     name: arohcpocpdev
+    overviewDashboard:
+      enabled: true
+      name: arohcpocpdev-overview
     replicationState: true
     untaggedImagesRetention:
       days: 90

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -18,6 +18,9 @@ acr:
         retentionInDays: 90
         sku: PerGB2018
     name: arohcpocpdev
+    overviewDashboard:
+      enabled: true
+      name: arohcpocpdev-overview
     replicationState: true
     untaggedImagesRetention:
       days: 90

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -18,6 +18,9 @@ acr:
         retentionInDays: 90
         sku: PerGB2018
     name: arohcpocpdev
+    overviewDashboard:
+      enabled: true
+      name: arohcpocpdev-overview
     replicationState: true
     untaggedImagesRetention:
       days: 90

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -18,6 +18,9 @@ acr:
         retentionInDays: 90
         sku: PerGB2018
     name: arohcpocpdev
+    overviewDashboard:
+      enabled: true
+      name: arohcpocpdev-overview
     replicationState: true
     untaggedImagesRetention:
       days: 90

--- a/dev-infrastructure/configurations/global-acr.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/global-acr.tmpl.bicepparam
@@ -25,3 +25,6 @@ param ocpAcrDiagnosticSettingsEnabled = {{ .acr.ocp.diagnosticSettings.enabled }
 param ocpAcrLogAnalyticsWorkspaceName = '{{ .acr.ocp.diagnosticSettings.logAnalyticsWorkspace.name }}'
 param ocpAcrLogAnalyticsWorkspaceSku = '{{ .acr.ocp.diagnosticSettings.logAnalyticsWorkspace.sku }}'
 param ocpAcrLogAnalyticsWorkspaceRetentionInDays = {{ .acr.ocp.diagnosticSettings.logAnalyticsWorkspace.retentionInDays }}
+
+param ocpAcrOverviewDashboardEnabled = {{ .acr.ocp.overviewDashboard.enabled }}
+param ocpAcrOverviewDashboardName = '{{ .acr.ocp.overviewDashboard.name }}'

--- a/dev-infrastructure/modules/monitor/acr-dashboard.bicep
+++ b/dev-infrastructure/modules/monitor/acr-dashboard.bicep
@@ -192,18 +192,53 @@ resource dashboard 'Microsoft.Portal/dashboards@2022-12-01-preview' = {
             buildMarkdownPart({ x: 0, y: 2, colSpan: 16, rowSpan: 1 }, 'Overview', '### Overview')
           ],
           [
-            buildChartPart({ x: 0, y: 3, colSpan: 8, rowSpan: 4 }, overviewCharts[0], logAnalyticsWorkspaceId, workspaceDisplayName)
-            buildChartPart({ x: 8, y: 3, colSpan: 8, rowSpan: 4 }, overviewCharts[1], logAnalyticsWorkspaceId, workspaceDisplayName)
-            buildChartPart({ x: 0, y: 7, colSpan: 8, rowSpan: 4 }, overviewCharts[2], logAnalyticsWorkspaceId, workspaceDisplayName)
-            buildChartPart({ x: 8, y: 7, colSpan: 8, rowSpan: 4 }, topRepositoriesChart, logAnalyticsWorkspaceId, workspaceDisplayName)
-            buildChartPart({ x: 0, y: 11, colSpan: 16, rowSpan: 4 }, overviewCharts[3], logAnalyticsWorkspaceId, workspaceDisplayName)
+            buildChartPart(
+              { x: 0, y: 3, colSpan: 8, rowSpan: 4 },
+              overviewCharts[0],
+              logAnalyticsWorkspaceId,
+              workspaceDisplayName
+            )
+            buildChartPart(
+              { x: 8, y: 3, colSpan: 8, rowSpan: 4 },
+              overviewCharts[1],
+              logAnalyticsWorkspaceId,
+              workspaceDisplayName
+            )
+            buildChartPart(
+              { x: 0, y: 7, colSpan: 8, rowSpan: 4 },
+              overviewCharts[2],
+              logAnalyticsWorkspaceId,
+              workspaceDisplayName
+            )
+            buildChartPart(
+              { x: 8, y: 7, colSpan: 8, rowSpan: 4 },
+              topRepositoriesChart,
+              logAnalyticsWorkspaceId,
+              workspaceDisplayName
+            )
+            buildChartPart(
+              { x: 0, y: 11, colSpan: 16, rowSpan: 4 },
+              overviewCharts[3],
+              logAnalyticsWorkspaceId,
+              workspaceDisplayName
+            )
           ],
           [
             buildMarkdownPart({ x: 0, y: 15, colSpan: 16, rowSpan: 1 }, 'Throttling', '### Throttling')
           ],
           [
-            buildChartPart({ x: 0, y: 16, colSpan: 8, rowSpan: 4 }, throttlingCharts[0], logAnalyticsWorkspaceId, workspaceDisplayName)
-            buildChartPart({ x: 8, y: 16, colSpan: 8, rowSpan: 4 }, throttlingCharts[1], logAnalyticsWorkspaceId, workspaceDisplayName)
+            buildChartPart(
+              { x: 0, y: 16, colSpan: 8, rowSpan: 4 },
+              throttlingCharts[0],
+              logAnalyticsWorkspaceId,
+              workspaceDisplayName
+            )
+            buildChartPart(
+              { x: 8, y: 16, colSpan: 8, rowSpan: 4 },
+              throttlingCharts[1],
+              logAnalyticsWorkspaceId,
+              workspaceDisplayName
+            )
           ]
         )
       }

--- a/dev-infrastructure/modules/monitor/acr-dashboard.bicep
+++ b/dev-infrastructure/modules/monitor/acr-dashboard.bicep
@@ -1,0 +1,231 @@
+@description('Name for the Azure portal dashboard resource')
+param dashboardName string
+
+@description('Azure region for the dashboard (dashboards are typically deployed to "global" location alongside the shared ACR)')
+param location string
+
+@description('Display title shown on the dashboard tile')
+param dashboardTitle string
+
+@description('Resource ID of the Log Analytics workspace the dashboard queries')
+param logAnalyticsWorkspaceId string
+
+var workspaceDisplayName = last(split(logAnalyticsWorkspaceId, '/'))
+
+// General overview: request volume, push/pull activity, top repositories,
+// result codes, latency. Sourced from the diagnostic logs
+// (ContainerRegistryLoginEvents/ContainerRegistryRepositoryEvents) and the
+// ACR platform metrics (AzureMetrics) - see diagnostic-settings.bicep. Azure
+// Monitor does not expose a replication-specific metric or log for ACR (only
+// Total/SuccessfulPull/PushCount and StorageUsed); replication health must
+// still be checked via `az acr replication list`.
+var overviewCharts = [
+  {
+    title: 'Total Requests Over Time (Login + Repository, last 24h)'
+    query: 'union ContainerRegistryLoginEvents, ContainerRegistryRepositoryEvents\n| where TimeGenerated > ago(24h)\n| summarize Requests=count() by bin(TimeGenerated, 10m)\n| render timechart'
+    controlType: 'FrameControlChart'
+    specificChart: 'Line'
+    dimensions: {
+      aggregation: 'Sum'
+      splitBy: []
+      xAxis: { name: 'TimeGenerated', type: 'datetime' }
+      yAxis: [{ name: 'Requests', type: 'long' }]
+    }
+  }
+  {
+    title: 'Push vs Pull Count (ACR Metrics, last 24h)'
+    query: 'AzureMetrics\n| where TimeGenerated > ago(24h)\n| where MetricName in ("TotalPullCount", "TotalPushCount")\n| summarize Count=sum(todouble(Total)) by bin(TimeGenerated, 10m), MetricName\n| render timechart'
+    controlType: 'FrameControlChart'
+    specificChart: 'Line'
+    dimensions: {
+      aggregation: 'Sum'
+      splitBy: [{ name: 'MetricName', type: 'string' }]
+      xAxis: { name: 'TimeGenerated', type: 'datetime' }
+      yAxis: [{ name: 'Count', type: 'real' }]
+    }
+  }
+  {
+    title: 'Login Result Breakdown (last 24h)'
+    query: 'ContainerRegistryLoginEvents\n| where TimeGenerated > ago(24h)\n| summarize count() by bin(TimeGenerated, 10m), ResultDescription\n| render timechart'
+    controlType: 'FrameControlChart'
+    specificChart: 'Line'
+    dimensions: {
+      aggregation: 'Sum'
+      splitBy: [{ name: 'ResultDescription', type: 'string' }]
+      xAxis: { name: 'TimeGenerated', type: 'datetime' }
+      yAxis: [{ name: 'count_', type: 'long' }]
+    }
+  }
+  {
+    title: 'Average Request Duration (ms, last 24h)'
+    query: 'union withsource=SourceTable ContainerRegistryLoginEvents, ContainerRegistryRepositoryEvents\n| where TimeGenerated > ago(24h)\n| summarize AvgDurationMs=avg(todouble(DurationMs)) by bin(TimeGenerated, 10m), SourceTable\n| render timechart'
+    controlType: 'FrameControlChart'
+    specificChart: 'Line'
+    dimensions: {
+      aggregation: 'Average'
+      splitBy: [{ name: 'SourceTable', type: 'string' }]
+      xAxis: { name: 'TimeGenerated', type: 'datetime' }
+      yAxis: [{ name: 'AvgDurationMs', type: 'real' }]
+    }
+  }
+]
+
+// Rendered as a table (not a bar chart) - repository names are long and a
+// categorical bar chart with 10 long labels was unreadable.
+var topRepositoriesChart = {
+  title: 'Top Repositories by Pull Count (last 24h)'
+  query: 'ContainerRegistryRepositoryEvents\n| where TimeGenerated > ago(24h)\n| where OperationName == "Pull"\n| summarize Pulls=count() by Repository\n| top 10 by Pulls desc'
+  controlType: 'AnalyticsGrid'
+}
+
+// Throttling: 429s specifically, split out so on-call can jump straight to
+// the signal that matters during an incident without wading through general
+// traffic charts. Query columns use the raw diagnostic log schema, in
+// particular `ResultDescription` (a string, e.g. "200"/"429"), not
+// `HttpStatusCode`.
+var throttlingCharts = [
+  {
+    title: 'ACR 429 Throttling (Login Events, last 24h)'
+    query: 'ContainerRegistryLoginEvents\n| where TimeGenerated > ago(24h)\n| where ResultDescription == "429"\n| summarize Throttled429=count() by bin(TimeGenerated, 10m)\n| render timechart'
+    controlType: 'FrameControlChart'
+    specificChart: 'Line'
+    dimensions: {
+      aggregation: 'Sum'
+      splitBy: []
+      xAxis: { name: 'TimeGenerated', type: 'datetime' }
+      yAxis: [{ name: 'Throttled429', type: 'long' }]
+    }
+  }
+  {
+    title: 'Total vs Throttled Login Requests (last 24h)'
+    query: 'ContainerRegistryLoginEvents\n| where TimeGenerated > ago(24h)\n| summarize Total=count(), Throttled429=countif(ResultDescription == "429") by bin(TimeGenerated, 10m)\n| extend ThrottleRatePct = round(100.0 * Throttled429 / Total, 2)\n| project TimeGenerated, Total, Throttled429, ThrottleRatePct\n| render timechart'
+    controlType: 'FrameControlChart'
+    specificChart: 'Line'
+    dimensions: {
+      aggregation: 'Sum'
+      splitBy: []
+      xAxis: { name: 'TimeGenerated', type: 'datetime' }
+      yAxis: [
+        { name: 'Total', type: 'long' }
+        { name: 'Throttled429', type: 'long' }
+      ]
+    }
+  }
+]
+
+// Builds one Microsoft_OperationsManagementSuite_Workspace/LogsDashboardPart
+// tile for a chart or table definition (see overviewCharts/throttlingCharts/
+// topRepositoriesChart above). `chart.controlType` is 'FrameControlChart' for
+// a line/bar chart (requires specificChart + dimensions) or 'AnalyticsGrid'
+// for a plain table (specificChart/dimensions unused). Bicep user-defined
+// functions cannot read outer-scope params/vars, so the workspace resource ID
+// and display name are passed in explicitly.
+func buildChartPart(position object, chart object, workspaceId string, workspaceLabel string) object => {
+  position: position
+  metadata: {
+    inputs: [
+      { name: 'resourceTypeMode', value: 'workspace', isOptional: true }
+      { name: 'ComponentId', value: workspaceId, isOptional: true }
+      { name: 'Scope', value: { resourceIds: [workspaceId] }, isOptional: true }
+      { name: 'PartId', isOptional: true }
+      { name: 'Version', value: '2.0', isOptional: true }
+      { name: 'TimeRange', value: 'P1D', isOptional: true }
+      { name: 'DashboardId', isOptional: true }
+      { name: 'DraftRequestParameters', isOptional: true }
+      { name: 'Query', value: chart.query, isOptional: true }
+      { name: 'ControlType', value: chart.controlType, isOptional: true }
+      { name: 'SpecificChart', value: chart.?specificChart, isOptional: true }
+      { name: 'PartTitle', value: chart.title, isOptional: true }
+      { name: 'PartSubTitle', value: workspaceLabel, isOptional: true }
+      { name: 'Dimensions', value: chart.?dimensions, isOptional: true }
+      { name: 'LegendOptions', value: { isEnabled: true, position: 'Bottom' }, isOptional: true }
+      { name: 'IsQueryContainTimeRange', value: false, isOptional: true }
+    ]
+    type: 'Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart'
+    settings: {
+      content: {
+        Query: chart.query
+        ControlType: chart.controlType
+        SpecificChart: chart.?specificChart
+        PartTitle: chart.title
+        PartSubTitle: workspaceLabel
+      }
+    }
+  }
+}
+
+func buildMarkdownPart(position object, title string, content string) object => {
+  position: position
+  metadata: {
+    inputs: []
+    type: 'Extension/HubsExtension/PartType/MarkdownPart'
+    settings: {
+      content: {
+        settings: {
+          content: content
+          title: title
+          subtitle: ''
+          markdownSource: 1
+        }
+      }
+    }
+  }
+}
+
+resource dashboard 'Microsoft.Portal/dashboards@2022-12-01-preview' = {
+  name: dashboardName
+  location: location
+  tags: {
+    'hidden-title': dashboardTitle
+  }
+  properties: {
+    lenses: [
+      {
+        order: 0
+        parts: concat(
+          [
+            buildMarkdownPart(
+              { x: 0, y: 0, colSpan: 16, rowSpan: 2 },
+              dashboardTitle,
+              '## ${dashboardTitle}\n\nMetrics and logs from the `${workspaceDisplayName}` Log Analytics workspace.'
+            )
+            buildMarkdownPart({ x: 0, y: 2, colSpan: 16, rowSpan: 1 }, 'Overview', '### Overview')
+          ],
+          [
+            buildChartPart({ x: 0, y: 3, colSpan: 8, rowSpan: 4 }, overviewCharts[0], logAnalyticsWorkspaceId, workspaceDisplayName)
+            buildChartPart({ x: 8, y: 3, colSpan: 8, rowSpan: 4 }, overviewCharts[1], logAnalyticsWorkspaceId, workspaceDisplayName)
+            buildChartPart({ x: 0, y: 7, colSpan: 8, rowSpan: 4 }, overviewCharts[2], logAnalyticsWorkspaceId, workspaceDisplayName)
+            buildChartPart({ x: 8, y: 7, colSpan: 8, rowSpan: 4 }, topRepositoriesChart, logAnalyticsWorkspaceId, workspaceDisplayName)
+            buildChartPart({ x: 0, y: 11, colSpan: 16, rowSpan: 4 }, overviewCharts[3], logAnalyticsWorkspaceId, workspaceDisplayName)
+          ],
+          [
+            buildMarkdownPart({ x: 0, y: 15, colSpan: 16, rowSpan: 1 }, 'Throttling', '### Throttling')
+          ],
+          [
+            buildChartPart({ x: 0, y: 16, colSpan: 8, rowSpan: 4 }, throttlingCharts[0], logAnalyticsWorkspaceId, workspaceDisplayName)
+            buildChartPart({ x: 8, y: 16, colSpan: 8, rowSpan: 4 }, throttlingCharts[1], logAnalyticsWorkspaceId, workspaceDisplayName)
+          ]
+        )
+      }
+    ]
+    metadata: {
+      model: {
+        timeRange: {
+          value: { relative: { duration: 24, timeUnit: 1 } }
+          type: 'MsPortalFx.Composition.Configuration.ValueTypes.TimeRange'
+        }
+        filterLocale: { value: 'en-us' }
+        filters: {
+          value: {
+            MsPortalFx_TimeRange: {
+              model: { format: 'utc', granularity: 'auto', relative: '24h' }
+              displayCache: { name: 'UTC Time', value: 'Past 24 hours' }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+output dashboardId string = dashboard.id

--- a/dev-infrastructure/templates/global-acr.bicep
+++ b/dev-infrastructure/templates/global-acr.bicep
@@ -46,7 +46,8 @@ param ocpAcrLogAnalyticsWorkspaceRetentionInDays int = 90
 param ocpAcrOverviewDashboardEnabled bool = false
 
 @description('Name of the Azure portal dashboard resource for OCP ACR overview/throttling visibility')
-param ocpAcrOverviewDashboardName string = ''
+@minLength(1)
+param ocpAcrOverviewDashboardName string = 'placeholder-dashboard-name'
 
 resource globalMSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
   name: globalMSIName
@@ -294,9 +295,12 @@ module ocpAcrDiagnosticSettings '../modules/acr/diagnostic-settings.bicep' = if 
   ]
 }
 
-module ocpAcrOverviewDashboard '../modules/monitor/acr-dashboard.bicep' = if (ocpAcrOverviewDashboardEnabled) {
+module ocpAcrOverviewDashboard '../modules/monitor/acr-dashboard.bicep' = if (ocpAcrOverviewDashboardEnabled && ocpAcrDiagnosticSettingsEnabled) {
   // Same rationale as ocpAcrLogAnalyticsWorkspace/ocpAcrDiagnosticSettings
   // above: one shared dashboard for the shared ACR, not one per environment.
+  // Also requires ocpAcrDiagnosticSettingsEnabled: the dashboard queries the
+  // diagnostics Log Analytics workspace (ocpAcrLogAnalyticsWorkspace), which
+  // only exists when diagnostic settings are enabled.
   name: '${ocpAcrName}-overview-dashboard'
   params: {
     dashboardName: ocpAcrOverviewDashboardName

--- a/dev-infrastructure/templates/global-acr.bicep
+++ b/dev-infrastructure/templates/global-acr.bicep
@@ -309,4 +309,3 @@ module ocpAcrOverviewDashboard '../modules/monitor/acr-dashboard.bicep' = if (oc
     logAnalyticsWorkspaceId: ocpAcrLogAnalyticsWorkspace!.outputs.workspaceId
   }
 }
-

--- a/dev-infrastructure/templates/global-acr.bicep
+++ b/dev-infrastructure/templates/global-acr.bicep
@@ -42,6 +42,12 @@ param ocpAcrLogAnalyticsWorkspaceSku string = 'PerGB2018'
 @maxValue(730)
 param ocpAcrLogAnalyticsWorkspaceRetentionInDays int = 90
 
+@description('Enable the ACR overview dashboard (request volume, result codes, top repositories, latency, and 429 throttling) for the OCP ACR. Requires ocpAcrDiagnosticSettingsEnabled.')
+param ocpAcrOverviewDashboardEnabled bool = false
+
+@description('Name of the Azure portal dashboard resource for OCP ACR overview/throttling visibility')
+param ocpAcrOverviewDashboardName string = ''
+
 resource globalMSI 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
   name: globalMSIName
 }
@@ -287,3 +293,16 @@ module ocpAcrDiagnosticSettings '../modules/acr/diagnostic-settings.bicep' = if 
     ocpAcr
   ]
 }
+
+module ocpAcrOverviewDashboard '../modules/monitor/acr-dashboard.bicep' = if (ocpAcrOverviewDashboardEnabled) {
+  // Same rationale as ocpAcrLogAnalyticsWorkspace/ocpAcrDiagnosticSettings
+  // above: one shared dashboard for the shared ACR, not one per environment.
+  name: '${ocpAcrName}-overview-dashboard'
+  params: {
+    dashboardName: ocpAcrOverviewDashboardName
+    location: location
+    dashboardTitle: 'ACR ${ocpAcrName} Overview'
+    logAnalyticsWorkspaceId: ocpAcrLogAnalyticsWorkspace!.outputs.workspaceId
+  }
+}
+


### PR DESCRIPTION
## Why

Follow-up to #6696 (ACR diagnostic settings). We now have request/login logs for the shared OCP ACR (`arohcpocpdev`) flowing into a Log Analytics workspace, but no way to look at them without hand-writing Kusto queries. This adds an Azure portal dashboard so on-call/SRE can see request volume, push/pull activity, and 429 throttling for the registry at a glance during an incident like [AROSLSRE-1883](https://redhat.atlassian.net/browse/AROSLSRE-1883).

## What

- New `dev-infrastructure/modules/monitor/acr-dashboard.bicep`: builds a `Microsoft.Portal/dashboards` resource with two sections:
  - **Overview**: total requests over time, push vs pull count (from ACR's own `AzureMetrics`), login result-code breakdown, top repositories by pull count (table), average request duration.
  - **Throttling**: 429 count over time, total-vs-throttled ratio.
- Wired into `global-acr.bicep` as `ocpAcrOverviewDashboard`, gated by `ocpAcrOverviewDashboardEnabled` (same pattern as `ocpAcrDiagnosticSettings`/`ocpAcrLogAnalyticsWorkspace`).
- New `acr.ocp.overviewDashboard` config block (`enabled`, `name`), enabled in the dev cloud with a static shared name (`arohcpocpdev-overview`), same rationale as the diagnostic-settings workspace: the OCP ACR is one physical resource shared by all 6 dev-cloud environments, so the dashboard name must resolve identically everywhere for redeploys to be idempotent updates rather than new resources.
- Schema updated (`config.schema.json`) for the new config block.

## Notes

- Azure Monitor does not expose an ACR replication-specific metric or log (confirmed via `az monitor metrics list-definitions`); only `Total/SuccessfulPullCount`, `Total/SuccessfulPushCount`, and `StorageUsed` are available. Replication health still needs `az acr replication list`.
- All dashboard queries and layout were validated against a live test deployment against the actual `arohcpocpdev-diag` workspace before being committed to bicep.

## Screenshots

Rendered dashboard (validated via direct test deployment):

- Overview section: total requests, push/pull counts, login result codes, top repositories table, average duration
- Throttling section: 429 count over time, total-vs-throttled ratio

<img width="1695" height="2171" alt="Screenshot 2026-08-27 at 10 14 05" src="https://github.com/user-attachments/assets/a83656b0-3121-4557-ab9a-27c1d9640e96" />

Ref: [AROSLSRE-1883](https://redhat.atlassian.net/browse/AROSLSRE-1883) / [AROSLSRE-1893](https://redhat.atlassian.net/browse/AROSLSRE-1893)

