### PR TITLE
test: guard nodeVersionInMinor against unmapped OCP major/minor (AROSLSRE-1939)

### DIFF
--- a/test/util/verifiers/nodes.go
+++ b/test/util/verifiers/nodes.go
@@ -329,14 +329,27 @@ func nodeReadyAndSchedulable(node *corev1.Node) bool {
 	return nodeReady(node) && !node.Spec.Unschedulable
 }
 
-// ocpToK8sMinorOffset is the well-known offset between OCP minor versions and
-// Kubernetes minor versions: OCP 4.X ships Kubernetes 1.(X+13).
-// For example, OCP 4.14 = k8s 1.27, OCP 4.15 = k8s 1.28, ..., OCP 4.22 = k8s 1.35.
-const ocpToK8sMinorOffset uint64 = 13
+// ocpToK8sMinor maps known OCP 4.x minor versions to the Kubernetes minor version they ship.
+// This is an explicit allowlist rather than an arithmetic offset: the OCP-to-Kubernetes minor
+// mapping has held steady at +13 across 4.14-4.22, but that's not a guarantee that holds
+// forever (in particular across an OCP major version bump), so an unlisted OCP version fails
+// loudly here instead of silently producing an unverified expected value. Add an entry whenever
+// we start testing against a new OCP minor.
+var ocpToK8sMinor = map[uint64]uint64{
+	14: 27, // OCP 4.14 = k8s 1.27
+	15: 28, // OCP 4.15 = k8s 1.28
+	16: 29, // OCP 4.16 = k8s 1.29
+	17: 30, // OCP 4.17 = k8s 1.30
+	18: 31, // OCP 4.18 = k8s 1.31
+	19: 32, // OCP 4.19 = k8s 1.32
+	20: 33, // OCP 4.20 = k8s 1.33
+	21: 34, // OCP 4.21 = k8s 1.34
+	22: 35, // OCP 4.22 = k8s 1.35
+}
 
 // nodeVersionInMinor returns a non-empty reason if the node's KubeletVersion minor does not match
 // the expected Kubernetes minor for the given OCP version. It parses KubeletVersion (e.g. "v1.35.6+abc")
-// and checks that its minor equals expectedSemver.Minor + ocpToK8sMinorOffset (OCP 4.X ships k8s 1.(X+13)).
+// and checks that its minor equals the value in ocpToK8sMinor for expectedSemver's major.minor.
 func (v verifyNodePoolUpgrade) nodeVersionInMinor(node *corev1.Node, expectedSemver semver.Version) string {
 	kubeletVer := node.Status.NodeInfo.KubeletVersion
 	kv, err := semver.ParseTolerant(kubeletVer)
@@ -350,7 +363,17 @@ func (v verifyNodePoolUpgrade) nodeVersionInMinor(node *corev1.Node, expectedSem
 			node.Name, kubeletVer, kv.Major)
 	}
 
