### PR TITLE
fix(mgmt-agent): fire node-health on the wedge shape prod produces (AROSLSRE-1973)

### DIFF
--- a/mgmt-agent/pkg/controller/nodehealth/detectors/decide_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/decide_test.go
@@ -155,11 +155,11 @@ func TestDecide(t *testing.T) {
 			name: "below the stuck-pod floor is not wedged",
 			node: testNode(true, true),
 			events: func() []*corev1.Event {
-				e, _ := stuckFailing(2, ago(15*time.Minute))
+				e, _ := stuckFailing(1, ago(15*time.Minute))
 				return e
 			}(),
 			pods: func() []*corev1.Pod {
-				_, p := stuckFailing(2, ago(15*time.Minute))
+				_, p := stuckFailing(1, ago(15*time.Minute))
 				return p
 			}(),
 			want: DecisionUnknown,

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/production_evidence_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/production_evidence_test.go
@@ -266,3 +266,69 @@ func TestFutureDatedSuccessDoesNotSuppressDetection(t *testing.T) {
 		t.Errorf("a future-dated success suppressed detection of a real wedge: Decide = %v, want %v", got, DecisionWedged)
 	}
 }
+
+// TestProductionHardWedgeShapeFires pins the failure floor against the pod count
+// the captured incident actually produced.
+//
+// The other tests in this file replay the wedge with three stuck pods, which is
+// comfortably over any floor and so cannot detect a floor set too high. The
+// distinguishing property of a hard wedge is the opposite of a storm: once the
+// node cannot build a sandbox, the scheduler stops getting new pods to a running
+// state there, so a very small number of pods retry indefinitely instead of many
+// pods failing once each.
+//
+// Kusto for the captured uksouth node over the incident, counting distinct pods
+// rather than events, shows exactly that:
+//
+//	node                                distinct pods   events   span
+//	aks-userswft2-40171262-vmss000001               2     1193   58.3h
+//
+// One sampled hour inside the wedge, 2026-07-27 09:00 to 10:00, is the shape
+// replayed below: 2 distinct failing pods, no fresh sandbox success at all.
+//
+// The same query over flapping (not wedged) nodes returns 30 to 70 distinct pods
+// per node, with successes throughout, so the flap population is ruled out by
+// dwell and requireZeroSuccess rather than by the floor. That is why the floor
+// can sit at 2 without letting flaps through: a flapping pod gets its sandbox on
+// retry, so it never stays stuck for the dwell.
+func TestProductionHardWedgeShapeFires(t *testing.T) {
+	now := time.Date(2026, 7, 27, 9, 30, 0, 0, time.UTC)
+	const ns = "openshift-monitoring"
+	const host = "aks-userswift0-00000000-vmss000000"
+
+	var pods []*corev1.Pod
+	var events []*corev1.Event
+	for i, name := range []string{"ovnkube-node-x1", "prometheus-k8s-0"} {
+		uid := types.UID("uid-" + name)
+		pods = append(pods, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, UID: uid},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+				Conditions: []corev1.PodCondition{{
+					Type:               corev1.PodReadyToStartContainers,
+					Status:             corev1.ConditionFalse,
+					LastTransitionTime: metav1.NewTime(now.Add(-45 * time.Minute)),
+				}},
+			},
+		})
+		events = append(events, &corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Namespace: ns, Name: name + ".evt"},
+			Reason:         reasonFailedCreatePodSandBox,
+			Message:        productionSandboxMessages[i%len(productionSandboxMessages)].message,
+			InvolvedObject: corev1.ObjectReference{Kind: "Pod", Namespace: ns, Name: name, UID: uid},
+			Source:         corev1.EventSource{Host: host},
+			LastTimestamp:  metav1.NewTime(now.Add(-1 * time.Minute)),
+		})
+	}
+
+	snap := swiftVFTeardown.Evaluate(events, pods, now)
+	if snap.SustainedCount != 2 {
+		t.Fatalf("captured wedge shape did not produce 2 sustained pods: SustainedCount = %d", snap.SustainedCount)
+	}
+	if snap.RecentSuccess {
+		t.Fatal("captured wedge shape must have no fresh sandbox success")
+	}
+	if got, _ := Decide(productionWedgedNode(), events, pods, now); got != DecisionWedged {
+		t.Errorf("the captured hard wedge did not fire: Decide = %v, want %v; the failure floor is above the pod count a real wedge produces", got, DecisionWedged)
+	}
+}

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/swift_vf.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/swift_vf.go
@@ -52,7 +52,16 @@ var swiftVFTeardown = signatureDetector{
 		`mtpnc is not ready`,
 		`dhcp discover.*timed out`,
 	),
