### PR TITLE
fix(test): call bicep directly instead of az bicep build (ARO-29399)

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -4,6 +4,8 @@ SHELL = /bin/bash
 
 all: build
 
+BICEP ?= bicep
+
 BICEP_OUTPUT_DIR=$(TEST_DIR)e2e/test-artifacts/generated-test-artifacts/
 
 DEMO_BICEP_DIR=$(TEST_DIR)../demo/bicep
@@ -11,14 +13,14 @@ DEMO_BICEP_SOURCES = $(shell find $(DEMO_BICEP_DIR) -name '*.bicep')
 DEMO_BICEP_OUTPUTS = $(addprefix $(BICEP_OUTPUT_DIR)standard-cluster-create/,$(addsuffix .json,$(basename $(notdir $(DEMO_BICEP_SOURCES)))))
 $(BICEP_OUTPUT_DIR)standard-cluster-create/%.json: $(DEMO_BICEP_DIR)/%.bicep
 	@mkdir -p $(dir $@)
-	bicep build $< --outfile $@
+	$(BICEP) build $< --outfile $@
 
 TEST_BICEP_DIR=$(TEST_DIR)e2e-setup/bicep
 TEST_BICEP_SOURCES = $(shell cd $(TEST_BICEP_DIR) && find * -name '*.bicep')
 TEST_BICEP_OUTPUTS = $(addprefix $(BICEP_OUTPUT_DIR),$(addsuffix .json,$(basename $(TEST_BICEP_SOURCES))))
 $(BICEP_OUTPUT_DIR)%.json: $(TEST_BICEP_DIR)/%.bicep
 	@mkdir -p $(dir $@)
-	bicep build $< --outfile $@
+	$(BICEP) build $< --outfile $@
 
 update-go-fixtures:
 	UPDATE=true go test --count=1 ./... -v

--- a/test/Makefile
+++ b/test/Makefile
@@ -11,14 +11,14 @@ DEMO_BICEP_SOURCES = $(shell find $(DEMO_BICEP_DIR) -name '*.bicep')
 DEMO_BICEP_OUTPUTS = $(addprefix $(BICEP_OUTPUT_DIR)standard-cluster-create/,$(addsuffix .json,$(basename $(notdir $(DEMO_BICEP_SOURCES)))))
 $(BICEP_OUTPUT_DIR)standard-cluster-create/%.json: $(DEMO_BICEP_DIR)/%.bicep
 	@mkdir -p $(dir $@)
-	az bicep build --file=$< --outfile=$@
+	bicep build $< --outfile $@
 
 TEST_BICEP_DIR=$(TEST_DIR)e2e-setup/bicep
 TEST_BICEP_SOURCES = $(shell cd $(TEST_BICEP_DIR) && find * -name '*.bicep')
 TEST_BICEP_OUTPUTS = $(addprefix $(BICEP_OUTPUT_DIR),$(addsuffix .json,$(basename $(TEST_BICEP_SOURCES))))
 $(BICEP_OUTPUT_DIR)%.json: $(TEST_BICEP_DIR)/%.bicep
 	@mkdir -p $(dir $@)
-	az bicep build --file=$< --outfile=$@
+	bicep build $< --outfile $@
 
 update-go-fixtures:
 	UPDATE=true go test --count=1 ./... -v


### PR DESCRIPTION
[ARO-29399](https://redhat.atlassian.net/browse/ARO-29399)

### What

Switches the two bicep build steps in `test/Makefile` from `az bicep build` to calling the standalone `bicep` binary directly.

### Why

The `aro-hcp-e2e-tests-amd64` image build has been failing intermittently on a network call from `az bicep build`. The bicep binary is already baked into the CI base image (`dev-infrastructure/openshift-ci/Dockerfile` installs it to `/usr/local/bin/bicep`), but `az bicep build` still checks `downloads.bicep.azure.com` for the latest version on every invocation, and that check has been timing out/resetting in CI (`ConnectionResetError`, read timeouts on `downloads.bicep.azure.com`, and the `mcr.microsoft.com` error in the original report, which is the same check's actual-download path).

Calling `bicep` directly instead of suppressing the check with `AZURE_BICEP_CHECK_VERSION=False` removes the network dependency for this step entirely, instead of just suppressing one check, and it skips the `az` CLI startup overhead.

### Testing

Verified locally that native `bicep build` produces the same output as `az bicep build` for all 25 generated fixtures in `test/Makefile`, and that `make build` (in `test/`) runs cleanly end to end with the updated recipes.

- [x] Unit tests (n/a, Makefile-only change)
- [ ] Integration tests
- [ ] E2E tests (relying on `ci/prow/e2e-images` and `ci/prow/e2e-parallel` to confirm no more bicep network failures)

### Special notes for your reviewer

Seen 4+ times today across PR #6748 and PR #6762 on `e2e-images`/`e2e-parallel`, always failing at this exact `az bicep build` call site.
