### PR TITLE
fix(test): clear UserAssignedIdentities values before CIDR-update PUT (AROSLSRE-1944)

### DIFF
--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -387,6 +387,11 @@ var _ = Describe("Authorized CIDRs", func() {
 				currentCluster.Properties.API.AuthorizedCIDRs = []*string{
 					to.Ptr("192.0.2.0/24"), // Use TEST-NET-1 (reserved for documentation)
 				}
+				// The Get above returns a fully populated UserAssignedIdentities map
+				// (ClientID/PrincipalID set by ARM). Re-sending those populated values on
+				// this PUT is rejected by ARM with InvalidIdentityValues; existing
+				// identities must be echoed back as empty objects.
+				framework.ClearUserAssignedIdentityValues20240610(currentCluster.Identity)
 
 				// Use CreateOrUpdate (PUT) to apply the change
 				poller, err := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().BeginCreateOrUpdate(

--- a/test/e2e/cluster_create_feature_aggregation.go
+++ b/test/e2e/cluster_create_feature_aggregation.go
@@ -232,6 +232,11 @@ var _ = Describe("Customer", func() {
 
 			By("updating the cluster to add the test runner IP to the authorized CIDR list")
 			cluster.Properties.API.AuthorizedCIDRs = []*string{to.Ptr(vmCIDR), to.Ptr(testRunnerCIDR)}
+			// The cluster we just Got has a fully populated UserAssignedIdentities map
+			// (ClientID/PrincipalID set by ARM). Re-sending those populated values on this
+			// PUT is rejected by ARM with InvalidIdentityValues; existing identities must be
+			// echoed back as empty objects.
+			framework.ClearUserAssignedIdentityValues20251223(cluster.Identity)
 			cidrUpdatePoller, err := tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().BeginCreateOrUpdate(
 				ctx,
 				*resourceGroup.Name,

--- a/test/e2e/cluster_fips_mode.go
+++ b/test/e2e/cluster_fips_mode.go
@@ -143,6 +143,11 @@ var _ = Describe("FIPS Mode Support", func() {
 
 				By("attempting to change cryptoRestrictions from FIPS to None - should be rejected")
 				actualHCPCluster.Properties.CryptoRestrictions = to.Ptr(v20260630preview.CryptoRestrictionsNone)
+				// The Get above returns a fully populated UserAssignedIdentities map
+				// (ClientID/PrincipalID set by ARM). Re-sending those populated values on
+				// this PUT is rejected by ARM with InvalidIdentityValues; existing
+				// identities must be echoed back as empty objects.
+				framework.ClearUserAssignedIdentityValues20260630(actualHCPCluster.Identity)
 				poller, err := tc.Get20260630ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient().BeginCreateOrUpdate(
 					ctx,
 					*resourceGroup.Name,

--- a/test/util/framework/helpers_v20240610preview.go
+++ b/test/util/framework/helpers_v20240610preview.go
@@ -162,6 +162,25 @@ func ConvertToUserAssignedIdentitiesProfile20240610(value interface{}) (*hcpsdk2
 	return &uamis, nil
 }
 
+// ClearUserAssignedIdentityValues20240610 resets every value in a
+// ManagedServiceIdentity's UserAssignedIdentities map to an empty struct,
+// preserving only the map keys (identity resource IDs).
+//
+// ARM requires that on a PUT of an existing resource, UserAssignedIdentities
+// map values for identities that should be kept unchanged are sent back as
+// empty objects ({}); the client/PrincipalID values a prior GET populated
+// must not be echoed back. Callers that Get a cluster, mutate an unrelated
+// field, and then BeginCreateOrUpdate the full object must call this first
+// or ARM rejects the request with error code InvalidIdentityValues.
+func ClearUserAssignedIdentityValues20240610(identity *hcpsdk20240610preview.ManagedServiceIdentity) {
+	if identity == nil {
+		return
+	}
+	for id := range identity.UserAssignedIdentities {
+		identity.UserAssignedIdentities[id] = &hcpsdk20240610preview.UserAssignedIdentity{}
+	}
+}
+
 func ConvertToManagedServiceIdentity20240610(value interface{}) (*hcpsdk20240610preview.ManagedServiceIdentity, error) {
 	if value == nil {
 		return nil, nil

--- a/test/util/framework/helpers_v20251223preview.go
+++ b/test/util/framework/helpers_v20251223preview.go
@@ -160,6 +160,25 @@ func ConvertToUserAssignedIdentitiesProfile20251223(value interface{}) (*hcpsdk2
 	return &uamis, nil
 }
 
+// ClearUserAssignedIdentityValues20251223 resets every value in a
+// ManagedServiceIdentity's UserAssignedIdentities map to an empty struct,
+// preserving only the map keys (identity resource IDs).
+//
+// ARM requires that on a PUT of an existing resource, UserAssignedIdentities
+// map values for identities that should be kept unchanged are sent back as
+// empty objects ({}); the client/PrincipalID values a prior GET populated
+// must not be echoed back. Callers that Get a cluster, mutate an unrelated
+// field, and then BeginCreateOrUpdate the full object must call this first
+// or ARM rejects the request with error code InvalidIdentityValues.
+func ClearUserAssignedIdentityValues20251223(identity *hcpsdk20251223preview.ManagedServiceIdentity) {
+	if identity == nil {
+		return
+	}
+	for id := range identity.UserAssignedIdentities {
+		identity.UserAssignedIdentities[id] = &hcpsdk20251223preview.UserAssignedIdentity{}
+	}
+}
+
 func ConvertToManagedServiceIdentity20251223(value interface{}) (*hcpsdk20251223preview.ManagedServiceIdentity, error) {
 	if value == nil {
 		return nil, nil

--- a/test/util/framework/helpers_v20260630preview.go
+++ b/test/util/framework/helpers_v20260630preview.go
@@ -163,6 +163,25 @@ func ConvertToUserAssignedIdentitiesProfile20260630(value interface{}) (*hcpsdk2
 	return &uamis, nil
 }
 
+// ClearUserAssignedIdentityValues20260630 resets every value in a
+// ManagedServiceIdentity's UserAssignedIdentities map to an empty struct,
+// preserving only the map keys (identity resource IDs).
+//
+// ARM requires that on a PUT of an existing resource, UserAssignedIdentities
+// map values for identities that should be kept unchanged are sent back as
+// empty objects ({}); the client/PrincipalID values a prior GET populated
+// must not be echoed back. Callers that Get a cluster, mutate an unrelated
+// field, and then BeginCreateOrUpdate the full object must call this first
+// or ARM rejects the request with error code InvalidIdentityValues.
+func ClearUserAssignedIdentityValues20260630(identity *hcpsdk20260630preview.ManagedServiceIdentity) {
+	if identity == nil {
+		return
+	}
+	for id := range identity.UserAssignedIdentities {
+		identity.UserAssignedIdentities[id] = &hcpsdk20260630preview.UserAssignedIdentity{}
+	}
+}
+
 func ConvertToManagedServiceIdentity20260630(value interface{}) (*hcpsdk20260630preview.ManagedServiceIdentity, error) {
 	if value == nil {
 		return nil, nil


### PR DESCRIPTION
<!-- Link to Jira issue -->
[AROSLSRE-1944](https://redhat.atlassian.net/browse/AROSLSRE-1944)

### What

Clears `UserAssignedIdentities` map values before re-`BeginCreateOrUpdate`-ing a cluster that was just fetched with `Get`, at the three e2e call sites that do this round trip on a cluster with pooled/assigned identities: `cluster_create_feature_aggregation.go`, `cluster_authorized_cidrs_connectivity.go`, `cluster_fips_mode.go`. Adds a `ClearUserAssignedIdentityValues<version>` helper per SDK version used in e2e (20240610, 20251223, 20260630).

### Why

`Customer should be able to create a cluster and node pools with aggregated advanced features` failed in the [2026-08-30 INT e2e-parallel run](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-e2e-integration-e2e-parallel/2093885166756827136) at `cluster_create_feature_aggregation.go:242`:

```
PUT .../hcpOpenShiftClusters/agg-cluster
RESPONSE 400: 400 Bad Request
ERROR CODE: InvalidIdentityValues
"The 'UserAssignedIdentities' property keys should only be empty json objects,
 null or the resource existing property."
```

The test does `Get` -> mutates only `AuthorizedCIDRs` -> re-`BeginCreateOrUpdate` (full PUT) reusing the GET response, whose `Identity.UserAssignedIdentities` map values are ARM-populated (`ClientID`/`PrincipalID` set). ARM's PUT contract requires existing identity map values be echoed back as empty objects, not the populated GET values.

`cluster_fips_mode.go` has the same round-trip pattern on a cluster with pooled identities and asserts the rejection error contains `"immutable"`, so it would have failed the same way (for the wrong reason) if it ever exercised that path with a populated identity map.

### Testing

`go build ./test/...` and `go vet ./test/e2e/... ./test/util/framework/...` both pass. Can't exercise the actual ARM PUT locally since it needs a live cluster; this is a real INT job failure so the reproduction is a fresh e2e run.

### Special notes for your reviewer

Unrelated to the separate clusters-service single-worker serialization issue also seen slowing down INT e2e-parallel runs; that's a vendor-side (OCM/CS) bottleneck tracked separately.

### PR Checklist

- [x] Tests pass
- [x] Documentation not needed (test-only change)
