### PR TITLE
test: add merge-gate subcommand

### DIFF
--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -263,3 +263,12 @@ cluster should exist but no metrics are flowing yet, so an absence alert can fir
 until all components are up. If this turns out to be a real problem in practice it will likely
 need a more comprehensive approach than adjusting this one metric -- other alerts may fire during
 bring-up too -- and we will only know once a few more management clusters have been stamped.
+
+## Merge gate
+
+Production alerts feed back into development through the **merge gate**, a CI check
+that blocks a PR when it touches a component with unresolved production alerts. If
+your merge is blocked, see
+[Unblocking a merge blocked by the merge gate](alerts/merge-gate.md) for how to
+declare a
+fix with an `Ameliorates-Alert:` commit trailer.

--- a/docs/alerts/merge-gate.md
+++ b/docs/alerts/merge-gate.md
@@ -1,0 +1,104 @@
+# Unblocking a merge blocked by the merge gate
+
+The **merge gate** is a CI check that blocks a PR when it touches a component that
+has production alerts firing which have not been accounted for. Only components
+whose image is built from this repository are gated. There are two ways to unblock a
+merge: land only bug fixes, or declare each firing alert as fixed.
+
+## Bug-fix PRs are never blocked
+
+So that alerting never gets in the way of fixing bugs, a PR whose commits **all** use
+the conventional-commits `fix:` prefix bypasses the gate entirely and is allowed
+without any alert check. The type must be `fix` (optionally scoped and/or breaking):
+
+```
+fix: correct the retry backoff
+fix(backend): stop leaking the lease on restart
+fix!: change the default that was causing outages
+```
+
+If even one commit in the PR uses another type (`feat:`, `chore:`, a bare subject,
+etc.), the normal gate applies. For a batch, every constituent PR's commits must be
+`fix:` for the bypass to apply.
+
+## Ameliorating an alert
+
+When the gate blocks your PR it links to a self-contained Kusto (ADX) query whose
+result rows are the alerts blocking you — each with its `region`, `component`,
+`alertname`, `severity`, `firedDateTime`, and `labels`; the query's header comments
+restate what it checked. Once you understand a firing alert — because your PR fixes
+it, or because a fix has already merged — declare it fixed with an
+`Ameliorates-Alert:` trailer in the commit that fixes it.
+
+### Trailer syntax
+
+Add one trailer per alert to the commit that contains (or represents) the fix:
+
+```
+Ameliorates-Alert: <alertname>
+```
+
+Optionally scope it to a specific firing with labels:
+
+```
+Ameliorates-Alert: <alertname>{key=value,key2=value2}
+```
+
+- `alertname` is the `alert:` name from the `PrometheusRule`
+  (`alertContext.labels.alertname` on the firing alert).
+- Labels are a **subset**: list only the labels that identify the specific firing you
+  fixed; any others on the alert are ignored. Omit the braces to match **any** firing
+  of that alertname.
+- The trailer is **repeatable** — one line per alert a commit addresses.
+
+### Adding trailers
+
+You can simply append the trailers as literal lines to the end of your commit message,
+or add these with `git commit --trailer` on versions of `git` newer than 2.32:
+
+```console
+$ git commit -m "Fix leader-election lease renewal on backend restart" \
+    --trailer "Ameliorates-Alert: LeaderElectionLeaseStale" \
+    --trailer "Ameliorates-Alert: BackendControllerQueueDepthHigh{name=operationphasemetrics}"
+```
+
+To add one to the commit you just made, amend it:
+
+```console
+$ git commit --amend --no-edit \
+    --trailer "Ameliorates-Alert: KubeNodeNotReady{node=aks-nodepool1-0}"
+```
+
+
+### Example
+
+```
+Fix leader-election lease renewal on backend restart
+
+Ameliorates-Alert: LeaderElectionLeaseStale
+Ameliorates-Alert: BackendControllerQueueDepthHigh{name=operationphasemetrics}
+```
+
+`LeaderElectionLeaseStale` suppresses any firing of that alert for the touched
+component; `BackendControllerQueueDepthHigh{name=operationphasemetrics}` suppresses
+only firings whose `name` label is `operationphasemetrics`.
+
+### Which commits count
+
+A declaration in **your PR's own commits** counts, so a PR can merge on the strength
+of its own fix before it is deployed. **Already-merged** declarations count per
+region: a fix merged after what a region is running, but not yet deployed there,
+suppresses the alert in that region; but if a region already runs the fix and the
+alert is *still* firing there, it keeps blocking — the fix did not work.
+
+## Mapping a directory to a component
+
+The gate maps changed paths to components using
+[`observability/component-map.yaml`](../../observability/component-map.yaml). If your
+service is not yet mapped and you want it gated, add an entry mapping its path glob
+to its alert `component` label; see the criteria in that file.
+
+## See also
+
+- [Writing Alerts](../alerts.md)
+- [Alert Verification](../alert-verification.md)

