### PR TITLE
fix(frontend): Add missing namespace operation

### DIFF
--- a/frontend/pkg/frontend/frontend_test.go
+++ b/frontend/pkg/frontend/frontend_test.go
@@ -80,6 +80,7 @@ func TestOperationsList(t *testing.T) {
 	// https://github.com/cloud-and-ai-microsoft/resource-provider-contract/blob/master/v1.0/proxy-api-reference.md#required-operations
 	requiredOperations := sets.New[string](
 		path.Join(coreapi.ProviderNamespace, "register", coreapi.NamespaceOperationAction),
+		path.Join(coreapi.ProviderNamespace, "unregister", coreapi.NamespaceOperationAction), // undocumented
 	)
 
 	reg := prometheus.NewRegistry()

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -73,13 +73,23 @@ const (
 // https://github.com/cloud-and-ai-microsoft/resource-provider-contract/blob/master/v1.0/proxy-api-reference.md#exposing-available-operations
 var AvailableOperations = []coreapi.NamespaceOperation{
 	{
-		// This is a required operation that is not specific to ARO-HCP.
+		// Per the RPC, this is a required operation. It is not specific to ARO-HCP.
 		Name: path.Join(coreapi.ProviderNamespace, "register", coreapi.NamespaceOperationAction),
 		Display: coreapi.NamespaceOperationDisplay{
 			Provider:    ProviderDisplay,
 			Resource:    ProviderDisplay,
 			Operation:   "Register the Azure Red Hat OpenShift (ARO) Resource Provider",
 			Description: "Register the subscription for the Azure Red Hat OpenShift (ARO) resource provider and enable the creation of OpenShift clusters",
+		},
+	},
+	{
+		// Another required operation not mentioned in the RPC. It is not specific to ARO-HCP.
+		Name: path.Join(coreapi.ProviderNamespace, "unregister", coreapi.NamespaceOperationAction),
+		Display: coreapi.NamespaceOperationDisplay{
+			Provider:    ProviderDisplay,
+			Resource:    ProviderDisplay,
+			Operation:   "Unregister the Azure Red Hat OpenShift (ARO) Resource Provider",
+			Description: "Unregister the subscription from the Azure Red Hat OpenShift (ARO) resource provider",
 		},
 	},
 	{


### PR DESCRIPTION
[S360 Operations ResourceType API Coverage KPI](https://redhat.atlassian.net/browse/ARO-21441)

### What

Adds an `/unregister/action` operation to the `/operations` response content.

### Why

We were informed our namespace is missing this operation, despite it not being listed as a [required operation in the Resource Provider Contract](https://eng.ms/docs/products/arm/api_contracts/resource-provider-contract/v10/proxy-api-reference#required-operations).  We now have to request an extension to the KPI as a result.

### Testing

Updated a unit test.

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if graph/UI/metrics changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