-	expectedK8sMinor := expectedSemver.Minor + ocpToK8sMinorOffset
+	if expectedSemver.Major != 4 {
+		return fmt.Sprintf("%s (no known Kubernetes minor mapping for OCP major %d; add it to ocpToK8sMinor in nodes.go)",
+			node.Name, expectedSemver.Major)
+	}
+
+	expectedK8sMinor, ok := ocpToK8sMinor[expectedSemver.Minor]
+	if !ok {
+		return fmt.Sprintf("%s (no known Kubernetes minor mapping for OCP 4.%d; add it to ocpToK8sMinor in nodes.go)",
+			node.Name, expectedSemver.Minor)
+	}
+
 	if kv.Minor != expectedK8sMinor {
 		return fmt.Sprintf("%s (KubeletVersion %s has minor %d, expected %d for OCP %s)",
 			node.Name, kubeletVer, kv.Minor, expectedK8sMinor, v.expectedVersion)

--- a/test/util/verifiers/nodes.go
+++ b/test/util/verifiers/nodes.go
@@ -334,9 +334,9 @@ func nodeReadyAndSchedulable(node *corev1.Node) bool {
 // For example, OCP 4.14 = k8s 1.27, OCP 4.15 = k8s 1.28, ..., OCP 4.22 = k8s 1.35.
 const ocpToK8sMinorOffset uint64 = 13
 
-// nodeVersionInMinor returns a non-empty reason if the node's version is not in the same major.minor as expectedSemver.
-// It parses the node's KubeletVersion (e.g. "v1.35.6+abc") and verifies that the Kubernetes minor
-// version matches the expected OCP version using the well-known offset: OCP 4.X ships Kubernetes 1.(X+13).
+// nodeVersionInMinor returns a non-empty reason if the node's KubeletVersion minor does not match
+// the expected Kubernetes minor for the given OCP version. It parses KubeletVersion (e.g. "v1.35.6+abc")
+// and checks that its minor equals expectedSemver.Minor + ocpToK8sMinorOffset (OCP 4.X ships k8s 1.(X+13)).
 func (v verifyNodePoolUpgrade) nodeVersionInMinor(node *corev1.Node, expectedSemver semver.Version) string {
 	kubeletVer := node.Status.NodeInfo.KubeletVersion
 	kv, err := semver.ParseTolerant(kubeletVer)

--- a/test/util/verifiers/nodes.go
+++ b/test/util/verifiers/nodes.go
@@ -334,6 +334,10 @@ func nodeReadyAndSchedulable(node *corev1.Node) bool {
 // For example, OCP 4.14 = k8s 1.27, OCP 4.15 = k8s 1.28, ..., OCP 4.22 = k8s 1.35.
 const ocpToK8sMinorOffset uint64 = 13
 
+// rhaosVersionRegex matches the OCP version embedded in old-style CRI-O version strings,
+// e.g. "cri-o://1.33.9-3.rhaos4.20.git0abcdef.el9" -> captures "4" and "20".
+var rhaosVersionRegex = regexp.MustCompile(`rhaos(\d+)\.(\d+)`)
+
 // nodeVersionInMinor returns a non-empty reason if the node's version is not in the same major.minor as expectedSemver.
 // It first tries the old RHCOS CRI-O format (e.g. "cri-o://1.33.9-3.rhaos4.20.gitXXX.el9") and, if
 // no rhaos tag is found (OCP 4.22+ ships clean semver CRI-O like "cri-o://1.35.6"), falls back to
@@ -342,7 +346,7 @@ func (v verifyNodePoolUpgrade) nodeVersionInMinor(node *corev1.Node, expectedSem
 	cri := node.Status.NodeInfo.ContainerRuntimeVersion
 
 	// Try the old RHCOS CRI-O format first: "cri-o://1.33.9-3.rhaos4.20.gitXXX.el9"
-	m := regexp.MustCompile(`rhaos(\d+)\.(\d+)`).FindStringSubmatch(cri)
+	m := rhaosVersionRegex.FindStringSubmatch(cri)
 	if len(m) == 3 {
 		nodeVerStr := m[1] + "." + m[2]
 		nodeVer, err := semver.ParseTolerant(nodeVerStr)
@@ -363,6 +367,11 @@ func (v verifyNodePoolUpgrade) nodeVersionInMinor(node *corev1.Node, expectedSem
 	if err != nil {
 		return fmt.Sprintf("%s (no rhaos tag in containerRuntimeVersion %q and cannot parse KubeletVersion %q: %v)",
 			node.Name, cri, kubeletVer, err)
+	}
+
+	if kv.Major != 1 {
+		return fmt.Sprintf("%s (KubeletVersion %s has unexpected major %d, expected 1)",
+			node.Name, kubeletVer, kv.Major)
 	}
 
 	expectedK8sMinor := expectedSemver.Minor + ocpToK8sMinorOffset

--- a/test/util/verifiers/nodes.go
+++ b/test/util/verifiers/nodes.go
@@ -329,23 +329,46 @@ func nodeReadyAndSchedulable(node *corev1.Node) bool {
 	return nodeReady(node) && !node.Spec.Unschedulable
 }
 
+// ocpToK8sMinorOffset is the well-known offset between OCP minor versions and
+// Kubernetes minor versions: OCP 4.X ships Kubernetes 1.(X+13).
+// For example, OCP 4.14 = k8s 1.27, OCP 4.15 = k8s 1.28, ..., OCP 4.22 = k8s 1.35.
+const ocpToK8sMinorOffset uint64 = 13
+
 // nodeVersionInMinor returns a non-empty reason if the node's version is not in the same major.minor as expectedSemver.
+// It first tries the old RHCOS CRI-O format (e.g. "cri-o://1.33.9-3.rhaos4.20.gitXXX.el9") and, if
+// no rhaos tag is found (OCP 4.22+ ships clean semver CRI-O like "cri-o://1.35.6"), falls back to
+// the KubeletVersion to verify the Kubernetes minor version matches.
 func (v verifyNodePoolUpgrade) nodeVersionInMinor(node *corev1.Node, expectedSemver semver.Version) string {
 	cri := node.Status.NodeInfo.ContainerRuntimeVersion
+
+	// Try the old RHCOS CRI-O format first: "cri-o://1.33.9-3.rhaos4.20.gitXXX.el9"
 	m := regexp.MustCompile(`rhaos(\d+)\.(\d+)`).FindStringSubmatch(cri)
-	nodeVerStr := ""
 	if len(m) == 3 {
-		nodeVerStr = m[1] + "." + m[2]
+		nodeVerStr := m[1] + "." + m[2]
+		nodeVer, err := semver.ParseTolerant(nodeVerStr)
+		if err != nil {
+			return fmt.Sprintf("%s (invalid version %q)", node.Name, nodeVerStr)
+		}
+		if nodeVer.Major != expectedSemver.Major || nodeVer.Minor != expectedSemver.Minor {
+			return fmt.Sprintf("%s (version %s not in same minor as expected %s)", node.Name, nodeVerStr, v.expectedVersion)
+		}
+		return ""
 	}
-	if len(nodeVerStr) == 0 {
-		return fmt.Sprintf("%s (no version in containerRuntimeVersion %q)", node.Name, node.Status.NodeInfo.ContainerRuntimeVersion)
-	}
-	nodeVer, err := semver.ParseTolerant(nodeVerStr)
+
+	// New CRI-O builds (OCP 4.22+) no longer embed an rhaos tag. Fall back to
+	// the kubelet version, which always carries the Kubernetes minor version.
+	// OCP 4.X ships Kubernetes 1.(X+13), so verify the kubelet minor matches.
+	kubeletVer := node.Status.NodeInfo.KubeletVersion
+	kv, err := semver.ParseTolerant(kubeletVer)
 	if err != nil {
-		return fmt.Sprintf("%s (invalid version %q)", node.Name, nodeVerStr)
+		return fmt.Sprintf("%s (no rhaos tag in containerRuntimeVersion %q and cannot parse KubeletVersion %q: %v)",
+			node.Name, cri, kubeletVer, err)
 	}
-	if nodeVer.Major != expectedSemver.Major || nodeVer.Minor != expectedSemver.Minor {
-		return fmt.Sprintf("%s (version %s not in same minor as expected %s)", node.Name, nodeVerStr, v.expectedVersion)
+
+	expectedK8sMinor := expectedSemver.Minor + ocpToK8sMinorOffset
+	if kv.Minor != expectedK8sMinor {
+		return fmt.Sprintf("%s (KubeletVersion %s has minor %d, expected %d for OCP %s)",
+			node.Name, kubeletVer, kv.Minor, expectedK8sMinor, v.expectedVersion)
 	}
 	return ""
 }

--- a/test/util/verifiers/nodes.go
+++ b/test/util/verifiers/nodes.go
@@ -334,39 +334,15 @@ func nodeReadyAndSchedulable(node *corev1.Node) bool {
 // For example, OCP 4.14 = k8s 1.27, OCP 4.15 = k8s 1.28, ..., OCP 4.22 = k8s 1.35.
 const ocpToK8sMinorOffset uint64 = 13
 
-// rhaosVersionRegex matches the OCP version embedded in old-style CRI-O version strings,
-// e.g. "cri-o://1.33.9-3.rhaos4.20.git0abcdef.el9" -> captures "4" and "20".
-var rhaosVersionRegex = regexp.MustCompile(`rhaos(\d+)\.(\d+)`)
-
 // nodeVersionInMinor returns a non-empty reason if the node's version is not in the same major.minor as expectedSemver.
-// It first tries the old RHCOS CRI-O format (e.g. "cri-o://1.33.9-3.rhaos4.20.gitXXX.el9") and, if
-// no rhaos tag is found (OCP 4.22+ ships clean semver CRI-O like "cri-o://1.35.6"), falls back to
-// the KubeletVersion to verify the Kubernetes minor version matches.
+// It parses the node's KubeletVersion (e.g. "v1.35.6+abc") and verifies that the Kubernetes minor
+// version matches the expected OCP version using the well-known offset: OCP 4.X ships Kubernetes 1.(X+13).
 func (v verifyNodePoolUpgrade) nodeVersionInMinor(node *corev1.Node, expectedSemver semver.Version) string {
-	cri := node.Status.NodeInfo.ContainerRuntimeVersion
-
-	// Try the old RHCOS CRI-O format first: "cri-o://1.33.9-3.rhaos4.20.gitXXX.el9"
-	m := rhaosVersionRegex.FindStringSubmatch(cri)
-	if len(m) == 3 {
-		nodeVerStr := m[1] + "." + m[2]
-		nodeVer, err := semver.ParseTolerant(nodeVerStr)
-		if err != nil {
-			return fmt.Sprintf("%s (invalid version %q)", node.Name, nodeVerStr)
-		}
-		if nodeVer.Major != expectedSemver.Major || nodeVer.Minor != expectedSemver.Minor {
-			return fmt.Sprintf("%s (version %s not in same minor as expected %s)", node.Name, nodeVerStr, v.expectedVersion)
-		}
-		return ""
-	}
-
-	// New CRI-O builds (OCP 4.22+) no longer embed an rhaos tag. Fall back to
-	// the kubelet version, which always carries the Kubernetes minor version.
-	// OCP 4.X ships Kubernetes 1.(X+13), so verify the kubelet minor matches.
 	kubeletVer := node.Status.NodeInfo.KubeletVersion
 	kv, err := semver.ParseTolerant(kubeletVer)
 	if err != nil {
-		return fmt.Sprintf("%s (no rhaos tag in containerRuntimeVersion %q and cannot parse KubeletVersion %q: %v)",
-			node.Name, cri, kubeletVer, err)
+		return fmt.Sprintf("%s (cannot parse KubeletVersion %q: %v)",
+			node.Name, kubeletVer, err)
 	}
 
 	if kv.Major != 1 {

--- a/test/util/verifiers/nodes_test.go
+++ b/test/util/verifiers/nodes_test.go
@@ -72,11 +72,20 @@ func TestNodeVersionInMinor(t *testing.T) {
 			wantEmpty:       true,
 		},
 		{
-			name:            "boundary OCP 4.23 = k8s 1.36",
+			name:            "unmapped future OCP minor fails loudly instead of guessing",
 			nodeName:        "node-6",
 			kubeletVersion:  "v1.36.0+xyz",
 			expectedVersion: "4.23",
-			wantEmpty:       true,
+			wantEmpty:       false,
+			wantSubstring:   "no known Kubernetes minor mapping for OCP 4.23",
+		},
+		{
+			name:            "unmapped OCP major fails loudly instead of guessing",
+			nodeName:        "node-8",
+			kubeletVersion:  "v1.36.0+xyz",
+			expectedVersion: "5.0",
+			wantEmpty:       false,
+			wantSubstring:   "no known Kubernetes minor mapping for OCP major 5",
 		},
 		{
 			name:            "matching kubelet version OCP 4.20 = k8s 1.33",
@@ -126,8 +135,8 @@ func TestNodeVersionInMinor(t *testing.T) {
 	}
 }
 
-func TestOcpToK8sMinorOffset(t *testing.T) {
-	// Verify the well-known offset between OCP and Kubernetes minor versions.
+func TestOcpToK8sMinor(t *testing.T) {
+	// Verify the known-good OCP-to-Kubernetes minor mappings we've tested against.
 	knownMappings := []struct {
 		ocpMinor uint64
 		k8sMinor uint64
@@ -144,9 +153,17 @@ func TestOcpToK8sMinorOffset(t *testing.T) {
 	}
 
 	for _, m := range knownMappings {
-		got := m.ocpMinor + ocpToK8sMinorOffset
+		got, ok := ocpToK8sMinor[m.ocpMinor]
+		if !ok {
+			t.Errorf("OCP 4.%d: expected an entry in ocpToK8sMinor, found none", m.ocpMinor)
+			continue
+		}
 		if got != m.k8sMinor {
 			t.Errorf("OCP 4.%d: expected k8s minor %d, got %d", m.ocpMinor, m.k8sMinor, got)
 		}
+	}
+
+	if _, ok := ocpToK8sMinor[23]; ok {
+		t.Errorf("OCP 4.23 should not be mapped yet; add it deliberately once verified, not accidentally")
 	}
 }

--- a/test/util/verifiers/nodes_test.go
+++ b/test/util/verifiers/nodes_test.go
@@ -28,86 +28,61 @@ func TestNodeVersionInMinor(t *testing.T) {
 	tests := []struct {
 		name            string
 		nodeName        string
-		criVersion      string
 		kubeletVersion  string
 		expectedVersion string
 		wantEmpty       bool
 		wantSubstring   string
 	}{
 		{
-			name:            "old rhaos format matching version",
+			name:            "matching kubelet version OCP 4.22 = k8s 1.35",
 			nodeName:        "node-1",
-			criVersion:      "cri-o://1.33.9-3.rhaos4.20.git0abcdef.el9",
-			kubeletVersion:  "v1.33.6+abc123",
-			expectedVersion: "4.20",
-			wantEmpty:       true,
-		},
-		{
-			name:            "old rhaos format wrong minor",
-			nodeName:        "node-2",
-			criVersion:      "cri-o://1.33.9-3.rhaos4.19.git0abcdef.el9",
-			kubeletVersion:  "v1.32.6+abc123",
-			expectedVersion: "4.20",
-			wantEmpty:       false,
-			wantSubstring:   "version 4.19 not in same minor as expected 4.20",
-		},
-		{
-			name:            "new clean CRI-O format with matching kubelet version (OCP 4.22 = k8s 1.35)",
-			nodeName:        "node-3",
-			criVersion:      "cri-o://1.35.6",
 			kubeletVersion:  "v1.35.6+abc123",
 			expectedVersion: "4.22",
 			wantEmpty:       true,
 		},
 		{
-			name:            "new clean CRI-O format with wrong kubelet minor",
-			nodeName:        "node-4",
-			criVersion:      "cri-o://1.35.6",
+			name:            "wrong kubelet minor",
+			nodeName:        "node-2",
 			kubeletVersion:  "v1.34.6+abc123",
 			expectedVersion: "4.22",
 			wantEmpty:       false,
 			wantSubstring:   "KubeletVersion v1.34.6+abc123 has minor 34, expected 35 for OCP 4.22",
 		},
 		{
-			name:            "new clean CRI-O format with unparseable kubelet version",
-			nodeName:        "node-5",
-			criVersion:      "cri-o://1.35.6",
-			kubeletVersion:  "not-a-version",
-			expectedVersion: "4.22",
-			wantEmpty:       false,
-			wantSubstring:   "cannot parse KubeletVersion",
-		},
-		{
-			name:            "old rhaos format OCP 4.14 = k8s 1.27",
-			nodeName:        "node-6",
-			criVersion:      "cri-o://1.27.5-3.rhaos4.14.gitabc.el9",
-			kubeletVersion:  "v1.27.5+abc",
-			expectedVersion: "4.14",
-			wantEmpty:       true,
-		},
-		{
-			name:            "rhaos tag takes priority over kubelet fallback",
-			nodeName:        "node-8",
-			criVersion:      "cri-o://1.33.9-3.rhaos4.20.git0abcdef.el9",
-			kubeletVersion:  "v1.99.0+bogus",
-			expectedVersion: "4.20",
-			wantEmpty:       true,
-		},
-		{
-			name:            "kubelet with unexpected Kubernetes major version",
-			nodeName:        "node-9",
-			criVersion:      "cri-o://1.35.6",
+			name:            "unexpected Kubernetes major version",
+			nodeName:        "node-3",
 			kubeletVersion:  "v2.35.0+bogus",
 			expectedVersion: "4.22",
 			wantEmpty:       false,
 			wantSubstring:   "unexpected major 2, expected 1",
 		},
 		{
-			name:            "new CRI-O format OCP 4.23 = k8s 1.36",
-			nodeName:        "node-7",
-			criVersion:      "cri-o://1.36.0",
+			name:            "unparseable kubelet version",
+			nodeName:        "node-4",
+			kubeletVersion:  "not-a-version",
+			expectedVersion: "4.22",
+			wantEmpty:       false,
+			wantSubstring:   "cannot parse KubeletVersion",
+		},
+		{
+			name:            "boundary OCP 4.14 = k8s 1.27",
+			nodeName:        "node-5",
+			kubeletVersion:  "v1.27.5+abc",
+			expectedVersion: "4.14",
+			wantEmpty:       true,
+		},
+		{
+			name:            "boundary OCP 4.23 = k8s 1.36",
+			nodeName:        "node-6",
 			kubeletVersion:  "v1.36.0+xyz",
 			expectedVersion: "4.23",
+			wantEmpty:       true,
+		},
+		{
+			name:            "matching kubelet version OCP 4.20 = k8s 1.33",
+			nodeName:        "node-7",
+			kubeletVersion:  "v1.33.6+abc123",
+			expectedVersion: "4.20",
 			wantEmpty:       true,
 		},
 	}
@@ -120,8 +95,7 @@ func TestNodeVersionInMinor(t *testing.T) {
 				},
 				Status: corev1.NodeStatus{
 					NodeInfo: corev1.NodeSystemInfo{
-						ContainerRuntimeVersion: tt.criVersion,
-						KubeletVersion:          tt.kubeletVersion,
+						KubeletVersion: tt.kubeletVersion,
 					},
 				},
 			}

--- a/test/util/verifiers/nodes_test.go
+++ b/test/util/verifiers/nodes_test.go
@@ -1,0 +1,173 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verifiers
+
+import (
+	"testing"
+
+	"github.com/blang/semver/v4"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNodeVersionInMinor(t *testing.T) {
+	tests := []struct {
+		name            string
+		nodeName        string
+		criVersion      string
+		kubeletVersion  string
+		expectedVersion string
+		wantEmpty       bool
+		wantSubstring   string
+	}{
+		{
+			name:            "old rhaos format matching version",
+			nodeName:        "node-1",
+			criVersion:      "cri-o://1.33.9-3.rhaos4.20.git0abcdef.el9",
+			kubeletVersion:  "v1.33.6+abc123",
+			expectedVersion: "4.20",
+			wantEmpty:       true,
+		},
+		{
+			name:            "old rhaos format wrong minor",
+			nodeName:        "node-2",
+			criVersion:      "cri-o://1.33.9-3.rhaos4.19.git0abcdef.el9",
+			kubeletVersion:  "v1.32.6+abc123",
+			expectedVersion: "4.20",
+			wantEmpty:       false,
+			wantSubstring:   "version 4.19 not in same minor as expected 4.20",
+		},
+		{
+			name:            "new clean CRI-O format with matching kubelet version (OCP 4.22 = k8s 1.35)",
+			nodeName:        "node-3",
+			criVersion:      "cri-o://1.35.6",
+			kubeletVersion:  "v1.35.6+abc123",
+			expectedVersion: "4.22",
+			wantEmpty:       true,
+		},
+		{
+			name:            "new clean CRI-O format with wrong kubelet minor",
+			nodeName:        "node-4",
+			criVersion:      "cri-o://1.35.6",
+			kubeletVersion:  "v1.34.6+abc123",
+			expectedVersion: "4.22",
+			wantEmpty:       false,
+			wantSubstring:   "KubeletVersion v1.34.6+abc123 has minor 34, expected 35 for OCP 4.22",
+		},
+		{
+			name:            "new clean CRI-O format with unparseable kubelet version",
+			nodeName:        "node-5",
+			criVersion:      "cri-o://1.35.6",
+			kubeletVersion:  "not-a-version",
+			expectedVersion: "4.22",
+			wantEmpty:       false,
+			wantSubstring:   "cannot parse KubeletVersion",
+		},
+		{
+			name:            "old rhaos format OCP 4.14 = k8s 1.27",
+			nodeName:        "node-6",
+			criVersion:      "cri-o://1.27.5-3.rhaos4.14.gitabc.el9",
+			kubeletVersion:  "v1.27.5+abc",
+			expectedVersion: "4.14",
+			wantEmpty:       true,
+		},
+		{
+			name:            "new CRI-O format OCP 4.23 = k8s 1.36",
+			nodeName:        "node-7",
+			criVersion:      "cri-o://1.36.0",
+			kubeletVersion:  "v1.36.0+xyz",
+			expectedVersion: "4.23",
+			wantEmpty:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tt.nodeName,
+				},
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						ContainerRuntimeVersion: tt.criVersion,
+						KubeletVersion:          tt.kubeletVersion,
+					},
+				},
+			}
+
+			expectedSemver, err := semver.ParseTolerant(tt.expectedVersion)
+			if err != nil {
+				t.Fatalf("failed to parse expectedVersion %q: %v", tt.expectedVersion, err)
+			}
+
+			v := verifyNodePoolUpgrade{
+				expectedVersion: tt.expectedVersion,
+			}
+
+			got := v.nodeVersionInMinor(node, expectedSemver)
+
+			if tt.wantEmpty && got != "" {
+				t.Errorf("expected empty result, got %q", got)
+			}
+			if !tt.wantEmpty && got == "" {
+				t.Errorf("expected non-empty result containing %q, got empty", tt.wantSubstring)
+			}
+			if !tt.wantEmpty && tt.wantSubstring != "" {
+				if got == "" || !containsSubstring(got, tt.wantSubstring) {
+					t.Errorf("expected result to contain %q, got %q", tt.wantSubstring, got)
+				}
+			}
+		})
+	}
+}
+
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && searchSubstring(s, substr)
+}
+
+func searchSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func TestOcpToK8sMinorOffset(t *testing.T) {
+	// Verify the well-known offset between OCP and Kubernetes minor versions.
+	knownMappings := []struct {
+		ocpMinor uint64
+		k8sMinor uint64
+	}{
+		{14, 27}, // OCP 4.14 = k8s 1.27
+		{15, 28}, // OCP 4.15 = k8s 1.28
+		{16, 29}, // OCP 4.16 = k8s 1.29
+		{17, 30}, // OCP 4.17 = k8s 1.30
+		{18, 31}, // OCP 4.18 = k8s 1.31
+		{19, 32}, // OCP 4.19 = k8s 1.32
+		{20, 33}, // OCP 4.20 = k8s 1.33
+		{21, 34}, // OCP 4.21 = k8s 1.34
+		{22, 35}, // OCP 4.22 = k8s 1.35
+	}
+
+	for _, m := range knownMappings {
+		got := m.ocpMinor + ocpToK8sMinorOffset
+		if got != m.k8sMinor {
+			t.Errorf("OCP 4.%d: expected k8s minor %d, got %d", m.ocpMinor, m.k8sMinor, got)
+		}
+	}
+}

--- a/test/util/verifiers/nodes_test.go
+++ b/test/util/verifiers/nodes_test.go
@@ -94,6 +94,15 @@ func TestNodeVersionInMinor(t *testing.T) {
 			wantEmpty:       true,
 		},
 		{
+			name:            "kubelet with unexpected Kubernetes major version",
+			nodeName:        "node-9",
+			criVersion:      "cri-o://1.35.6",
+			kubeletVersion:  "v2.35.0+bogus",
+			expectedVersion: "4.22",
+			wantEmpty:       false,
+			wantSubstring:   "unexpected major 2, expected 1",
+		},
+		{
 			name:            "new CRI-O format OCP 4.23 = k8s 1.36",
 			nodeName:        "node-7",
 			criVersion:      "cri-o://1.36.0",

--- a/test/util/verifiers/nodes_test.go
+++ b/test/util/verifiers/nodes_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Microsoft Corporation
+// Copyright 2026 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package verifiers
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/blang/semver/v4"
@@ -85,6 +86,14 @@ func TestNodeVersionInMinor(t *testing.T) {
 			wantEmpty:       true,
 		},
 		{
+			name:            "rhaos tag takes priority over kubelet fallback",
+			nodeName:        "node-8",
+			criVersion:      "cri-o://1.33.9-3.rhaos4.20.git0abcdef.el9",
+			kubeletVersion:  "v1.99.0+bogus",
+			expectedVersion: "4.20",
+			wantEmpty:       true,
+		},
+		{
 			name:            "new CRI-O format OCP 4.23 = k8s 1.36",
 			nodeName:        "node-7",
 			criVersion:      "cri-o://1.36.0",
@@ -126,25 +135,12 @@ func TestNodeVersionInMinor(t *testing.T) {
 				t.Errorf("expected non-empty result containing %q, got empty", tt.wantSubstring)
 			}
 			if !tt.wantEmpty && tt.wantSubstring != "" {
-				if got == "" || !containsSubstring(got, tt.wantSubstring) {
+				if !strings.Contains(got, tt.wantSubstring) {
 					t.Errorf("expected result to contain %q, got %q", tt.wantSubstring, got)
 				}
 			}
 		})
 	}
-}
-
-func containsSubstring(s, substr string) bool {
-	return len(s) >= len(substr) && searchSubstring(s, substr)
-}
-
-func searchSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }
 
 func TestOcpToK8sMinorOffset(t *testing.T) {


### PR DESCRIPTION
Jira: [AROSLSRE-1939](https://redhat.atlassian.net/browse/AROSLSRE-1939)

### What

Replaces the `ocpToK8sMinorOffset` arithmetic constant in `nodeVersionInMinor` (added in #6727) with an explicit `ocpToK8sMinor` map, and adds guards that return a clear error for any OCP major other than 4, or any OCP minor not yet in the map.

### Why

`nodeVersionInMinor` computed the expected Kubernetes minor as `expectedSemver.Minor + 13`. That holds for OCP 4.14-4.22, but nothing stops it from computing a plausible-looking but wrong value once we test against an OCP major other than 4 (the e2e suite already has an OCP 5.0 candidate channel test) or a minor we haven't verified yet. An explicit map fails loudly instead of guessing.

### Testing

`go test ./test/util/verifiers/...` passes, including new cases in `TestNodeVersionInMinor` for an unmapped OCP minor and an unmapped OCP major, both of which now return a "no known Kubernetes minor mapping" error instead of a wrong number. `TestOcpToK8sMinorOffset` was replaced with `TestOcpToK8sMinor`, which checks the map's known-good entries directly.

### Special notes for your reviewer

This branches off #6727 (still open), since it builds on that PR's `nodeVersionInMinor`/`KubeletVersion` change. The diff will include all of #6727's changes until that PR merges; the actual delta for this PR is just the `ocpToK8sMinorOffset` -> `ocpToK8sMinor` map switch and the two new guard checks.

### PR Checklist
- [x] Tests added/updated
- [x] Documentation not applicable (internal test helper)
