### PR TITLE
fix(ev2): retry mitigations step on ACI shell-provisioning failure

### DIFF
--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -739,10 +739,12 @@ resourceGroups:
       errorContainsAny:
       - "500 Internal Server Error"
       - "Internal error occurred"
-      # Retry when the shell extension's backing ACI container never provisions
-      # (empty log/exit code -1), a transient ACI-side failure distinct from an
-      # app-level error. See AROSLSRE-1945.
-      - '"ShellProvisioningState": "Failed"'
+      # Retry when the shell extension's backing ACI container is stuck pending
+      # and never actually runs (empty log, exit code -1), a transient ACI-side
+      # provisioning failure distinct from an app-level script error. Matches
+      # only the "still waiting to run" detail status, not any Failed shell run.
+      # See AROSLSRE-1945.
+      - '"DetailStatus": "Waiting to run"'
       maximumRetryCount: 3
       durationBetweenRetries: 1m
   - name: kubelet-ds

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -739,6 +739,10 @@ resourceGroups:
       errorContainsAny:
       - "500 Internal Server Error"
       - "Internal error occurred"
+      # Retry when the shell extension's backing ACI container never provisions
+      # (empty log/exit code -1), a transient ACI-side failure distinct from an
+      # app-level error. See AROSLSRE-1945.
+      - "\"ShellProvisioningState\": \"Failed\""
       maximumRetryCount: 3
       durationBetweenRetries: 1m
   - name: kubelet-ds

--- a/dev-infrastructure/mgmt-pipeline.yaml
+++ b/dev-infrastructure/mgmt-pipeline.yaml
@@ -742,7 +742,7 @@ resourceGroups:
       # Retry when the shell extension's backing ACI container never provisions
       # (empty log/exit code -1), a transient ACI-side failure distinct from an
       # app-level error. See AROSLSRE-1945.
-      - "\"ShellProvisioningState\": \"Failed\""
+      - '"ShellProvisioningState": "Failed"'
       maximumRetryCount: 3
       durationBetweenRetries: 1m
   - name: kubelet-ds


### PR DESCRIPTION
[AROSLSRE-1945](https://redhat.atlassian.net/browse/AROSLSRE-1945)

### What

Adds `"DetailStatus": "Waiting to run"` to the `mitigations` step's `automatedRetry.errorContainsAny` in `dev-infrastructure/mgmt-pipeline.yaml`.

### Why

A prod canary rollout hit a failure on the `mitigations` shell step where the backing ACI container never started (empty log, exit code -1, `ExecutionView.DetailStatus: "Waiting to run"`). The step's existing `errorContainsAny` only matched app-level error text (`500 Internal Server Error`, `Internal error occurred`), so this transient ACI-side infra failure never auto-retried and needed a manual retry from on-call.

`"DetailStatus": "Waiting to run"` only occurs when the shell extension's container is stuck pending and never actually executes, so this narrowly targets the infra failure without matching a real app-level script failure.

### Testing

- `make validate-config-pipelines ONLY_CHANGED="--only-changed"` passes locally.
- No functional/generated output changes beyond the pipeline yaml itself (no bicep/helm/config regen needed).

### Special notes for your reviewer

Scoped to the `mitigations` step only, matching the specific failure observed. Several other Helm steps in this file share the same base `automatedRetry` pattern; if this proves broadly useful, a follow-up could consider it more broadly, but this keeps the change minimal for now.
