### PR TITLE
fix(e2e): honor infra-precondition EV2 retry marker in regionalGating

### DIFF
--- a/docs/ci/ev2-retry-catcher.md
+++ b/docs/ci/ev2-retry-catcher.md
@@ -203,17 +203,18 @@ automatedRetry:
   - "failed to get token"
   - "Failed to connect to MSI"
   - "ev2-retryable-known-issue-failure"
+  - "ev2-retryable-infra-precondition-failure"
   maximumRetryCount: 1
   durationBetweenRetries: 1m
 ```
 
-EV2 substring-scans the step's output for any of the `errorContainsAny` strings and, on a match, redrives the whole step up to `maximumRetryCount` times, waiting `durationBetweenRetries` in between. Setting `automatedRetry` explicitly on a step **replaces** sdp-pipelines' default retry policy for that step (which only covers the three MSI/connection-failure phrases above) rather than extending it - so the three default phrases have to be repeated here alongside the new marker, or the gate would lose its existing infra-retry behavior.
+EV2 substring-scans the step's output for any of the `errorContainsAny` strings and, on a match, redrives the whole step up to `maximumRetryCount` times, waiting `durationBetweenRetries` in between. Setting `automatedRetry` explicitly on a step **replaces** sdp-pipelines' default retry policy for that step (which only covers the three MSI/connection-failure phrases above) rather than extending it - so the three default phrases have to be repeated here alongside the new markers, or the gate would lose its existing infra-retry behavior. `ev2-retryable-infra-precondition-failure` is the marker for the `InfraPreconditionEligible` case (AROSLSRE-1926): a gate failure where no step's `finished.json` ever carried the `ev2-failed-tests` metadata key at all, because a shared pre-step (e.g. `aro-hcp-lease-acquire` exhausting the e2e slot pool) failed before the `aro-hcp-tests` step got a chance to run and write it - distinct from `ev2-retryable-known-issue-failure`, which covers a per-test allow-retry decision once results were reported.
 
 `sdp-pipelines`'s `tooling/pkg/types/pipeline/prow.go` passes `--allow-ev2-retry` to every generated `ProwJob` step's command unconditionally; this is safe because the flag is inert unless `gate-promotion` is also set on the step, which is only true for the Stage/Prod EV2 gating steps and never for periodic or pre-merge jobs.
 
-**This currently only takes effect in prod.** `stg` and `int` both set `useExclusiveLocks: true` in sdp-pipelines' `hcp/stages.yaml`, which makes the generator treat those stages as fail-fast. `orchestratedStepFor` (`tooling/pkg/ev2/manifests/generate/graph_step.go`) ignores any explicit `automatedRetry` whenever a stage is fail-fast, falling back to the default MSI-only policy instead - so today, a stage gating run still needs a manual retry. Extending the generator to honor a custom `automatedRetry` even under fail-fast (while still forcing `FallbackToManualMitigation: false`, preserving the "don't hold the exclusive lock for a week" intent behind fail-fast) is a shared code path used by roughly 30 other pipelines and is tracked as a separate follow-up in AROSLSRE-1764, rather than bundled into this change.
+**This now takes effect in stg and int too, not just prod (AROSLSRE-1764).** `stg` and `int` both set `useExclusiveLocks: true` in sdp-pipelines' `hcp/stages.yaml`, which makes the generator treat those stages as fail-fast. `orchestratedStepFor`/`buildOnFailure` (`tooling/pkg/ev2/manifests/generate/graph_step.go`) used to ignore any explicit `automatedRetry` whenever a stage is fail-fast, falling back to the default MSI-only policy instead - so a stage gating run needed a manual retry. The generator now merges a step's custom `errorContainsAny` patterns into the fail-fast retry instead of dropping them, while still keeping `MaxRetryAttempts`/`WaitDurationBetweenRetry` pinned and `FallbackToManualMitigation: false` (preserving the "don't hold the exclusive lock for a week" intent behind fail-fast).
 
-> ⚠️ Do not reproduce the literal string `ev2-retryable-known-issue-failure` anywhere else that could end up in a gating step's stdout (comments in `common.sh`, other steps' `automatedRetry` lists, etc.). EV2's substring scan is applied to the whole step output, and a stray match would cause a genuinely failed, non-eligible run to be spuriously retried - exactly the class of bug described in AROSLSRE-1292.
+> ⚠️ Do not reproduce the literal strings `ev2-retryable-known-issue-failure` or `ev2-retryable-infra-precondition-failure` anywhere else that could end up in a gating step's stdout (comments in `common.sh`, other steps' `automatedRetry` lists, etc.). EV2's substring scan is applied to the whole step output, and a stray match would cause a genuinely failed, non-eligible run to be spuriously retried - exactly the class of bug described in AROSLSRE-1292.
 
 ## Expiration configuration
 
@@ -250,7 +251,6 @@ The label and signal names went through some discussion (`flaky`, `retry-during-
 
 ## Follow-ups
 
