### PR TITLE
fix: inconsistent json formatting

### DIFF
--- a/observability/grafana-dashboards/istio/control_plane_dashboard.json
+++ b/observability/grafana-dashboards/istio/control_plane_dashboard.json
@@ -1,950 +1,948 @@
 {
-  "dashboard": {
-    "__inputs": [
-      {
-        "name": "DS_PROMETHEUS",
-        "label": "Prometheus",
-        "description": "",
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "6.4.3"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "5.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
+  "description": "Istio Control Plane Dashboard version 1.25.1",
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Deployed Versions",
+      "type": "row"
+    },
+    {
+      "datasource": {
         "type": "datasource",
-        "pluginId": "prometheus",
-        "pluginName": "Prometheus"
-      }
-    ],
-    "__requires": [
-      {
-        "type": "grafana",
-        "id": "grafana",
-        "name": "Grafana",
-        "version": "6.4.3"
+        "uid": "-- Mixed --"
       },
-      {
-        "type": "panel",
-        "id": "graph",
-        "name": "Graph",
-        "version": ""
-      },
-      {
-        "type": "datasource",
-        "id": "prometheus",
-        "name": "Prometheus",
-        "version": "5.0.0"
-      },
-      {
-        "type": "panel",
-        "id": "table",
-        "name": "Table",
-        "version": ""
-      }
-    ],
-    "description": "Istio Control Plane Dashboard version 1.25.1",
-    "graphTooltip": 1,
-    "panels": [
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "id": 1,
-        "panels": [],
-        "title": "Deployed Versions",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "datasource",
-          "uid": "-- Mixed --"
-        },
-        "description": "Version number of each running instance",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "fillOpacity": 10,
-              "gradientMode": "hue",
-              "showPoints": "never"
-            }
+      "description": "Version number of each running instance",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "showPoints": "never"
           }
-        },
-        "gridPos": {
-          "h": 5,
-          "w": 24,
-          "x": 0,
-          "y": 1
-        },
-        "id": 2,
-        "interval": "5s",
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list"
-          }
-        },
-        "pluginVersion": "v11.0.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum by (tag) (istio_build{component=\"pilot\"})",
-            "legendFormat": "Version ({{tag}})"
-          }
-        ],
-        "title": "Pilot Versions",
-        "type": "timeseries"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 1
-        },
-        "id": 3,
-        "panels": [],
-        "title": "Resource Usage",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "datasource",
-          "uid": "-- Mixed --"
-        },
-        "description": "Memory usage of each running instance",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "fillOpacity": 10,
-              "gradientMode": "hue",
-              "showPoints": "never"
-            },
-            "unit": "bytes"
-          }
-        },
-        "gridPos": {
-          "h": 10,
-          "w": 6,
-          "x": 0,
-          "y": 2
-        },
-        "id": 4,
-        "interval": "5s",
-        "options": {
-          "legend": {
-            "calcs": [
-              "last",
-              "max"
-            ],
-            "displayMode": "table"
-          }
-        },
-        "pluginVersion": "v11.0.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum by (pod) (container_memory_working_set_bytes{container=\"discovery\",pod=~\"istiod-.*\"})",
-            "legendFormat": "Container ({{pod}})"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum by (pod) (go_memstats_stack_inuse_bytes{app=\"istiod\"})",
-            "legendFormat": "Stack ({{pod}})"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum by (pod) (go_memstats_heap_inuse_bytes{app=\"istiod\"})",
-            "legendFormat": "Heap (In Use) ({{pod}})"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum by (pod) (go_memstats_heap_alloc_bytes{app=\"istiod\"})",
-            "legendFormat": "Heap (Allocated) ({{pod}})"
-          }
-        ],
-        "title": "Memory Usage",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "datasource",
-          "uid": "-- Mixed --"
-        },
-        "description": "Details about memory allocations",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "fillOpacity": 10,
-              "gradientMode": "hue",
-              "showPoints": "never"
-            },
-            "unit": "Bps"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byFrameRefID",
-                "options": "B"
-              },
-              "properties": [
-                {
-                  "id": "custom.axisPlacement",
-                  "value": "right"
-                },
-                {
-                  "id": "unit",
-                  "value": "c/s"
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 10,
-          "w": 6,
-          "x": 6,
-          "y": 2
-        },
-        "id": 5,
-        "interval": "5s",
-        "options": {
-          "legend": {
-            "calcs": [
-              "last",
-              "max"
-            ],
-            "displayMode": "table"
-          }
-        },
-        "pluginVersion": "v11.0.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum by (pod) (rate(go_memstats_alloc_bytes_total{app=\"istiod\"}[$__rate_interval]))",
-            "legendFormat": "Bytes ({{pod}})"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum by (pod) (rate(go_memstats_mallocs_total{app=\"istiod\"}[$__rate_interval]))",
-            "legendFormat": "Objects ({{pod}})"
-          }
-        ],
-        "title": "Memory Allocations",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "datasource",
-          "uid": "-- Mixed --"
-        },
-        "description": "CPU usage of each running instance",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "fillOpacity": 10,
-              "gradientMode": "hue",
-              "showPoints": "never"
-            }
-          }
-        },
-        "gridPos": {
-          "h": 10,
-          "w": 6,
-          "x": 12,
-          "y": 2
-        },
-        "id": 6,
-        "interval": "5s",
-        "options": {
-          "legend": {
-            "calcs": [
-              "last",
-              "max"
-            ],
-            "displayMode": "table"
-          }
-        },
-        "pluginVersion": "v11.0.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum by (pod) (irate(container_cpu_usage_seconds_total{container=\"discovery\",pod=~\"istiod-.*\"}[$__rate_interval]))",
-            "legendFormat": "Container ({{pod}})"
-          }
-        ],
-        "title": "CPU Usage",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "datasource",
-          "uid": "-- Mixed --"
-        },
-        "description": "Goroutine count for each running instance",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "fillOpacity": 10,
-              "gradientMode": "hue",
-              "showPoints": "never"
-            }
-          }
-        },
-        "gridPos": {
-          "h": 10,
-          "w": 6,
-          "x": 18,
-          "y": 2
-        },
-        "id": 7,
-        "interval": "5s",
-        "options": {
-          "legend": {
-            "calcs": [
-              "last",
-              "max"
-            ],
-            "displayMode": "table"
-          }
-        },
-        "pluginVersion": "v11.0.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum by (pod) (go_goroutines{app=\"istiod\"})",
-            "legendFormat": "Goroutines ({{pod}})"
-          }
-        ],
-        "title": "Goroutines",
-        "type": "timeseries"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 3
-        },
-        "id": 8,
-        "panels": [],
-        "title": "Push Information",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "datasource",
-          "uid": "-- Mixed --"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "drawStyle": "bars",
-              "fillOpacity": 100,
-              "gradientMode": "none",
-              "showPoints": "never",
-              "stacking": {
-                "mode": "normal"
-              }
-            },
-            "unit": "ops"
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "cds"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Clusters"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "eds"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Endpoints"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "lds"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Listeners"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "rds"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Routes"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "nds"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "DNS Tables"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "istio.io/debug"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Debug"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "istio.io/debug/syncz"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Debug"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "wads"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Authorization"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "wds"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Workloads"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "type.googleapis.com/istio.security.Authorization"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Authorizations"
-                }
-              ]
-            },
-            {
-              "matcher": {
-                "id": "byName",
-                "options": "type.googleapis.com/istio.workload.Address"
-              },
-              "properties": [
-                {
-                  "id": "displayName",
-                  "value": "Addresses"
-                }
-              ]
-            }
-          ]
-        },
-        "gridPos": {
-          "h": 10,
-          "w": 8,
-          "x": 0,
-          "y": 4
-        },
-        "id": 9,
-        "interval": "15s",
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list"
-          }
-        },
-        "pluginVersion": "v11.0.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum by (type) (irate(pilot_xds_pushes[$__rate_interval]))",
-            "legendFormat": "{{type}}"
-          }
-        ],
-        "title": "XDS Pushes",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "datasource",
-          "uid": "-- Mixed --"
-        },
-        "description": "Size of each xDS push.\n",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "fillOpacity": 10,
-              "gradientMode": "hue",
-              "showPoints": "never"
-            }
-          }
-        },
-        "gridPos": {
-          "h": 10,
-          "w": 8,
-          "x": 8,
-          "y": 4
-        },
-        "id": 10,
-        "interval": "5s",
-        "options": {
-          "legend": {
-            "calcs": [
-              "last",
-              "max"
-            ],
-            "displayMode": "table"
-          }
-        },
-        "pluginVersion": "v11.0.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum by (type,event) (rate(pilot_k8s_reg_events[$__rate_interval]))",
-            "legendFormat": "{{event}} {{type}}"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum by (type,event) (rate(pilot_k8s_cfg_events[$__rate_interval]))",
-            "legendFormat": "{{event}} {{type}}"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum by (type) (rate(pilot_push_triggers[$__rate_interval]))",
-            "legendFormat": "Push {{type}}"
-          }
-        ],
-        "title": "Events",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "datasource",
-          "uid": "-- Mixed --"
-        },
-        "description": "Total number of XDS connections\n",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "fillOpacity": 10,
-              "gradientMode": "hue",
-              "showPoints": "never"
-            }
-          }
-        },
-        "gridPos": {
-          "h": 10,
-          "w": 8,
-          "x": 16,
-          "y": 4
-        },
-        "id": 11,
-        "interval": "5s",
-        "options": {
-          "legend": {
-            "calcs": [
-              "last",
-              "max"
-            ],
-            "displayMode": "table"
-          }
-        },
-        "pluginVersion": "v11.0.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum(envoy_cluster_upstream_cx_active{cluster_name=\"xds-grpc\"})",
-            "legendFormat": "Connections (client reported)"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum (pilot_xds)",
-            "legendFormat": "Connections (server reported)"
-          }
-        ],
-        "title": "Connections",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "datasource",
-          "uid": "-- Mixed --"
-        },
-        "description": "Number of push errors. Many of these are at least potentional fatal and should be explored in-depth via Istiod logs.\nNote: metrics here do not use rate() to avoid missing transition from \"No series\"; series are not reported if there are no errors at all.\n",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "fillOpacity": 10,
-              "gradientMode": "hue",
-              "showPoints": "never"
-            }
-          }
-        },
-        "gridPos": {
-          "h": 10,
-          "w": 8,
-          "x": 0,
-          "y": 14
-        },
-        "id": 12,
-        "interval": "5s",
-        "options": {
-          "legend": {
-            "calcs": [
-              "last",
-              "max"
-            ],
-            "displayMode": "table"
-          }
-        },
-        "pluginVersion": "v11.0.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum by (type) (pilot_total_xds_rejects)",
-            "legendFormat": "Rejected Config ({{type}})"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "pilot_total_xds_internal_errors",
-            "legendFormat": "Internal Errors"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "pilot_xds_push_context_errors",
-            "legendFormat": "Push Context Errors"
-          }
-        ],
-        "title": "Push Errors",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "datasource",
-          "uid": "-- Mixed --"
-        },
-        "description": "Count of active and pending proxies managed by each instance.\nPending is expected to converge to zero.\n",
-        "gridPos": {
-          "h": 10,
-          "w": 8,
-          "x": 8,
-          "y": 14
-        },
-        "id": 13,
-        "interval": "1m",
-        "options": {
-          "calculation": {
-            "xBuckets": {
-              "mode": "size",
-              "value": "1min"
-            }
-          },
-          "cellGap": 0,
-          "color": {
-            "mode": "scheme",
-            "scheme": "Spectral",
-            "steps": 128
-          },
-          "yAxis": {
-            "decimals": 0,
-            "unit": "s"
-          }
-        },
-        "pluginVersion": "v11.0.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum(rate(pilot_xds_push_time_bucket{}[1m])) by (le)",
-            "format": "heatmap",
-            "legendFormat": "{{le}}"
-          }
-        ],
-        "title": "Push Time",
-        "type": "heatmap"
-      },
-      {
-        "datasource": {
-          "type": "datasource",
-          "uid": "-- Mixed --"
-        },
-        "description": "Size of each xDS push.\n",
-        "gridPos": {
-          "h": 10,
-          "w": 8,
-          "x": 16,
-          "y": 14
-        },
-        "id": 14,
-        "interval": "1m",
-        "options": {
-          "calculation": {
-            "xBuckets": {
-              "mode": "size",
-              "value": "1min"
-            }
-          },
-          "cellGap": 0,
-          "color": {
-            "mode": "scheme",
-            "scheme": "Spectral",
-            "steps": 128
-          },
-          "yAxis": {
-            "decimals": 0,
-            "unit": "bytes"
-          }
-        },
-        "pluginVersion": "v11.0.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum(rate(pilot_xds_config_size_bytes_bucket{}[1m])) by (le)",
-            "format": "heatmap",
-            "legendFormat": "{{le}}"
-          }
-        ],
-        "title": "Push Size",
-        "type": "heatmap"
-      },
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 100
-        },
-        "id": 15,
-        "panels": [],
-        "title": "Webhooks",
-        "type": "row"
-      },
-      {
-        "datasource": {
-          "type": "datasource",
-          "uid": "-- Mixed --"
-        },
-        "description": "Rate of XDS push operations, by type. This is incremented on a per-proxy basis.\n",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "fillOpacity": 10,
-              "gradientMode": "hue",
-              "showPoints": "never"
-            }
-          }
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 101
-        },
-        "id": 16,
-        "interval": "5s",
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list"
-          }
-        },
-        "pluginVersion": "v11.0.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum (rate(galley_validation_passed[$__rate_interval]))",
-            "legendFormat": "Success"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum (rate(galley_validation_failed[$__rate_interval]))",
-            "legendFormat": "Failure"
-          }
-        ],
-        "title": "Validation",
-        "type": "timeseries"
-      },
-      {
-        "datasource": {
-          "type": "datasource",
-          "uid": "-- Mixed --"
-        },
-        "description": "Size of each xDS push.\n",
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "fillOpacity": 10,
-              "gradientMode": "hue",
-              "showPoints": "never"
-            }
-          }
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 12,
-          "y": 101
-        },
-        "id": 17,
-        "interval": "5s",
-        "options": {
-          "legend": {
-            "calcs": [],
-            "displayMode": "list"
-          }
-        },
-        "pluginVersion": "v11.0.0",
-        "targets": [
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum (rate(sidecar_injection_success_total[$__rate_interval]))",
-            "legendFormat": "Success"
-          },
-          {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "$datasource"
-            },
-            "expr": "sum (rate(sidecar_injection_failure_total[$__rate_interval]))",
-            "legendFormat": "Failure"
-          }
-        ],
-        "title": "Injection",
-        "type": "timeseries"
-      }
-    ],
-    "refresh": "15s",
-    "schemaVersion": 39,
-    "templating": {
-      "list": [
-        {
-          "name": "datasource",
-          "query": "prometheus",
-          "type": "datasource",
-          "regex": "^Managed_Prometheus_services-.*$"
         }
-      ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list"
+        }
+      },
+      "pluginVersion": "v11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (tag) (istio_build{component=\"pilot\"})",
+          "legendFormat": "Version ({{tag}})"
+        }
+      ],
+      "title": "Pilot Versions",
+      "type": "timeseries"
     },
