### PR TITLE
fix(e2e): fall back to 20240610 admin creds when 0901 poll fails on unregistered API version (AROSLSRE-1933)

### DIFF
--- a/test/util/framework/helpers_v20260901preview.go
+++ b/test/util/framework/helpers_v20260901preview.go
@@ -25,6 +25,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -36,6 +38,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -767,6 +770,38 @@ func (tc *perItOrDescribeTestContext) get20260901ClientFactoryUnlocked(ctx conte
 	return tc.clientFactory20260901, nil
 }
 
+// isAPIVersionUnavailableError returns true if err indicates that the
+// 2026-09-01-preview API version is not registered for the target
+// subscription/location (e.g. during the rollout window, or in
+// subscriptions that were never onboarded to this preview version). This is
+// distinct from an operation actually failing after it started, which should
+// not be silently retried on a different API version.
+func isAPIVersionUnavailableError(err error) bool {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	return respErr.StatusCode == http.StatusBadRequest &&
+		strings.Contains(respErr.ErrorCode, "NoRegisteredProviderFound")
+}
+
+// fallbackAdminRESTConfigTo20240610 re-requests admin credentials via the
+// stable 20240610 API version. Used when the 2026-09-01-preview path cannot
+// be used because that API version isn't available in this environment.
+func (tc *perItOrDescribeTestContext) fallbackAdminRESTConfigTo20240610(
+	ctx context.Context,
+	resourceGroupName string,
+	hcpClusterName string,
+	timeout time.Duration,
+	causeErr error,
+) (*rest.Config, error) {
+	fallbackFactory, fallbackErr := tc.Get20240610ClientFactory(ctx)
+	if fallbackErr != nil {
+		return nil, fmt.Errorf("0901 credential request failed: %w; fallback client factory error: %w", causeErr, fallbackErr)
+	}
+	return tc.GetAdminRESTConfigForHCPCluster20240610(ctx, fallbackFactory.NewHcpOpenShiftClustersClient(), resourceGroupName, hcpClusterName, timeout)
+}
+
 func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster20260901(
 	ctx context.Context,
 	hcpClient *hcpsdk20260901preview.HcpOpenShiftClustersClient,
@@ -810,11 +845,7 @@ func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster20260901(
 	)
 	if err != nil {
 		// Fall back to the old 0240610 mechanism during the transition period.
-		fallbackFactory, fallbackErr := tc.Get20240610ClientFactory(ctx)
-		if fallbackErr != nil {
-			return nil, fmt.Errorf("0901 credential request failed: %w; fallback client factory error: %w", err, fallbackErr)
-		}
-		return tc.GetAdminRESTConfigForHCPCluster20240610(ctx, fallbackFactory.NewHcpOpenShiftClustersClient(), resourceGroupName, hcpClusterName, timeout)
+		return tc.fallbackAdminRESTConfigTo20240610(ctx, resourceGroupName, hcpClusterName, timeout, err)
 	}
 
 	operationResult, err := adminCredentialRequestPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
@@ -823,6 +854,15 @@ func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster20260901(
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return nil, fmt.Errorf("failed waiting for hcpCluster=%q in resourcegroup=%q to finish getting creds, caused by: %w, error: %w", hcpClusterName, resourceGroupName, context.Cause(ctx), err)
+		}
+		if isAPIVersionUnavailableError(err) {
+			// The initial request succeeded (the resource/action itself is
+			// registered), but polling locations/hcpOperationStatuses at
+			// 2026-09-01-preview failed because that api-version isn't
+			// registered for this subscription/location. Fall back to the
+			// old 0240610 mechanism during the transition period, same as
+			// when the initial request fails outright.
+			return tc.fallbackAdminRESTConfigTo20240610(ctx, resourceGroupName, hcpClusterName, timeout, err)
 		}
 		return nil, fmt.Errorf("failed waiting for hcpCluster=%q in resourcegroup=%q to finish getting creds: %w", hcpClusterName, resourceGroupName, err)
 	}

