### PR TITLE
fix(e2e): retry transient 401 during ARM deployment LRO polling

### DIFF
--- a/test/util/framework/azure_client_policies.go
+++ b/test/util/framework/azure_client_policies.go
@@ -162,35 +162,56 @@ func (p *requestIDPolicy) Do(req *policy.Request) (*http.Response, error) {
 	return req.Next()
 }
 
-// lroPollerRetryDeploymentNotFoundPolicy is a pipeline policy that retries transient
-// 404 DeploymentNotFound errors during ARM deployment LRO polling.
+// lroPollerRetryPolicy is a pipeline policy that retries transient errors during
+// ARM deployment LRO polling.
 //
-// This addresses Azure Resource Manager's eventual consistency behavior where
-// the operationStatuses endpoint may return 404 immediately after a deployment
-// is created, even though the deployment will eventually succeed.
+// It handles two distinct transients:
+//
+// 404 DeploymentNotFound addresses Azure Resource Manager's eventual consistency
+// behavior where the operationStatuses endpoint may return 404 immediately after
+// a deployment is created, even though the deployment will eventually succeed.
+//
+// 401 Unauthorized addresses ARM rejecting a previously-valid bearer token
+// mid-poll (observed as WWW-Authenticate error="invalid_token"). azcore's
+// BearerTokenPolicy only auto-recovers from CAE challenges carrying
+// error="insufficient_claims", and ARM installs no OnChallenge handler, so every
+// other 401 is surfaced unhandled. It does however call Expire() on the cached
+// token before giving up, so simply re-issuing the request acquires a fresh one.
 //
 // The policy only activates for GET requests to URLs matching:
 //
 //	/providers/Microsoft.Resources/deployments/{name}/operationStatuses/{id}
 //
 // All other requests pass through unmodified.
