### PR TITLE
test: reduce timeout for verifyAllClusterOperators

### DIFF
--- a/test/util/verifiers/clusteroperator.go
+++ b/test/util/verifiers/clusteroperator.go
@@ -47,7 +47,7 @@ func (v verifyAllClusterOperatorsAvailableImpl) Verify(ctx context.Context, admi
 	start := time.Now()
 	var lastErr error
 	var lastErrMsg string
-	verifyErr := wait.PollUntilContextTimeout(ctx, 20*time.Second, 30*time.Minute, true, func(ctx context.Context) (done bool, err error) {
+	verifyErr := wait.PollUntilContextTimeout(ctx, 20*time.Second, 10*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		clusterOperators, err := configClient.ClusterOperators().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			lastErr = fmt.Errorf("failed to list ClusterOperators: %w", err)


### PR DESCRIPTION
[ARO-24684](https://redhat.atlassian.net/browse/ARO-24684)

### What

Reduce timeout of verifyAllClusterOperators to 10 minutes.

### Why

Adjust an excessive test verifier timeout. Logging introduced in https://github.com/Azure/ARO-HCP/pull/5231 and investigation of recent runs show the 10-minute timeout is sufficient. 

Prow job investigation across all environments (dev, int, stg, prod):
Count:   119
Min:     20.1s
Median:  40.4s
Average: 1m19.3s
p90:     2m40.3s
p99:     7m53.1s
Max:     8m40.1s

based directly on timing step from prow logs. Kusto isn't as precise for this purpose. 

### Testing

adjusts existing test verifier timeout. 

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge