### PR TITLE
fix(backend): omit no-message sources from operation status (AROSLSRE-1943)

### DIFF
--- a/backend/pkg/utils/operationutils/operation_state.go
+++ b/backend/pkg/utils/operationutils/operation_state.go
@@ -79,6 +79,11 @@ func CompareOperationState(lhs, rhs *OperationState) int {
 }
 
 // PickWorstOperationState expects states pre-sorted and returns the worst state with merged messages.
+//
+// Only sources that report an actual message are included in the merged message: a source tied
+// for the worst provisioning state with no message of its own has nothing blocking to report (e.g.
+// it is simply still in progress), so it is omitted rather than rendered as a confusing "<no_message>"
+// placeholder that reads like an error.
 func PickWorstOperationState(states []*OperationState) (*OperationState, error) {
 	if len(states) == 0 {
 		return nil, errors.New("no operation states")
@@ -92,15 +97,14 @@ func PickWorstOperationState(states []*OperationState) (*OperationState, error) 
 		if s.ProvisioningState != worstProvisioningState {
 			break
 		}
+		if s.Message == "" {
+			continue
+		}
 		currentSource := "<no_source>"
 		if s.Source != "" {
 			currentSource = s.Source
 		}
-		currentMessage := "<no_message>"
-		if s.Message != "" {
-			currentMessage = s.Message
-		}
-		messageParts = append(messageParts, fmt.Sprintf("[%s] %s", currentSource, currentMessage))
+		messageParts = append(messageParts, fmt.Sprintf("[%s] %s", currentSource, s.Message))
 	}
 	return NewOperationState(worstProvisioningState, strings.Join(messageParts, "; ")), nil
 }

--- a/backend/pkg/utils/operationutils/operation_state_test.go
+++ b/backend/pkg/utils/operationutils/operation_state_test.go
@@ -143,12 +143,21 @@ func TestPickWorstOperationState(t *testing.T) {
 			wantMessage: "[<no_source>] worst",
 		},
 		{
-			name: "empty message uses placeholder",
+			name: "source with empty message is omitted, not rendered as a placeholder",
 			states: []*OperationState{
 				NewOperationState(coreapi.ProvisioningStateFailed, "").WithSource("checkA"),
 			},
 			wantProv:    coreapi.ProvisioningStateFailed,
-			wantMessage: "[checkA] <no_message>",
+			wantMessage: "",
+		},
+		{
+			name: "source with empty message is omitted alongside sources with a real message",
+			states: []*OperationState{
+				NewOperationState(coreapi.ProvisioningStateFailed, "").WithSource("checkA"),
+				NewOperationState(coreapi.ProvisioningStateFailed, "NotReady: cluster is not ready").WithSource("checkB"),
+			},
+			wantProv:    coreapi.ProvisioningStateFailed,
+			wantMessage: "[checkB] NotReady: cluster is not ready",
 		},
 	}
 


### PR DESCRIPTION
[AROSLSRE-1943](https://redhat.atlassian.net/browse/AROSLSRE-1943)

### What

`PickWorstOperationState` (`backend/pkg/utils/operationutils/operation_state.go`) now skips sources with an empty `Message` when building the merged operation status string, instead of rendering them as a `[source] <no_message>` placeholder.

### Why

While investigating a recurring INT `e2e-integration-e2e-parallel` failure, the operation status showed `[clusterServiceClusterStatus] <no_message>`, which reads like an unreported error. Tracing the code showed it isn't one: any source tied for the current worst provisioning state gets merged into the message, even ones with nothing to report (just still reconciling). During normal `Provisioning` this shows up for basically every cluster create, making it impossible to tell a genuine unreported error apart from routine in-progress noise.

### Testing

```
cd backend && go build ./... && go vet ./pkg/utils/operationutils/...
cd backend && go test ./pkg/utils/operationutils/... -run TestPickWorstOperationState -v
```

All existing and updated unit tests pass. Updated the "empty message uses placeholder" test case in `operation_state_test.go` to reflect the new omit-instead-of-placeholder behavior, and added a case covering an empty-message source alongside one with a real message.

### Special notes for your reviewer

Presentation-only change to the merged status string, no change to reconciliation/provisioning logic. Found while triaging INT capacity/failures (see [AROSLSRE-1942](https://redhat.atlassian.net/browse/AROSLSRE-1942) for the related, separate mgmt-capacity fix in sdp-pipelines).