-- Extend EV2 automated retry to `stg`/`int`: today it only takes effect in prod, since those stages fail fast and the generator ignores custom `automatedRetry` in that mode. Tracked in AROSLSRE-1764.
 - Pick and implement one of the [expiration configuration](#expiration-configuration) options above so the TTL/timebomb intent is enforced rather than just documented.
 
 ## See also

--- a/test/e2e-pipeline.yaml
+++ b/test/e2e-pipeline.yaml
@@ -35,21 +35,23 @@ resourceGroups:
       name: globalMSIId
     # Setting this explicitly replaces the default MSI/connection-failure retry
     # (see sdp-pipelines graph_step.go buildOnFailure), so it must keep those
-    # phrases as well as the new marker prow-job-executor emits when finished.json
-    # marks a gate failure as a known, tracked issue safe to retry (AROSLSRE-1721).
-    # Do not reproduce ev2-retryable-known-issue-failure verbatim anywhere else this
-    # gate's inlined common.sh script could echo back into stdout, or a genuine,
+    # phrases as well as the new markers prow-job-executor emits when finished.json
+    # marks a gate failure as a known, tracked issue safe to retry (AROSLSRE-1721),
+    # or as a pre-test infra precondition failure safe to retry once (AROSLSRE-1926).
+    # Do not reproduce ev2-retryable-known-issue-failure or
+    # ev2-retryable-infra-precondition-failure verbatim anywhere else this gate's
+    # inlined common.sh script could echo back into stdout, or a genuine,
     # non-eligible failure would be spuriously retried (see AROSLSRE-1292).
-    # NOTE: this currently only takes effect in prod. stg and int set
-    # useExclusiveLocks in stages.yaml, and sdp-pipelines' generator ignores an
-    # explicit automatedRetry whenever the stage fails fast, so those stages
-    # still fall back to the default MSI/connection-failure-only retry. Tracked
-    # as a follow-up generator fix in AROSLSRE-1764.
+    # stg and int set useExclusiveLocks in stages.yaml, which makes the generator
+    # fail fast on this step; even there, these errorContainsAny patterns are
+    # still honored (merged into the fixed, bounded fail-fast retry) as of
+    # AROSLSRE-1764 - only the retry count/wait duration are pinned in that path.
     automatedRetry:
       errorContainsAny:
       - "failed to establish a new connection"
       - "failed to get token"
       - "Failed to connect to MSI"
       - "ev2-retryable-known-issue-failure"
+      - "ev2-retryable-infra-precondition-failure"
       maximumRetryCount: 1
       durationBetweenRetries: 1m


### PR DESCRIPTION
## Why

[AROSLSRE-1926](https://redhat.atlassian.net/browse/AROSLSRE-1926) - a stg
`e2e-parallel` gating job failed in the `aro-hcp-lease-acquire` pre-step
(slot-pool capacity exhaustion), before any test ran. The existing EV2
gating-retry mechanism (AROSLSRE-1721, `ev2-retryable-known-issue-failure`)
can't cover this: it depends on per-test `allow-retry` metadata the test
binary writes, and the test binary never started.

Azure/ARO-Tools#324 adds a new retry-eligibility class in
`prow-job-executor` for this "test binary never ran" case, surfaced via a
new marker string `ev2-retryable-infra-precondition-failure`.

## What

- Adds the new marker to `regionalGating`'s `automatedRetry.errorContainsAny`
  alongside the existing known-issue marker.
- Updates the inline comment: a companion sdp-pipelines fix
  ([AROSLSRE-1764](https://redhat.atlassian.net/browse/AROSLSRE-1764)) now merges a step's custom `errorContainsAny` patterns
  into the retry conditions even in the stg/int fail-fast
  (`useExclusiveLocks`) path, so these markers take effect there too, not
  just in prod.

Validated with `templatize pipeline validate --only-changed`.

Depends on Azure/ARO-Tools#324 merging and the sdp-pipelines companion PR
(bumps the `prow-job-executor` dependency) for the marker to actually be
emitted; this PR is a no-op until then (the string just never appears).