### PR TITLE
docs: clarify dashboard screenshot requirements

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,7 @@ justification.
 - [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
 - [ ] Summary explains the "Why" behind the change
 - [ ] Linked to relevant ticket/issue
-- [ ] Screenshots included (if graph/UI/metrics changes)
+- [ ] Screenshots included (if dashboards or other UI changes)
 - [ ] Self-reviewed the diff
 - [ ] CI/CD checks are passing (ignore Tide)
 - [ ] Draft PR used for WIP (if applicable)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,9 +92,9 @@ All pull requests must follow these standards. Reviewers will check for complian
 - Use formats like `Fixes #123`, `Closes PROJ-456`, or a direct URL.
 - If no ticket exists, create one first or explain why in the PR body.
 
-### 5. Include Screenshots for Graph/UI/Metrics/Performance Changes
-- Any change that affects dashboards, graphs, metrics visualizations, UI, or performance/metrics must include before/after screenshots.
-- This includes changes to alerting rules, SLOs, monitoring dashboards, and any observable behavioral change.
+### 5. Include Screenshots for Dashboard and UI Changes
+- Include before/after screenshots for changes to user-visible dashboards, graphs, metrics visualizations, or other UI.
+- Screenshots are not required for alerting-rule changes, routing/configuration changes, generated artifacts, or other backend-only monitoring changes unless they also change a user-visible dashboard or UI.
 - Annotate screenshots when the change is subtle.
 
 ### 6. Self-Review Before Requesting Review


### PR DESCRIPTION
### What

Clarify the screenshot policy and PR checklist so before/after screenshots are required for user-visible dashboards and UI changes only.

### Why

The previous policy classified alerting rules, routing, and other monitoring plumbing as screenshot-required even when no visual surface existed. This produced an incorrect screenshot request on https://github.com/Azure/ARO-HCP/pull/6758, which only adds an empty alert-routing lane.

### Testing

Documentation-only change; verified the rendered Markdown diff is whitespace-clean.

### Special notes for your reviewer

No tracking ticket exists; this policy correction follows the review feedback on https://github.com/Azure/ARO-HCP/pull/6758.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if dashboards or other UI changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge