### PR TITLE
feat(mgmt-agent): watch built-in GVRs for resource snapshots

### DIFF
--- a/mgmt-agent/pkg/controller/resourcewatcher.go
+++ b/mgmt-agent/pkg/controller/resourcewatcher.go
@@ -44,13 +44,28 @@ var watchedGroupSuffixes = []string{
 	"velero.io",
 }
 
+// watchedBuiltinGVRs is the hardcoded list of built-in (non-CRD)
+// GroupVersionResources to watch in addition to everything discovered via
+// watchedGroupSuffixes. These are core/apps types that are not covered by the
+// CRD group suffixes above but still carry useful management-cluster state. To
+// snapshot another built-in type, add its GVR here.
+var watchedBuiltinGVRs = []schema.GroupVersionResource{
+	{Group: "", Version: "v1", Resource: "namespaces"},
+	{Group: "", Version: "v1", Resource: "nodes"},
+	{Group: "apps", Version: "v1", Resource: "deployments"},
+	{Group: "apps", Version: "v1", Resource: "daemonsets"},
+	{Group: "apps", Version: "v1", Resource: "statefulsets"},
+	{Group: "apps", Version: "v1", Resource: "replicasets"},
+}
+
 // ServerResourceDiscoverer is the subset of the discovery API that ResourceWatcher needs.
 type ServerResourceDiscoverer interface {
 	ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error)
 }
 
 // ResourceWatcher discovers API resources matching a set of group suffixes, also
-// watches core/v1/namespaces, and logs every event via dynamic informers as structured JSON.
+// watches a fixed set of built-in GroupVersionResources (watchedBuiltinGVRs), and
+// logs every event via dynamic informers as structured JSON.
 type ResourceWatcher struct {
 	dynamicClient   dynamic.Interface
 	discoveryClient ServerResourceDiscoverer
@@ -64,8 +79,9 @@ func NewResourceWatcher(dynamicClient dynamic.Interface, discoveryClient ServerR
 	}
 }
 
-// Run discovers GVRs for the configured group suffixes, also watches core/v1/namespaces,
-// starts dynamic informers for each, and blocks until the context is cancelled. Events are
+// Run discovers GVRs for the configured group suffixes, also watches the built-in
+// GVRs in watchedBuiltinGVRs, starts dynamic informers for each, and blocks until
+// the context is cancelled. Events are
 // logged as structured JSON via klog. A CRD informer watches for new CustomResourceDefinitions;
 // if a new CRD is registered whose group matches the watched suffixes and introduces
 // GVRs not known at startup, the process exits so the pod restarts and picks them up.
@@ -77,7 +93,7 @@ func (w *ResourceWatcher) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	gvrs = append(gvrs, schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"})
+	gvrs = append(gvrs, watchedBuiltinGVRs...)
 	logger.Info("Discovered resources to watch", "count", len(gvrs))
 
 	knownGVRs := sets.New[schema.GroupVersionResource](gvrs...)

--- a/mgmt-agent/pkg/controller/resourcewatcher_test.go
+++ b/mgmt-agent/pkg/controller/resourcewatcher_test.go
@@ -137,6 +137,26 @@ func TestDiscoverGVRs(t *testing.T) {
 	}
 }
 
+func TestWatchedBuiltinGVRs(t *testing.T) {
+	// These built-in (non-CRD) resources are not covered by watchedGroupSuffixes,
+	// so they must be listed explicitly in watchedBuiltinGVRs to be snapshotted.
+	required := []schema.GroupVersionResource{
+		{Group: "", Version: "v1", Resource: "namespaces"},
+		{Group: "", Version: "v1", Resource: "nodes"},
+		{Group: "apps", Version: "v1", Resource: "deployments"},
+		{Group: "apps", Version: "v1", Resource: "daemonsets"},
+		{Group: "apps", Version: "v1", Resource: "statefulsets"},
+		{Group: "apps", Version: "v1", Resource: "replicasets"},
+	}
+
+	have := sets.New[schema.GroupVersionResource](watchedBuiltinGVRs...)
+	for _, want := range required {
+		if !have.Has(want) {
+			t.Errorf("watchedBuiltinGVRs is missing %v", want)
+		}
+	}
+}
+
 // fakeDiscovery implements ServerResourceDiscoverer for testing.
 type fakeDiscovery struct {
 	resources []*metav1.APIResourceList


### PR DESCRIPTION
Add a watchedBuiltinGVRs list so specific built-in (non-CRD) resources can be snapshotted alongside the suffix-discovered CRDs, and populate it with namespaces plus apps/v1 deployments, daemonsets, statefulsets, and replicasets. This replaces the single hardcoded namespaces entry with a declarative list that is easy to extend. RBAC already allows list/watch on all resources, so no permission change is needed.

<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
