### PR TITLE
fix: grafana regex to work with pers dev environment resources

### DIFF
--- a/observability/grafana-dashboards/backend/backend.json
+++ b/observability/grafana-dashboards/backend/backend.json
@@ -254,7 +254,7 @@
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "^.*-svc-\\d+$",
+        "regex": "^.*-svc(?:-\\d+)?$",
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"

--- a/observability/grafana-dashboards/clusters-service/cluster-service-slo-compund-metrics.json
+++ b/observability/grafana-dashboards/clusters-service/cluster-service-slo-compund-metrics.json
@@ -868,7 +868,7 @@
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "^.*-svc-\\d+$",
+        "regex": "^.*-svc(?:-\\d+)?$",
         "type": "query"
       }
     ]

--- a/observability/grafana-dashboards/clusters-service/cluster-service-slo.json
+++ b/observability/grafana-dashboards/clusters-service/cluster-service-slo.json
@@ -2244,7 +2244,7 @@
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "^.*-svc-\\d+$",
+        "regex": "^.*-svc(?:-\\d+)?$",
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"

--- a/observability/grafana-dashboards/frontend/frontend-control-plane-latency.json
+++ b/observability/grafana-dashboards/frontend/frontend-control-plane-latency.json
@@ -371,7 +371,7 @@
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "^.*-svc-\\d+$",
+        "regex": "^.*-svc(?:-\\d+)?$",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"

--- a/observability/grafana-dashboards/frontend/frontend.json
+++ b/observability/grafana-dashboards/frontend/frontend.json
@@ -769,7 +769,7 @@
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,
-        "regex": "^.*-svc-\\d+$",
+        "regex": "^.*-svc(?:-\\d+)?$",
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"

--- a/observability/grafana-dashboards/frontend/mise.json
+++ b/observability/grafana-dashboards/frontend/mise.json
@@ -37,7 +37,7 @@
           "qryType": 1
         },
         "refresh": 1,
-        "regex": "^.*-svc-\\d+$",
+        "regex": "^.*-svc(?:-\\d+)?$",
         "hide": 0
       }
     ]

--- a/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
+++ b/observability/grafana-dashboards/sre/user-journey/frontend-slo.json
@@ -753,7 +753,7 @@
         "name": "cluster",
         "query": "label_values(frontend_http_requests_total, cluster)",
         "refresh": 2,
-        "regex": "^.*-svc-\\d+$",
+        "regex": "^.*-svc(?:-\\d+)?$",
         "type": "query"
       }
     ]


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/ARO-27702

Relates to: https://github.com/Azure/ARO-HCP/pull/6733

### What

Changed the regex from `^.*-svc-\d+$` to `^.*-svc(?:-\d+)?$` in all dashboards that reference the service cluster datasource.

### Why

The PR linked above contains changes to allow for local Grafana development using our personal dev environments. On non-personal environments, the service clusters end with a dash and a number, e.g. `cspr-westus3-svc-1`, whereas the personal dev environment service cluster does not contain the suffix, e.g. `pers-sw3dsei-svc`. As a result, the local Grafana dashboards were showing no service cluster even when one existed in the personal dev environment. The updated regex now accounts for both scenarios.

### Testing

Old regex on the left shows a match only for the dev resource, new regex on the right matches both dev and pers resource:
<img width="2252" height="660" alt="4 regex verification" src="https://github.com/user-attachments/assets/5ebd5bdf-17ee-4023-aeeb-9d35c6670e60" />

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge