### PR TITLE
fix(infra): retry image-mirror steps on transient ACR registry errors (AROSLSRE-1919)

### DIFF
--- a/admin/pipeline.yaml
+++ b/admin/pipeline.yaml
@@ -36,6 +36,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
 - name: kusto

--- a/backend/pipeline.yaml
+++ b/backend/pipeline.yaml
@@ -36,6 +36,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
 - name: kusto

--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -36,6 +36,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
 - name: kusto

--- a/dev-infrastructure/global-pipeline-stg.yaml
+++ b/dev-infrastructure/global-pipeline-stg.yaml
@@ -401,6 +401,9 @@ resourceGroups:
       errorContainsAny:
       - "unknown_storage_failure"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
   # deploys the image mirror for the ACRs

--- a/dev-infrastructure/global-pipeline.yaml
+++ b/dev-infrastructure/global-pipeline.yaml
@@ -339,6 +339,9 @@ resourceGroups:
       errorContainsAny:
       - "unknown_storage_failure"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
   # deploys the image mirror for the ACRs

--- a/dev-infrastructure/svc-pipeline.yaml
+++ b/dev-infrastructure/svc-pipeline.yaml
@@ -933,6 +933,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
   - name: exporter-output

--- a/fleet/pipeline.yaml
+++ b/fleet/pipeline.yaml
@@ -36,6 +36,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
 - name: kusto

--- a/fleet/registration/pipeline.yaml
+++ b/fleet/registration/pipeline.yaml
@@ -36,6 +36,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
 - name: kusto

--- a/frontend/pipeline.yaml
+++ b/frontend/pipeline.yaml
@@ -36,6 +36,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
 - name: kusto

--- a/hypershiftoperator/pipeline.yaml
+++ b/hypershiftoperator/pipeline.yaml
@@ -36,6 +36,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
   - name: mirror-shared-ingress-image
@@ -62,6 +65,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
 - name: kusto

--- a/kube-applier/pipeline.yaml
+++ b/kube-applier/pipeline.yaml
@@ -36,6 +36,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
 - name: kusto

--- a/maestro/agent/pipeline.yaml
+++ b/maestro/agent/pipeline.yaml
@@ -36,6 +36,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
 - name: kusto

--- a/maestro/server/pipeline.yaml
+++ b/maestro/server/pipeline.yaml
@@ -36,6 +36,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
 - name: kusto

--- a/mgmt-agent/pipeline.yaml
+++ b/mgmt-agent/pipeline.yaml
@@ -36,6 +36,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
 - name: kusto

--- a/secret-sync-controller/pipeline.yaml
+++ b/secret-sync-controller/pipeline.yaml
@@ -36,6 +36,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
 - name: kusto

--- a/sessiongate/pipeline.yaml
+++ b/sessiongate/pipeline.yaml
@@ -36,6 +36,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
 - name: kusto

--- a/velero/pipeline.yaml
+++ b/velero/pipeline.yaml
@@ -36,6 +36,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
   - name: mirror-azure-plugin-image
@@ -62,6 +65,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
   - name: mirror-hypershift-plugin-image
@@ -88,6 +94,9 @@ resourceGroups:
       - "unknown_storage_failure"
       - "unexpected EOF"
       - "unauthorized: authentication required"
+      # Transient ACR pull/push failures during image mirroring (docker registry RegistryErrorResponse, "Please retry later").
+      - "RegistryErrorResponse"
+      - "Please retry later"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
 - name: kusto


### PR DESCRIPTION
<!-- Link to Jira issue -->
Jira: [AROSLSRE-1919](https://redhat.atlassian.net/browse/AROSLSRE-1919)

### What

Add `RegistryErrorResponse` and `Please retry later` to the `automatedRetry.errorContainsAny` list on every `ImageMirror` (mirror-image / mirror-oc-mirror-image) step across the pipelines.

### Why

During the prod Canary GlobalBuildout in eastus2euap, the `Fleet.Registration` mirror-image step failed putting the container group with `RegistryErrorResponse: An error response is received from the docker registry 'azsvcdepeus1.azurecr.io'. Please retry later.` That is a transient ACR condition, but the existing retry only matched `unknown_storage_failure`, `unexpected EOF`, and `unauthorized: authentication required`, so the step failed the rollout. Every mirror-image step pushes/pulls the same ACR and can hit this, so I added the markers to all of them.

### Testing

`make validate-config-pipelines` passes. Pipeline config change with no code path to unit test; the retry is exercised by EV2 at rollout time.

### Special notes for your reviewer

`errorContainsAny` is an OR match and case-insensitive. I matched the ACR error code `RegistryErrorResponse` plus the registry's own `Please retry later` hint. The edit is the same two lines added to each identical retry block (60 insertions across 17 files), so the diff is repetitive but mechanical. Rollout to int/stg/prod happens via sdp-pipelines after merge.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