-type lroPollerRetryDeploymentNotFoundPolicy struct {
+type lroPollerRetryPolicy struct {
 	MaxRetries     int
+	MaxAuthRetries int
 	BaseBackoff    time.Duration
 	MaxBackoff     time.Duration
 	MaxRetryWindow time.Duration
 }
 
-func NewLROPollerRetryDeploymentNotFoundPolicy() *lroPollerRetryDeploymentNotFoundPolicy {
-	return &lroPollerRetryDeploymentNotFoundPolicy{
+func NewLROPollerRetryPolicy() *lroPollerRetryPolicy {
+	return &lroPollerRetryPolicy{
 		MaxRetries:     5,
+		MaxAuthRetries: 1,
 		BaseBackoff:    2 * time.Second,
 		MaxBackoff:     10 * time.Second,
 		MaxRetryWindow: 90 * time.Second,
 	}
 }
 
-func (p *lroPollerRetryDeploymentNotFoundPolicy) Do(req *policy.Request) (*http.Response, error) {
+// retryReason identifies which transient a poll response hit, so each has its own
+// attempt budget and a 401 cannot consume the DeploymentNotFound allowance.
+type retryReason int
+
+const (
+	retryNone retryReason = iota
+	retryDeploymentNotFound
+	retryUnauthorized
+)
+
+func (p *lroPollerRetryPolicy) Do(req *policy.Request) (*http.Response, error) {
 	if !strings.EqualFold(req.Raw().Method, http.MethodGet) {
 		return req.Next()
 	}
@@ -201,18 +222,19 @@ func (p *lroPollerRetryDeploymentNotFoundPolicy) Do(req *policy.Request) (*http.
 
 	start := time.Now()
 	attempt := 0
+	authAttempt := 0
 
 	for {
 
-		resp, err, retry := func(req *policy.Request) (resp *http.Response, err error, retry bool) {
+		resp, reason, err := func(req *policy.Request) (resp *http.Response, reason retryReason, err error) {
 			retryReq := req.Clone(req.Raw().Context())
 			if err := retryReq.RewindBody(); err != nil {
-				return nil, err, false
+				return nil, retryNone, err
 			}
 
 			resp, err = retryReq.Next()
 			if err == nil {
-				return resp, nil, false
+				return resp, retryNone, nil
 			}
 			defer func(resp *http.Response) {
 				if resp != nil {
@@ -223,28 +245,43 @@ func (p *lroPollerRetryDeploymentNotFoundPolicy) Do(req *policy.Request) (*http.
 			}(resp)
 
 			var respErr *azcore.ResponseError
-			if errors.As(err, &respErr) &&
-				respErr.StatusCode == http.StatusNotFound &&
-				strings.EqualFold(respErr.ErrorCode, "DeploymentNotFound") {
-				return nil, err, true
+			if errors.As(err, &respErr) {
+				switch {
+				case respErr.StatusCode == http.StatusNotFound && strings.EqualFold(respErr.ErrorCode, "DeploymentNotFound"):
+					return nil, retryDeploymentNotFound, err
+				case respErr.StatusCode == http.StatusUnauthorized:
+					return nil, retryUnauthorized, err
+				}
 			}
 			// don't retry on any other error
-			return nil, err, false
+			return nil, retryNone, err
 		}(req)
 
-		if !retry {
+		var (
+			counter *int
+			budget  int
+			logMsg  string
+		)
+		switch reason {
+		case retryNone:
 			return resp, err
+		case retryDeploymentNotFound:
+			counter, budget = &attempt, p.MaxRetries
+			logMsg = "transient 404 DeploymentNotFound on operationStatuses"
+		case retryUnauthorized:
+			counter, budget = &authAttempt, p.MaxAuthRetries
+			logMsg = "transient 401 Unauthorized on operationStatuses, retrying with a refreshed token"
 		}
 
-		if attempt >= p.MaxRetries || time.Since(start) >= p.MaxRetryWindow {
+		if *counter >= budget || time.Since(start) >= p.MaxRetryWindow {
 			err := fmt.Errorf("max retries or max retry window reached: %w", err)
 			return resp, err
 		}
 
-		sleep := p.backoff(attempt)
+		sleep := p.backoff(*counter)
 
-		ginkgo.GinkgoLogr.Info("transient 404 DeploymentNotFound on operationStatuses",
-			"attempt", attempt+1,
+		ginkgo.GinkgoLogr.Info(logMsg,
+			"attempt", *counter+1,
 			"sleep", sleep.String(),
 			"url", req.Raw().URL.String())
 
@@ -255,11 +292,11 @@ func (p *lroPollerRetryDeploymentNotFoundPolicy) Do(req *policy.Request) (*http.
 			return nil, req.Raw().Context().Err()
 		}
 
-		attempt++
+		*counter++
 	}
 }
 
-func (p *lroPollerRetryDeploymentNotFoundPolicy) backoff(attempt int) time.Duration {
+func (p *lroPollerRetryPolicy) backoff(attempt int) time.Duration {
 	sleep := min(p.BaseBackoff<<attempt, p.MaxBackoff)
 	jitter := time.Duration(rand.Int63n(int64(max(p.BaseBackoff/2, time.Millisecond))))
 	return sleep + jitter

--- a/test/util/framework/azure_client_policies_test.go
+++ b/test/util/framework/azure_client_policies_test.go
@@ -472,14 +472,14 @@ func TestSanitizeAuthHeaderPolicy(t *testing.T) {
 	})
 }
 
-func TestLROPollerRetryDeploymentNotFoundPolicy(t *testing.T) {
+func TestLROPollerRetryPolicy(t *testing.T) {
 	t.Parallel()
 
 	lroPath := "/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.Resources/deployments/my-deploy/operationStatuses/op-id"
 
 	t.Run("passes through non-GET requests", func(t *testing.T) {
 		t.Parallel()
-		pol := NewLROPollerRetryDeploymentNotFoundPolicy()
+		pol := NewLROPollerRetryPolicy()
 		transport := &fakeTransport{
 			do: func(r *http.Request) (*http.Response, error) {
 				return okResponse()
@@ -496,7 +496,7 @@ func TestLROPollerRetryDeploymentNotFoundPolicy(t *testing.T) {
 
 	t.Run("passes through non-matching paths", func(t *testing.T) {
 		t.Parallel()
-		pol := NewLROPollerRetryDeploymentNotFoundPolicy()
+		pol := NewLROPollerRetryPolicy()
 		transport := &fakeTransport{
 			do: func(r *http.Request) (*http.Response, error) {
 				return okResponse()
@@ -525,7 +525,7 @@ func TestLROPollerRetryDeploymentNotFoundPolicy(t *testing.T) {
 
 	t.Run("returns success on first attempt", func(t *testing.T) {
 		t.Parallel()
-		pol := &lroPollerRetryDeploymentNotFoundPolicy{
+		pol := &lroPollerRetryPolicy{
 			MaxRetries:     5,
 			BaseBackoff:    time.Millisecond,
 			MaxBackoff:     5 * time.Millisecond,
@@ -548,7 +548,7 @@ func TestLROPollerRetryDeploymentNotFoundPolicy(t *testing.T) {
 	t.Run("retries DeploymentNotFound then succeeds", func(t *testing.T) {
 		t.Parallel()
 		callCount := 0
-		pol := &lroPollerRetryDeploymentNotFoundPolicy{
+		pol := &lroPollerRetryPolicy{
 			MaxRetries:     5,
 			BaseBackoff:    time.Millisecond,
 			MaxBackoff:     5 * time.Millisecond,
@@ -579,7 +579,7 @@ func TestLROPollerRetryDeploymentNotFoundPolicy(t *testing.T) {
 	t.Run("exhausts retries on persistent DeploymentNotFound", func(t *testing.T) {
 		t.Parallel()
 		callCount := 0
-		pol := &lroPollerRetryDeploymentNotFoundPolicy{
+		pol := &lroPollerRetryPolicy{
 			MaxRetries:     3,
 			BaseBackoff:    time.Millisecond,
 			MaxBackoff:     5 * time.Millisecond,
@@ -607,7 +607,7 @@ func TestLROPollerRetryDeploymentNotFoundPolicy(t *testing.T) {
 	t.Run("does not retry non-DeploymentNotFound errors", func(t *testing.T) {
 		t.Parallel()
 		callCount := 0
-		pol := &lroPollerRetryDeploymentNotFoundPolicy{
+		pol := &lroPollerRetryPolicy{
 			MaxRetries:     5,
 			BaseBackoff:    time.Millisecond,
 			MaxBackoff:     5 * time.Millisecond,
@@ -631,10 +631,131 @@ func TestLROPollerRetryDeploymentNotFoundPolicy(t *testing.T) {
 		assert.Equal(t, 1, callCount)
 	})
 
+	t.Run("retries 401 Unauthorized then succeeds", func(t *testing.T) {
+		t.Parallel()
+		callCount := 0
+		pol := &lroPollerRetryPolicy{
+			MaxRetries:     5,
+			MaxAuthRetries: 1,
+			BaseBackoff:    time.Millisecond,
+			MaxBackoff:     5 * time.Millisecond,
+			MaxRetryWindow: time.Second,
+		}
+		transport := &fakeTransport{
+			do: func(r *http.Request) (*http.Response, error) {
+				callCount++
+				if callCount == 1 {
+					return nil, &azcore.ResponseError{
+						StatusCode: http.StatusUnauthorized,
+						ErrorCode:  "AuthenticationFailed",
+					}
+				}
+				return okResponse()
+			},
+		}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(context.Background(), http.MethodGet, "https://management.azure.com"+lroPath)
+		require.NoError(t, err)
+
+		resp, err := pipeline.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("exhausts auth retries on persistent 401", func(t *testing.T) {
+		t.Parallel()
+		callCount := 0
+		pol := &lroPollerRetryPolicy{
+			MaxRetries:     5,
+			MaxAuthRetries: 1,
+			BaseBackoff:    time.Millisecond,
+			MaxBackoff:     5 * time.Millisecond,
+			MaxRetryWindow: time.Second,
+		}
+		transport := &fakeTransport{
+			do: func(r *http.Request) (*http.Response, error) {
+				callCount++
+				return nil, &azcore.ResponseError{
+					StatusCode: http.StatusUnauthorized,
+					ErrorCode:  "AuthenticationFailed",
+				}
+			},
+		}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(context.Background(), http.MethodGet, "https://management.azure.com"+lroPath)
+		require.NoError(t, err)
+
+		_, err = pipeline.Do(req)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "max retries or max retry window reached")
+		assert.Equal(t, 2, callCount)
+	})
+
+	t.Run("401 does not consume the DeploymentNotFound budget", func(t *testing.T) {
+		t.Parallel()
+		callCount := 0
+		pol := &lroPollerRetryPolicy{
+			MaxRetries:     2,
+			MaxAuthRetries: 1,
+			BaseBackoff:    time.Millisecond,
+			MaxBackoff:     5 * time.Millisecond,
+			MaxRetryWindow: time.Second,
+		}
+		transport := &fakeTransport{
+			do: func(r *http.Request) (*http.Response, error) {
+				callCount++
+				switch callCount {
+				case 1:
+					return nil, &azcore.ResponseError{
+						StatusCode: http.StatusUnauthorized,
+						ErrorCode:  "AuthenticationFailed",
+					}
+				case 2, 3:
+					return nil, &azcore.ResponseError{
+						StatusCode: http.StatusNotFound,
+						ErrorCode:  "DeploymentNotFound",
+					}
+				}
+				return okResponse()
+			},
+		}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(context.Background(), http.MethodGet, "https://management.azure.com"+lroPath)
+		require.NoError(t, err)
+
+		resp, err := pipeline.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, 4, callCount)
+	})
+
+	t.Run("does not retry 401 on non-matching paths", func(t *testing.T) {
+		t.Parallel()
+		callCount := 0
+		pol := NewLROPollerRetryPolicy()
+		transport := &fakeTransport{
+			do: func(r *http.Request) (*http.Response, error) {
+				callCount++
+				return nil, &azcore.ResponseError{
+					StatusCode: http.StatusUnauthorized,
+					ErrorCode:  "AuthenticationFailed",
+				}
+			},
+		}
+		pipeline := newTestPipeline(pol, transport)
+		req, err := runtime.NewRequest(context.Background(), http.MethodGet, "https://management.azure.com/subscriptions/sub-id/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm")
+		require.NoError(t, err)
+
+		_, err = pipeline.Do(req)
+		assert.Error(t, err)
+		assert.Equal(t, 1, callCount)
+	})
+
 	t.Run("respects context cancellation", func(t *testing.T) {
 		t.Parallel()
 		ctx, cancel := context.WithCancel(context.Background())
-		pol := &lroPollerRetryDeploymentNotFoundPolicy{
+		pol := &lroPollerRetryPolicy{
 			MaxRetries:     10,
 			BaseBackoff:    time.Millisecond,
 			MaxBackoff:     5 * time.Millisecond,
@@ -660,7 +781,7 @@ func TestLROPollerRetryDeploymentNotFoundPolicy(t *testing.T) {
 
 	t.Run("backoff respects bounds", func(t *testing.T) {
 		t.Parallel()
-		pol := &lroPollerRetryDeploymentNotFoundPolicy{
+		pol := &lroPollerRetryPolicy{
 			BaseBackoff: 2 * time.Second,
 			MaxBackoff:  10 * time.Second,
 		}

--- a/test/util/framework/per_invocation_framework.go
+++ b/test/util/framework/per_invocation_framework.go
@@ -187,7 +187,7 @@ func (tc *perBinaryInvocationTestContext) getClientFactoryOptions() *azcorearm.C
 	clientOpts := azsdk.NewClientOptions(azsdk.ComponentE2E)
 	clientOpts.Retry = azureRetryOptions
 	clientOpts.PerCallPolicies = []policy.Policy{
-		NewLROPollerRetryDeploymentNotFoundPolicy(),
+		NewLROPollerRetryPolicy(),
 		&sanitizeAuthHeaderPolicy{},
 	}
 	if tc.isDevelopmentEnvironment {


### PR DESCRIPTION
[AROSLSRE-1920](https://redhat.atlassian.net/browse/AROSLSRE-1920)

### What

Extends the existing `operationStatuses` poller policy so it retries a transient `401 Unauthorized` once, alongside the `404 DeploymentNotFound` handling it already does.

The two transients get **separate attempt budgets**, so a 401 cannot consume the `DeploymentNotFound` allowance. Path scope is unchanged — GET requests to:

```
/providers/Microsoft.Resources/deployments/{name}/operationStatuses/{id}
```

Renamed `lroPollerRetryDeploymentNotFoundPolicy` → `lroPollerRetryPolicy`, since the name no longer described what it does.

### Why

In [prow run 2092949454679183360](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel/2092949454679183360) (switzerlandnorth, 2026-08-27 13:28), `Customer should be able to update node pool labels and taints` failed in `creating customer resources`. The sequence:

1. Credential acquisition — OK
2. Resource group creation — OK
3. `PUT` of deployment `customer-infra-cluster-np-labels-taints-2l24k9` — OK
4. Early poll of `operationStatuses/...` — `200 OK`
5. Later poll of the **same** endpoint — `401 Unauthorized`, `WWW-Authenticate: ... error="invalid_token"`

That aborted `PollUntilDone`. The spec never reached the RP — no `frontendLogs` rows exist for the resource group — so this is not a node-pool defect. An otherwise-healthy run is lost before it starts doing useful work.

**azcore will not recover from this on its own.** In `runtime.BearerTokenPolicy.handleChallenge` (azcore v1.21.1):

- CAE auto-retry is gated on `c.params["error"] == "insufficient_claims"` with a `claims` value. `error="invalid_token"` does not match, so `parseCAEChallenge` returns nil.
- ARM's `arm/runtime.NewBearerTokenPolicy` sets only `AuthorizationHandler{OnRequest: ...}`; `OnChallenge` is nil.
- Both branches miss, control reaches `default:`, and the 401 is returned to the pipeline untouched.

Crucially, it calls `b.mainResource.Expire()` on **every** 401 *before* deciding not to handle it. The cached token is therefore already invalidated by the time the error reaches a PerCall policy, so simply re-issuing the request acquires a fresh token. That is what makes a bounded retry here sufficient rather than a no-op replay of the same bad token.

Adding `401` to `policy.RetryOptions.StatusCodes` was rejected as an alternative: azcore matches on status code only and cannot scope to an endpoint, so it would slow every genuine authz failure across the suite.

### Testing

Unit tests, added alongside the existing ones in `azure_client_policies_test.go`:

| Test | Asserts |
| --- | --- |
| `retries 401 Unauthorized then succeeds` | one retry, 2 transport calls |
| `exhausts auth retries on persistent 401` | stops at the budget, 2 calls, surfaces the error |
| `401 does not consume the DeploymentNotFound budget` | 401 → 404 → 404 → OK all succeed with `MaxRetries: 2` |
| `does not retry 401 on non-matching paths` | a 401 outside the poller path is untouched, 1 call |

```
$ golangci-lint-v2.5.0 run --build-tags='E2Etests' ./util/framework/...
0 issues.

$ go test ./util/framework/ -count=1
ok      github.com/Azure/ARO-HCP/test/util/framework    0.106s
```

`gofmt -l` and `go vet` both clean. No E2E changes.

### Special notes for your reviewer

- **Frequency is 1 occurrence.** This was the "Related but distinct — not actioned" item in [AROSLSRE-1920](https://redhat.atlassian.net/browse/AROSLSRE-1920), recorded but deliberately not fixed at the time. The argument for doing it now is that the policy and its test scaffolding already exist, so the marginal cost is small. Happy to hold if you'd rather wait for a recurrence.
- **`MaxAuthRetries` defaults to 1**, deliberately. A broad 401 retry would turn a genuine RBAC misconfiguration into a slow failure instead of a fast one; one attempt covers the token-refresh case without meaningfully delaying real authz errors.
- **Any 401 on the guarded path is retried**, not just `invalid_token`. ARM surfaces this as `AuthenticationFailed` in some paths and `invalid_token` in others; filtering on the error code risks missing variants, and the path scope already keeps the blast radius tiny.
- `tooling/templatize/pkg/pipeline/arm_retry_policy.go` carries an independent copy of the 404-only policy. It is a separate package serving the deployment tool rather than the e2e harness, so I left it alone — flagging it in case you want it aligned.
