### PR TITLE
test: trim releaseImages noise in nodepool upgrade failure output (AROSLSRE-1938)

### DIFF
--- a/test/util/verifiers/nodes.go
+++ b/test/util/verifiers/nodes.go
@@ -232,18 +232,41 @@ type nodeSummary struct {
 func summarizeNodes(nodes []corev1.Node) []nodeSummary {
 	summaries := make([]nodeSummary, len(nodes))
 	for i, node := range nodes {
-		var releaseImages []string
-		for _, img := range node.Status.Images {
-			releaseImages = append(releaseImages, img.Names...)
-		}
 		summaries[i] = nodeSummary{
 			Name:                    node.Name,
 			Ready:                   nodeReady(to.Ptr(node)),
 			ContainerRuntimeVersion: node.Status.NodeInfo.ContainerRuntimeVersion,
-			ReleaseImages:           releaseImages,
+			ReleaseImages:           summarizeReleaseImages(node.Status.Images),
 		}
 	}
 	return summaries
+}
+
+// maxReleaseImagesInSummary caps how many release image names appear in a node summary used
+// for human-readable error output. The verification logic (nodeReleaseImagesUpdated) still
+// compares the node's complete, untruncated set of image names; this cap only affects what
+// gets printed on failure.
+const maxReleaseImagesInSummary = 5
+
+// summarizeReleaseImages returns a short, deduplicated list of release image names for use in
+// error output. A single image is typically referenced by several aliases in img.Names (e.g. a
+// "repo@sha256:..." digest pull spec and a "repo:tag" tag pointing at the same image), even
+// though the node can only be running one version of that image. Keeping every alias for every
+// image on the node produces failure messages with dozens of near-duplicate entries that don't
+// help diagnose which OCP/release version is actually running, so this keeps one representative
+// name per image and truncates the result.
+func summarizeReleaseImages(images []corev1.ContainerImage) []string {
+	var names []string
+	for _, img := range images {
+		if len(img.Names) > 0 {
+			names = append(names, img.Names[0])
+		}
+	}
+	if len(names) > maxReleaseImagesInSummary {
+		elided := len(names) - maxReleaseImagesInSummary
+		names = append(names[:maxReleaseImagesInSummary], fmt.Sprintf("(+%d more)", elided))
+	}
+	return names
 }
 
 func (v verifyNodePoolUpgrade) Name() string {

--- a/test/util/verifiers/nodes.go
+++ b/test/util/verifiers/nodes.go
@@ -248,13 +248,15 @@ func summarizeNodes(nodes []corev1.Node) []nodeSummary {
 // gets printed on failure.
 const maxReleaseImagesInSummary = 5
 
-// summarizeReleaseImages returns a short, deduplicated list of release image names for use in
-// error output. A single image is typically referenced by several aliases in img.Names (e.g. a
-// "repo@sha256:..." digest pull spec and a "repo:tag" tag pointing at the same image), even
-// though the node can only be running one version of that image. Keeping every alias for every
-// image on the node produces failure messages with dozens of near-duplicate entries that don't
-// help diagnose which OCP/release version is actually running, so this keeps one representative
-// name per image and truncates the result.
+// summarizeReleaseImages returns a short list of release image names for use in error output:
+// one representative name per image, truncated to maxReleaseImagesInSummary entries with an
+// "(+N more)" marker appended if any were elided (so the returned slice can have up to
+// maxReleaseImagesInSummary+1 elements). A single image is typically referenced by several
+// aliases in img.Names (e.g. a "repo@sha256:..." digest pull spec and a "repo:tag" tag pointing
+// at the same image), even though the node can only be running one version of that image.
+// Keeping every alias for every image on the node produces failure messages with dozens of
+// near-duplicate entries that don't help diagnose which OCP/release version is actually running,
+// so this keeps only the first name per image.
 func summarizeReleaseImages(images []corev1.ContainerImage) []string {
 	var names []string
 	for _, img := range images {
@@ -415,5 +417,7 @@ func (v verifyNodePoolUpgrade) nodeReleaseImagesUpdated(node *corev1.Node) strin
 			return "" // at least one new image differs from previous
 		}
 	}
-	return fmt.Sprintf("%s (release images unchanged: %v)", node.Name, currentImgs)
+	// The failure message only needs to show a bounded, human-readable sample of the images;
+	// the comparison above already used the complete, untruncated currentImgs.
+	return fmt.Sprintf("%s (release images unchanged: %v)", node.Name, summarizeReleaseImages(node.Status.Images))
 }

--- a/test/util/verifiers/nodes_test.go
+++ b/test/util/verifiers/nodes_test.go
@@ -167,3 +167,60 @@ func TestOcpToK8sMinor(t *testing.T) {
 		t.Errorf("OCP 4.23 should not be mapped yet; add it deliberately once verified, not accidentally")
 	}
 }
+
+func TestSummarizeReleaseImages(t *testing.T) {
+	tests := []struct {
+		name      string
+		images    []corev1.ContainerImage
+		wantNames []string
+	}{
+		{
+			name:      "no images",
+			images:    nil,
+			wantNames: nil,
+		},
+		{
+			name: "each image contributes only its first name, even with multiple aliases",
+			images: []corev1.ContainerImage{
+				{Names: []string{"quay.io/repo@sha256:abc", "quay.io/repo:4.20.1"}},
+				{Names: []string{"quay.io/other@sha256:def", "quay.io/other:4.20.1"}},
+			},
+			wantNames: []string{"quay.io/repo@sha256:abc", "quay.io/other@sha256:def"},
+		},
+		{
+			name: "image with no names is skipped",
+			images: []corev1.ContainerImage{
+				{Names: nil},
+				{Names: []string{"quay.io/repo@sha256:abc"}},
+			},
+			wantNames: []string{"quay.io/repo@sha256:abc"},
+		},
+		{
+			name: "truncates beyond the cap and reports how many were elided",
+			images: []corev1.ContainerImage{
+				{Names: []string{"img-1"}},
+				{Names: []string{"img-2"}},
+				{Names: []string{"img-3"}},
+				{Names: []string{"img-4"}},
+				{Names: []string{"img-5"}},
+				{Names: []string{"img-6"}},
+				{Names: []string{"img-7"}},
+			},
+			wantNames: []string{"img-1", "img-2", "img-3", "img-4", "img-5", "(+2 more)"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := summarizeReleaseImages(tt.images)
+			if len(got) != len(tt.wantNames) {
+				t.Fatalf("expected %d names, got %d: %v", len(tt.wantNames), len(got), got)
+			}
+			for i := range got {
+				if got[i] != tt.wantNames[i] {
+					t.Errorf("index %d: expected %q, got %q", i, tt.wantNames[i], got[i])
+				}
+			}
+		})
+	}
+}

--- a/test/util/verifiers/nodes_test.go
+++ b/test/util/verifiers/nodes_test.go
@@ -22,6 +22,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/set"
 )
 
 func TestNodeVersionInMinor(t *testing.T) {
@@ -222,5 +223,36 @@ func TestSummarizeReleaseImages(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestNodeReleaseImagesUpdated(t *testing.T) {
+	previous := set.New[string]("img-1", "img-2", "img-3", "img-4", "img-5", "img-6", "img-7")
+	v := verifyNodePoolUpgrade{previousReleaseImages: previous}
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+		Status: corev1.NodeStatus{
+			Images: []corev1.ContainerImage{
+				{Names: []string{"img-1"}},
+				{Names: []string{"img-2"}},
+				{Names: []string{"img-3"}},
+				{Names: []string{"img-4"}},
+				{Names: []string{"img-5"}},
+				{Names: []string{"img-6"}},
+				{Names: []string{"img-7"}},
+			},
+		},
+	}
+
+	got := v.nodeReleaseImagesUpdated(node)
+	if got == "" {
+		t.Fatal("expected a non-empty reason since no image differs from previous")
+	}
+	if strings.Contains(got, "img-6") || strings.Contains(got, "img-7") {
+		t.Errorf("expected the failure message to be bounded by summarizeReleaseImages, got: %s", got)
+	}
+	if !strings.Contains(got, "(+2 more)") {
+		t.Errorf("expected the failure message to report the elided count, got: %s", got)
 	}
 }


### PR DESCRIPTION
[AROSLSRE-1938](https://redhat.atlassian.net/browse/AROSLSRE-1938)

### What

Trims the release image list in `VerifyNodePoolUpgrade`'s failure message so it doesn't dump every alias of every image on a node.

### Why

The failure message included every entry in `node.Status.Images[].Names` for each image. A single image is typically referenced by both a digest pull spec (`repo@sha256:...`) and a tag (`repo:tag`) pointing at the same image, so the printed list ballooned into dozens of near-duplicate entries that didn't help identify which OCP/release version was actually running. This came up as a follow-up during review of [#6727](https://github.com/Azure/ARO-HCP/pull/6727) ("why are there 12397612983 release images? cluster can only be running one of them").

`summarizeReleaseImages` now keeps one representative name per image and caps the result to 5 entries, noting how many were elided. The actual comparison in `nodeReleaseImagesUpdated` is untouched and still checks the node's complete, untruncated set of image names, only the human-readable summary used in error output changes.

### Testing

Added `TestSummarizeReleaseImages` covering no images, multi-alias images, images with no names, and truncation past the cap. `go build`, `go vet`, and `go test ./test/util/verifiers/...` all pass locally.

### Special notes for your reviewer

Independent of #6727, this touches `summarizeNodes`/`nodeSummary`, which predates that PR.

### PR Checklist

- [x] Tests added/updated
- [x] `go build` / `go vet` clean