-    "time": {
-      "from": "now-30m",
-      "to": "now"
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 3,
+      "panels": [],
+      "title": "Resource Usage",
+      "type": "row"
     },
-    "timezone": "utc",
-    "title": "Istio Control Plane Dashboard",
-    "uid": "1813f692a8e4ac77155348d4c7d2fba8",
-    "gnetId": 7645
-  }
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Memory usage of each running instance",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "showPoints": "never"
+          },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 0,
+        "y": 2
+      },
+      "id": 4,
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table"
+        }
+      },
+      "pluginVersion": "v11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (container_memory_working_set_bytes{container=\"discovery\",pod=~\"istiod-.*\"})",
+          "legendFormat": "Container ({{pod}})"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (go_memstats_stack_inuse_bytes{app=\"istiod\"})",
+          "legendFormat": "Stack ({{pod}})"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (go_memstats_heap_inuse_bytes{app=\"istiod\"})",
+          "legendFormat": "Heap (In Use) ({{pod}})"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (go_memstats_heap_alloc_bytes{app=\"istiod\"})",
+          "legendFormat": "Heap (Allocated) ({{pod}})"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Details about memory allocations",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "showPoints": "never"
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "c/s"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 6,
+        "y": 2
+      },
+      "id": 5,
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table"
+        }
+      },
+      "pluginVersion": "v11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (rate(go_memstats_alloc_bytes_total{app=\"istiod\"}[$__rate_interval]))",
+          "legendFormat": "Bytes ({{pod}})"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (rate(go_memstats_mallocs_total{app=\"istiod\"}[$__rate_interval]))",
+          "legendFormat": "Objects ({{pod}})"
+        }
+      ],
+      "title": "Memory Allocations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "CPU usage of each running instance",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "showPoints": "never"
+          }
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 12,
+        "y": 2
+      },
+      "id": 6,
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table"
+        }
+      },
+      "pluginVersion": "v11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (irate(container_cpu_usage_seconds_total{container=\"discovery\",pod=~\"istiod-.*\"}[$__rate_interval]))",
+          "legendFormat": "Container ({{pod}})"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Goroutine count for each running instance",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "showPoints": "never"
+          }
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 18,
+        "y": 2
+      },
+      "id": 7,
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table"
+        }
+      },
+      "pluginVersion": "v11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (go_goroutines{app=\"istiod\"})",
+          "legendFormat": "Goroutines ({{pod}})"
+        }
+      ],
+      "title": "Goroutines",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 8,
+      "panels": [],
+      "title": "Push Information",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cds"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Clusters"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "eds"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Endpoints"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "lds"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Listeners"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "rds"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Routes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "nds"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "DNS Tables"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "istio.io/debug"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Debug"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "istio.io/debug/syncz"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Debug"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "wads"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Authorization"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "wds"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Workloads"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "type.googleapis.com/istio.security.Authorization"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Authorizations"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "type.googleapis.com/istio.workload.Address"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Addresses"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 4
+      },
+      "id": 9,
+      "interval": "15s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list"
+        }
+      },
+      "pluginVersion": "v11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (type) (irate(pilot_xds_pushes[$__rate_interval]))",
+          "legendFormat": "{{type}}"
+        }
+      ],
+      "title": "XDS Pushes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Size of each xDS push.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "showPoints": "never"
+          }
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 4
+      },
+      "id": 10,
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table"
+        }
+      },
+      "pluginVersion": "v11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (type,event) (rate(pilot_k8s_reg_events[$__rate_interval]))",
+          "legendFormat": "{{event}} {{type}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (type,event) (rate(pilot_k8s_cfg_events[$__rate_interval]))",
+          "legendFormat": "{{event}} {{type}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (type) (rate(pilot_push_triggers[$__rate_interval]))",
+          "legendFormat": "Push {{type}}"
+        }
+      ],
+      "title": "Events",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Total number of XDS connections\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "showPoints": "never"
+          }
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 4
+      },
+      "id": 11,
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table"
+        }
+      },
+      "pluginVersion": "v11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum(envoy_cluster_upstream_cx_active{cluster_name=\"xds-grpc\"})",
+          "legendFormat": "Connections (client reported)"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum (pilot_xds)",
+          "legendFormat": "Connections (server reported)"
+        }
+      ],
+      "title": "Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Number of push errors. Many of these are at least potentional fatal and should be explored in-depth via Istiod logs.\nNote: metrics here do not use rate() to avoid missing transition from \"No series\"; series are not reported if there are no errors at all.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "showPoints": "never"
+          }
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 14
+      },
+      "id": 12,
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "table"
+        }
+      },
+      "pluginVersion": "v11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum by (type) (pilot_total_xds_rejects)",
+          "legendFormat": "Rejected Config ({{type}})"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "pilot_total_xds_internal_errors",
+          "legendFormat": "Internal Errors"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "pilot_xds_push_context_errors",
+          "legendFormat": "Push Context Errors"
+        }
+      ],
+      "title": "Push Errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Count of active and pending proxies managed by each instance.\nPending is expected to converge to zero.\n",
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 14
+      },
+      "id": 13,
+      "interval": "1m",
+      "options": {
+        "calculation": {
+          "xBuckets": {
+            "mode": "size",
+            "value": "1min"
+          }
+        },
+        "cellGap": 0,
+        "color": {
+          "mode": "scheme",
+          "scheme": "Spectral",
+          "steps": 128
+        },
+        "yAxis": {
+          "decimals": 0,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "v11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(pilot_xds_push_time_bucket{}[1m])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}"
+        }
+      ],
+      "title": "Push Time",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Size of each xDS push.\n",
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 14
+      },
+      "id": 14,
+      "interval": "1m",
+      "options": {
+        "calculation": {
+          "xBuckets": {
+            "mode": "size",
+            "value": "1min"
+          }
+        },
+        "cellGap": 0,
+        "color": {
+          "mode": "scheme",
+          "scheme": "Spectral",
+          "steps": 128
+        },
+        "yAxis": {
+          "decimals": 0,
+          "unit": "bytes"
+        }
+      },
+      "pluginVersion": "v11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(pilot_xds_config_size_bytes_bucket{}[1m])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}"
+        }
+      ],
+      "title": "Push Size",
+      "type": "heatmap"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 100
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Webhooks",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Rate of XDS push operations, by type. This is incremented on a per-proxy basis.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "showPoints": "never"
+          }
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 101
+      },
+      "id": 16,
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list"
+        }
+      },
+      "pluginVersion": "v11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum (rate(galley_validation_passed[$__rate_interval]))",
+          "legendFormat": "Success"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum (rate(galley_validation_failed[$__rate_interval]))",
+          "legendFormat": "Failure"
+        }
+      ],
+      "title": "Validation",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Size of each xDS push.\n",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "showPoints": "never"
+          }
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 101
+      },
+      "id": 17,
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list"
+        }
+      },
+      "pluginVersion": "v11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum (rate(sidecar_injection_success_total[$__rate_interval]))",
+          "legendFormat": "Success"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "expr": "sum (rate(sidecar_injection_failure_total[$__rate_interval]))",
+          "legendFormat": "Failure"
+        }
+      ],
+      "title": "Injection",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "15s",
+  "schemaVersion": 39,
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "query": "prometheus",
+        "type": "datasource",
+        "regex": "^Managed_Prometheus_services-.*$"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timezone": "utc",
+  "title": "Istio Control Plane Dashboard",
+  "uid": "1813f692a8e4ac77155348d4c7d2fba8",
+  "gnetId": 7645
 }


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/ARO-27702

