### PR TITLE
fix: exclude maestro-agent-lock lease from alerting to supress alerts…

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedPrometheusAlertingRules.bicep
@@ -2261,7 +2261,7 @@ resource leaderelection 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03
           summary: 'Leader election lease {{ $labels.lease }} in namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} stale for more than 37 minutes'
           title: 'Leader election lease {{ $labels.lease }} in namespace {{ $labels.namespace }} on cluster {{ $labels.cluster }} stale for more than 37 minutes'
         }
-        expression: 'time() - max without (prometheus_replica) (kube_lease_renew_time{lease!="managed-cluster-lease",namespace!~"^(kube-system|kube-public|kube-node-lease|default|kube-applier|aro-hcp|mgmt-agent)$"}) > 720'
+        expression: 'time() - max without (prometheus_replica) (kube_lease_renew_time{lease!~"^(managed-cluster-lease|maestro-agent-lock)$",namespace!~"^(kube-system|kube-public|kube-node-lease|default|kube-applier|aro-hcp|mgmt-agent)$"}) > 720'
         for: 'PT25M'
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }

--- a/observability/alerts/leaderelection-prometheusRule.yaml
+++ b/observability/alerts/leaderelection-prometheusRule.yaml
@@ -17,9 +17,10 @@ spec:
     - alert: LeaderElectionLeaseStale
       # Fires when a leader election lease has not been renewed for >37m (12m expr threshold + 25m for:); excludes namespaces covered by LeaderElectionLeaseStaleCritical and standard k8s system namespaces (kube-node-lease has node heartbeat leases that are not leader election).
       # Excludes managed-cluster-lease: this is the OCM/ACM cluster-availability heartbeat lease (renewed by the registration-agent, lease_holder == lease name), not a leader-election lock. It lives per-HCP in hashed managedcluster namespaces on management clusters and routinely goes stale when an HCP is deprovisioned, producing false positives.
+      # Excludes maestro-agent-lock: when maestro runs as a single instance no leader election takes place, so this lease is never renewed and would go permanently stale. Whether maestro is single-instance is not visible to the alert, so the lease is excluded to avoid false positives.
       expr: |
         time() - max without(prometheus_replica) (
-          kube_lease_renew_time{namespace!~"^(kube-system|kube-public|kube-node-lease|default|kube-applier|aro-hcp|mgmt-agent)$", lease!="managed-cluster-lease"}
+          kube_lease_renew_time{namespace!~"^(kube-system|kube-public|kube-node-lease|default|kube-applier|aro-hcp|mgmt-agent)$", lease!~"^(managed-cluster-lease|maestro-agent-lock)$"}
         ) > 720
       for: 25m
       labels:


### PR DESCRIPTION
… that are not warranted.

https://redhat.atlassian.net/browse/ARO-28542

### What

exclude maestro-agent-lock lease from alerting to supress alerts that are not warranted.

### Why

To avoid alert spam.

Background: when maestro is configured to run with a single instance, no leader election takes place. That's why the lease is not renewed. This information is not available when alerting, so we have to leave out this alert.

### Testing

- Unit tests ✅ 
- Grafana Tryout:

Before:

time since renewal for maestro-agent-lock is > 720 (so large that threshold is not visible)
<img width="1209" height="874" alt="image" src="https://github.com/user-attachments/assets/49a71b72-2d96-4df1-87ae-acaf2ba6c5b4" />

After:

Only threshold is visible, no entry for time since renewal for maestro-agent-lock is > 720
<img width="1212" height="877" alt="image" src="https://github.com/user-attachments/assets/49eb7d59-62f1-4a91-ae9a-1195e70152d1" />

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x Commit history is clean (rebased/squashed)
- [ ] All comment threads resolved before merge
