### PR TITLE
fix: redacting changefeed datadump

### DIFF
--- a/internal/database/cosmosstorage/cosmosstorageutils/redact.go
+++ b/internal/database/cosmosstorage/cosmosstorageutils/redact.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cosmosstorageutils
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+)
+
+const RedactStr = "REDACTED"
+
+// RedactTypedDocument replaces the caller identities in the document's systemData with RedactStr.
+// Every code path that logs an HCP cluster must call this first. On error the document is left
+// untouched, so callers must not log it.
+func RedactTypedDocument(d *TypedDocument) error {
+	if d == nil {
+		return fmt.Errorf("typed document is nil")
+	}
+
+	if len(d.Properties) == 0 {
+		return nil
+	}
+
+	var props unstructured.Unstructured
+	if err := json.Unmarshal(d.Properties, &props.Object); err != nil {
+		return fmt.Errorf("failed to unmarshal typed document properties for %s: %w", resourceIDToString(d.ResourceID), err)
+	}
+
+	if _, found, err := unstructured.NestedString(props.Object, "systemData", "createdBy"); err != nil {
+		return fmt.Errorf("failed to read systemData.createdBy for %s: %w", resourceIDToString(d.ResourceID), err)
+	} else if found {
+		if err := unstructured.SetNestedField(props.Object, RedactStr, "systemData", "createdBy"); err != nil {
+			return fmt.Errorf("failed to set systemData.createdBy for %s: %w", resourceIDToString(d.ResourceID), err)
+		}
+	}
+
+	if _, found, err := unstructured.NestedString(props.Object, "systemData", "lastModifiedBy"); err != nil {
+		return fmt.Errorf("failed to read systemData.lastModifiedBy for %s: %w", resourceIDToString(d.ResourceID), err)
+	} else if found {
+		if err := unstructured.SetNestedField(props.Object, RedactStr, "systemData", "lastModifiedBy"); err != nil {
+			return fmt.Errorf("failed to set systemData.lastModifiedBy for %s: %w", resourceIDToString(d.ResourceID), err)
+		}
+	}
+
+	redactedProps, err := json.Marshal(props.Object)
+	if err != nil {
+		return fmt.Errorf("failed to marshal redacted typed document properties for %s: %w", resourceIDToString(d.ResourceID), err)
+	}
+
+	d.Properties = redactedProps
+	return nil
+}
+
+func resourceIDToString(id *azcorearm.ResourceID) string {
+	if id == nil {
+		return "<missing>"
+	}
+	return id.String()
+}