Relates to: https://github.com/Azure/ARO-HCP/pull/6733

### What

Removed the top-level "dashboard" wrapper in `observability/grafana-dashboards/istio/control_plane_dashboard.json` in order to make the json consistent with all other dashboards, and to fix local dashboard rendering. This change is formatting only. It does not change the dashboard behavior.

### Why

The istio control plane dashboard JSON had inconsistent formatting that broke page loading with local Grafana development.

### Testing

Local Grafana dashboards before the update was missing the "Istio Control Plane Dashboard":
<img width="657" height="931" alt="14 istio before" src="https://github.com/user-attachments/assets/3aa5f76e-01e7-4a4a-bab2-d4e557c663c6" />

The json update fixes it:
<img width="658" height="922" alt="15 istio after" src="https://github.com/user-attachments/assets/4864ad37-652b-4786-ae26-59c157ad2b79" />

The dashboard renders as expected:
<img width="1280" height="1345" alt="16 istio dashboard is working" src="https://github.com/user-attachments/assets/5351f705-4197-41f6-854f-d42ac9d6ca65" />

### Special notes for your reviewer

GitHub's diff rendering makes it hard to see what changed. Here is the diff in VS Code:
<img width="1225" height="1304" alt="17 VS Code diff 1" src="https://github.com/user-attachments/assets/96d3ea2f-49db-4ab7-a9b9-a54157c0cc82" />
<img width="1225" height="1261" alt="18 VS Code diff 2" src="https://github.com/user-attachments/assets/0c887c92-1201-4b88-baa2-6a6c6b68d749" />

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge
