### PR TITLE
Fix: change file name to hcpctl-arm64.exe for ARM build

### DIFF
--- a/tooling/hcpctl/Makefile
+++ b/tooling/hcpctl/Makefile
@@ -70,9 +70,9 @@ clean:
 help:
 	@echo "Available targets:"
 	@echo "  build                - Build the hcpctl binary (default)"
-	@echo "  build-windows        - Build both Windows binaries (amd64 and arm64)"
-	@echo "  build-windows-amd64  - Build Windows x86_64 binary"
-	@echo "  build-windows-arm64  - Build Windows ARM64 binary"
+	@echo "  windows              - Build both Windows binaries (amd64 and arm64)"
+	@echo "  $(WINDOWS_BINARY)           - Build Windows x86_64 binary"
+	@echo "  $(WINDOWS_BINARY_ARM64)     - Build Windows ARM64 binary"
 	@echo "  test                 - Run unit tests"
 	@echo "  test-e2e             - Run Go-based end-to-end tests (set E2E_MC_CLUSTER=<name> to use different cluster)"
 	@echo "  clean                - Remove build artifacts"

--- a/tooling/hcpctl/Makefile
+++ b/tooling/hcpctl/Makefile
@@ -3,7 +3,7 @@ SHELL = /bin/bash
 # Binary name
 BINARY = hcpctl
 WINDOWS_BINARY = hcpctl.exe
-WINDOWS_BINARY_AMD64 = hcpctl-amd64.exe
+WINDOWS_BINARY_ARM64 = hcpctl-arm64.exe
 
 # Version information
 CURRENT_COMMIT ?= $(shell git rev-parse --short=7 HEAD)
@@ -53,11 +53,11 @@ $(WINDOWS_BINARY):
 	GOOS=windows GOARCH=amd64 go build $(LDFLAGS) -o $(WINDOWS_BINARY) .
 
 # Build for Windows ARM64
-$(WINDOWS_BINARY_AMD64):
-	GOOS=windows GOARCH=arm64 go build $(LDFLAGS) -o $(WINDOWS_BINARY_AMD64) .
+$(WINDOWS_BINARY_ARM64):
+	GOOS=windows GOARCH=arm64 go build $(LDFLAGS) -o $(WINDOWS_BINARY_ARM64) .
 
 # Build both Windows binaries
-windows: $(WINDOWS_BINARY) $(WINDOWS_BINARY_AMD64)
+windows: $(WINDOWS_BINARY) $(WINDOWS_BINARY_ARM64)
 
 # Clean build artifacts
 clean:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-29400

### What

change file name to hcpctl-arm64.exe for ARM build

### Why

to avoid confusion by having the filename actually describe what the file contains.

### Testing

Tried out manually

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [X] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [X] Commit history is clean (rebased/squashed)
- [ ] All comment threads resolved before merge