### PR TITLE
Chore: Remove resolveClusterLinks use as CS now embeds the full autoscaler config in the GET cluster repsonse

### DIFF
--- a/internal/ocm/client.go
+++ b/internal/ocm/client.go
@@ -236,7 +236,7 @@ func (csc *clusterServiceClient) GetCluster(ctx context.Context, internalID Inte
 	if !ok {
 		return nil, fmt.Errorf("empty response body")
 	}
-	return resolveClusterLinks(ctx, csc.conn, cluster)
+	return cluster, nil
 }
 
 func (csc *clusterServiceClient) GetClusterStatus(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.ClusterStatus, error) {


### PR DESCRIPTION
[ARO-28376](https://redhat.atlassian.net/browse/ARO-28376)

### What

This PR gets rid of a redundant API call to resolve the cluster autoscaler link. 
`resolveClusterLinks` resolves the link and embeds the autoscaler in the cluster object, which is no longer needed as CS embeds the full autoscaler config in the GET cluster request.

### Why

Before, ARO-HCP GetCluster sends a separate autoscaler GET as the autoscaler attribute is just a link which needs to be resolved. 
As CS should embed the full autoscaler config on the GET cluster request, there is no longer a need to resolve the autoscaler link anymore.

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

While working on this PR, I noticed that `resolveClusterLinks` could be dropped entirely. There is a separate effort to work on this, as I want this PR to be focused solely on the ticket requirements.

<!-- optional -->

### PR Checklist

- [X] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [X] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
