### PR TITLE
feat(arobit): source Shoebox resource ID from namespace annotation

### DIFF
--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
@@ -224,9 +224,8 @@ data:
         # filter's Namespace_annotations On). This is the namespace-annotation
         # alternative to resolving the ID from the ACM-managed /shoebox-config file
         # mapping. Only mgmt clusters emit ocm.logs to the containerLogs Kusto table.
-        # Fail-soft: records without the annotation are left unchanged. Runs before the
-        # shoebox re-tag; transform-shoebox.lua builds its own record, so shoebox output
-        # is unaffected.
+        # Fail-soft: records without the annotation are left unchanged. This runs before
+        # the shoebox re-tag so transform-shoebox.lua can reuse the normalized cluster_id.
         Name            lua
         Alias           lua.set_cluster_id_from_annotation
         Match           ocm.logs
@@ -814,7 +813,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 3501288ffab1d1c75f0ba55fd49989e8ed4f707394312cd5df27607dab54bf41
+        checksum/configmap: f8e52cebcc1b2cf167053c89c90acf477eebba8961840d2f59e612e6c894d8d6
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'

--- a/observability/arobit/deploy/templates/forwarder-configmap.yaml
+++ b/observability/arobit/deploy/templates/forwarder-configmap.yaml
@@ -233,9 +233,8 @@ data:
         # filter's Namespace_annotations On). This is the namespace-annotation
         # alternative to resolving the ID from the ACM-managed /shoebox-config file
         # mapping. Only mgmt clusters emit ocm.logs to the containerLogs Kusto table.
-        # Fail-soft: records without the annotation are left unchanged. Runs before the
-        # shoebox re-tag; transform-shoebox.lua builds its own record, so shoebox output
-        # is unaffected.
+        # Fail-soft: records without the annotation are left unchanged. This runs before
+        # the shoebox re-tag so transform-shoebox.lua can reuse the normalized cluster_id.
         Name            lua
         Alias           lua.set_cluster_id_from_annotation
         Match           ocm.logs
@@ -358,10 +357,6 @@ data:
     -- Lua script for transforming Kubernetes control plane logs to Shoebox format.
     -- Supports all 11 log categories defined in the Shoebox manifest.
 
-    -- Cache for resourceId lookups (namespace -> resourceId)
-    -- ResourceIds are immutable per cluster, so we cache forever
-    local resourceid_cache = {}
-
     -- Container name to category mapping
     local container_category_map = {
         ["audit-logs"] = "kube-audit",
@@ -372,27 +367,6 @@ data:
         ["snapshot-controller"] = "csi-snapshot-controller",
         ["cluster-autoscaler"] = "cluster-autoscaler"
     }
-
-    -- Get resourceId for a namespace by reading the corresponding file
-    local function get_resource_id(namespace)
-        local cached = resourceid_cache[namespace]
-        if cached then
-            return cached
-        end
-
-        local filepath = "/shoebox-config/" .. namespace
-        local file = io.open(filepath, "r")
-        if file then
-            local resourceId = file:read("*all")
-            file:close()
-            resourceId = resourceId:match("^%s*(.-)%s*$")
-            resourceId = string.upper(resourceId)
-            resourceid_cache[namespace] = resourceId
-            return resourceId
-        end
-
-        return nil
-    end
 
     -- Determine category based on container name and pod name
     local function get_category(container_name, pod_name, log_data)
@@ -432,14 +406,10 @@ data:
 
     -- Transform Kubernetes control plane log to Shoebox format
     function transform_to_shoebox(tag, timestamp, record)
-        local namespace = ""
         local container_name = ""
         local pod_name = ""
 
         if record["kubernetes"] then
-            if record["kubernetes"]["namespace_name"] then
-                namespace = record["kubernetes"]["namespace_name"]
-            end
             if record["kubernetes"]["container_name"] then
                 container_name = record["kubernetes"]["container_name"]
             end
@@ -448,7 +418,9 @@ data:
             end
         end
 