--- a/internal/database/cosmosstorage/cosmosstorageutils/redact_test.go
+++ b/internal/database/cosmosstorage/cosmosstorageutils/redact_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package serverutils
+package cosmosstorageutils
 
 import (
 	"encoding/json"
@@ -24,7 +24,6 @@ import (
 
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
 	"github.com/Azure/ARO-HCP/internal/apitesting/coreapitesting"
-	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
 )
 
 func TestRedactTypedDocument_RedactsSupportedResourceTypes(t *testing.T) {
@@ -32,13 +31,13 @@ func TestRedactTypedDocument_RedactsSupportedResourceTypes(t *testing.T) {
 		name         string
 		resourceID   string
 		resourceType string
-		newDocument  func() (any, *cosmosstorageutils.TypedDocument)
+		newDocument  func() (any, *TypedDocument)
 	}{
 		{
 			name:         "cluster",
 			resourceID:   coreapitesting.TestClusterResourceID,
 			resourceType: coreapi.ClusterResourceType.String(),
-			newDocument: func() (any, *cosmosstorageutils.TypedDocument) {
+			newDocument: func() (any, *TypedDocument) {
 				resourceID := mustParseResourceID(t, coreapitesting.TestClusterResourceID)
 				createdAt := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 				obj := &coreapi.HCPOpenShiftCluster{
@@ -62,7 +61,7 @@ func TestRedactTypedDocument_RedactsSupportedResourceTypes(t *testing.T) {
 			name:         "nodepool",
 			resourceID:   coreapitesting.TestNodePoolResourceID,
 			resourceType: coreapi.NodePoolResourceType.String(),
-			newDocument: func() (any, *cosmosstorageutils.TypedDocument) {
+			newDocument: func() (any, *TypedDocument) {
 				resourceID := mustParseResourceID(t, coreapitesting.TestNodePoolResourceID)
 				createdAt := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
 				obj := &coreapi.HCPOpenShiftClusterNodePool{
@@ -86,7 +85,7 @@ func TestRedactTypedDocument_RedactsSupportedResourceTypes(t *testing.T) {
 			name:         "external-auth",
 			resourceID:   coreapitesting.TestExternalAuthResourceID,
 			resourceType: coreapi.ExternalAuthResourceType.String(),
-			newDocument: func() (any, *cosmosstorageutils.TypedDocument) {
+			newDocument: func() (any, *TypedDocument) {
 				resourceID := mustParseResourceID(t, coreapitesting.TestExternalAuthResourceID)
 				createdAt := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
 				obj := &coreapi.HCPOpenShiftClusterExternalAuth{
@@ -113,8 +112,8 @@ func TestRedactTypedDocument_RedactsSupportedResourceTypes(t *testing.T) {
 			expectedObject, doc := tt.newDocument()
 			originalProperties := append(json.RawMessage(nil), doc.Properties...)
 
-			if err := redactTypedDocument(doc); err != nil {
-				t.Fatalf("redactTypedDocument() error = %v", err)
+			if err := RedactTypedDocument(doc); err != nil {
+				t.Fatalf("RedactTypedDocument() error = %v", err)
 			}
 
 			if doc.ResourceType != tt.resourceType {
@@ -157,8 +156,8 @@ func TestRedactTypedDocument_RedactsSupportedResourceTypes(t *testing.T) {
 
 func TestRedactTypedDocument_ReturnsNestedFieldTypeError(t *testing.T) {
 	resourceID := mustParseResourceID(t, coreapitesting.TestClusterResourceID)
-	doc := &cosmosstorageutils.TypedDocument{
-		BaseDocument: cosmosstorageutils.BaseDocument{
+	doc := &TypedDocument{
+		BaseDocument: BaseDocument{
 			ID: resourceID.Name,
 		},
 		PartitionKey: resourceID.SubscriptionID,
@@ -167,9 +166,9 @@ func TestRedactTypedDocument_ReturnsNestedFieldTypeError(t *testing.T) {
 		Properties:   json.RawMessage(`{"systemData":{"createdBy":123}}`),
 	}
 
-	err := redactTypedDocument(doc)
+	err := RedactTypedDocument(doc)
 	if err == nil {
-		t.Fatal("redactTypedDocument() error = nil, want nested field type error")
+		t.Fatal("RedactTypedDocument() error = nil, want nested field type error")
 	}
 	if !strings.Contains(err.Error(), "failed to read systemData.createdBy") {
 		t.Fatalf("error = %q, want it to mention createdBy read failure", err.Error())
@@ -179,7 +178,7 @@ func TestRedactTypedDocument_ReturnsNestedFieldTypeError(t *testing.T) {
 	}
 }
 
-func newTypedDocument(t *testing.T, resourceID *azcorearm.ResourceID, resourceType string, properties any) *cosmosstorageutils.TypedDocument {
+func newTypedDocument(t *testing.T, resourceID *azcorearm.ResourceID, resourceType string, properties any) *TypedDocument {
 	t.Helper()
 
 	propertiesBytes, err := json.Marshal(properties)
@@ -187,8 +186,8 @@ func newTypedDocument(t *testing.T, resourceID *azcorearm.ResourceID, resourceTy
 		t.Fatalf("marshal properties: %v", err)
 	}
 
-	return &cosmosstorageutils.TypedDocument{
-		BaseDocument: cosmosstorageutils.BaseDocument{
+	return &TypedDocument{
+		BaseDocument: BaseDocument{
 			ID: resourceID.Name,
 		},
 		PartitionKey: resourceID.SubscriptionID,

--- a/internal/database/informers/informerutils/changefeed_list_watch.go
+++ b/internal/database/informers/informerutils/changefeed_list_watch.go
@@ -466,7 +466,8 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 		return nil
 	}
 
-	loggedDocument := objAsTypedDocument
+	loggedDocument := &cosmosstorageutils.TypedDocument{}
+	*loggedDocument = *objAsTypedDocument
 	if err := cosmosstorageutils.RedactTypedDocument(loggedDocument); err != nil {
 		utilruntime.HandleError(utils.TrackError(err))
 		loggedDocument = nil

--- a/internal/database/informers/informerutils/changefeed_list_watch.go
+++ b/internal/database/informers/informerutils/changefeed_list_watch.go
@@ -466,6 +466,12 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 		return nil
 	}
 
+	loggedDocument := objAsTypedDocument
+	if err := cosmosstorageutils.RedactTypedDocument(loggedDocument); err != nil {
+		utilruntime.HandleError(utils.TrackError(err))
+		loggedDocument = nil
+	}
+
 	objDeleted := false
 	if objAsTypedDocument.DeletionTimestamp != nil {
 		if objPreviouslySeen {
@@ -473,7 +479,7 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 		} else {
 			logger.Info("skipping soft-deleted document not previously seen",
 				"snapshotType", "cosmos",
-				"content", cosmosObj)
+				"content", loggedDocument)
 			return nil
 		}
 	} else if c.shouldDeliverItemFn != nil && !c.shouldDeliverItemFn(internalObj) {
@@ -482,15 +488,14 @@ func (c *ChangeFeedWatcher[InternalAPIType, InternalAPITypePointer, CosmosAPITyp
 		} else {
 			logger.Info("should not deliver document",
 				"snapshotType", "cosmos",
-				"content", cosmosObj)
+				"content", loggedDocument)
 			return nil
 		}
 	}
 
 	logger.Info("delivering change feed item",
 		"snapshotType", "cosmos",
-		"content", cosmosObj,
-		"internalObj", internalObj,
+		"content", loggedDocument,
 	)
 	if objDeleted {
 		c.resourceIDToInstanceVersion.Delete(canonicalResourceID)

--- a/internal/serverutils/dump_data.go
+++ b/internal/serverutils/dump_data.go
@@ -16,12 +16,9 @@ package serverutils
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
@@ -32,8 +29,6 @@ import (
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/kubeappliercosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
-
-const RedactStr = "REDACTED"
 
 // DumpDataToLogger writes a structured-log entry for every document related
 // to resourceID. It covers three storage layers:
@@ -70,7 +65,7 @@ func DumpDataToLogger(
 	if err != nil {
 		return utils.TrackError(err)
 	}
-	err = redactTypedDocument(startingCosmosRecord)
+	err = cosmosstorageutils.RedactTypedDocument(startingCosmosRecord)
 	if err != nil {
 		return utils.TrackError(err)
 	}
@@ -88,7 +83,7 @@ func DumpDataToLogger(
 
 	errs := []error{}
 	for _, typedDocument := range allCosmosRecords.Items(ctx) {
-		if err := redactTypedDocument(typedDocument); err != nil {
+		if err := cosmosstorageutils.RedactTypedDocument(typedDocument); err != nil {
 			errs = append(errs, utils.TrackError(err))
 			continue
 		}
@@ -242,44 +237,5 @@ func DumpBillingToLogger(ctx context.Context, resourcesDBClient corecosmosstorag
 		"content", billingDoc,
 	)
 
-	return nil
-}
-
-func redactTypedDocument(d *cosmosstorageutils.TypedDocument) error {
-	if d == nil {
-		return fmt.Errorf("typed document is nil")
-	}
-
-	if len(d.Properties) == 0 {
-		return nil
-	}
-
-	var props unstructured.Unstructured
-	if err := json.Unmarshal(d.Properties, &props.Object); err != nil {
-		return fmt.Errorf("failed to unmarshal typed document properties for %s: %w", resourceIDToString(d.ResourceID), err)
-	}
-
-	if _, found, err := unstructured.NestedString(props.Object, "systemData", "createdBy"); err != nil {
-		return fmt.Errorf("failed to read systemData.createdBy for %s: %w", resourceIDToString(d.ResourceID), err)
-	} else if found {
-		if err := unstructured.SetNestedField(props.Object, RedactStr, "systemData", "createdBy"); err != nil {
-			return fmt.Errorf("failed to set systemData.createdBy for %s: %w", resourceIDToString(d.ResourceID), err)
-		}
-	}
-
-	if _, found, err := unstructured.NestedString(props.Object, "systemData", "lastModifiedBy"); err != nil {
-		return fmt.Errorf("failed to read systemData.lastModifiedBy for %s: %w", resourceIDToString(d.ResourceID), err)
-	} else if found {
-		if err := unstructured.SetNestedField(props.Object, RedactStr, "systemData", "lastModifiedBy"); err != nil {
-			return fmt.Errorf("failed to set systemData.lastModifiedBy for %s: %w", resourceIDToString(d.ResourceID), err)
-		}
-	}
-
-	redactedProps, err := json.Marshal(props.Object)
-	if err != nil {
-		return fmt.Errorf("failed to marshal redacted typed document properties for %s: %w", resourceIDToString(d.ResourceID), err)
-	}
-
-	d.Properties = redactedProps
 	return nil
 }


### PR DESCRIPTION
[ARO-29355](https://redhat.atlassian.net/browse/ARO-29355)

### What

Redacting createdBy and modifiedBy email addresses from the cosmosResourceSnapshots database

### Why

Those fields can contain customer email addresses

### Testing

Contains unit tests testing the redaction

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge

If E2E tests are included:

- [x] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [x] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
