### PR TITLE
test: trim verbose release image dump from nodepool upgrade errors (AROSLSRE-1938)

### DIFF
--- a/test/util/verifiers/nodes.go
+++ b/test/util/verifiers/nodes.go
@@ -221,26 +221,29 @@ type verifyNodePoolUpgrade struct {
 }
 
 // nodeSummary is a compact representation of a node for error messages.
-// Full node objects can be 10KB+ due to annotations and are too large for error output.
+// Full node objects can be 10KB+ due to annotations and image lists,
+// and are too large for error output.
 type nodeSummary struct {
-	Name                    string   `json:"name"`
-	Ready                   bool     `json:"ready"`
-	ContainerRuntimeVersion string   `json:"containerRuntimeVersion"`
-	ReleaseImages           []string `json:"releaseImages,omitempty"`
+	Name                    string `json:"name"`
+	Ready                   bool   `json:"ready"`
+	KubeletVersion          string `json:"kubeletVersion"`
+	ContainerRuntimeVersion string `json:"containerRuntimeVersion"`
+	ImageCount              int    `json:"imageCount"`
 }
 
 func summarizeNodes(nodes []corev1.Node) []nodeSummary {
 	summaries := make([]nodeSummary, len(nodes))
 	for i, node := range nodes {
-		var releaseImages []string
+		imageCount := 0
 		for _, img := range node.Status.Images {
-			releaseImages = append(releaseImages, img.Names...)
+			imageCount += len(img.Names)
 		}
 		summaries[i] = nodeSummary{
 			Name:                    node.Name,
 			Ready:                   nodeReady(to.Ptr(node)),
+			KubeletVersion:          node.Status.NodeInfo.KubeletVersion,
 			ContainerRuntimeVersion: node.Status.NodeInfo.ContainerRuntimeVersion,
-			ReleaseImages:           releaseImages,
+			ImageCount:              imageCount,
 		}
 	}
 	return summaries
@@ -361,5 +364,5 @@ func (v verifyNodePoolUpgrade) nodeReleaseImagesUpdated(node *corev1.Node) strin
 			return "" // at least one new image differs from previous
 		}
 	}
-	return fmt.Sprintf("%s (release images unchanged: %v)", node.Name, currentImgs)
+	return fmt.Sprintf("%s (release images unchanged: %d images, all match pre-upgrade set of %d)", node.Name, len(currentImgs), v.previousReleaseImages.Len())
 }


### PR DESCRIPTION
## Summary

The `VerifyNodePoolUpgrade` failure message dumps every container image on every node (50+ entries each), producing thousands of characters of noise that obscure the actual failure reason. This makes timeout errors nearly unreadable in Prow logs.

## Changes

- Replace `ReleaseImages []string` in `nodeSummary` with `ImageCount int` — shows how many images exist without listing them all
- Add `KubeletVersion` to `nodeSummary` — provides the actual version info needed for debugging
- Change `nodeReleaseImagesUpdated` error from dumping the full image list to a concise count comparison

### Before
```
nodes=[{"name":"node-1","releaseImages":["quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:abc...","quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:def...", ... 50+ more ...]}]
```

### After
```
nodes=[{"name":"node-1","kubeletVersion":"v1.35.6+abc","containerRuntimeVersion":"cri-o://1.35.6","imageCount":52}]
```

## Jira

Fixes [AROSLSRE-1938](https://redhat.atlassian.net/browse/AROSLSRE-1938) (subtask of [AROSLSRE-1936](https://redhat.atlassian.net/browse/AROSLSRE-1936))

Follow-up from [#6727](https://github.com/Azure/ARO-HCP/pull/6727) review feedback (stevekuznetsov).