-	failuresFloor:      3,
+	// failuresFloor is 2, not 3, because a hard wedge presents with very few
+	// distinct pods. Once a node cannot build a sandbox, almost nothing new is
+	// placed on it, so the same handful of pods retry indefinitely rather than a
+	// crowd of pods each failing once. The captured uksouth wedge
+	// (TestProductionHardWedgeShapeFires) produced 1193 failure events from only
+	// 2 distinct pods over 58 hours, so a floor of 3 would never have fired on it.
+	// False positives are held off by dwell and requireZeroSuccess, not by this
+	// floor: a flapping node's pods succeed on retry, so they never reach the
+	// dwell, and the node's other successes trip requireZeroSuccess anyway.
+	failuresFloor:      2,
 	window:             10 * time.Minute,
 	dwell:              10 * time.Minute,
 	requireZeroSuccess: true,


### PR DESCRIPTION
[AROSLSRE-1973](https://redhat.atlassian.net/browse/AROSLSRE-1973)

### What

Lowers `failuresFloor` on the `swift-vf-teardown` detector from 3 to 2, and pins the pod count against the captured incident with a production-evidence test.

### Why

The detector has never fired in production. It is on by default and running in every region, but a check across eastus2, uksouth and australiaeast found only controller lifecycle logs and zero `detector fired; node labeled wedged`.

It is not starved of input. eastus2 alone saw 2124 `mtpnc is not ready` events across 21 nodes in 14 days.

`failuresFloor` counts distinct pods stuck past the dwell, and a hard wedge produces very few of them. Once a node cannot build a sandbox, almost nothing new reaches a running state there, so a couple of pods retry indefinitely rather than a crowd of pods each failing once. Counting distinct pods is close to backwards for this case, because being wedged is what stops new pods arriving to be counted.

The captured uksouth node, counting distinct pods rather than events:

```
node                                distinct pods   events   span
aks-userswft2-40171262-vmss000001               2     1193   58.3h
```

One sampled hour inside that wedge, 2026-07-27 09:00 to 10:00, gave 21 failure events, 2 distinct failing pods and 0 fresh sandbox successes. `requireZeroSuccess` was satisfied, so the floor of 3 was the only thing holding it back.

Flaps are a different population and are already handled. Over 21 days australiaeast never exceeded 1.8 retries per pod, against 596 on the wedged node. A flapping pod gets its sandbox on retry, so it never reaches the dwell, and its node has other successes anyway. The false-positive protection comes from dwell and `requireZeroSuccess`, not from the floor.

### Testing

- Unit tests

`TestProductionHardWedgeShapeFires` replays the captured 2 pod, 0 success shape and asserts it fires. It is a real regression guard, not a tautology: it passes at `failuresFloor: 2` and fails at 3 with a message naming the cause. I verified both directions by flipping the constant.

The existing below-the-floor case in `decide_test.go` moves from 2 pods to 1, so it keeps testing the same property against the new floor.

`go test ./...` and `go vet` pass across `mgmt-agent`.

No new firings on current traffic: measured across every eastus2 window with 2 or more failing pods over 3 days, 0 of 19 would fire, all still blocked by a fresh success.

```
pods in window   windows   would fire at floor 2   blocked by success
2                     10                       0                  10
3                      5                       0                   5
4 or more              4                       0                   4
```

### Special notes for your reviewer

Behaviour is unchanged for everything except the 2 pod case, and that case is exactly the captured wedge.

This does not touch remediation. The controller still only labels and annotates, and its RBAC on nodes is get/list/watch/patch with no delete or eviction, so cordon, taint, evict and delete remain owned by a controller that does not exist yet.

The signatures are untouched. They are already pinned against this incident and match it correctly.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
