### PR TITLE
Add retry logic to e2e az bicep build

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -5,20 +5,36 @@ SHELL = /bin/bash
 all: build
 
 BICEP_OUTPUT_DIR=$(TEST_DIR)e2e/test-artifacts/generated-test-artifacts/
+BICEP_BUILD_RETRIES := 3
+BICEP_RETRY_INTERVAL := 5
 
 DEMO_BICEP_DIR=$(TEST_DIR)../demo/bicep
 DEMO_BICEP_SOURCES = $(shell find $(DEMO_BICEP_DIR) -name '*.bicep')
 DEMO_BICEP_OUTPUTS = $(addprefix $(BICEP_OUTPUT_DIR)standard-cluster-create/,$(addsuffix .json,$(basename $(notdir $(DEMO_BICEP_SOURCES)))))
 $(BICEP_OUTPUT_DIR)standard-cluster-create/%.json: $(DEMO_BICEP_DIR)/%.bicep
 	@mkdir -p $(dir $@)
-	az bicep build --file=$< --outfile=$@
+	@for i in $$(seq 1 $(BICEP_BUILD_RETRIES)); do \
+		az bicep build --file=$< --outfile=$@ && break || \
+		if [ $$i -lt $(BICEP_BUILD_RETRIES) ]; then \
+			echo "az bicep build failed (attempt $$i/$(BICEP_BUILD_RETRIES)), retrying in $(BICEP_RETRY_INTERVAL)s..."; sleep $(BICEP_RETRY_INTERVAL); \
+		else \
+			echo "az bicep build failed after $(BICEP_BUILD_RETRIES) attempts"; exit 1; \
+		fi; \
+	done
 
 TEST_BICEP_DIR=$(TEST_DIR)e2e-setup/bicep
 TEST_BICEP_SOURCES = $(shell cd $(TEST_BICEP_DIR) && find * -name '*.bicep')
 TEST_BICEP_OUTPUTS = $(addprefix $(BICEP_OUTPUT_DIR),$(addsuffix .json,$(basename $(TEST_BICEP_SOURCES))))
 $(BICEP_OUTPUT_DIR)%.json: $(TEST_BICEP_DIR)/%.bicep
 	@mkdir -p $(dir $@)
-	az bicep build --file=$< --outfile=$@
+	@for i in $$(seq 1 $(BICEP_BUILD_RETRIES)); do \
+		az bicep build --file=$< --outfile=$@ && break || \
+		if [ $$i -lt $(BICEP_BUILD_RETRIES) ]; then \
+			echo "az bicep build failed (attempt $$i/$(BICEP_BUILD_RETRIES)), retrying in $(BICEP_RETRY_INTERVAL)s..."; sleep $(BICEP_RETRY_INTERVAL); \
+		else \
+			echo "az bicep build failed after $(BICEP_BUILD_RETRIES) attempts"; exit 1; \
+		fi; \
+	done
 
 update-go-fixtures:
 	UPDATE=true go test --count=1 ./... -v


### PR DESCRIPTION
**Jira**: [ARO-29387](https://redhat.atlassian.net/browse/ARO-29387)

## What
  - Add retry logic (3 attempts, 5s interval) to `az bicep build` calls in `test/Makefile` to handle Bicep's `Connection reset by peer` network failures during CI image builds

## Why
  Prow job `pull-ci-Azure-ARO-HCP-main-e2e-images` failed with `ConnectionResetError(104, 'Connection reset by peer')` when `az bicep build` tried to reach Azure's CDN during the Docker build step. This is a transient network issue, not a code defect.

  Failing job:
  https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/6748/pull-ci-Azure-ARO-HCP-main-e2e-images/2094375882004107264
  
  Other examples:
https://search.dptools.openshift.org/?search=Connection+reset+by+peer&maxAge=48h&context=1&type=bug%2Bissue%2Bjunit&name=ARO-HCP.*image&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

  ## Test plan
  - [x] Verified `make -C test build` passes locally