### PR TITLE
fix: suppress unused severity ceiling in empty alert modules

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedDevHcpsPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedDevHcpsPrometheusAlertingRules.bicep
@@ -5,6 +5,7 @@ param azureMonitoring string
 param actionGroups array
 
 @description('The minimum IcM severity level (highest priority) that alerts can fire at. Alerts more critical than this ceiling will be degraded to this value. 0 means no ceiling.')
+#disable-next-line no-unused-params
 param severityCeiling int = 0
 
 #disable-next-line no-unused-params

--- a/dev-infrastructure/modules/metrics/rules/generatedDevServicesPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedDevServicesPrometheusAlertingRules.bicep
@@ -5,6 +5,7 @@ param azureMonitoring string
 param actionGroups array
 
 @description('The minimum IcM severity level (highest priority) that alerts can fire at. Alerts more critical than this ceiling will be degraded to this value. 0 means no ceiling.')
+#disable-next-line no-unused-params
 param severityCeiling int = 0
 
 #disable-next-line no-unused-params

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -406,9 +406,9 @@ func (o *Options) Generate() error {
 	isRecordingRulesFile := strings.Contains(o.outputBicep, "RecordingRules")
 	isAlertingRulesFile := strings.Contains(o.outputBicep, "AlertingRules")
 
-	// Validate that the filename contains the required keywords
-	if !isRecordingRulesFile && !isAlertingRulesFile {
-		return fmt.Errorf("output filename must contain either 'AlertingRules' or 'RecordingRules' to determine the rule type. Got: %s", o.outputBicep)
+	// Validate that the filename identifies exactly one rule type.
+	if isRecordingRulesFile == isAlertingRulesFile {
+		return fmt.Errorf("output filename must contain exactly one of 'AlertingRules' or 'RecordingRules' to determine the rule type. Got: %s", o.outputBicep)
 	}
 
 	generatedRules := &bytes.Buffer{}

--- a/tooling/prometheus-rules/internal/generator.go
+++ b/tooling/prometheus-rules/internal/generator.go
@@ -411,32 +411,9 @@ func (o *Options) Generate() error {
 		return fmt.Errorf("output filename must contain either 'AlertingRules' or 'RecordingRules' to determine the rule type. Got: %s", o.outputBicep)
 	}
 
-	// Write parameters based on file type
-	if isAlertingRulesFile {
-		if _, err := output.Write([]byte(`#disable-next-line no-unused-params
-param azureMonitoring string
-
-#disable-next-line no-unused-params
-param actionGroups array
-
-@description('The minimum IcM severity level (highest priority) that alerts can fire at. Alerts more critical than this ceiling will be degraded to this value. 0 means no ceiling.')
-param severityCeiling int = 0
-
-#disable-next-line no-unused-params
-param location string = resourceGroup().location
-`)); err != nil {
-			return err
-		}
-	} else {
-		if _, err := output.Write([]byte(`
-param azureMonitoring string
-
-param location string = resourceGroup().location
-`)); err != nil {
-			return err
-		}
-	}
-
+	generatedRules := &bytes.Buffer{}
+	replacementWriter := NewReplacementWriter(generatedRules, o.outputReplacements, o.regexOutputReplacements)
+	hasGeneratedRules := false
 	var titleErrors []error
 	for _, irf := range o.ruleFiles {
 		if irf.testDependency {
@@ -644,8 +621,6 @@ param location string = resourceGroup().location
 				// Use the file type to determine which function to call
 				// Groups are guaranteed to contain only one type of rule
 
-				replacementWriter := NewReplacementWriter(output, o.outputReplacements, o.regexOutputReplacements)
-
 				if isRecordingRulesFile {
 					if err := writeRecordingGroups(armGroup, replacementWriter); err != nil {
 						return err
@@ -655,13 +630,47 @@ param location string = resourceGroup().location
 						return err
 					}
 				}
+				hasGeneratedRules = true
 			}
 		}
 	}
 	if len(titleErrors) > 0 {
 		return errors.Join(titleErrors...)
 	}
-	return nil
+
+	// Write parameters based on file type. Empty alerting modules need to
+	// suppress severityCeiling because no generated rule references it.
+	if isAlertingRulesFile {
+		severityCeilingSuppression := ""
+		if !hasGeneratedRules {
+			severityCeilingSuppression = "#disable-next-line no-unused-params\n"
+		}
+		if _, err := fmt.Fprintf(output, `#disable-next-line no-unused-params
+param azureMonitoring string
+
+#disable-next-line no-unused-params
+param actionGroups array
+
+@description('The minimum IcM severity level (highest priority) that alerts can fire at. Alerts more critical than this ceiling will be degraded to this value. 0 means no ceiling.')
+%sparam severityCeiling int = 0
+
+#disable-next-line no-unused-params
+param location string = resourceGroup().location
+`, severityCeilingSuppression); err != nil {
+			return err
+		}
+	} else {
+		if _, err := output.Write([]byte(`
+param azureMonitoring string
+
+param location string = resourceGroup().location
+`)); err != nil {
+			return err
+		}
+	}
+
+	_, err = generatedRules.WriteTo(output)
+	return err
 }
 
 // A note on IcM: the connection between prometheusRuleGroups to IcM via actionGroups is tenuous. Keep the following

