### PR TITLE
fix(arobit): stop forwarder OOMKill via emitter buffer limit and add memory alert coverage (AROSLSRE-1928)

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedKustoOnlyServicePrometheusAlertingRules.bicep
@@ -1802,7 +1802,7 @@ This may indicate a memory leak or workload growth that requires right-sizing th
           summary: '{{ $labels.container }} in {{ $labels.namespace }} exceeds 1.5x its memory request on cluster {{ $labels.cluster }}. pod:{{ $labels.pod }}'
           title: '{{ $labels.container }} in {{ $labels.namespace }} exceeds 1.5x its memory request on cluster {{ $labels.cluster }}. pod:{{ $labels.pod }}'
         }
-        expression: '(container_memory_working_set_bytes{container!="",namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"} / on (namespace, pod, container, cluster) group_left () max by (namespace, pod, container, cluster) (kube_pod_container_resource_requests{job="kube-state-metrics",namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate",resource="memory"})) > 1.5'
+        expression: '(container_memory_working_set_bytes{container!="",namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|arobit|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"} / on (namespace, pod, container, cluster) group_left () max by (namespace, pod, container, cluster) (kube_pod_container_resource_requests{job="kube-state-metrics",namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|arobit|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate",resource="memory"})) > 1.5'
         for: 'PT15M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
@@ -1838,7 +1838,7 @@ Investigate for potential memory leaks or increased workload.
           summary: '{{ $labels.container }} in {{ $labels.namespace }} memory trending toward 2x its request on cluster {{ $labels.cluster }}. pod:{{ $labels.pod }}'
           title: '{{ $labels.container }} in {{ $labels.namespace }} memory trending toward 2x its request on cluster {{ $labels.cluster }}. pod:{{ $labels.pod }}'
         }
-        expression: '(predict_linear(container_memory_working_set_bytes{container!="",namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"}[6h], 4 * 3600) / on (namespace, pod, container, cluster) group_left () max by (namespace, pod, container, cluster) (kube_pod_container_resource_requests{job="kube-state-metrics",namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate",resource="memory"})) > 2'
+        expression: '(predict_linear(container_memory_working_set_bytes{container!="",namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|arobit|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"}[6h], 4 * 3600) / on (namespace, pod, container, cluster) group_left () max by (namespace, pod, container, cluster) (kube_pod_container_resource_requests{job="kube-state-metrics",namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|arobit|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate",resource="memory"})) > 2'
         for: 'PT30M'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
@@ -142,6 +142,7 @@ data:
         Match                 kubernetes.*
         multiline.parser      klog
         multiline.key_content log
+        Emitter_Mem_Buf_Limit 50M
 
     [FILTER]
         # Drop noisy kube-proxy topology.go INFO messages that generate 10x log volume
@@ -801,7 +802,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 6410116a85ebfb861baa74f423692c70c4390d88c1ede544e72a1b10432562a2
+        checksum/configmap: cfdd034fd318877833b68e46ecaa9066ec801f76e434e7543128ff4c29afa171
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
@@ -142,6 +142,7 @@ data:
         Match                 kubernetes.*
         multiline.parser      klog
         multiline.key_content log
+        Emitter_Mem_Buf_Limit 50M
 
     [FILTER]
         # Drop noisy kube-proxy topology.go INFO messages that generate 10x log volume
