### PR TITLE
fix(infra): retry cluster ARM step on Key Vault RBAC propagation (AROSLSRE-1918)

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -425,6 +425,10 @@ resourceGroups:
       - "Resource is in Updating state"
       - "There was a problem communicating with the identity service"
       - "DeploymentScriptExceededMaxAllowedTime"
+      # Transient RBAC propagation lag, mostly on fresh region buildout: the
+      # deployment identity's Key Vault role assignment (needed to create the
+      # aks-etcd-encryption key) may not have propagated yet. Retry once it lands.
+      - "ForbiddenByRbac"
       maximumRetryCount: 3
       durationBetweenRetries: 2m
   - name: svc-mgmt-aks-permissions

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -480,6 +480,10 @@ resourceGroups:
       - "AnmPreconditionFailedException"
       - "MaxRetryCountReached"
       - "ServiceUnavailable"
+      # Transient RBAC propagation lag, mostly on fresh region buildout: the
+      # deployment identity's Key Vault role assignment (needed to create the
+      # aks-etcd-encryption key) may not have propagated yet. Retry once it lands.
+      - "ForbiddenByRbac"
       maximumRetryCount: 3
       durationBetweenRetries: 2m
   - name: upgrade-aks-cluster


### PR DESCRIPTION
<!-- Link to Jira issue -->
Jira: [AROSLSRE-1918](https://redhat.atlassian.net/browse/AROSLSRE-1918)

### What

Add `ForbiddenByRbac` to the existing `automatedRetry.errorContainsAny` list on the `cluster` ARM step in both `dev-infrastructure/svc-pipeline.yaml` and `dev-infrastructure/mgmt-pipeline.yaml`.

### Why

During a prod Canary GlobalBuildout in eastus2euap, the `Service.Infra` cluster step failed with `ForbiddenByRbac` on `Microsoft.KeyVault/vaults/keys/write` for the `aks-etcd-encryption` key. Creating that key via bicep is a control-plane write, so the deployment identity needs a Key Vault role that grants `keys/write`. On a fresh region the role assignment can lag propagation, and the whole rollout step fails. Both cluster steps deploy `aks-cluster-base.bicep` and create that key, so both can hit the same race. The retry lets the step recover once the assignment lands.

This only covers the propagation race. A genuinely missing grant still fails after the retries, same as today, just a few minutes later.

### Testing

`make validate-config-pipelines` passes. This is a pipeline config change with no code path to unit test; the retry itself is exercised by EV2 at rollout time.

### Special notes for your reviewer

`errorContainsAny` is an OR match and case-insensitive, so I matched the stable error code `ForbiddenByRbac` rather than a longer phrase. Rollout to int/stg/prod happens via sdp-pipelines after this merges.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