-        local resourceId = get_resource_id(namespace)
+        -- set-cluster-id-from-annotation.lua runs on ocm.logs before the Shoebox
+        -- re-tag and normalizes the namespace annotation into this top-level field.
+        local resourceId = record["cluster_id"]
 
         if not resourceId or resourceId == "" then
             return -1, 0, 0

--- a/observability/arobit/deploy/templates/forwarder-daemonset.yaml
+++ b/observability/arobit/deploy/templates/forwarder-daemonset.yaml
@@ -103,9 +103,6 @@ spec:
               mountPath: /forwarder/etc
               readOnly: true
         {{- if and .Values.forwarder.mdsd.enabled (eq .Values.forwarder.clusterType "mgmt") }}
-            - name: shoebox-mappings
-              mountPath: /shoebox-config
-              readOnly: true
         - name: mdsd-clusterlogs
           image: {{ .Values.forwarder.mdsd.image.registry }}/{{ .Values.forwarder.mdsd.image.repository }}@{{ .Values.forwarder.mdsd.image.digest }}
           imagePullPolicy: '{{ .Values.forwarder.mdsd.image.pullPolicy }}'
@@ -333,10 +330,6 @@ spec:
         {{- if and .Values.forwarder.mdsd.enabled (eq .Values.forwarder.clusterType "mgmt") }}
         - name: mdsd-run-clusterlogs
           emptyDir: {}
-        - name: shoebox-mappings
-          configMap:
-            name: namespace-resourceid-mapping
-            optional: true
         - name: geneva-certs-clusterlogs
           csi:
             driver: secrets-store.csi.k8s.io

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -226,9 +226,8 @@ data:
         # filter's Namespace_annotations On). This is the namespace-annotation
         # alternative to resolving the ID from the ACM-managed /shoebox-config file
         # mapping. Only mgmt clusters emit ocm.logs to the containerLogs Kusto table.
-        # Fail-soft: records without the annotation are left unchanged. Runs before the
-        # shoebox re-tag; transform-shoebox.lua builds its own record, so shoebox output
-        # is unaffected.
+        # Fail-soft: records without the annotation are left unchanged. This runs before
+        # the shoebox re-tag so transform-shoebox.lua can reuse the normalized cluster_id.
         Name            lua
         Alias           lua.set_cluster_id_from_annotation
         Match           ocm.logs
@@ -349,10 +348,6 @@ data:
     -- Lua script for transforming Kubernetes control plane logs to Shoebox format.
     -- Supports all 11 log categories defined in the Shoebox manifest.
 
-    -- Cache for resourceId lookups (namespace -> resourceId)
-    -- ResourceIds are immutable per cluster, so we cache forever
-    local resourceid_cache = {}
-
     -- Container name to category mapping
     local container_category_map = {
         ["audit-logs"] = "kube-audit",
@@ -363,27 +358,6 @@ data:
         ["snapshot-controller"] = "csi-snapshot-controller",
         ["cluster-autoscaler"] = "cluster-autoscaler"
     }
-
-    -- Get resourceId for a namespace by reading the corresponding file
-    local function get_resource_id(namespace)
-        local cached = resourceid_cache[namespace]
-        if cached then
-            return cached
-        end
-
-        local filepath = "/shoebox-config/" .. namespace
-        local file = io.open(filepath, "r")
-        if file then
-            local resourceId = file:read("*all")
-            file:close()
-            resourceId = resourceId:match("^%s*(.-)%s*$")
-            resourceId = string.upper(resourceId)
-            resourceid_cache[namespace] = resourceId
-            return resourceId
-        end
-
-        return nil
-    end
 
     -- Determine category based on container name and pod name
     local function get_category(container_name, pod_name, log_data)
@@ -423,14 +397,10 @@ data:
 
     -- Transform Kubernetes control plane log to Shoebox format
     function transform_to_shoebox(tag, timestamp, record)
-        local namespace = ""
         local container_name = ""
         local pod_name = ""
 
         if record["kubernetes"] then