@@ -634,7 +635,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 7fefe43779be7bca010b892f93b1ac5d8f0505b1d92f4961c2f276b742d5a186
+        checksum/configmap: 86202014b0d855a6b68f09d25890639546ad0017836d39b9f0c76bb93cd5cd2d
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/alerts/serviceMemoryResources-prometheusRule.yaml
+++ b/observability/alerts/serviceMemoryResources-prometheusRule.yaml
@@ -21,10 +21,10 @@ spec:
     - alert: ServiceMemoryDrift
       expr: |
         (
-          container_memory_working_set_bytes{container!="", namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"}
+          container_memory_working_set_bytes{container!="", namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|arobit|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"}
           / on(namespace, pod, container, cluster) group_left()
           max by(namespace, pod, container, cluster) (
-            kube_pod_container_resource_requests{resource="memory", job="kube-state-metrics", namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"}
+            kube_pod_container_resource_requests{resource="memory", job="kube-state-metrics", namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|arobit|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"}
           )
         ) > 1.5
       for: 15m
@@ -42,11 +42,11 @@ spec:
       expr: |
         (
           predict_linear(
-            container_memory_working_set_bytes{container!="", namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"}[6h], 4 * 3600
+            container_memory_working_set_bytes{container!="", namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|arobit|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"}[6h], 4 * 3600
           )
           / on(namespace, pod, container, cluster) group_left()
           max by(namespace, pod, container, cluster) (
-            kube_pod_container_resource_requests{resource="memory", job="kube-state-metrics", namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"}
+            kube_pod_container_resource_requests{resource="memory", job="kube-state-metrics", namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|arobit|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"}
           )
         ) > 2.0
       for: 30m

--- a/observability/alerts/serviceMemoryResources-prometheusRule_test.yaml
+++ b/observability/alerts/serviceMemoryResources-prometheusRule_test.yaml
@@ -67,6 +67,33 @@ tests:
           This may indicate a memory leak or workload growth that requires right-sizing the request in config.yaml.
         runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/service-memory-resources.md
         owning_team: hcp-sl
+# ServiceMemoryDrift - alert fires for arobit namespace too (AROSLSRE-1928)
+- interval: 1m
+  input_series:
+  - series: 'container_memory_working_set_bytes{container="fluentbit", namespace="arobit", pod="arobit-forwarder-0", cluster="test"}'
+    values: "220200960+0x20"
+  - series: 'kube_pod_container_resource_requests{container="fluentbit", namespace="arobit", pod="arobit-forwarder-0", cluster="test", resource="memory", job="kube-state-metrics"}'
+    values: "134217728+0x20"
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: ServiceMemoryDrift
+    exp_alerts:
+    - exp_labels:
+        alertname: ServiceMemoryDrift
+        severity: warning
+        team: hcp-sl
+        component: service-memory
+        cluster: test
+        container: fluentbit
+        namespace: arobit
+        pod: arobit-forwarder-0
+      exp_annotations:
+        summary: fluentbit in arobit exceeds 1.5x its memory request on cluster test. pod:arobit-forwarder-0
+        description: |
+          Container fluentbit in pod arobit-forwarder-0 (namespace arobit) on cluster test is using 164.1% of its memory request for more than 15 minutes.
+          This may indicate a memory leak or workload growth that requires right-sizing the request in config.yaml.
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/service-memory-resources.md
+        owning_team: hcp-sl
 # ServiceMemoryDrift - no alert for namespaces outside the regex
 - interval: 1m
   input_series:
@@ -118,3 +145,31 @@ tests:
   - eval_time: 390m
     alertname: ServiceMemoryTrend
     exp_alerts: []
+# ServiceMemoryTrend - alert fires for arobit namespace too
+- interval: 1m
+  input_series:
+  - series: 'container_memory_working_set_bytes{container="fluentbit", namespace="arobit", pod="arobit-forwarder-0", cluster="test"}'
+    values: "134217728+1048576x390"
+  - series: 'kube_pod_container_resource_requests{container="fluentbit", namespace="arobit", pod="arobit-forwarder-0", cluster="test", resource="memory", job="kube-state-metrics"}'
+    values: "134217728+0x390"
+  alert_rule_test:
+  - eval_time: 390m
+    alertname: ServiceMemoryTrend
+    exp_alerts:
+    - exp_labels:
+        alertname: ServiceMemoryTrend
+        severity: info
+        team: hcp-sl
+        component: service-memory
+        cluster: test
+        container: fluentbit
+        namespace: arobit
+        pod: arobit-forwarder-0
+      exp_annotations:
+        summary: fluentbit in arobit memory trending toward 2x its request on cluster test. pod:arobit-forwarder-0
+        description: |
+          Container fluentbit in pod arobit-forwarder-0 (namespace arobit) on cluster test memory is growing steadily.
+          At the current rate over the past 6 hours, it will exceed 2x its memory request within 4 hours.
+          Investigate for potential memory leaks or increased workload.
+        runbook_url: https://github.com/Azure/ARO-HCP/blob/main/docs/alerts/service-memory-resources.md
+        owning_team: hcp-sl

--- a/observability/arobit/deploy/templates/forwarder-configmap.yaml
+++ b/observability/arobit/deploy/templates/forwarder-configmap.yaml
@@ -148,6 +148,7 @@ data:
         Match                 kubernetes.*
         multiline.parser      klog
         multiline.key_content log
+        Emitter_Mem_Buf_Limit 50M
 
     [FILTER]
         # Drop noisy kube-proxy topology.go INFO messages that generate 10x log volume

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
@@ -142,6 +142,7 @@ data:
         Match                 kubernetes.*
         multiline.parser      klog
         multiline.key_content log
+        Emitter_Mem_Buf_Limit 50M
 
     [FILTER]
         # Drop noisy kube-proxy topology.go INFO messages that generate 10x log volume
@@ -533,7 +534,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 80175949321a476b74cc7a8a94f396dee387c2cacb38ebfd9c66e499dfbefc5b
+        checksum/configmap: 4ff5a12b18a32a1a100d7a33068c0110983b25e8672cfe1817da72d77ab8a87d
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
@@ -141,6 +141,7 @@ data:
         Match                 kubernetes.*
         multiline.parser      klog
         multiline.key_content log
+        Emitter_Mem_Buf_Limit 50M
 
     [FILTER]
         # Drop noisy kube-proxy topology.go INFO messages that generate 10x log volume
@@ -633,7 +634,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 143ecc3bfdcc32d58596d637fc25318b5cadd3cc961e1d3d13deb13dc7c4d42d
+        checksum/configmap: a165c96ca9665e4867305467131975f39e9444f1052bb95c4812f3dd7a85e713
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
@@ -142,6 +142,7 @@ data:
         Match                 kubernetes.*
         multiline.parser      klog
         multiline.key_content log
+        Emitter_Mem_Buf_Limit 50M
 
     [FILTER]
         # Drop noisy kube-proxy topology.go INFO messages that generate 10x log volume
@@ -634,7 +635,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 888f7a416f236eeabeb01a9465e6bb594c47ee5e6f3921af5fc4f3f557f29061
+        checksum/configmap: 726cb469095342e57acfa7edd56befd37879cb19b8f94a70ee65c668a0789b89
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -144,6 +144,7 @@ data:
         Match                 kubernetes.*
         multiline.parser      klog
         multiline.key_content log
+        Emitter_Mem_Buf_Limit 50M
 
     [FILTER]
         # Drop noisy kube-proxy topology.go INFO messages that generate 10x log volume
@@ -997,7 +998,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 35482d7d830c2e71804253e8311a4f55d5c59f93b6cb4f46c513f2f030f8d4a5
+        checksum/configmap: 5b0f7652584a80bc9ce7a000ad45161157cc477a289a0e5222ba0e5a571e334a
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
@@ -142,6 +142,7 @@ data:
         Match                 kubernetes.*
         multiline.parser      klog
         multiline.key_content log
+        Emitter_Mem_Buf_Limit 50M
 
     [FILTER]
         # Drop noisy kube-proxy topology.go INFO messages that generate 10x log volume
@@ -634,7 +635,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 7572fb4a6c4b6d03c798dea3e80408fb86a55e91e64601ffc6bd16bb2a1a455a
+        checksum/configmap: 90bdb484f02c5034be1f81a34fc53c89a4bcda8e291576e97be33b67d3a65aa1
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'


### PR DESCRIPTION
Jira: [AROSLSRE-1928](https://redhat.atlassian.net/browse/AROSLSRE-1928)

### What

Two commits, one per subtask, fixing the `arobit-forwarder` (fluent-bit) OOMKill/probe-failure loop:

1. [AROSLSRE-1932](https://redhat.atlassian.net/browse/AROSLSRE-1932) - add `arobit` to the `ServiceMemoryDrift`/`ServiceMemoryTrend` alert namespace regex.
2. [AROSLSRE-1931](https://redhat.atlassian.net/browse/AROSLSRE-1931) - **root cause fix**: `filter.multiline_klog` had no explicit `Emitter_Mem_Buf_Limit`, silently defaulting to fluent-bit's 10MB ceiling. Under normal `aro-hcp-backend` log bursts this paused the whole pipeline (incl. the health-probe endpoint) for 15-90s at a time. Set to `50M`, matching the `forward` input.

Dropped the [AROSLSRE-1930](https://redhat.atlassian.net/browse/AROSLSRE-1930) memory request/limit bump from this PR - prod resource config is owned in sdp-pipelines, not here, so that's handled separately.

### Why

[AROSLSRE-1927](https://redhat.atlassian.net/browse/AROSLSRE-1927): the `fluentbit` container was OOMKilled under normal prod log volume, failing probes and blocking an EV2 rollout. Probes/limits themselves were already correctly sized - the buffer starvation was masking that, so they're unchanged here.

### Testing

`make -C config materialize` + `make -C tooling/helmtest test` pass after each commit. Root-cause fix live-tested in prod eastus2 via JIT kubectl: 0 restarts after applying, vs. repeated OOMKill/BackOff before.

### PR Checklist

- [x] Tested changes locally
- [x] Applicable docs updated (N/A - config/alert only)
- [x] Added/updated tests