--- a/test/util/framework/helpers_v20260901preview.go
+++ b/test/util/framework/helpers_v20260901preview.go
@@ -25,7 +25,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -775,14 +774,16 @@ func (tc *perItOrDescribeTestContext) get20260901ClientFactoryUnlocked(ctx conte
 // subscription/location (e.g. during the rollout window, or in
 // subscriptions that were never onboarded to this preview version). This is
 // distinct from an operation actually failing after it started, which should
-// not be silently retried on a different API version.
+// not be silently retried on a different API version. NoRegisteredProviderFound
+// isn't pinned to a single HTTP status across endpoints/rollout state, so this
+// only checks the ARM error code (matching the convention used elsewhere in
+// the e2e suite, e.g. isAPINotDeployedError).
 func isAPIVersionUnavailableError(err error) bool {
 	var respErr *azcore.ResponseError
 	if !errors.As(err, &respErr) {
 		return false
 	}
-	return respErr.StatusCode == http.StatusBadRequest &&
-		strings.Contains(respErr.ErrorCode, "NoRegisteredProviderFound")
+	return strings.Contains(respErr.ErrorCode, "NoRegisteredProviderFound")
 }
 
 // fallbackAdminRESTConfigTo20240610 re-requests admin credentials via the
@@ -844,7 +845,7 @@ func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster20260901(
 		nil,
 	)
 	if err != nil {
-		// Fall back to the old 0240610 mechanism during the transition period.
+		// Fall back to the old 20240610 mechanism during the transition period.
 		return tc.fallbackAdminRESTConfigTo20240610(ctx, resourceGroupName, hcpClusterName, timeout, err)
 	}
 
@@ -860,7 +861,7 @@ func (tc *perItOrDescribeTestContext) GetAdminRESTConfigForHCPCluster20260901(
 			// registered), but polling locations/hcpOperationStatuses at
 			// 2026-09-01-preview failed because that api-version isn't
 			// registered for this subscription/location. Fall back to the
-			// old 0240610 mechanism during the transition period, same as
+			// old 20240610 mechanism during the transition period, same as
 			// when the initial request fails outright.
 			return tc.fallbackAdminRESTConfigTo20240610(ctx, resourceGroupName, hcpClusterName, timeout, err)
 		}


### PR DESCRIPTION
[AROSLSRE-1933](https://redhat.atlassian.net/browse/AROSLSRE-1933)

### What

Adds a fallback path in `GetAdminRESTConfigForHCPCluster20260901` so that if `PollUntilDone` fails while polling `locations/hcpOperationStatuses` at api-version `2026-09-01-preview`, the helper falls back to the stable `20240610` path, the same way it already does when the initial `BeginRequestAdminCredential` call fails.

### Why

Today's UK South e2e failures (`NoRegisteredProviderFound` for `locations/hcpOperationStatuses` at api-version `2026-09-01-preview`) surfaced this gap. `GetAdminRESTConfigForHCPCluster20260901` is used by 25+ e2e tests to fetch admin credentials regardless of which API version created the cluster. In subscriptions/regions where `2026-09-01-preview` isn't registered yet (e.g. the Test Tenant e2e subscriptions used for UK South, or during ARM rollout propagation lag), the initial request can succeed while the poll fails, and with no fallback for that failure mode, every e2e test needing admin credentials failed outright.

### Testing

- `go build ./...` for the `test` module passes.
- `go vet ./util/framework/...` passes.
- `gofmt -l` reports no formatting issues on the changed file.
- No new unit test added for this specific fallback branch; happy to add one if reviewers want coverage for a faked `NoRegisteredProviderFound` response from the poller.

### Special notes for your reviewer

`context.DeadlineExceeded` is still returned as-is and not masked by the new fallback, so genuine timeouts keep their existing behavior.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