--- a/observability/component-map.yaml
+++ b/observability/component-map.yaml
@@ -1,0 +1,28 @@
+# component-map.yaml maps repository path globs to the alert `component` label the
+# release-dashboard merge gate uses to decide which components a PR touches.
+#
+#   - name:  the alert `component` label (spec.groups[].labels.component in the
+#            *-prometheusRule.yaml files).
+#   - paths: doublestar globs; a changed file matching any of them belongs to the
+#            component. Files that match nothing are ignored.
+#
+# Only map directories that build an image from this repository. The gate reasons
+# about whether an ARO-HCP change broke production, so components whose images are
+# built elsewhere (maestro, hypershift, clusters-service, ...) cannot be reasoned
+# about from an ARO-HCP PR and are intentionally omitted.
+components:
+- name: backend
+  paths:
+  - backend/**
+- name: frontend
+  paths:
+  - frontend/**
+- name: admin
+  paths:
+  - admin/**
+- name: fleet
+  paths:
+  - fleet/**
+- name: kube-applier
+  paths:
+  - kube-applier/**

--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -44,6 +44,7 @@ import (
 	customlinktools "github.com/Azure/ARO-HCP/test/cmd/aro-hcp-tests/custom-link-tools"
 	gatherobservability "github.com/Azure/ARO-HCP/test/cmd/aro-hcp-tests/gather-observability"
 	gathersnapshot "github.com/Azure/ARO-HCP/test/cmd/aro-hcp-tests/gather-snapshot"
+	mergegate "github.com/Azure/ARO-HCP/test/cmd/aro-hcp-tests/merge-gate"
 	slotmanager "github.com/Azure/ARO-HCP/test/cmd/aro-hcp-tests/slot-manager"
 	"github.com/Azure/ARO-HCP/test/cmd/aro-hcp-tests/visualize"
 	"github.com/Azure/ARO-HCP/test/util/framework"
@@ -779,6 +780,7 @@ func setupCli() *cobra.Command {
 	}
 	root.AddCommand(extensionCmds...)
 	root.AddCommand(cleanup.NewCommand())
+	root.AddCommand(metadataapi.Must(mergegate.NewCommand()))
 	root.AddCommand(metadataapi.Must(visualize.NewCommand()))
 	root.AddCommand(metadataapi.Must(customlinktools.NewCommand()))
 	root.AddCommand(metadataapi.Must(gatherobservability.NewCommand()))

--- a/test/cmd/aro-hcp-tests/merge-gate/cmd.go
+++ b/test/cmd/aro-hcp-tests/merge-gate/cmd.go
@@ -1,0 +1,58 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mergegate
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+
+	"github.com/Azure/ARO-HCP/test/pkg/logger"
+)
+
+func NewCommand() (*cobra.Command, error) {
+	var logVerbosity int
+
+	opts := DefaultOptions()
+	cmd := &cobra.Command{
+		Use:   "merge-gate",
+		Short: "Ask the release dashboard whether this PR should merge given production alerts.",
+		Long: "merge-gate posts the prow JOB_SPEC to the release-dashboard merge-gate API and fails " +
+			"the test run when the change touches components with unresolved production alerts. " +
+			"The job spec defaults to the JOB_SPEC environment variable.",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			ctx := logr.NewContext(cmd.Context(), logger.NewWithVerbosity(logVerbosity))
+			cmd.SetContext(ctx)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			validated, err := opts.Validate()
+			if err != nil {
+				return err
+			}
+			completed, err := validated.Complete(cmd.Context())
+			if err != nil {
+				return err
+			}
+			return completed.Run(cmd.Context())
+		},
+	}
+
+	cmd.PersistentFlags().IntVarP(&logVerbosity, "verbosity", "v", 0, "set the verbosity level")
+	if err := BindOptions(opts, cmd); err != nil {
+		return nil, err
+	}
+	return cmd, nil
+}

--- a/test/cmd/aro-hcp-tests/merge-gate/options.go
+++ b/test/cmd/aro-hcp-tests/merge-gate/options.go
@@ -1,0 +1,306 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mergegate implements the `merge-gate` subcommand: it asks the
+// release-dashboard merge-gate API whether the PR (or batch) described by the prow
+// JOB_SPEC should be allowed to merge, and fails the test run if it should not.
+package mergegate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const mergeGatePath = "/api/merge-gate"
+
+// ameliorationDocsURL points at the guide for unblocking a merge by declaring a
+// fix with an Ameliorates-Alert commit trailer.
+const ameliorationDocsURL = "https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/merge-gate.md"
+
+// Retry backoff parameters for transient (503/network) failures.
+const (
+	retryBaseDelay = 1 * time.Second
+	retryFactor    = 2.0
+	retryJitter    = 0.2
+	retryCap       = 30 * time.Second
+)
+
+func DefaultOptions() *RawOptions {
+	return &RawOptions{
+		JobSpec:     os.Getenv("JOB_SPEC"),
+		Token:       os.Getenv("RELEASE_DASHBOARD_TOKEN"),
+		URL:         os.Getenv("RELEASE_DASHBOARD_URL"),
+		Timeout:     30 * time.Second,
+		Retries:     3,
+		FailOnError: true,
+	}
+}
+
+// BindOptions registers the merge-gate flags.
+func BindOptions(opts *RawOptions, cmd *cobra.Command) error {
+	cmd.Flags().StringVar(&opts.URL, "url", opts.URL, "Base URL of the release dashboard (defaults to RELEASE_DASHBOARD_URL).")
+	cmd.Flags().StringVar(&opts.JobSpec, "job-spec", opts.JobSpec, "Prow JOB_SPEC JSON (defaults to the JOB_SPEC environment variable).")
+	cmd.Flags().StringVar(&opts.JobSpecFile, "job-spec-file", opts.JobSpecFile, "Path to a file containing the prow JOB_SPEC JSON.")
+	cmd.Flags().StringVar(&opts.Token, "token", opts.Token, "Optional bearer token for the endpoint (defaults to RELEASE_DASHBOARD_TOKEN).")
+	cmd.Flags().DurationVar(&opts.Timeout, "timeout", opts.Timeout, "Timeout for a single request to the merge gate.")
+	cmd.Flags().IntVar(&opts.Retries, "retries", opts.Retries, "Number of additional attempts on transient (503/network) failures.")
+	cmd.Flags().BoolVar(&opts.FailOnError, "fail-on-error", opts.FailOnError, "Treat an indeterminate verdict (or an unreachable gate) as a block.")
+	return nil
+}
+
+// RawOptions holds input values.
+type RawOptions struct {
+	// URL is the base URL of the release dashboard (the /api/merge-gate path is
+	// appended automatically).
+	URL string
+	// JobSpec is the prow JOB_SPEC JSON. Defaults to the JOB_SPEC env var.
+	JobSpec string
+	// JobSpecFile, if set, is read instead of JobSpec.
+	JobSpecFile string
+	// Token is an optional bearer token for the endpoint.
+	Token string
+	// Timeout bounds a single HTTP attempt.
+	Timeout time.Duration
+	// Retries is the number of additional attempts on transient failures.
+	Retries int
+	// FailOnError treats an indeterminate (error) verdict as a block.
+	FailOnError bool
+}
+
+type validatedOptions struct {
+	*RawOptions
+	endpoint string
+	jobSpec  []byte
+}
+
+type ValidatedOptions struct {
+	*validatedOptions
+}
+
+type completedOptions struct {
+	*validatedOptions
+	client *http.Client
+}
+
+type Options struct {
+	*completedOptions
+}
+
+func (o *RawOptions) Validate() (*ValidatedOptions, error) {
+	if o.URL == "" {
+		return nil, fmt.Errorf("the release dashboard URL must be provided with --url (or RELEASE_DASHBOARD_URL)")
+	}
+	u, err := url.Parse(o.URL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --url %q: %w", o.URL, err)
+	}
+	// Never send a bearer token in cleartext: require https, except when talking to
+	// a loopback address for local testing.
+	if o.Token != "" && !isSecureURL(u) {
+		return nil, fmt.Errorf("refusing to send a bearer token to insecure URL %q; use https (http is allowed only for localhost)", o.URL)
+	}
+
+	jobSpec := []byte(o.JobSpec)
+	if o.JobSpecFile != "" {
+		data, err := os.ReadFile(o.JobSpecFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read --job-spec-file %q: %w", o.JobSpecFile, err)
+		}
+		jobSpec = data
+	}
+	if len(bytes.TrimSpace(jobSpec)) == 0 {
+		return nil, fmt.Errorf("a prow job spec must be provided via JOB_SPEC, --job-spec, or --job-spec-file")
+	}
+	// Fail fast on obviously malformed input.
+	if !json.Valid(jobSpec) {
+		return nil, fmt.Errorf("the provided job spec is not valid JSON")
+	}
+
+	if o.Timeout <= 0 {
+		o.Timeout = 30 * time.Second
+	}
+	if o.Retries < 0 {
+		o.Retries = 0
+	}
+
+	return &ValidatedOptions{
+		validatedOptions: &validatedOptions{
+			RawOptions: o,
+			endpoint:   strings.TrimRight(o.URL, "/") + mergeGatePath,
+			jobSpec:    jobSpec,
+		},
+	}, nil
+}
+
+// isSecureURL reports whether u is safe to send a bearer token to: https anywhere,
+// or http to a loopback host (for local testing).
+func isSecureURL(u *url.URL) bool {
+	switch u.Scheme {
+	case "https":
+		return true
+	case "http":
+		switch u.Hostname() {
+		case "localhost", "127.0.0.1", "::1":
+			return true
+		}
+	}
+	return false
+}
+
+func (o *ValidatedOptions) Complete(_ context.Context) (*Options, error) {
+	return &Options{
+		completedOptions: &completedOptions{
+			validatedOptions: o.validatedOptions,
+			client:           &http.Client{Timeout: o.Timeout},
+		},
+	}, nil
+}
+
+// verdict mirrors the release-dashboard response body.
+type verdict struct {
+	Merge  bool   `json:"merge"`
+	Reason string `json:"reason"`
+	ADXURL string `json:"adxUrl"`
+}
+
+// Run queries the merge-gate API and returns an error (failing the test) when the
+// PR should not merge.
+func (o *Options) Run(ctx context.Context) error {
+	logger := logr.FromContextOrDiscard(ctx)
+
+	v, err := o.query(ctx, logger)
+	if err != nil {
+		if o.FailOnError {
+			return fmt.Errorf("merge gate could not be evaluated (failing closed): %w", err)
+		}
+		logger.Error(err, "Merge gate could not be evaluated; allowing due to --fail-on-error=false.")
+		return nil
+	}
+
+	logger.Info("Merge gate verdict.", "merge", v.Merge, "reason", v.Reason, "adxUrl", v.ADXURL)
+	if v.ADXURL != "" {
+		fmt.Fprintf(os.Stderr, "\nInspect the alerts considered by this decision:\n  %s\n\n", v.ADXURL)
+	}
+
+	if v.Merge {
+		logger.Info("Merge gate passed.", "reason", v.Reason)
+		return nil
+	}
+
+	if v.Reason == "error" && !o.FailOnError {
+		logger.Error(nil, "Merge gate returned an indeterminate verdict; allowing due to --fail-on-error=false.")
+		return nil
+	}
+
+	fmt.Fprintf(os.Stderr, `
+This merge is blocked by production alerts for the components it touches.
+To unblock, do one of:
+  1. Limit the PR to bug fixes: make every commit use the conventional "fix:"
+     prefix (fix:, fix(scope):, fix!:), which exempts the PR from this gate.
+  2. Understand the alerts shown above and declare each one fixed with an
+     "Ameliorates-Alert:" trailer in the relevant commit message.
+See %s
+
+`, ameliorationDocsURL)
+	return fmt.Errorf("merge gate blocked the merge (reason: %s)", v.Reason)
+}
+
+// query POSTs the job spec, retrying transient failures (network errors and 503)
+// with exponential backoff and jitter.
+func (o *Options) query(ctx context.Context, logger logr.Logger) (verdict, error) {
+	backoff := wait.Backoff{
+		Duration: retryBaseDelay,
+		Factor:   retryFactor,
+		Jitter:   retryJitter,
+		Cap:      retryCap,
+		Steps:    o.Retries + 1,
+	}
+
+	var (
+		v       verdict
+		lastErr error
+	)
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		got, retryable, attemptErr := o.attempt(ctx)
+		if attemptErr == nil {
+			v = got
+			return true, nil
+		}
+		if !retryable {
+			return false, attemptErr
+		}
+		lastErr = attemptErr
+		logger.Error(attemptErr, "Transient merge-gate failure; will retry.")
+		return false, nil
+	})
+	if err != nil {
+		// On retry exhaustion wait returns a timeout error; surface the last
+		// transient failure, which is more actionable.
+		if lastErr != nil {
+			return verdict{}, lastErr
+		}
+		return verdict{}, err
+	}
+	return v, nil
+}
+
+// attempt performs one HTTP request. The bool reports whether the error is
+// retryable (transient).
+func (o *Options) attempt(ctx context.Context) (verdict, bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.endpoint, bytes.NewReader(o.jobSpec))
+	if err != nil {
+		return verdict{}, false, fmt.Errorf("failed to build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if o.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+o.Token)
+	}
+
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return verdict{}, true, fmt.Errorf("request to %s failed: %w", o.endpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return verdict{}, true, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var v verdict
+		if err := json.Unmarshal(body, &v); err != nil {
+			return verdict{}, false, fmt.Errorf("failed to parse verdict %q: %w", string(body), err)
+		}
+		return v, false, nil
+	case http.StatusServiceUnavailable:
+		return verdict{}, true, fmt.Errorf("merge gate temporarily unavailable (503): %s", strings.TrimSpace(string(body)))
+	default:
+		return verdict{}, false, fmt.Errorf("unexpected status %d from merge gate: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+}

--- a/test/cmd/aro-hcp-tests/merge-gate/options_test.go
+++ b/test/cmd/aro-hcp-tests/merge-gate/options_test.go
@@ -1,0 +1,47 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mergegate
+
+import "testing"
+
+const validSpec = `{"type":"presubmit","refs":{"org":"Azure","repo":"ARO-HCP"}}`
+
+func TestValidateTokenRequiresSecureURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		token   string
+		wantErr bool
+	}{
+		{name: "https with token", url: "https://dash.example.com", token: "t"},
+		{name: "http localhost with token", url: "http://localhost:8080", token: "t"},
+		{name: "http 127.0.0.1 with token", url: "http://127.0.0.1:8080", token: "t"},
+		{name: "plain http with token is rejected", url: "http://dash.example.com", token: "t", wantErr: true},
+		{name: "plain http without token is allowed", url: "http://dash.example.com", token: ""},
+		{name: "http non-loopback host with token rejected", url: "http://10.0.0.5:8080", token: "t", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &RawOptions{URL: tc.url, Token: tc.token, JobSpec: validSpec}
+			_, err := opts.Validate()
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected validation error for url=%q token=%q", tc.url, tc.token)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
observability: add component-map.yaml for the merge gate

Map repository paths to alert component labels so the release-dashboard
merge gate can determine which components a PR touches. Seeded with the
ARO-HCP-sourced, image-backed components (backend, frontend, admin,
fleet, kube-applier); components built from other repositories are not
gated and are intentionally omitted.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

test: add merge-gate subcommand

aro-hcp-tests merge-gate posts the prow JOB_SPEC to the release-dashboard
merge-gate API and fails the run when the change touches components with
unresolved production alerts. Reads JOB_SPEC / RELEASE_DASHBOARD_URL /
RELEASE_DASHBOARD_TOKEN from the environment, retries transient failures,
and fails closed on an indeterminate verdict.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

docs: document the merge gate (amelioration + bug-fix bypass)

Add docs/alerts/merge-gate.md describing why the merge gate blocks a PR,
that bug-fix PRs (all commits use the conventional fix: prefix) bypass the
gate, how to read the returned ADX query, and how to declare a fix with an
Ameliorates-Alert commit trailer. Link it from docs/alerts.md.

Signed-off-by: Steve Kuznetsov <stekuznetsov@microsoft.com>

---