-            if record["kubernetes"]["namespace_name"] then
-                namespace = record["kubernetes"]["namespace_name"]
-            end
             if record["kubernetes"]["container_name"] then
                 container_name = record["kubernetes"]["container_name"]
             end
@@ -439,7 +409,9 @@ data:
             end
         end
 
-        local resourceId = get_resource_id(namespace)
+        -- set-cluster-id-from-annotation.lua runs on ocm.logs before the Shoebox
+        -- re-tag and normalizes the namespace annotation into this top-level field.
+        local resourceId = record["cluster_id"]
 
         if not resourceId or resourceId == "" then
             return -1, 0, 0
@@ -1010,7 +982,7 @@ spec:
         app: arobit-forwarder
         azure.workload.identity/use: "true"
       annotations:
-        checksum/configmap: 8181bfeb7a27a81934b0ffcc3a6ac867fdc904d050c6bd52d6ba638d75ac4336
+        checksum/configmap: d77a6291a229aa8716de1277492ff62e103f4434d7bf9406c24716740b5a8435
     spec:
       priorityClassName: service-lifecycle-critical
       serviceAccountName: 'arobit-forwarder'
@@ -1083,9 +1055,6 @@ spec:
               readOnly: true
             - name: flb-config
               mountPath: /forwarder/etc
-              readOnly: true
-            - name: shoebox-mappings
-              mountPath: /shoebox-config
               readOnly: true
         - name: mdsd-clusterlogs
           image: mcr.microsoft.com/geneva/distroless/mdsd@sha256:1234567890
@@ -1312,10 +1281,6 @@ spec:
             defaultMode: 0755
         - name: mdsd-run-clusterlogs
           emptyDir: {}
-        - name: shoebox-mappings
-          configMap:
-            name: namespace-resourceid-mapping
-            optional: true
         - name: geneva-certs-clusterlogs
           csi:
             driver: secrets-store.csi.k8s.io

