### PR TITLE
fix(config): remove unused poolCount from systemAgentPool

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -544,6 +544,44 @@
         "zoneRedundantMode"
       ]
     },
+    "aksSystemAgentPool": {
+      "type": "object",
+      "description": "Like aksAgentPool, but without poolCount: the system pool is always a single Microsoft.ContainerService/managedClusters/agentPools resource (defined inline on the cluster, spanning all configured zones), never looped into multiple pool resources the way userAgentPool/infraAgentPool are, so poolCount has no meaning here.",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "maxCount": {
+          "type": "number"
+        },
+        "minCount": {
+          "type": "number"
+        },
+        "osDiskSizeGB": {
+          "type": "number"
+        },
+        "vmSize": {
+          "type": "string"
+        },
+        "zones": {
+          "$ref": "#/definitions/zones",
+          "description": "Zones to use for the pools."
+        },
+        "zoneRedundantMode": {
+          "$ref": "#/definitions/zoneRedundantMode"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "maxCount",
+        "minCount",
+        "osDiskSizeGB",
+        "vmSize",
+        "zones",
+        "zoneRedundantMode"
+      ]
+    },
     "aksUpgradeSettings": {
       "type": "object",
       "additionalProperties": false,
@@ -608,7 +646,7 @@
           "$ref": "#/definitions/aksAgentPool"
         },
         "systemAgentPool": {
-          "$ref": "#/definitions/aksAgentPool"
+          "$ref": "#/definitions/aksSystemAgentPool"
         },
         "infraAgentPool": {
           "$ref": "#/definitions/aksAgentPool"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -593,7 +593,6 @@ defaults:
         maxCount: 3
         vmSize: 'Standard_D2s_v3'
         osDiskSizeGB: 32
-        poolCount: 3
         zones: ""
         zoneRedundantMode: "Auto"
       userAgentPool:
@@ -732,7 +731,6 @@ defaults:
         vmSize: 'Standard_E8ds_v6'
         osDiskSizeGB: 128
         minCount: 1
-        poolCount: 3
         zones: ""
         zoneRedundantMode: "Auto"
       userAgentPool:
@@ -1385,8 +1383,6 @@ clouds:
           infraAgentPool:
             poolCount: 1
             vmSize: 'Standard_D2s_v3'
-          systemAgentPool:
-            poolCount: 1
         prometheus:
           prometheusSpec:
             shards: 1
@@ -1402,7 +1398,6 @@ clouds:
           systemAgentPool:
             vmSize: 'Standard_E8s_v3'
             maxCount: 4
-            poolCount: 1
           userAgentPool:
             maxCount: 14
             vmSize: 'Standard_D4s_v3'

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -669,7 +669,6 @@ mgmt:
       minCount: 1
       name: system
       osDiskSizeGB: 32
-      poolCount: 1
       vmSize: Standard_D8ds_v6
       zoneRedundantMode: Auto
       zones: ""
@@ -1032,7 +1031,6 @@ svc:
       minCount: 1
       name: system
       osDiskSizeGB: 32
-      poolCount: 1
       vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -669,7 +669,6 @@ mgmt:
       minCount: 1
       name: system
       osDiskSizeGB: 32
-      poolCount: 1
       vmSize: Standard_D8ds_v6
       zoneRedundantMode: Auto
       zones: ""
@@ -1032,7 +1031,6 @@ svc:
       minCount: 1
       name: system
       osDiskSizeGB: 32
-      poolCount: 1
       vmSize: Standard_D4ds_v6
       zoneRedundantMode: Auto
       zones: ""

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -669,7 +669,6 @@ mgmt:
       minCount: 1
       name: system
       osDiskSizeGB: 128
-      poolCount: 1
       vmSize: Standard_E8s_v3
       zoneRedundantMode: Auto
       zones: ""
@@ -1030,7 +1029,6 @@ svc:
       minCount: 1
       name: system
       osDiskSizeGB: 32
-      poolCount: 1
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -669,7 +669,6 @@ mgmt:
       minCount: 1
       name: system
       osDiskSizeGB: 128
-      poolCount: 1
       vmSize: Standard_E8s_v3
       zoneRedundantMode: Auto
       zones: ""
@@ -1030,7 +1029,6 @@ svc:
       minCount: 1
       name: system
       osDiskSizeGB: 32
-      poolCount: 1
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -669,7 +669,6 @@ mgmt:
       minCount: 1
       name: system
       osDiskSizeGB: 128
-      poolCount: 1
       vmSize: Standard_E8s_v3
       zoneRedundantMode: Auto
       zones: ""
@@ -1030,7 +1029,6 @@ svc:
       minCount: 1
       name: system
       osDiskSizeGB: 32
-      poolCount: 1
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -669,7 +669,6 @@ mgmt:
       minCount: 1
       name: system
       osDiskSizeGB: 32
-      poolCount: 1
       vmSize: Standard_D4s_v3
       zoneRedundantMode: Auto
       zones: ""
@@ -1032,7 +1031,6 @@ svc:
       minCount: 1
       name: system
       osDiskSizeGB: 32
-      poolCount: 1
       vmSize: Standard_D2s_v3
       zoneRedundantMode: Auto
       zones: ""


### PR DESCRIPTION
## What

`systemAgentPool.poolCount` defaulted to `3` for both svc and mgmt AKS clusters in `config/config.yaml`, but it was never actually consumed anywhere. This PR removes it entirely from the system pool's config/schema rather than fixing the number.

## Why

`aks-cluster-base.bicep` never reads `poolCount` for the system pool. It's a single hardcoded `agentPoolProfiles` entry defined inline on the cluster (not looped into N separate pool resources like `userAgentPool`/`infraAgentPool` are via `modules/aks/pool.bicep`) - it already achieves multi-zone coverage through `availabilityZones` on that one resource. The field was pure dead config data, misleading for capacity/quota planning (implied 3x the actual vCPU consumption for the system pool).

This came up during capacity/quota planning for stg westus3 ([AROSLSRE-1843](https://redhat.atlassian.net/browse/AROSLSRE-1843)).

An earlier version of this PR tried wiring the value through bicep (constraining it to `@allowed([1])` and tagging the resource with it), but that's propagation for its own sake - the value can never be anything other than what the pool already does, so validating/tagging it doesn't add anything real. The honest fix is to remove the field entirely:

- Split a new `aksSystemAgentPool` schema definition (`aksAgentPool` minus `poolCount`) and point `systemAgentPool` at it. `userAgentPool`/`infraAgentPool` keep the original `aksAgentPool` definition unchanged, since `poolCount` is real and consumed for those.
- Remove `poolCount` from both `systemAgentPool` base defaults in `config.yaml`, and from the two dev-environment overrides that had explicitly set `poolCount: 1` for `systemAgentPool` (now redundant, and no longer a valid schema field) - these overrides independently confirmed the default was wrong.

No functional/deployment change: bicep never read this field.

## Testing

- `cd config && make materialize` - render + full test suite passed. The only rendered diff is the `poolCount` line disappearing from `systemAgentPool` blocks in the dev fixtures.
- Confirmed via repo-wide search that `poolCount` for `systemAgentPool` had no consumer anywhere in bicep or Go tooling.
- Ran the sdp-pipelines EV2 resolve-mode render check against this commit to confirm the schema/config change doesn't break EV2 manifest generation.