--- a/tooling/prometheus-rules/internal/generator_test.go
+++ b/tooling/prometheus-rules/internal/generator_test.go
@@ -592,6 +592,19 @@ func TestOptionsRunTests(t *testing.T) {
 func TestOptionsGenerate(t *testing.T) {
 	const unusedSeverityCeilingSuppression = "#disable-next-line no-unused-params\nparam severityCeiling int = 0"
 
+	t.Run("rejects ambiguous output filename", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		outputFile := filepath.Join(tmpDir, "generatedAlertingRulesRecordingRules.bicep")
+
+		opts := &Options{
+			outputBicep: outputFile,
+		}
+
+		err := opts.Generate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "must contain exactly one of 'AlertingRules' or 'RecordingRules'")
+	})
+
 	t.Run("empty alerting output suppresses unused severity ceiling", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		outputFile := filepath.Join(tmpDir, "generatedAlertingRules.bicep")

--- a/tooling/prometheus-rules/internal/generator_test.go
+++ b/tooling/prometheus-rules/internal/generator_test.go
@@ -590,6 +590,27 @@ func TestOptionsRunTests(t *testing.T) {
 }
 
 func TestOptionsGenerate(t *testing.T) {
+	const unusedSeverityCeilingSuppression = "#disable-next-line no-unused-params\nparam severityCeiling int = 0"
+
+	t.Run("empty alerting output suppresses unused severity ceiling", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		outputFile := filepath.Join(tmpDir, "generatedAlertingRules.bicep")
+
+		opts := &Options{
+			outputBicep: outputFile,
+		}
+
+		err := opts.Generate()
+		assert.NoError(t, err)
+
+		content, err := os.ReadFile(outputFile)
+		assert.NoError(t, err)
+
+		generated := string(content)
+		assert.Contains(t, generated, unusedSeverityCeilingSuppression)
+		assert.NotContains(t, generated, "Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01")
+	})
+
 	t.Run("basic generation", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		outputFile := filepath.Join(tmpDir, "AlertingRules_output.bicep")
@@ -637,6 +658,7 @@ func TestOptionsGenerate(t *testing.T) {
 		assert.Contains(t, generated, "param azureMonitoring string")
 		assert.Contains(t, generated, "param actionGroups array")
 		assert.Contains(t, generated, "param severityCeiling int = 0")
+		assert.NotContains(t, generated, unusedSeverityCeilingSuppression)
 		assert.Contains(t, generated, "Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01")
 		assert.Contains(t, generated, "alert: 'TestAlert'")
 		assert.Contains(t, generated, "severity: severityCeiling > 0 ? max(2, severityCeiling) : 2")
@@ -693,6 +715,52 @@ func TestOptionsGenerate(t *testing.T) {
 		generated := string(content)
 		assert.Contains(t, generated, "alert: 'AllowedAlert'")
 		assert.NotContains(t, generated, "alert: 'BlockedAlert'")
+	})
+
+	t.Run("alerts filtered from output suppress unused severity ceiling", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		outputFile := filepath.Join(tmpDir, "generatedAlertingRules.bicep")
+
+		opts := &Options{
+			outputBicep: outputFile,
+			includedAlerts: map[string][]string{
+				"test-group": {"MissingAlert"},
+			},
+			ruleFiles: []alertingRuleFile{
+				{
+					Rules: monitoringv1.PrometheusRule{
+						Spec: monitoringv1.PrometheusRuleSpec{
+							Groups: []monitoringv1.RuleGroup{
+								{
+									Name: "test-group",
+									Rules: []monitoringv1.Rule{
+										{
+											Alert: "FilteredAlert",
+											Expr:  intstr.FromString("up == 0"),
+											Labels: map[string]string{
+												"severity":  "critical",
+												"component": "test",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		err := opts.Generate()
+		assert.NoError(t, err)
+
+		content, err := os.ReadFile(outputFile)
+		assert.NoError(t, err)
+
+		generated := string(content)
+		assert.Contains(t, generated, unusedSeverityCeilingSuppression)
+		assert.NotContains(t, generated, "alert: 'FilteredAlert'")
+		assert.NotContains(t, generated, "Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01")
 	})
 
 	t.Run("preserves per-alert correlationId override", func(t *testing.T) {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1738

### Human What

- If a fresh alert lane has no alerts defined yet, the severityCeiling bit requires `#disable-next-line no-unused-params` for linter to not complain about it
- This is pretty much never an issue (how often do we have empty alert lanes)
- But since I was already in the area, this change makes the bicep generator alert-count-aware. And if the alert count in the bicep is 0, it adds the linter line.

### What

Update the Prometheus rule generator to add `#disable-next-line no-unused-params` for `severityCeiling` only when the final generated alerting module contains no rule resources.

The generator now buffers generated resources before writing the Bicep parameter header, allowing the decision to reflect dependency, group, per-alert, and rule-type filtering. Non-empty generated modules remain unchanged.

Add tests covering:

- Empty alerting output.
- Alert inputs filtered down to an empty output.
- Non-empty output retaining the existing `severityCeiling` usage without suppression.

### Why

The generator supports configurations that intentionally produce empty alerting modules. In those modules, `severityCeiling` remains part of the stable generated-module interface but has no resource expression that references it, resulting in a Bicep `no-unused-params` warning.

This was exposed by https://github.com/Azure/ARO-HCP/pull/6758, but the behavior is a general generator concern and is fixed separately here.

### Testing

- `go test ./...` in `tooling/prometheus-rules`
- `git diff --check`

No screenshots are applicable because this changes generator output handling only and does not add or modify alert expressions, dashboards, visualizations, or deployed behavior.

### Special notes for your reviewer

The generated resource body is buffered in memory so the header can be selected from the final emitted result rather than duplicating filtering logic in a pre-scan.