--- a/test/e2e/shoebox_logs.go
+++ b/test/e2e/shoebox_logs.go
@@ -149,11 +149,13 @@ type eventHubResult struct {
 
 func createEventHub(ctx context.Context, subscriptionID string, creds azcore.TokenCredential, resourceGroupName, location string) (*eventHubResult, error) {
 	const (
-		namespaceName = "shoebox-eh-ns"
-		hubName       = "shoebox-eh"
-		authRuleName  = "shoebox-eh-auth"
-		pollTimeout   = 10 * time.Minute
+		hubName      = "shoebox-eh"
+		authRuleName = "shoebox-eh-auth"
+		pollTimeout  = 10 * time.Minute
 	)
+
+	// Event Hubs namespace names are globally unique, including across parallel test runs.
+	namespaceName := "shoebox-eh-ns-" + rand.String(5)
 
 	nsClient, err := armeventhub.NewNamespacesClient(subscriptionID, creds, nil)
 	if err != nil {
@@ -275,8 +277,6 @@ var _ = Describe("Customer", func() {
 			creds, err := tc.AzureCredential()
 			Expect(err).NotTo(HaveOccurred(), "failed to get Azure credential")
 
-			// TODO: convert shoebox-specific steps below to hard-fail assertions once validated in all stage/prod regions.
-
 			By("creating storage account and Event Hub namespace in parallel")
 			var (
 				storage  *storageAccountResult
@@ -294,10 +294,8 @@ var _ = Describe("Customer", func() {
 				eventHub, err = createEventHub(gCtx, subscriptionID, creds, *resourceGroup.Name, tc.Location())
 				return err
 			})
-			if err := g.Wait(); err != nil {
-				GinkgoLogr.Error(err, "failed to create shoebox destination resources")
-				return
-			}
+			err = g.Wait()
+			Expect(err).NotTo(HaveOccurred(), "failed to create shoebox storage account and Event Hub destination resources")
 			GinkgoLogr.Info("shoebox destination resources created",
 				"storageAccount", storage.AccountName,
 				"eventHub", eventHub.EventHubName,
@@ -310,10 +308,7 @@ var _ = Describe("Customer", func() {
 			diagnosticsClient, err := armmonitor.NewDiagnosticSettingsClient(creds, &azcorearm.ClientOptions{
 				ClientOptions: azsdk.NewClientOptions(azsdk.ComponentE2E),
 			})
-			if err != nil {
-				GinkgoLogr.Error(err, "failed to create diagnostics client")
-				return
-			}
+			Expect(err).NotTo(HaveOccurred(), "failed to create diagnostics client")
 
 			_, err = diagnosticsClient.CreateOrUpdate(ctx, resourceID, "shoebox-storage-diag", armmonitor.DiagnosticSettingsResource{
 				Properties: &armmonitor.DiagnosticSettings{
@@ -321,10 +316,7 @@ var _ = Describe("Customer", func() {
 					Logs:             logSettings,
 				},
 			}, nil)
-			if err != nil {
-				GinkgoLogr.Error(err, "failed to create storage account diagnostic setting")
-				return
-			}
+			Expect(err).NotTo(HaveOccurred(), "failed to create storage account diagnostic setting for cluster %s", resourceID)
 			GinkgoLogr.Info("storage account diagnostic setting created")
 
 			_, err = diagnosticsClient.CreateOrUpdate(ctx, resourceID, "shoebox-eh-diag", armmonitor.DiagnosticSettingsResource{
@@ -334,18 +326,12 @@ var _ = Describe("Customer", func() {
 					Logs:                        logSettings,
 				},
 			}, nil)
-			if err != nil {
-				GinkgoLogr.Error(err, "failed to create Event Hub diagnostic setting")
-				return
-			}
+			Expect(err).NotTo(HaveOccurred(), "failed to create Event Hub diagnostic setting for cluster %s", resourceID)
 			GinkgoLogr.Info("Event Hub diagnostic setting created")
 
 			By("waiting for shoebox logs to appear in storage account and Event Hub")
 			blobContainersClient, err := armstorage.NewBlobContainersClient(subscriptionID, creds, nil)
-			if err != nil {
-				GinkgoLogr.Error(err, "failed to create blob containers client")
-				return
-			}
+			Expect(err).NotTo(HaveOccurred(), "failed to create blob containers client")
 
 			storageVerifier := verifiers.VerifyShoeboxLogs(blobContainersClient, *resourceGroup.Name, storage.AccountName)
 			eventHubVerifier := verifiers.VerifyShoeboxEventHub(eventHub.ConnectionString, eventHub.EventHubName)
@@ -363,9 +349,7 @@ var _ = Describe("Customer", func() {
 				}
 				return nil
 			})
-			if err := g.Wait(); err != nil {
-				GinkgoLogr.Error(err, "shoebox log verification failed")
-				return
-			}
+			err = g.Wait()
+			Expect(err).NotTo(HaveOccurred(), "failed to verify shoebox logs reached storage account %s and Event Hub %s for cluster %s", storage.AccountName, eventHub.EventHubName, resourceID)
 		})
 })


### PR DESCRIPTION
Related:
- https://redhat.atlassian.net/browse/AROSLSRE-687
- https://github.com/openshift/hypershift/pull/8312
- https://github.com/Azure/ARO-HCP/pull/6588

### What

Switch the Shoebox transform to use the annotation-derived `cluster_id` populated by the existing Fluent Bit filter. Remove the legacy `/shoebox-config/<namespace>` lookup, resource ID cache, and `namespace-resourceid-mapping` ConfigMap mount from the Arobit DaemonSet.

### Why

HyperShift now propagates the Azure resource ID annotation to the control-plane namespace, and PR #6588 already normalizes it into `cluster_id` before the Shoebox re-tag runs. Reusing that field removes the duplicate ConfigMap lookup and decouples the Fluent Bit consumer from the ACM-generated mapping. The ACM policy remains unchanged for a staged cleanup.