### PR TITLE
feat: ARO-25981 - Prometheus Alerts For etcd Availability Metrics

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
@@ -368,3 +368,556 @@ Namespace: {{ $labels.namespace }}
     ]
   }
 }
+
+resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'rp-etcd-availability'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdBackendCommitDurationHigh1h5m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '1h'
+          severity: '3'
+          short_window: '5m'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdBackendCommitDurationHigh1h5m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd backend commit duration is high for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd backend commit duration is high for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[5m]))) > 0.1 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[1h]))) > 0.1) unless on (subscription_id) internal_subscription:info'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdBackendCommitDurationHigh6h30m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '6h'
+          severity: '3'
+          short_window: '30m'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdBackendCommitDurationHigh6h30m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd backend commit duration is high for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd backend commit duration is high for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[30m]))) > 0.1 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.1) unless on (subscription_id) internal_subscription:info'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdBackendCommitDurationHigh3d'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '3d'
+          severity: '4'
+          short_window: '6h'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdBackendCommitDurationHigh3d/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd backend commit duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd backend commit duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.1) unless on (subscription_id) internal_subscription:info'
+        for: 'PT6H'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdDatabaseHighFragmentation1h5m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '1h'
+          severity: '3'
+          short_window: '5m'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdDatabaseHighFragmentation1h5m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Fast burn (1h/5m).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Fast burn (1h/5m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd database fragmentation is high for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd database fragmentation is high for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '((etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_size_in_bytes) < 0.25) unless on (subscription_id) internal_subscription:info'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdDatabaseHighFragmentation6h30m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '6h'
+          severity: '3'
+          short_window: '30m'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdDatabaseHighFragmentation6h30m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Medium burn (6h/30m).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Medium burn (6h/30m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd database fragmentation is high for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd database fragmentation is high for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '((etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_size_in_bytes) < 0.25) unless on (subscription_id) internal_subscription:info'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdDatabaseHighFragmentation3d'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '3d'
+          severity: '4'
+          short_window: '6h'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdDatabaseHighFragmentation3d/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd database fragmentation is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd database fragmentation is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '((etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_size_in_bytes) < 0.25) unless on (subscription_id) internal_subscription:info'
+        for: 'PT6H'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdDatabaseSizeExceeded1h5m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '1h'
+          severity: '3'
+          short_window: '5m'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdDatabaseSizeExceeded1h5m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Fast burn (1h/5m).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Fast burn (1h/5m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd database size is too large for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd database size is too large for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '(etcd_mvcc_db_total_size_in_bytes > 8000000000) unless on (subscription_id) internal_subscription:info'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdDatabaseSizeExceeded6h30m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '6h'
+          severity: '3'
+          short_window: '30m'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdDatabaseSizeExceeded6h30m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Medium burn (6h/30m).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Medium burn (6h/30m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd database size is too large for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd database size is too large for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '(etcd_mvcc_db_total_size_in_bytes > 8000000000) unless on (subscription_id) internal_subscription:info'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdDatabaseSizeExceeded3d'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '3d'
+          severity: '4'
+          short_window: '6h'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdDatabaseSizeExceeded3d/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd database size is chronically too large for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd database size is chronically too large for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '(etcd_mvcc_db_total_size_in_bytes > 8000000000) unless on (subscription_id) internal_subscription:info'
+        for: 'PT6H'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdFrequentLeaderChanges1h5m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '1h'
+          severity: '3'
+          short_window: '5m'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdFrequentLeaderChanges1h5m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Fast burn (1h/5m).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Fast burn (1h/5m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd cluster experiencing frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd cluster experiencing frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '(increase(etcd_server_leader_changes_seen_total[15m]) > 4) unless on (subscription_id) internal_subscription:info'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdFrequentLeaderChanges6h30m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '6h'
+          severity: '3'
+          short_window: '30m'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdFrequentLeaderChanges6h30m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Medium burn (6h/30m).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Medium burn (6h/30m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd cluster experiencing frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd cluster experiencing frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '(increase(etcd_server_leader_changes_seen_total[15m]) > 4) unless on (subscription_id) internal_subscription:info'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdFrequentLeaderChanges3d'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '3d'
+          severity: '4'
+          short_window: '6h'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdFrequentLeaderChanges3d/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd cluster experiencing chronic frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd cluster experiencing chronic frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '(increase(etcd_server_leader_changes_seen_total[15m]) > 4) unless on (subscription_id) internal_subscription:info'
+        for: 'PT6H'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdPeerRoundTripTimeHigh1h5m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '1h'
+          severity: '3'
+          short_window: '5m'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh1h5m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd peer round-trip time is high for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd peer round-trip time is high for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[5m]))) > 0.1 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[1h]))) > 0.1) unless on (subscription_id) internal_subscription:info'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdPeerRoundTripTimeHigh6h30m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '6h'
+          severity: '3'
+          short_window: '30m'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh6h30m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd peer round-trip time is high for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd peer round-trip time is high for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[30m]))) > 0.1 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1) unless on (subscription_id) internal_subscription:info'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdPeerRoundTripTimeHigh3d'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '3d'
+          severity: '4'
+          short_window: '6h'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh3d/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd peer round-trip time is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd peer round-trip time is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1) unless on (subscription_id) internal_subscription:info'
+        for: 'PT6H'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdWALFsyncDurationHigh1h5m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '1h'
+          severity: '3'
+          short_window: '5m'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdWALFsyncDurationHigh1h5m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd WAL fsync duration is high for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd WAL fsync duration is high for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m]))) > 0.05 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[1h]))) > 0.05) unless on (subscription_id) internal_subscription:info'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdWALFsyncDurationHigh6h30m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '6h'
+          severity: '3'
+          short_window: '30m'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdWALFsyncDurationHigh6h30m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd WAL fsync duration is high for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd WAL fsync duration is high for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[30m]))) > 0.05 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05) unless on (subscription_id) internal_subscription:info'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdWALFsyncDurationHigh3d'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '3d'
+          severity: '4'
+          short_window: '6h'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdWALFsyncDurationHigh3d/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd WAL fsync duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
+          title: 'etcd WAL fsync duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
+        }
+        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05) unless on (subscription_id) internal_subscription:info'
+        for: 'PT6H'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}

--- a/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
@@ -445,7 +445,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
             }
           }
         ]
-        alert: 'userJourneyEtcdBackendCommitDurationHigh3d'
+        alert: 'userJourneyEtcdBackendCommitDurationHigh3d6h'
         enabled: true
         labels: {
           component: 'hcp'
@@ -454,7 +454,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '6h'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdBackendCommitDurationHigh3d/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdBackendCommitDurationHigh3d6h/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -535,7 +535,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
             }
           }
         ]
-        alert: 'userJourneyEtcdDatabaseHighFragmentation3d'
+        alert: 'userJourneyEtcdDatabaseHighFragmentation3d6h'
         enabled: true
         labels: {
           component: 'hcp'
@@ -544,9 +544,9 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '6h'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdDatabaseHighFragmentation3d/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d).'
+          correlationId: 'userJourneyEtcdDatabaseHighFragmentation3d6h/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d/6h).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d/6h).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
           summary: 'etcd database fragmentation is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
           title: 'etcd database fragmentation is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
@@ -625,7 +625,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
             }
           }
         ]
-        alert: 'userJourneyEtcdDatabaseSizeExceeded3d'
+        alert: 'userJourneyEtcdDatabaseSizeExceeded3d6h'
         enabled: true
         labels: {
           component: 'hcp'
@@ -634,9 +634,9 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '6h'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdDatabaseSizeExceeded3d/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d).'
+          correlationId: 'userJourneyEtcdDatabaseSizeExceeded3d6h/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d/6h).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d/6h).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
           summary: 'etcd database size is chronically too large for {{ $labels.resource_id }} {{ $labels.instance }}'
           title: 'etcd database size is chronically too large for {{ $labels.resource_id }} {{ $labels.instance }}'
@@ -715,7 +715,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
             }
           }
         ]
-        alert: 'userJourneyEtcdFrequentLeaderChanges3d'
+        alert: 'userJourneyEtcdFrequentLeaderChanges3d6h'
         enabled: true
         labels: {
           component: 'hcp'
@@ -724,9 +724,9 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '6h'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdFrequentLeaderChanges3d/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d).'
+          correlationId: 'userJourneyEtcdFrequentLeaderChanges3d6h/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d/6h).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d/6h).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
           summary: 'etcd cluster experiencing chronic frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}'
           title: 'etcd cluster experiencing chronic frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}'
@@ -805,7 +805,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
             }
           }
         ]
-        alert: 'userJourneyEtcdPeerRoundTripTimeHigh3d'
+        alert: 'userJourneyEtcdPeerRoundTripTimeHigh3d6h'
         enabled: true
         labels: {
           component: 'hcp'
@@ -814,7 +814,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '6h'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh3d/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh3d6h/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -895,7 +895,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
             }
           }
         ]
-        alert: 'userJourneyEtcdWALFsyncDurationHigh3d'
+        alert: 'userJourneyEtcdWALFsyncDurationHigh3d6h'
         enabled: true
         labels: {
           component: 'hcp'
@@ -904,7 +904,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '6h'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdWALFsyncDurationHigh3d/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdWALFsyncDurationHigh3d6h/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'

--- a/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
@@ -369,8 +369,8 @@ Namespace: {{ $labels.namespace }}
   }
 }
 
-resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
-  name: 'rp-etcd-availability'
+resource hcpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'hcp-etcd-availability'
   location: location
   properties: {
     interval: 'PT1M'

--- a/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
@@ -394,7 +394,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '5m'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdBackendCommitDurationHigh1h5m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdBackendCommitDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -424,7 +424,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '30m'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdBackendCommitDurationHigh6h30m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdBackendCommitDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -454,7 +454,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '6h'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdBackendCommitDurationHigh3d6h/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdBackendCommitDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -484,7 +484,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '5m'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdDatabaseHighFragmentation1h5m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdDatabaseHighFragmentation/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Fast burn (1h/5m).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Fast burn (1h/5m).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -514,7 +514,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '30m'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdDatabaseHighFragmentation6h30m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdDatabaseHighFragmentation/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Medium burn (6h/30m).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Medium burn (6h/30m).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -544,7 +544,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '6h'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdDatabaseHighFragmentation3d6h/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdDatabaseHighFragmentation/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d/6h).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d/6h).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -574,7 +574,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '5m'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdDatabaseSizeExceeded1h5m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdDatabaseSizeExceeded/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Fast burn (1h/5m).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Fast burn (1h/5m).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -604,7 +604,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '30m'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdDatabaseSizeExceeded6h30m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdDatabaseSizeExceeded/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Medium burn (6h/30m).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Medium burn (6h/30m).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -634,7 +634,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '6h'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdDatabaseSizeExceeded3d6h/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdDatabaseSizeExceeded/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d/6h).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d/6h).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -664,7 +664,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '5m'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdFrequentLeaderChanges1h5m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdFrequentLeaderChanges/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Fast burn (1h/5m).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Fast burn (1h/5m).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -694,7 +694,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '30m'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdFrequentLeaderChanges6h30m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdFrequentLeaderChanges/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Medium burn (6h/30m).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Medium burn (6h/30m).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -724,7 +724,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '6h'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdFrequentLeaderChanges3d6h/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdFrequentLeaderChanges/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d/6h).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d/6h).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -754,7 +754,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '5m'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh1h5m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -784,7 +784,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '30m'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh6h30m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -814,7 +814,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '6h'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh3d6h/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -844,7 +844,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '5m'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdWALFsyncDurationHigh1h5m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdWALFsyncDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -874,7 +874,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '30m'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdWALFsyncDurationHigh6h30m/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdWALFsyncDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
@@ -904,7 +904,7 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
           short_window: '6h'
         }
         annotations: {
-          correlationId: 'userJourneyEtcdWALFsyncDurationHigh3d6h/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
+          correlationId: 'userJourneyEtcdWALFsyncDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
           description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h).'
           info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'

--- a/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
@@ -455,14 +455,14 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         }
         annotations: {
           correlationId: 'userJourneyEtcdBackendCommitDurationHigh3d/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d).'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
           summary: 'etcd backend commit duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
           title: 'etcd backend commit duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
         }
-        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.1) unless on (subscription_id) internal_subscription:info'
-        for: 'PT6H'
+        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.1 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[3d]))) > 0.1) unless on (subscription_id) internal_subscription:info'
+        for: 'PT3H'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
@@ -815,14 +815,14 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         }
         annotations: {
           correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh3d/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d).'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
           summary: 'etcd peer round-trip time is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
           title: 'etcd peer round-trip time is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
         }
-        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1) unless on (subscription_id) internal_subscription:info'
-        for: 'PT6H'
+        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[3d]))) > 0.1) unless on (subscription_id) internal_subscription:info'
+        for: 'PT3H'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
@@ -905,14 +905,14 @@ resource rpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@202
         }
         annotations: {
           correlationId: 'userJourneyEtcdWALFsyncDurationHigh3d/{{ $labels.cluster }}/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d).'
+          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h).'
+          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h).'
           runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
           summary: 'etcd WAL fsync duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
           title: 'etcd WAL fsync duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
         }
-        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05) unless on (subscription_id) internal_subscription:info'
-        for: 'PT6H'
+        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[3d]))) > 0.05) unless on (subscription_id) internal_subscription:info'
+        for: 'PT3H'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
     ]

--- a/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
@@ -17,13 +17,15 @@ resource rpUserjourneyKasAvailabilityMonitorRules 'Microsoft.AlertsManagement/pr
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyKubeApiserverAvailability1h5m'
         enabled: true
         labels: {
@@ -52,13 +54,15 @@ Namespace: {{ $labels.namespace }}
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyKubeApiserverAvailability6h30m'
         enabled: true
         labels: {
@@ -87,13 +91,15 @@ Namespace: {{ $labels.namespace }}
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyKubeApiserverAvailability3d6h'
         enabled: true
         labels: {
@@ -135,13 +141,15 @@ resource hcpEtcdGrpcLatencyAlerts 'Microsoft.AlertsManagement/prometheusRuleGrou
     interval: 'PT1M'
     rules: [
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyEtcdReadLatencyP991h5m'
         enabled: true
         labels: {
@@ -170,13 +178,15 @@ Namespace: {{ $labels.namespace }}
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyEtcdReadLatencyP996h30m'
         enabled: true
         labels: {
@@ -205,13 +215,15 @@ Namespace: {{ $labels.namespace }}
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyEtcdReadLatencyP993d6h'
         enabled: true
         labels: {
@@ -240,13 +252,15 @@ Namespace: {{ $labels.namespace }}
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyEtcdWriteLatencyP991h5m'
         enabled: true
         labels: {
@@ -275,13 +289,15 @@ Namespace: {{ $labels.namespace }}
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyEtcdWriteLatencyP996h30m'
         enabled: true
         labels: {
@@ -310,13 +326,15 @@ Namespace: {{ $labels.namespace }}
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [for g in actionGroups: {
-          actionGroupId: g
-          actionProperties: {
-            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-            'IcM.CorrelationId': '#$.annotations.correlationId#'
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
           }
-        }]
+        ]
         alert: 'userJourneyEtcdWriteLatencyP993d6h'
         enabled: true
         labels: {
@@ -341,6 +359,385 @@ Namespace: {{ $labels.namespace }}
           title: '[userJourneyEtcdWriteLatencyP99] {{ $labels.cluster }} / {{ $labels.namespace }} P99 > 500ms (3d/6h)'
         }
         expression: '(histogram_quantile(0.99, sum by (namespace, cluster, le, region) (rate(grpc_server_handling_seconds_bucket{grpc_method="Txn",grpc_service="etcdserverpb.KV",namespace=~"ocm-.*"}[3d]))) > 0.5) and (histogram_quantile(0.99, sum by (namespace, cluster, le, region) (rate(grpc_server_handling_seconds_bucket{grpc_method="Txn",grpc_service="etcdserverpb.KV",namespace=~"ocm-.*"}[6h]))) > 0.5)'
+        for: 'PT3H'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+    ]
+    scopes: [
+      azureMonitoring
+    ]
+  }
+}
+
+resource hcpEtcdAvailabilityAlertRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'hcp-etcd-availability-alert-rules'
+  location: location
+  properties: {
+    interval: 'PT1M'
+    rules: [
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdBackendCommitDurationHigh1h5m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '1h'
+          severity: '3'
+          short_window: '5m'
+          slo: 'etcd-backend-commit-duration'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdBackendCommitDurationHigh/{{ $labels.cluster }}/{{ $labels.namespace }}'
+          description: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m).'
+          info: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd backend commit duration is high for {{ $labels.cluster }} {{ $labels.namespace }}'
+          title: 'etcd backend commit duration is high for {{ $labels.cluster }} {{ $labels.namespace }}'
+        }
+        expression: 'histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[5m]))) > 0.1 and histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[1h]))) > 0.1'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdBackendCommitDurationHigh6h30m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '6h'
+          severity: '3'
+          short_window: '30m'
+          slo: 'etcd-backend-commit-duration'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdBackendCommitDurationHigh/{{ $labels.cluster }}/{{ $labels.namespace }}'
+          description: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m).'
+          info: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd backend commit duration is high for {{ $labels.cluster }} {{ $labels.namespace }}'
+          title: 'etcd backend commit duration is high for {{ $labels.cluster }} {{ $labels.namespace }}'
+        }
+        expression: 'histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[30m]))) > 0.1 and histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.1'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdBackendCommitDurationHigh3d6h'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '3d'
+          severity: '4'
+          short_window: '6h'
+          slo: 'etcd-backend-commit-duration'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdBackendCommitDurationHigh/{{ $labels.cluster }}/{{ $labels.namespace }}'
+          description: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h).'
+          info: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd backend commit duration is chronically high for {{ $labels.cluster }} {{ $labels.namespace }}'
+          title: 'etcd backend commit duration is chronically high for {{ $labels.cluster }} {{ $labels.namespace }}'
+        }
+        expression: 'histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.1 and histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[3d]))) > 0.1'
+        for: 'PT3H'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdDatabaseHighFragmentation'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          severity: '3'
+          slo: 'etcd-database-fragmentation'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdDatabaseHighFragmentation/{{ $labels.cluster }}/{{ $labels.namespace }}'
+          description: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space.'
+          info: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space.'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd database fragmentation is high for {{ $labels.cluster }} {{ $labels.namespace }}'
+          title: 'etcd database fragmentation is high for {{ $labels.cluster }} {{ $labels.namespace }}'
+        }
+        expression: '(etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_size_in_bytes) < 0.25'
+        for: 'PT15M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdDatabaseSizeExceeded'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          severity: '3'
+          slo: 'etcd-database-size'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdDatabaseSizeExceeded/{{ $labels.cluster }}/{{ $labels.namespace }}'
+          description: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd database size is {{ $value | humanize }}B (threshold: 7GB). Database may need compaction or quota increase.'
+          info: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd database size is {{ $value | humanize }}B (threshold: 7GB). Database may need compaction or quota increase.'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd database size is too large for {{ $labels.cluster }} {{ $labels.namespace }}'
+          title: 'etcd database size is too large for {{ $labels.cluster }} {{ $labels.namespace }}'
+        }
+        expression: 'etcd_mvcc_db_total_size_in_bytes > 7000000000'
+        for: 'PT15M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdFrequentLeaderChanges'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          severity: '3'
+          slo: 'etcd-leader-changes'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdFrequentLeaderChanges/{{ $labels.cluster }}/{{ $labels.namespace }}'
+          description: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has seen {{ $value }} leader changes in the last 15 minutes (threshold: 3). This may indicate network issues or cluster instability.'
+          info: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has seen {{ $value }} leader changes in the last 15 minutes (threshold: 3). This may indicate network issues or cluster instability.'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd cluster experiencing frequent leader changes for {{ $labels.cluster }} {{ $labels.namespace }}'
+          title: 'etcd cluster experiencing frequent leader changes for {{ $labels.cluster }} {{ $labels.namespace }}'
+        }
+        expression: 'increase(etcd_server_leader_changes_seen_total[15m]) > 3'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdPeerRoundTripTimeHigh1h5m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '1h'
+          severity: '3'
+          short_window: '5m'
+          slo: 'etcd-peer-round-trip-time'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.cluster }}/{{ $labels.namespace }}'
+          description: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m).'
+          info: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd peer round-trip time is high for {{ $labels.cluster }} {{ $labels.namespace }}'
+          title: 'etcd peer round-trip time is high for {{ $labels.cluster }} {{ $labels.namespace }}'
+        }
+        expression: 'histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[5m]))) > 0.1 and histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[1h]))) > 0.1'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdPeerRoundTripTimeHigh6h30m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '6h'
+          severity: '3'
+          short_window: '30m'
+          slo: 'etcd-peer-round-trip-time'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.cluster }}/{{ $labels.namespace }}'
+          description: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m).'
+          info: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd peer round-trip time is high for {{ $labels.cluster }} {{ $labels.namespace }}'
+          title: 'etcd peer round-trip time is high for {{ $labels.cluster }} {{ $labels.namespace }}'
+        }
+        expression: 'histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[30m]))) > 0.1 and histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdPeerRoundTripTimeHigh3d6h'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '3d'
+          severity: '4'
+          short_window: '6h'
+          slo: 'etcd-peer-round-trip-time'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.cluster }}/{{ $labels.namespace }}'
+          description: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h).'
+          info: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd peer round-trip time is chronically high for {{ $labels.cluster }} {{ $labels.namespace }}'
+          title: 'etcd peer round-trip time is chronically high for {{ $labels.cluster }} {{ $labels.namespace }}'
+        }
+        expression: 'histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1 and histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[3d]))) > 0.1'
+        for: 'PT3H'
+        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdWALFsyncDurationHigh1h5m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '1h'
+          severity: '3'
+          short_window: '5m'
+          slo: 'etcd-wal-fsync-duration'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdWALFsyncDurationHigh/{{ $labels.cluster }}/{{ $labels.namespace }}'
+          description: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m).'
+          info: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd WAL fsync duration is high for {{ $labels.cluster }} {{ $labels.namespace }}'
+          title: 'etcd WAL fsync duration is high for {{ $labels.cluster }} {{ $labels.namespace }}'
+        }
+        expression: 'histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m]))) > 0.05 and histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[1h]))) > 0.05'
+        for: 'PT5M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdWALFsyncDurationHigh6h30m'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '6h'
+          severity: '3'
+          short_window: '30m'
+          slo: 'etcd-wal-fsync-duration'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdWALFsyncDurationHigh/{{ $labels.cluster }}/{{ $labels.namespace }}'
+          description: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m).'
+          info: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd WAL fsync duration is high for {{ $labels.cluster }} {{ $labels.namespace }}'
+          title: 'etcd WAL fsync duration is high for {{ $labels.cluster }} {{ $labels.namespace }}'
+        }
+        expression: 'histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[30m]))) > 0.05 and histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05'
+        for: 'PT30M'
+        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
+      }
+      {
+        actions: [
+          for g in actionGroups: {
+            actionGroupId: g
+            actionProperties: {
+              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+              'IcM.CorrelationId': '#$.annotations.correlationId#'
+            }
+          }
+        ]
+        alert: 'userJourneyEtcdWALFsyncDurationHigh3d6h'
+        enabled: true
+        labels: {
+          component: 'hcp'
+          long_window: '3d'
+          severity: '4'
+          short_window: '6h'
+          slo: 'etcd-wal-fsync-duration'
+        }
+        annotations: {
+          correlationId: 'userJourneyEtcdWALFsyncDurationHigh/{{ $labels.cluster }}/{{ $labels.namespace }}'
+          description: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h).'
+          info: '{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h).'
+          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
+          summary: 'etcd WAL fsync duration is chronically high for {{ $labels.cluster }} {{ $labels.namespace }}'
+          title: 'etcd WAL fsync duration is chronically high for {{ $labels.cluster }} {{ $labels.namespace }}'
+        }
+        expression: 'histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05 and histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[3d]))) > 0.05'
         for: 'PT3H'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }

--- a/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
@@ -17,15 +17,13 @@ resource rpUserjourneyKasAvailabilityMonitorRules 'Microsoft.AlertsManagement/pr
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyKubeApiserverAvailability1h5m'
         enabled: true
         labels: {
@@ -54,15 +52,13 @@ Namespace: {{ $labels.namespace }}
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyKubeApiserverAvailability6h30m'
         enabled: true
         labels: {
@@ -91,15 +87,13 @@ Namespace: {{ $labels.namespace }}
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyKubeApiserverAvailability3d6h'
         enabled: true
         labels: {
@@ -141,15 +135,13 @@ resource hcpEtcdGrpcLatencyAlerts 'Microsoft.AlertsManagement/prometheusRuleGrou
     interval: 'PT1M'
     rules: [
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyEtcdReadLatencyP991h5m'
         enabled: true
         labels: {
@@ -178,15 +170,13 @@ Namespace: {{ $labels.namespace }}
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyEtcdReadLatencyP996h30m'
         enabled: true
         labels: {
@@ -215,15 +205,13 @@ Namespace: {{ $labels.namespace }}
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyEtcdReadLatencyP993d6h'
         enabled: true
         labels: {
@@ -252,15 +240,13 @@ Namespace: {{ $labels.namespace }}
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyEtcdWriteLatencyP991h5m'
         enabled: true
         labels: {
@@ -289,15 +275,13 @@ Namespace: {{ $labels.namespace }}
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyEtcdWriteLatencyP996h30m'
         enabled: true
         labels: {
@@ -326,15 +310,13 @@ Namespace: {{ $labels.namespace }}
         severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
       }
       {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
+        actions: [for g in actionGroups: {
+          actionGroupId: g
+          actionProperties: {
+            'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
+            'IcM.CorrelationId': '#$.annotations.correlationId#'
           }
-        ]
+        }]
         alert: 'userJourneyEtcdWriteLatencyP993d6h'
         enabled: true
         labels: {
@@ -359,559 +341,6 @@ Namespace: {{ $labels.namespace }}
           title: '[userJourneyEtcdWriteLatencyP99] {{ $labels.cluster }} / {{ $labels.namespace }} P99 > 500ms (3d/6h)'
         }
         expression: '(histogram_quantile(0.99, sum by (namespace, cluster, le, region) (rate(grpc_server_handling_seconds_bucket{grpc_method="Txn",grpc_service="etcdserverpb.KV",namespace=~"ocm-.*"}[3d]))) > 0.5) and (histogram_quantile(0.99, sum by (namespace, cluster, le, region) (rate(grpc_server_handling_seconds_bucket{grpc_method="Txn",grpc_service="etcdserverpb.KV",namespace=~"ocm-.*"}[6h]))) > 0.5)'
-        for: 'PT3H'
-        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
-      }
-    ]
-    scopes: [
-      azureMonitoring
-    ]
-  }
-}
-
-resource hcpEtcdAvailability 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
-  name: 'hcp-etcd-availability'
-  location: location
-  properties: {
-    interval: 'PT1M'
-    rules: [
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdBackendCommitDurationHigh1h5m'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '1h'
-          severity: '3'
-          short_window: '5m'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdBackendCommitDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd backend commit duration is high for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd backend commit duration is high for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[5m]))) > 0.1 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[1h]))) > 0.1) unless on (subscription_id) internal_subscription:info'
-        for: 'PT5M'
-        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdBackendCommitDurationHigh6h30m'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '6h'
-          severity: '3'
-          short_window: '30m'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdBackendCommitDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd backend commit duration is high for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd backend commit duration is high for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[30m]))) > 0.1 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.1) unless on (subscription_id) internal_subscription:info'
-        for: 'PT30M'
-        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdBackendCommitDurationHigh3d6h'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '3d'
-          severity: '4'
-          short_window: '6h'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdBackendCommitDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd backend commit duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd backend commit duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.1 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[3d]))) > 0.1) unless on (subscription_id) internal_subscription:info'
-        for: 'PT3H'
-        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdDatabaseHighFragmentation1h5m'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '1h'
-          severity: '3'
-          short_window: '5m'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdDatabaseHighFragmentation/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Fast burn (1h/5m).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Fast burn (1h/5m).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd database fragmentation is high for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd database fragmentation is high for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '((etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_size_in_bytes) < 0.25) unless on (subscription_id) internal_subscription:info'
-        for: 'PT5M'
-        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdDatabaseHighFragmentation6h30m'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '6h'
-          severity: '3'
-          short_window: '30m'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdDatabaseHighFragmentation/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Medium burn (6h/30m).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Medium burn (6h/30m).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd database fragmentation is high for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd database fragmentation is high for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '((etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_size_in_bytes) < 0.25) unless on (subscription_id) internal_subscription:info'
-        for: 'PT30M'
-        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdDatabaseHighFragmentation3d6h'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '3d'
-          severity: '4'
-          short_window: '6h'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdDatabaseHighFragmentation/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d/6h).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d/6h).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd database fragmentation is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd database fragmentation is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '((etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_size_in_bytes) < 0.25) unless on (subscription_id) internal_subscription:info'
-        for: 'PT6H'
-        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdDatabaseSizeExceeded1h5m'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '1h'
-          severity: '3'
-          short_window: '5m'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdDatabaseSizeExceeded/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Fast burn (1h/5m).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Fast burn (1h/5m).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd database size is too large for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd database size is too large for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '(etcd_mvcc_db_total_size_in_bytes > 8000000000) unless on (subscription_id) internal_subscription:info'
-        for: 'PT5M'
-        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdDatabaseSizeExceeded6h30m'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '6h'
-          severity: '3'
-          short_window: '30m'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdDatabaseSizeExceeded/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Medium burn (6h/30m).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Medium burn (6h/30m).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd database size is too large for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd database size is too large for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '(etcd_mvcc_db_total_size_in_bytes > 8000000000) unless on (subscription_id) internal_subscription:info'
-        for: 'PT30M'
-        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdDatabaseSizeExceeded3d6h'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '3d'
-          severity: '4'
-          short_window: '6h'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdDatabaseSizeExceeded/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d/6h).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d/6h).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd database size is chronically too large for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd database size is chronically too large for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '(etcd_mvcc_db_total_size_in_bytes > 8000000000) unless on (subscription_id) internal_subscription:info'
-        for: 'PT6H'
-        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdFrequentLeaderChanges1h5m'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '1h'
-          severity: '3'
-          short_window: '5m'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdFrequentLeaderChanges/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Fast burn (1h/5m).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Fast burn (1h/5m).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd cluster experiencing frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd cluster experiencing frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '(increase(etcd_server_leader_changes_seen_total[15m]) > 4) unless on (subscription_id) internal_subscription:info'
-        for: 'PT5M'
-        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdFrequentLeaderChanges6h30m'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '6h'
-          severity: '3'
-          short_window: '30m'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdFrequentLeaderChanges/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Medium burn (6h/30m).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Medium burn (6h/30m).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd cluster experiencing frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd cluster experiencing frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '(increase(etcd_server_leader_changes_seen_total[15m]) > 4) unless on (subscription_id) internal_subscription:info'
-        for: 'PT30M'
-        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdFrequentLeaderChanges3d6h'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '3d'
-          severity: '4'
-          short_window: '6h'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdFrequentLeaderChanges/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d/6h).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d/6h).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd cluster experiencing chronic frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd cluster experiencing chronic frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '(increase(etcd_server_leader_changes_seen_total[15m]) > 4) unless on (subscription_id) internal_subscription:info'
-        for: 'PT6H'
-        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdPeerRoundTripTimeHigh1h5m'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '1h'
-          severity: '3'
-          short_window: '5m'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd peer round-trip time is high for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd peer round-trip time is high for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[5m]))) > 0.1 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[1h]))) > 0.1) unless on (subscription_id) internal_subscription:info'
-        for: 'PT5M'
-        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdPeerRoundTripTimeHigh6h30m'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '6h'
-          severity: '3'
-          short_window: '30m'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd peer round-trip time is high for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd peer round-trip time is high for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[30m]))) > 0.1 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1) unless on (subscription_id) internal_subscription:info'
-        for: 'PT30M'
-        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdPeerRoundTripTimeHigh3d6h'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '3d'
-          severity: '4'
-          short_window: '6h'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd peer round-trip time is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd peer round-trip time is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[3d]))) > 0.1) unless on (subscription_id) internal_subscription:info'
-        for: 'PT3H'
-        severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdWALFsyncDurationHigh1h5m'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '1h'
-          severity: '3'
-          short_window: '5m'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdWALFsyncDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd WAL fsync duration is high for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd WAL fsync duration is high for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m]))) > 0.05 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[1h]))) > 0.05) unless on (subscription_id) internal_subscription:info'
-        for: 'PT5M'
-        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdWALFsyncDurationHigh6h30m'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '6h'
-          severity: '3'
-          short_window: '30m'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdWALFsyncDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd WAL fsync duration is high for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd WAL fsync duration is high for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[30m]))) > 0.05 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05) unless on (subscription_id) internal_subscription:info'
-        for: 'PT30M'
-        severity: severityCeiling > 0 ? max(3, severityCeiling) : 3
-      }
-      {
-        actions: [
-          for g in actionGroups: {
-            actionGroupId: g
-            actionProperties: {
-              'IcM.Title': '#$.labels.cluster#: #$.annotations.title#'
-              'IcM.CorrelationId': '#$.annotations.correlationId#'
-            }
-          }
-        ]
-        alert: 'userJourneyEtcdWALFsyncDurationHigh3d6h'
-        enabled: true
-        labels: {
-          component: 'hcp'
-          long_window: '3d'
-          severity: '4'
-          short_window: '6h'
-        }
-        annotations: {
-          correlationId: 'userJourneyEtcdWALFsyncDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}'
-          description: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h).'
-          info: '{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h).'
-          runbook_url: 'https://aka.ms/arohcp-runbook-etcd'
-          summary: 'etcd WAL fsync duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
-          title: 'etcd WAL fsync duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}'
-        }
-        expression: '(histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05 and histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[3d]))) > 0.05) unless on (subscription_id) internal_subscription:info'
         for: 'PT3H'
         severity: severityCeiling > 0 ? max(4, severityCeiling) : 4
       }

--- a/observability/alerts-rp-hcps.yaml
+++ b/observability/alerts-rp-hcps.yaml
@@ -2,7 +2,11 @@ prometheusRules:
   rulesFolders:
   - alerts/UserJourneyKubeApiserverAvailabilityMonitor-prometheusRule-KSM.yaml
   - alerts/UserJourneyEtcdLatencyMonitor-prometheusRule.yaml
+  - alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
   untestedRules: []
   testDependencies:
   - recording-rules-hcps.yaml
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
+internalSubscriptionFilter:
+  enabled: true
+  table: internal_subscription:info

--- a/observability/alerts-rp-hcps.yaml
+++ b/observability/alerts-rp-hcps.yaml
@@ -7,6 +7,3 @@ prometheusRules:
   testDependencies:
   - recording-rules-hcps.yaml
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedRPHCPPrometheusAlertingRules.bicep
-internalSubscriptionFilter:
-  enabled: true
-  table: internal_subscription:info

--- a/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
+++ b/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
@@ -1,0 +1,306 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: etcd-availability
+  namespace: monitoring
+spec:
+  groups:
+  - name: rp-etcd-availability
+    rules:
+    # ========================================
+    # Burn-rate tiers per ADR-001 (MWMBR):
+    #   Fast  (1h/5m):  fires in 5m   — severity: 3
+    #   Medium (6h/30m): fires in 30m  — severity: 3
+    #   Slow  (3d):     fires in 6h   — severity: 4
+    # For histogram metrics the rate window matches the short window,
+    # with a dual-window (short AND long) confirmation for fast/medium.
+    # For gauge/increase metrics only the 'for' duration varies.
+    # ========================================
+
+    # ----------------------------------------
+    # userJourneyEtcdBackendCommitDurationHigh
+    # ----------------------------------------
+    - alert: userJourneyEtcdBackendCommitDurationHigh1h5m
+      expr: |
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[5m]))) > 0.100
+        and
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[1h]))) > 0.100
+      for: 5m
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "3"
+        long_window: 1h
+        short_window: 5m
+      annotations:
+        summary: "etcd backend commit duration is high for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+    - alert: userJourneyEtcdBackendCommitDurationHigh6h30m
+      expr: |
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[30m]))) > 0.100
+        and
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.100
+      for: 30m
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "3"
+        long_window: 6h
+        short_window: 30m
+      annotations:
+        summary: "etcd backend commit duration is high for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+    - alert: userJourneyEtcdBackendCommitDurationHigh3d
+      expr: |
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.100
+      for: 6h
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "4"
+        long_window: 3d
+        short_window: 6h
+      annotations:
+        summary: "etcd backend commit duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+
+    # ----------------------------------------
+    # userJourneyEtcdDatabaseHighFragmentation
+    # ----------------------------------------
+    - alert: userJourneyEtcdDatabaseHighFragmentation1h5m
+      expr: |
+        (etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_size_in_bytes) < 0.25
+      for: 5m
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "3"
+        long_window: 1h
+        short_window: 5m
+      annotations:
+        summary: "etcd database fragmentation is high for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Fast burn (1h/5m)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+    - alert: userJourneyEtcdDatabaseHighFragmentation6h30m
+      expr: |
+        (etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_size_in_bytes) < 0.25
+      for: 30m
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "3"
+        long_window: 6h
+        short_window: 30m
+      annotations:
+        summary: "etcd database fragmentation is high for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Medium burn (6h/30m)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+    - alert: userJourneyEtcdDatabaseHighFragmentation3d
+      expr: |
+        (etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_size_in_bytes) < 0.25
+      for: 6h
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "4"
+        long_window: 3d
+        short_window: 6h
+      annotations:
+        summary: "etcd database fragmentation is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+
+    # ----------------------------------------
+    # userJourneyEtcdDatabaseSizeExceeded
+    # ----------------------------------------
+    - alert: userJourneyEtcdDatabaseSizeExceeded1h5m
+      expr: |
+        etcd_mvcc_db_total_size_in_bytes > 8000000000
+      for: 5m
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "3"
+        long_window: 1h
+        short_window: 5m
+      annotations:
+        summary: "etcd database size is too large for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Fast burn (1h/5m)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+    - alert: userJourneyEtcdDatabaseSizeExceeded6h30m
+      expr: |
+        etcd_mvcc_db_total_size_in_bytes > 8000000000
+      for: 30m
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "3"
+        long_window: 6h
+        short_window: 30m
+      annotations:
+        summary: "etcd database size is too large for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Medium burn (6h/30m)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+    - alert: userJourneyEtcdDatabaseSizeExceeded3d
+      expr: |
+        etcd_mvcc_db_total_size_in_bytes > 8000000000
+      for: 6h
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "4"
+        long_window: 3d
+        short_window: 6h
+      annotations:
+        summary: "etcd database size is chronically too large for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+
+    # ----------------------------------------
+    # userJourneyEtcdFrequentLeaderChanges
+    # ----------------------------------------
+    - alert: userJourneyEtcdFrequentLeaderChanges1h5m
+      expr: |
+        increase(etcd_server_leader_changes_seen_total[15m]) > 4
+      for: 5m
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "3"
+        long_window: 1h
+        short_window: 5m
+      annotations:
+        summary: "etcd cluster experiencing frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Fast burn (1h/5m)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+    - alert: userJourneyEtcdFrequentLeaderChanges6h30m
+      expr: |
+        increase(etcd_server_leader_changes_seen_total[15m]) > 4
+      for: 30m
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "3"
+        long_window: 6h
+        short_window: 30m
+      annotations:
+        summary: "etcd cluster experiencing frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Medium burn (6h/30m)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+    - alert: userJourneyEtcdFrequentLeaderChanges3d
+      expr: |
+        increase(etcd_server_leader_changes_seen_total[15m]) > 4
+      for: 6h
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "4"
+        long_window: 3d
+        short_window: 6h
+      annotations:
+        summary: "etcd cluster experiencing chronic frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+
+    # ----------------------------------------
+    # userJourneyEtcdPeerRoundTripTimeHigh
+    # ----------------------------------------
+    - alert: userJourneyEtcdPeerRoundTripTimeHigh1h5m
+      expr: |
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[5m]))) > 0.1
+        and
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[1h]))) > 0.1
+      for: 5m
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "3"
+        long_window: 1h
+        short_window: 5m
+      annotations:
+        summary: "etcd peer round-trip time is high for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+    - alert: userJourneyEtcdPeerRoundTripTimeHigh6h30m
+      expr: |
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[30m]))) > 0.1
+        and
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1
+      for: 30m
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "3"
+        long_window: 6h
+        short_window: 30m
+      annotations:
+        summary: "etcd peer round-trip time is high for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+    - alert: userJourneyEtcdPeerRoundTripTimeHigh3d
+      expr: |
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1
+      for: 6h
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "4"
+        long_window: 3d
+        short_window: 6h
+      annotations:
+        summary: "etcd peer round-trip time is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+
+    # ----------------------------------------
+    # userJourneyEtcdWALFsyncDurationHigh
+    # ----------------------------------------
+    - alert: userJourneyEtcdWALFsyncDurationHigh1h5m
+      expr: |
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m]))) > 0.05
+        and
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[1h]))) > 0.05
+      for: 5m
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "3"
+        long_window: 1h
+        short_window: 5m
+      annotations:
+        summary: "etcd WAL fsync duration is high for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+    - alert: userJourneyEtcdWALFsyncDurationHigh6h30m
+      expr: |
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[30m]))) > 0.05
+        and
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05
+      for: 30m
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "3"
+        long_window: 6h
+        short_window: 30m
+      annotations:
+        summary: "etcd WAL fsync duration is high for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+    - alert: userJourneyEtcdWALFsyncDurationHigh3d
+      expr: |
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05
+      for: 6h
+      labels:
+        component: hcp
+        exclude_internal_subscriptions: "true"
+        severity: "4"
+        long_window: 3d
+        short_window: 6h
+      annotations:
+        summary: "etcd WAL fsync duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}"
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d)."
+        runbook_url: https://aka.ms/arohcp-runbook-etcd

--- a/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
+++ b/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
@@ -52,7 +52,7 @@ spec:
         summary: "etcd backend commit duration is high for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-    - alert: userJourneyEtcdBackendCommitDurationHigh3d
+    - alert: userJourneyEtcdBackendCommitDurationHigh3d6h
       expr: |
         histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.100
         and
@@ -100,7 +100,7 @@ spec:
         summary: "etcd database fragmentation is high for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Medium burn (6h/30m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-    - alert: userJourneyEtcdDatabaseHighFragmentation3d
+    - alert: userJourneyEtcdDatabaseHighFragmentation3d6h
       expr: |
         (etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_size_in_bytes) < 0.25
       for: 6h
@@ -112,7 +112,7 @@ spec:
         short_window: 6h
       annotations:
         summary: "etcd database fragmentation is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d)."
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d/6h)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
 
     # ----------------------------------------
@@ -146,7 +146,7 @@ spec:
         summary: "etcd database size is too large for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Medium burn (6h/30m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-    - alert: userJourneyEtcdDatabaseSizeExceeded3d
+    - alert: userJourneyEtcdDatabaseSizeExceeded3d6h
       expr: |
         etcd_mvcc_db_total_size_in_bytes > 8000000000
       for: 6h
@@ -158,7 +158,7 @@ spec:
         short_window: 6h
       annotations:
         summary: "etcd database size is chronically too large for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d)."
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d/6h)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
 
     # ----------------------------------------
@@ -192,7 +192,7 @@ spec:
         summary: "etcd cluster experiencing frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Medium burn (6h/30m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-    - alert: userJourneyEtcdFrequentLeaderChanges3d
+    - alert: userJourneyEtcdFrequentLeaderChanges3d6h
       expr: |
         increase(etcd_server_leader_changes_seen_total[15m]) > 4
       for: 6h
@@ -204,7 +204,7 @@ spec:
         short_window: 6h
       annotations:
         summary: "etcd cluster experiencing chronic frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d)."
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d/6h)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
 
     # ----------------------------------------
@@ -242,7 +242,7 @@ spec:
         summary: "etcd peer round-trip time is high for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-    - alert: userJourneyEtcdPeerRoundTripTimeHigh3d
+    - alert: userJourneyEtcdPeerRoundTripTimeHigh3d6h
       expr: |
         histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1
         and
@@ -294,7 +294,7 @@ spec:
         summary: "etcd WAL fsync duration is high for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-    - alert: userJourneyEtcdWALFsyncDurationHigh3d
+    - alert: userJourneyEtcdWALFsyncDurationHigh3d6h
       expr: |
         histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05
         and

--- a/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
+++ b/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
@@ -15,6 +15,8 @@ spec:
     # For histogram metrics the rate window matches the short window,
     # with a dual-window (short AND long) confirmation for all three tiers.
     # For gauge/increase metrics only the 'for' duration varies.
+    # correlationId groups all three burn-rate tiers of an alert family into
+    # one IcM incident (dropping the tier suffix from the alert name).
     # ========================================
 
     # ----------------------------------------
@@ -36,6 +38,7 @@ spec:
         summary: "etcd backend commit duration is high for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdBackendCommitDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
     - alert: userJourneyEtcdBackendCommitDurationHigh6h30m
       expr: |
         histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[30m]))) > 0.100
@@ -52,6 +55,7 @@ spec:
         summary: "etcd backend commit duration is high for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdBackendCommitDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
     - alert: userJourneyEtcdBackendCommitDurationHigh3d6h
       expr: |
         histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.100
@@ -68,6 +72,7 @@ spec:
         summary: "etcd backend commit duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdBackendCommitDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
 
     # ----------------------------------------
     # userJourneyEtcdDatabaseHighFragmentation
@@ -86,6 +91,7 @@ spec:
         summary: "etcd database fragmentation is high for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Fast burn (1h/5m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdDatabaseHighFragmentation/{{ $labels.resource_id }}/{{ $labels.instance }}"
     - alert: userJourneyEtcdDatabaseHighFragmentation6h30m
       expr: |
         (etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_size_in_bytes) < 0.25
@@ -100,6 +106,7 @@ spec:
         summary: "etcd database fragmentation is high for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Medium burn (6h/30m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdDatabaseHighFragmentation/{{ $labels.resource_id }}/{{ $labels.instance }}"
     - alert: userJourneyEtcdDatabaseHighFragmentation3d6h
       expr: |
         (etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_size_in_bytes) < 0.25
@@ -114,6 +121,7 @@ spec:
         summary: "etcd database fragmentation is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d/6h)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdDatabaseHighFragmentation/{{ $labels.resource_id }}/{{ $labels.instance }}"
 
     # ----------------------------------------
     # userJourneyEtcdDatabaseSizeExceeded
@@ -132,6 +140,7 @@ spec:
         summary: "etcd database size is too large for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Fast burn (1h/5m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdDatabaseSizeExceeded/{{ $labels.resource_id }}/{{ $labels.instance }}"
     - alert: userJourneyEtcdDatabaseSizeExceeded6h30m
       expr: |
         etcd_mvcc_db_total_size_in_bytes > 8000000000
@@ -146,6 +155,7 @@ spec:
         summary: "etcd database size is too large for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Medium burn (6h/30m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdDatabaseSizeExceeded/{{ $labels.resource_id }}/{{ $labels.instance }}"
     - alert: userJourneyEtcdDatabaseSizeExceeded3d6h
       expr: |
         etcd_mvcc_db_total_size_in_bytes > 8000000000
@@ -160,6 +170,7 @@ spec:
         summary: "etcd database size is chronically too large for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d/6h)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdDatabaseSizeExceeded/{{ $labels.resource_id }}/{{ $labels.instance }}"
 
     # ----------------------------------------
     # userJourneyEtcdFrequentLeaderChanges
@@ -178,6 +189,7 @@ spec:
         summary: "etcd cluster experiencing frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Fast burn (1h/5m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdFrequentLeaderChanges/{{ $labels.resource_id }}/{{ $labels.instance }}"
     - alert: userJourneyEtcdFrequentLeaderChanges6h30m
       expr: |
         increase(etcd_server_leader_changes_seen_total[15m]) > 4
@@ -192,6 +204,7 @@ spec:
         summary: "etcd cluster experiencing frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Medium burn (6h/30m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdFrequentLeaderChanges/{{ $labels.resource_id }}/{{ $labels.instance }}"
     - alert: userJourneyEtcdFrequentLeaderChanges3d6h
       expr: |
         increase(etcd_server_leader_changes_seen_total[15m]) > 4
@@ -206,6 +219,7 @@ spec:
         summary: "etcd cluster experiencing chronic frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d/6h)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdFrequentLeaderChanges/{{ $labels.resource_id }}/{{ $labels.instance }}"
 
     # ----------------------------------------
     # userJourneyEtcdPeerRoundTripTimeHigh
@@ -226,6 +240,7 @@ spec:
         summary: "etcd peer round-trip time is high for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
     - alert: userJourneyEtcdPeerRoundTripTimeHigh6h30m
       expr: |
         histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[30m]))) > 0.1
@@ -242,6 +257,7 @@ spec:
         summary: "etcd peer round-trip time is high for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
     - alert: userJourneyEtcdPeerRoundTripTimeHigh3d6h
       expr: |
         histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1
@@ -258,6 +274,7 @@ spec:
         summary: "etcd peer round-trip time is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
 
     # ----------------------------------------
     # userJourneyEtcdWALFsyncDurationHigh
@@ -278,6 +295,7 @@ spec:
         summary: "etcd WAL fsync duration is high for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdWALFsyncDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
     - alert: userJourneyEtcdWALFsyncDurationHigh6h30m
       expr: |
         histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[30m]))) > 0.05
@@ -294,6 +312,7 @@ spec:
         summary: "etcd WAL fsync duration is high for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdWALFsyncDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
     - alert: userJourneyEtcdWALFsyncDurationHigh3d6h
       expr: |
         histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05
@@ -310,3 +329,4 @@ spec:
         summary: "etcd WAL fsync duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}"
         description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdWALFsyncDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"

--- a/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
+++ b/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: prometheus
 spec:
   groups:
-  - name: rp-etcd-availability
+  - name: hcp-etcd-availability
     rules:
     # ========================================
     # Burn-rate tiers per ADR-001 (MWMBR):

--- a/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
+++ b/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
@@ -9,11 +9,11 @@ spec:
     rules:
     # ========================================
     # Burn-rate tiers per ADR-001 (MWMBR):
-    #   Fast  (1h/5m):  fires in 5m   — severity: 3
-    #   Medium (6h/30m): fires in 30m  — severity: 3
-    #   Slow  (3d):     fires in 6h   — severity: 4
+    #   Fast   (1h/5m):  fires in 5m  — severity: 3
+    #   Medium (6h/30m): fires in 30m — severity: 3
+    #   Slow   (3d/6h):  fires in 3h  — severity: 4
     # For histogram metrics the rate window matches the short window,
-    # with a dual-window (short AND long) confirmation for fast/medium.
+    # with a dual-window (short AND long) confirmation for all three tiers.
     # For gauge/increase metrics only the 'for' duration varies.
     # ========================================
 
@@ -55,7 +55,9 @@ spec:
     - alert: userJourneyEtcdBackendCommitDurationHigh3d
       expr: |
         histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.100
-      for: 6h
+        and
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[3d]))) > 0.100
+      for: 3h
       labels:
         component: hcp
         exclude_internal_subscriptions: "true"
@@ -64,7 +66,7 @@ spec:
         short_window: 6h
       annotations:
         summary: "etcd backend commit duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d)."
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
 
     # ----------------------------------------
@@ -243,7 +245,9 @@ spec:
     - alert: userJourneyEtcdPeerRoundTripTimeHigh3d
       expr: |
         histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1
-      for: 6h
+        and
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[3d]))) > 0.1
+      for: 3h
       labels:
         component: hcp
         exclude_internal_subscriptions: "true"
@@ -252,7 +256,7 @@ spec:
         short_window: 6h
       annotations:
         summary: "etcd peer round-trip time is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d)."
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
 
     # ----------------------------------------
@@ -293,7 +297,9 @@ spec:
     - alert: userJourneyEtcdWALFsyncDurationHigh3d
       expr: |
         histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05
-      for: 6h
+        and
+        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[3d]))) > 0.05
+      for: 3h
       labels:
         component: hcp
         exclude_internal_subscriptions: "true"
@@ -302,5 +308,5 @@ spec:
         short_window: 6h
       annotations:
         summary: "etcd WAL fsync duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d)."
+        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd

--- a/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
+++ b/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
@@ -11,7 +11,7 @@ spec:
     # Burn-rate tiers per ADR-001 (MWMBR):
     #   Fast   (1h/5m):  fires in 5m  — severity: 3
     #   Medium (6h/30m): fires in 30m — severity: 3
-    #   Slow   (3d/6h):  fires in 3h  — severity: 4
+    #   Slow   (3d/6h):  fires in 3h (histograms) / 6h (gauges & increase) — severity: 4
     # For histogram metrics the rate window matches the short window,
     # with a dual-window (short AND long) confirmation for all three tiers.
     # For gauge/increase metrics only the 'for' duration varies.

--- a/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
+++ b/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: etcd-availability
-  namespace: monitoring
+  namespace: prometheus
 spec:
   groups:
   - name: rp-etcd-availability

--- a/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
+++ b/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
@@ -35,7 +35,6 @@ spec:
       for: 5m
       labels:
         component: hcp
-        exclude_internal_subscriptions: "true"
         severity: "3"
         long_window: 1h
         short_window: 5m
@@ -53,7 +52,6 @@ spec:
       for: 30m
       labels:
         component: hcp
-        exclude_internal_subscriptions: "true"
         severity: "3"
         long_window: 6h
         short_window: 30m
@@ -71,7 +69,6 @@ spec:
       for: 3h
       labels:
         component: hcp
-        exclude_internal_subscriptions: "true"
         severity: "4"
         long_window: 3d
         short_window: 6h
@@ -91,7 +88,6 @@ spec:
       for: 15m
       labels:
         component: hcp
-        exclude_internal_subscriptions: "true"
         severity: "3"
         slo: etcd-database-fragmentation
       annotations:
@@ -109,7 +105,6 @@ spec:
       for: 15m
       labels:
         component: hcp
-        exclude_internal_subscriptions: "true"
         severity: "3"
         slo: etcd-database-size
       annotations:
@@ -127,7 +122,6 @@ spec:
       for: 5m
       labels:
         component: hcp
-        exclude_internal_subscriptions: "true"
         severity: "3"
         slo: etcd-leader-changes
       annotations:
@@ -147,7 +141,6 @@ spec:
       for: 5m
       labels:
         component: hcp
-        exclude_internal_subscriptions: "true"
         severity: "3"
         long_window: 1h
         short_window: 5m
@@ -165,7 +158,6 @@ spec:
       for: 30m
       labels:
         component: hcp
-        exclude_internal_subscriptions: "true"
         severity: "3"
         long_window: 6h
         short_window: 30m
@@ -183,7 +175,6 @@ spec:
       for: 3h
       labels:
         component: hcp
-        exclude_internal_subscriptions: "true"
         severity: "4"
         long_window: 3d
         short_window: 6h
@@ -205,7 +196,6 @@ spec:
       for: 5m
       labels:
         component: hcp
-        exclude_internal_subscriptions: "true"
         severity: "3"
         long_window: 1h
         short_window: 5m
@@ -223,7 +213,6 @@ spec:
       for: 30m
       labels:
         component: hcp
-        exclude_internal_subscriptions: "true"
         severity: "3"
         long_window: 6h
         short_window: 30m
@@ -241,7 +230,6 @@ spec:
       for: 3h
       labels:
         component: hcp
-        exclude_internal_subscriptions: "true"
         severity: "4"
         long_window: 3d
         short_window: 6h

--- a/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
+++ b/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
@@ -21,7 +21,9 @@ spec:
     # The remaining alerts (database size, fragmentation, leader changes)
     # compare a gauge/increase directly against a fixed threshold, so the
     # expression doesn't vary by window — these are single, non-tiered
-    # alerts (for: 15m, severity: 3) instead of three burn-rate tiers.
+    # alerts (for: 15m, severity: 3) instead of three burn-rate tiers,
+    # except the frequent etcd leader changes alert, which uses for: 5m.
+    #
     # ========================================
 
     # ----------------------------------------

--- a/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
+++ b/observability/alerts/UserJourneyEtcdAvailability-prometheusRule.yaml
@@ -1,22 +1,27 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: etcd-availability
+  name: hcp-etcd-availability-alerts
   namespace: prometheus
 spec:
   groups:
-  - name: hcp-etcd-availability
+  - name: hcp-etcd-availability-alert-rules
     rules:
     # ========================================
-    # Burn-rate tiers per ADR-001 (MWMBR):
+    # Burn-rate tiers per ADR-001 (MWMBR), used for the histogram-based
+    # alerts (backend commit duration, peer round-trip time, WAL fsync):
     #   Fast   (1h/5m):  fires in 5m  — severity: 3
     #   Medium (6h/30m): fires in 30m — severity: 3
-    #   Slow   (3d/6h):  fires in 3h (histograms) / 6h (gauges & increase) — severity: 4
-    # For histogram metrics the rate window matches the short window,
-    # with a dual-window (short AND long) confirmation for all three tiers.
-    # For gauge/increase metrics only the 'for' duration varies.
+    #   Slow   (3d/6h):  fires in 3h  — severity: 4
+    # The rate window matches the short window, with a dual-window
+    # (short AND long) confirmation for all three tiers.
     # correlationId groups all three burn-rate tiers of an alert family into
     # one IcM incident (dropping the tier suffix from the alert name).
+    #
+    # The remaining alerts (database size, fragmentation, leader changes)
+    # compare a gauge/increase directly against a fixed threshold, so the
+    # expression doesn't vary by window — these are single, non-tiered
+    # alerts (for: 15m, severity: 3) instead of three burn-rate tiers.
     # ========================================
 
     # ----------------------------------------
@@ -24,9 +29,9 @@ spec:
     # ----------------------------------------
     - alert: userJourneyEtcdBackendCommitDurationHigh1h5m
       expr: |
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[5m]))) > 0.100
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[5m]))) > 0.100
         and
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[1h]))) > 0.100
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[1h]))) > 0.100
       for: 5m
       labels:
         component: hcp
@@ -34,16 +39,17 @@ spec:
         severity: "3"
         long_window: 1h
         short_window: 5m
+        slo: etcd-backend-commit-duration
       annotations:
-        summary: "etcd backend commit duration is high for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m)."
+        summary: "etcd backend commit duration is high for {{ $labels.cluster }} {{ $labels.namespace }}"
+        description: "{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdBackendCommitDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
+        correlationId: "userJourneyEtcdBackendCommitDurationHigh/{{ $labels.cluster }}/{{ $labels.namespace }}"
     - alert: userJourneyEtcdBackendCommitDurationHigh6h30m
       expr: |
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[30m]))) > 0.100
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[30m]))) > 0.100
         and
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.100
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.100
       for: 30m
       labels:
         component: hcp
@@ -51,16 +57,17 @@ spec:
         severity: "3"
         long_window: 6h
         short_window: 30m
+        slo: etcd-backend-commit-duration
       annotations:
-        summary: "etcd backend commit duration is high for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m)."
+        summary: "etcd backend commit duration is high for {{ $labels.cluster }} {{ $labels.namespace }}"
+        description: "{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdBackendCommitDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
+        correlationId: "userJourneyEtcdBackendCommitDurationHigh/{{ $labels.cluster }}/{{ $labels.namespace }}"
     - alert: userJourneyEtcdBackendCommitDurationHigh3d6h
       expr: |
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.100
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[6h]))) > 0.100
         and
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[3d]))) > 0.100
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_backend_commit_duration_seconds_bucket[3d]))) > 0.100
       for: 3h
       labels:
         component: hcp
@@ -68,167 +75,75 @@ spec:
         severity: "4"
         long_window: 3d
         short_window: 6h
+        slo: etcd-backend-commit-duration
       annotations:
-        summary: "etcd backend commit duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h)."
+        summary: "etcd backend commit duration is chronically high for {{ $labels.cluster }} {{ $labels.namespace }}"
+        description: "{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile backend commit duration of {{ $value }}s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdBackendCommitDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
+        correlationId: "userJourneyEtcdBackendCommitDurationHigh/{{ $labels.cluster }}/{{ $labels.namespace }}"
 
     # ----------------------------------------
     # userJourneyEtcdDatabaseHighFragmentation
     # ----------------------------------------
-    - alert: userJourneyEtcdDatabaseHighFragmentation1h5m
+    - alert: userJourneyEtcdDatabaseHighFragmentation
       expr: |
         (etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_size_in_bytes) < 0.25
-      for: 5m
+      for: 15m
       labels:
         component: hcp
         exclude_internal_subscriptions: "true"
         severity: "3"
-        long_window: 1h
-        short_window: 5m
+        slo: etcd-database-fragmentation
       annotations:
-        summary: "etcd database fragmentation is high for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Fast burn (1h/5m)."
+        summary: "etcd database fragmentation is high for {{ $labels.cluster }} {{ $labels.namespace }}"
+        description: "{{ $labels.namespace }} / {{ $labels.cluster }} etcd database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdDatabaseHighFragmentation/{{ $labels.resource_id }}/{{ $labels.instance }}"
-    - alert: userJourneyEtcdDatabaseHighFragmentation6h30m
-      expr: |
-        (etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_size_in_bytes) < 0.25
-      for: 30m
-      labels:
-        component: hcp
-        exclude_internal_subscriptions: "true"
-        severity: "3"
-        long_window: 6h
-        short_window: 30m
-      annotations:
-        summary: "etcd database fragmentation is high for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Medium burn (6h/30m)."
-        runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdDatabaseHighFragmentation/{{ $labels.resource_id }}/{{ $labels.instance }}"
-    - alert: userJourneyEtcdDatabaseHighFragmentation3d6h
-      expr: |
-        (etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_size_in_bytes) < 0.25
-      for: 6h
-      labels:
-        component: hcp
-        exclude_internal_subscriptions: "true"
-        severity: "4"
-        long_window: 3d
-        short_window: 6h
-      annotations:
-        summary: "etcd database fragmentation is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database in-use ratio is {{ $value | humanizePercentage }} (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d/6h)."
-        runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdDatabaseHighFragmentation/{{ $labels.resource_id }}/{{ $labels.instance }}"
+        correlationId: "userJourneyEtcdDatabaseHighFragmentation/{{ $labels.cluster }}/{{ $labels.namespace }}"
 
     # ----------------------------------------
     # userJourneyEtcdDatabaseSizeExceeded
     # ----------------------------------------
-    - alert: userJourneyEtcdDatabaseSizeExceeded1h5m
+    - alert: userJourneyEtcdDatabaseSizeExceeded
       expr: |
-        etcd_mvcc_db_total_size_in_bytes > 8000000000
-      for: 5m
+        etcd_mvcc_db_total_size_in_bytes > 7000000000
+      for: 15m
       labels:
         component: hcp
         exclude_internal_subscriptions: "true"
         severity: "3"
-        long_window: 1h
-        short_window: 5m
+        slo: etcd-database-size
       annotations:
-        summary: "etcd database size is too large for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Fast burn (1h/5m)."
+        summary: "etcd database size is too large for {{ $labels.cluster }} {{ $labels.namespace }}"
+        description: "{{ $labels.namespace }} / {{ $labels.cluster }} etcd database size is {{ $value | humanize }}B (threshold: 7GB). Database may need compaction or quota increase."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdDatabaseSizeExceeded/{{ $labels.resource_id }}/{{ $labels.instance }}"
-    - alert: userJourneyEtcdDatabaseSizeExceeded6h30m
-      expr: |
-        etcd_mvcc_db_total_size_in_bytes > 8000000000
-      for: 30m
-      labels:
-        component: hcp
-        exclude_internal_subscriptions: "true"
-        severity: "3"
-        long_window: 6h
-        short_window: 30m
-      annotations:
-        summary: "etcd database size is too large for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Medium burn (6h/30m)."
-        runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdDatabaseSizeExceeded/{{ $labels.resource_id }}/{{ $labels.instance }}"
-    - alert: userJourneyEtcdDatabaseSizeExceeded3d6h
-      expr: |
-        etcd_mvcc_db_total_size_in_bytes > 8000000000
-      for: 6h
-      labels:
-        component: hcp
-        exclude_internal_subscriptions: "true"
-        severity: "4"
-        long_window: 3d
-        short_window: 6h
-      annotations:
-        summary: "etcd database size is chronically too large for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} database size is {{ $value | humanize }}B (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d/6h)."
-        runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdDatabaseSizeExceeded/{{ $labels.resource_id }}/{{ $labels.instance }}"
+        correlationId: "userJourneyEtcdDatabaseSizeExceeded/{{ $labels.cluster }}/{{ $labels.namespace }}"
 
     # ----------------------------------------
     # userJourneyEtcdFrequentLeaderChanges
     # ----------------------------------------
-    - alert: userJourneyEtcdFrequentLeaderChanges1h5m
+    - alert: userJourneyEtcdFrequentLeaderChanges
       expr: |
-        increase(etcd_server_leader_changes_seen_total[15m]) > 4
+        increase(etcd_server_leader_changes_seen_total[15m]) > 3
       for: 5m
       labels:
         component: hcp
         exclude_internal_subscriptions: "true"
         severity: "3"
-        long_window: 1h
-        short_window: 5m
+        slo: etcd-leader-changes
       annotations:
-        summary: "etcd cluster experiencing frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Fast burn (1h/5m)."
+        summary: "etcd cluster experiencing frequent leader changes for {{ $labels.cluster }} {{ $labels.namespace }}"
+        description: "{{ $labels.namespace }} / {{ $labels.cluster }} etcd has seen {{ $value }} leader changes in the last 15 minutes (threshold: 3). This may indicate network issues or cluster instability."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdFrequentLeaderChanges/{{ $labels.resource_id }}/{{ $labels.instance }}"
-    - alert: userJourneyEtcdFrequentLeaderChanges6h30m
-      expr: |
-        increase(etcd_server_leader_changes_seen_total[15m]) > 4
-      for: 30m
-      labels:
-        component: hcp
-        exclude_internal_subscriptions: "true"
-        severity: "3"
-        long_window: 6h
-        short_window: 30m
-      annotations:
-        summary: "etcd cluster experiencing frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Medium burn (6h/30m)."
-        runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdFrequentLeaderChanges/{{ $labels.resource_id }}/{{ $labels.instance }}"
-    - alert: userJourneyEtcdFrequentLeaderChanges3d6h
-      expr: |
-        increase(etcd_server_leader_changes_seen_total[15m]) > 4
-      for: 6h
-      labels:
-        component: hcp
-        exclude_internal_subscriptions: "true"
-        severity: "4"
-        long_window: 3d
-        short_window: 6h
-      annotations:
-        summary: "etcd cluster experiencing chronic frequent leader changes for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d/6h)."
-        runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdFrequentLeaderChanges/{{ $labels.resource_id }}/{{ $labels.instance }}"
+        correlationId: "userJourneyEtcdFrequentLeaderChanges/{{ $labels.cluster }}/{{ $labels.namespace }}"
 
     # ----------------------------------------
     # userJourneyEtcdPeerRoundTripTimeHigh
     # ----------------------------------------
     - alert: userJourneyEtcdPeerRoundTripTimeHigh1h5m
       expr: |
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[5m]))) > 0.1
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[5m]))) > 0.1
         and
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[1h]))) > 0.1
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[1h]))) > 0.1
       for: 5m
       labels:
         component: hcp
@@ -236,16 +151,17 @@ spec:
         severity: "3"
         long_window: 1h
         short_window: 5m
+        slo: etcd-peer-round-trip-time
       annotations:
-        summary: "etcd peer round-trip time is high for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m)."
+        summary: "etcd peer round-trip time is high for {{ $labels.cluster }} {{ $labels.namespace }}"
+        description: "{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
+        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.cluster }}/{{ $labels.namespace }}"
     - alert: userJourneyEtcdPeerRoundTripTimeHigh6h30m
       expr: |
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[30m]))) > 0.1
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[30m]))) > 0.1
         and
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1
       for: 30m
       labels:
         component: hcp
@@ -253,16 +169,17 @@ spec:
         severity: "3"
         long_window: 6h
         short_window: 30m
+        slo: etcd-peer-round-trip-time
       annotations:
-        summary: "etcd peer round-trip time is high for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m)."
+        summary: "etcd peer round-trip time is high for {{ $labels.cluster }} {{ $labels.namespace }}"
+        description: "{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
+        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.cluster }}/{{ $labels.namespace }}"
     - alert: userJourneyEtcdPeerRoundTripTimeHigh3d6h
       expr: |
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[6h]))) > 0.1
         and
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[3d]))) > 0.1
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket[3d]))) > 0.1
       for: 3h
       labels:
         component: hcp
@@ -270,20 +187,21 @@ spec:
         severity: "4"
         long_window: 3d
         short_window: 6h
+        slo: etcd-peer-round-trip-time
       annotations:
-        summary: "etcd peer round-trip time is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h)."
+        summary: "etcd peer round-trip time is chronically high for {{ $labels.cluster }} {{ $labels.namespace }}"
+        description: "{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile peer round-trip time of {{ $value }}s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
+        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/{{ $labels.cluster }}/{{ $labels.namespace }}"
 
     # ----------------------------------------
     # userJourneyEtcdWALFsyncDurationHigh
     # ----------------------------------------
     - alert: userJourneyEtcdWALFsyncDurationHigh1h5m
       expr: |
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m]))) > 0.05
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m]))) > 0.05
         and
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[1h]))) > 0.05
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[1h]))) > 0.05
       for: 5m
       labels:
         component: hcp
@@ -291,16 +209,17 @@ spec:
         severity: "3"
         long_window: 1h
         short_window: 5m
+        slo: etcd-wal-fsync-duration
       annotations:
-        summary: "etcd WAL fsync duration is high for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m)."
+        summary: "etcd WAL fsync duration is high for {{ $labels.cluster }} {{ $labels.namespace }}"
+        description: "{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdWALFsyncDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
+        correlationId: "userJourneyEtcdWALFsyncDurationHigh/{{ $labels.cluster }}/{{ $labels.namespace }}"
     - alert: userJourneyEtcdWALFsyncDurationHigh6h30m
       expr: |
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[30m]))) > 0.05
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[30m]))) > 0.05
         and
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05
       for: 30m
       labels:
         component: hcp
@@ -308,16 +227,17 @@ spec:
         severity: "3"
         long_window: 6h
         short_window: 30m
+        slo: etcd-wal-fsync-duration
       annotations:
-        summary: "etcd WAL fsync duration is high for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m)."
+        summary: "etcd WAL fsync duration is high for {{ $labels.cluster }} {{ $labels.namespace }}"
+        description: "{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdWALFsyncDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
+        correlationId: "userJourneyEtcdWALFsyncDurationHigh/{{ $labels.cluster }}/{{ $labels.namespace }}"
     - alert: userJourneyEtcdWALFsyncDurationHigh3d6h
       expr: |
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[6h]))) > 0.05
         and
-        histogram_quantile(0.99, sum by (cluster, subscription_id, resource_id, instance, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[3d]))) > 0.05
+        histogram_quantile(0.99, sum by (namespace, cluster, le) (rate(etcd_disk_wal_fsync_duration_seconds_bucket[3d]))) > 0.05
       for: 3h
       labels:
         component: hcp
@@ -325,8 +245,9 @@ spec:
         severity: "4"
         long_window: 3d
         short_window: 6h
+        slo: etcd-wal-fsync-duration
       annotations:
-        summary: "etcd WAL fsync duration is chronically high for {{ $labels.resource_id }} {{ $labels.instance }}"
-        description: "{{ $labels.resource_id }} etcd instance {{ $labels.instance }} has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h)."
+        summary: "etcd WAL fsync duration is chronically high for {{ $labels.cluster }} {{ $labels.namespace }}"
+        description: "{{ $labels.namespace }} / {{ $labels.cluster }} etcd has 99th percentile WAL fsync duration of {{ $value }}s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h)."
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdWALFsyncDurationHigh/{{ $labels.resource_id }}/{{ $labels.instance }}"
+        correlationId: "userJourneyEtcdWALFsyncDurationHigh/{{ $labels.cluster }}/{{ $labels.namespace }}"

--- a/observability/alerts/UserJourneyEtcdAvailability-prometheusRule_test.yaml
+++ b/observability/alerts/UserJourneyEtcdAvailability-prometheusRule_test.yaml
@@ -1,0 +1,628 @@
+rule_files:
+- UserJourneyEtcdAvailability-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+
+# ========================================
+# userJourneyEtcdBackendCommitDurationHigh
+# Threshold: p99 > 100ms
+# Data: all le buckets incrementing at constant rates -> p99 always at 0.128s
+# MWMBR: fast/medium tiers require both short AND long window confirmation
+# Fast  (1h5m):  fires after 5m  -> check at 11m
+# Medium (6h30m): fires after 30m -> check at 61m
+# Slow  (3d):    fires after 6h  -> check at 365m
+# ========================================
+
+# Scenario 1: High commit duration — all three tiers fire
+- interval: 1m
+  input_series:
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.001"}'
+    values: "0+10x370"
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.002"}'
+    values: "0+20x370"
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.004"}'
+    values: "0+30x370"
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.008"}'
+    values: "0+40x370"
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.016"}'
+    values: "0+60x370"
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.032"}'
+    values: "0+80x370"
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.064"}'
+    values: "0+90x370"
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.128"}'
+    values: "0+95x370"
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="+Inf"}'
+    values: "0+100x370"
+  alert_rule_test:
+  # Fast fires at 11m; medium and slow have not yet fired
+  - eval_time: 11m
+    alertname: userJourneyEtcdBackendCommitDurationHigh1h5m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdBackendCommitDurationHigh1h5m
+        severity: "3"
+        long_window: 1h
+        short_window: 5m
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m)."
+        summary: "etcd backend commit duration is high for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+  - eval_time: 11m
+    alertname: userJourneyEtcdBackendCommitDurationHigh6h30m
+    exp_alerts: []
+  - eval_time: 11m
+    alertname: userJourneyEtcdBackendCommitDurationHigh3d
+    exp_alerts: []
+  # Medium fires at 61m
+  - eval_time: 61m
+    alertname: userJourneyEtcdBackendCommitDurationHigh6h30m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdBackendCommitDurationHigh6h30m
+        severity: "3"
+        long_window: 6h
+        short_window: 30m
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m)."
+        summary: "etcd backend commit duration is high for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+  - eval_time: 61m
+    alertname: userJourneyEtcdBackendCommitDurationHigh3d
+    exp_alerts: []
+  # Slow fires at 365m
+  - eval_time: 365m
+    alertname: userJourneyEtcdBackendCommitDurationHigh3d
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdBackendCommitDurationHigh3d
+        severity: "4"
+        long_window: 3d
+        short_window: 6h
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d)."
+        summary: "etcd backend commit duration is chronically high for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+
+# Scenario 2: Normal commit duration — no tiers fire
+- interval: 1m
+  input_series:
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.001"}'
+    values: "0+20x15"
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.002"}'
+    values: "0+50x15"
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.004"}'
+    values: "0+80x15"
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.008"}'
+    values: "0+95x15"
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="+Inf"}'
+    values: "0+100x15"
+  alert_rule_test:
+  - eval_time: 11m
+    alertname: userJourneyEtcdBackendCommitDurationHigh1h5m
+    exp_alerts: []
+  - eval_time: 11m
+    alertname: userJourneyEtcdBackendCommitDurationHigh6h30m
+    exp_alerts: []
+
+# ========================================
+# userJourneyEtcdDatabaseHighFragmentation
+# Threshold: in-use ratio < 25% (high fragmentation)
+# Gauge metric: value is 12.5% = 0.125 throughout all tiers
+# Fast  (1h5m):  fires after 5m  -> check at 11m
+# Medium (6h30m): fires after 30m -> check at 61m
+# Slow  (3d):    fires after 6h  -> check at 365m
+# ========================================
+
+# Scenario 1: Database high fragmentation (low in-use ratio) — all three tiers fire
+- interval: 1m
+  input_series:
+  - series: 'etcd_mvcc_db_total_size_in_bytes{instance="etcd-0",resource_id="test-hcp-cluster"}'
+    values: "8000000000+0x370"
+  - series: 'etcd_mvcc_db_total_size_in_use_in_bytes{instance="etcd-0",resource_id="test-hcp-cluster"}'
+    values: "1000000000+0x370"
+  alert_rule_test:
+  - eval_time: 11m
+    alertname: userJourneyEtcdDatabaseHighFragmentation1h5m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdDatabaseHighFragmentation1h5m
+        severity: "3"
+        long_window: 1h
+        short_window: 5m
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 database in-use ratio is 12.5% (threshold: 25%). Database defragmentation may be needed to reclaim space. Fast burn (1h/5m)."
+        summary: "etcd database fragmentation is high for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+  - eval_time: 11m
+    alertname: userJourneyEtcdDatabaseHighFragmentation6h30m
+    exp_alerts: []
+  - eval_time: 11m
+    alertname: userJourneyEtcdDatabaseHighFragmentation3d
+    exp_alerts: []
+  - eval_time: 61m
+    alertname: userJourneyEtcdDatabaseHighFragmentation6h30m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdDatabaseHighFragmentation6h30m
+        severity: "3"
+        long_window: 6h
+        short_window: 30m
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 database in-use ratio is 12.5% (threshold: 25%). Database defragmentation may be needed to reclaim space. Medium burn (6h/30m)."
+        summary: "etcd database fragmentation is high for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+  - eval_time: 61m
+    alertname: userJourneyEtcdDatabaseHighFragmentation3d
+    exp_alerts: []
+  - eval_time: 365m
+    alertname: userJourneyEtcdDatabaseHighFragmentation3d
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdDatabaseHighFragmentation3d
+        severity: "4"
+        long_window: 3d
+        short_window: 6h
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 database in-use ratio is 12.5% (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d)."
+        summary: "etcd database fragmentation is chronically high for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+
+# Scenario 2: Database in-use ratio healthy (no fragmentation) — no tiers fire
+- interval: 1m
+  input_series:
+  - series: 'etcd_mvcc_db_total_size_in_bytes{instance="etcd-1",resource_id="test-hcp-cluster-healthy"}'
+    values: "8000000000+0x15"
+  - series: 'etcd_mvcc_db_total_size_in_use_in_bytes{instance="etcd-1",resource_id="test-hcp-cluster-healthy"}'
+    values: "6000000000+0x15"
+  alert_rule_test:
+  - eval_time: 11m
+    alertname: userJourneyEtcdDatabaseHighFragmentation1h5m
+    exp_alerts: []
+
+# Scenario 3: Ratio temporarily low then recovers — fast may fire briefly, medium does not
+- interval: 1m
+  input_series:
+  - series: 'etcd_mvcc_db_total_size_in_bytes{instance="etcd-2",resource_id="test-hcp-cluster-transient"}'
+    values: "8000000000+0x15"
+  - series: 'etcd_mvcc_db_total_size_in_use_in_bytes{instance="etcd-2",resource_id="test-hcp-cluster-transient"}'
+    values: "1000000000 1000000000 6000000000+0x13"
+  alert_rule_test:
+  - eval_time: 61m
+    alertname: userJourneyEtcdDatabaseHighFragmentation6h30m
+    exp_alerts: []
+
+# ========================================
+# userJourneyEtcdDatabaseSizeExceeded
+# Threshold: size > 8GB (8000000000 bytes)
+# Gauge metric: 9GB throughout
+# Fast  (1h5m):  fires after 5m  -> check at 11m
+# Medium (6h30m): fires after 30m -> check at 61m
+# Slow  (3d):    fires after 6h  -> check at 365m
+# ========================================
+
+# Scenario 1: Database size exceeds 8GB — all three tiers fire
+- interval: 1m
+  input_series:
+  - series: 'etcd_mvcc_db_total_size_in_bytes{instance="etcd-0",resource_id="test-hcp-cluster"}'
+    values: "9000000000+0x370"
+  alert_rule_test:
+  - eval_time: 11m
+    alertname: userJourneyEtcdDatabaseSizeExceeded1h5m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdDatabaseSizeExceeded1h5m
+        severity: "3"
+        long_window: 1h
+        short_window: 5m
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 database size is 9GB (threshold: 8GB). Database may need compaction or quota increase. Fast burn (1h/5m)."
+        summary: "etcd database size is too large for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+  - eval_time: 11m
+    alertname: userJourneyEtcdDatabaseSizeExceeded6h30m
+    exp_alerts: []
+  - eval_time: 11m
+    alertname: userJourneyEtcdDatabaseSizeExceeded3d
+    exp_alerts: []
+  - eval_time: 61m
+    alertname: userJourneyEtcdDatabaseSizeExceeded6h30m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdDatabaseSizeExceeded6h30m
+        severity: "3"
+        long_window: 6h
+        short_window: 30m
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 database size is 9GB (threshold: 8GB). Database may need compaction or quota increase. Medium burn (6h/30m)."
+        summary: "etcd database size is too large for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+  - eval_time: 61m
+    alertname: userJourneyEtcdDatabaseSizeExceeded3d
+    exp_alerts: []
+  - eval_time: 365m
+    alertname: userJourneyEtcdDatabaseSizeExceeded3d
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdDatabaseSizeExceeded3d
+        severity: "4"
+        long_window: 3d
+        short_window: 6h
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 database size is 9GB (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d)."
+        summary: "etcd database size is chronically too large for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+
+# Scenario 2: Database size below threshold — no tiers fire
+- interval: 1m
+  input_series:
+  - series: 'etcd_mvcc_db_total_size_in_bytes{instance="etcd-1",resource_id="test-hcp-cluster-healthy"}'
+    values: "7000000000+0x15"
+  alert_rule_test:
+  - eval_time: 11m
+    alertname: userJourneyEtcdDatabaseSizeExceeded1h5m
+    exp_alerts: []
+
+# Scenario 3: Brief spike then drops — medium and slow do not fire
+- interval: 1m
+  input_series:
+  - series: 'etcd_mvcc_db_total_size_in_bytes{instance="etcd-2",resource_id="test-hcp-cluster-transient"}'
+    values: "7000000000 9000000000 9000000000 7000000000+0x12"
+  alert_rule_test:
+  - eval_time: 61m
+    alertname: userJourneyEtcdDatabaseSizeExceeded6h30m
+    exp_alerts: []
+
+# ========================================
+# userJourneyEtcdFrequentLeaderChanges
+# Threshold: increase([15m]) > 4
+# Series: counter increments by 1/min -> at steady state increase([15m]) = 15
+# Fast  (1h5m):  for:5m  — condition true from ~t=4m, fires at ~t=9m  -> check at 15m
+# Medium (6h30m): for:30m — fires at ~t=34m                            -> check at 61m
+# Slow  (3d):    for:6h  — fires at ~t=364m                           -> check at 365m
+# ========================================
+
+# Scenario 1: Frequent leader changes — all three tiers fire
+- interval: 1m
+  input_series:
+  - series: 'etcd_server_leader_changes_seen_total{instance="etcd-0",resource_id="test-hcp-cluster"}'
+    values: "0+1x370"
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: userJourneyEtcdFrequentLeaderChanges1h5m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdFrequentLeaderChanges1h5m
+        severity: "3"
+        long_window: 1h
+        short_window: 5m
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 has seen 15 leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Fast burn (1h/5m)."
+        summary: "etcd cluster experiencing frequent leader changes for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+  - eval_time: 15m
+    alertname: userJourneyEtcdFrequentLeaderChanges6h30m
+    exp_alerts: []
+  - eval_time: 15m
+    alertname: userJourneyEtcdFrequentLeaderChanges3d
+    exp_alerts: []
+  - eval_time: 61m
+    alertname: userJourneyEtcdFrequentLeaderChanges6h30m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdFrequentLeaderChanges6h30m
+        severity: "3"
+        long_window: 6h
+        short_window: 30m
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 has seen 15 leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Medium burn (6h/30m)."
+        summary: "etcd cluster experiencing frequent leader changes for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+  - eval_time: 61m
+    alertname: userJourneyEtcdFrequentLeaderChanges3d
+    exp_alerts: []
+  - eval_time: 365m
+    alertname: userJourneyEtcdFrequentLeaderChanges3d
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdFrequentLeaderChanges3d
+        severity: "4"
+        long_window: 3d
+        short_window: 6h
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 has seen 15 leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d)."
+        summary: "etcd cluster experiencing chronic frequent leader changes for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+
+# Scenario 2: Stable leader — no tiers fire
+- interval: 1m
+  input_series:
+  - series: 'etcd_server_leader_changes_seen_total{instance="etcd-1",resource_id="test-hcp-cluster-healthy"}'
+    values: "0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 2"
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: userJourneyEtcdFrequentLeaderChanges1h5m
+    exp_alerts: []
+  - eval_time: 15m
+    alertname: userJourneyEtcdFrequentLeaderChanges6h30m
+    exp_alerts: []
+
+# Scenario 3: Leader changes exactly at threshold — no tiers fire
+- interval: 1m
+  input_series:
+  - series: 'etcd_server_leader_changes_seen_total{instance="etcd-2",resource_id="test-hcp-cluster-transient"}'
+    values: "0 0 0 0 0 1 1 1 1 1 2 2 2 2 2 4"
+  alert_rule_test:
+  - eval_time: 15m
+    alertname: userJourneyEtcdFrequentLeaderChanges1h5m
+    exp_alerts: []
+
+# ========================================
+# userJourneyEtcdPeerRoundTripTimeHigh
+# Threshold: p99 > 100ms
+# Data: many le buckets, p99 at 0.2048s across all rate windows
+# MWMBR: fast/medium tiers require both short AND long window confirmation
+# Fast  (1h5m):  fires after 5m  -> check at 11m
+# Medium (6h30m): fires after 30m -> check at 61m
+# Slow  (3d):    fires after 6h  -> check at 365m
+# ========================================
+
+# Scenario 1: High peer RTT — all three tiers fire
+- interval: 1m
+  input_series:
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0001"}'
+    values: "0+5x370"
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0002"}'
+    values: "0+10x370"
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0004"}'
+    values: "0+15x370"
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0008"}'
+    values: "0+20x370"
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0016"}'
+    values: "0+25x370"
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0032"}'
+    values: "0+30x370"
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0064"}'
+    values: "0+35x370"
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0128"}'
+    values: "0+40x370"
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0256"}'
+    values: "0+50x370"
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0512"}'
+    values: "0+70x370"
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.1024"}'
+    values: "0+90x370"
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.2048"}'
+    values: "0+95x370"
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="+Inf"}'
+    values: "0+100x370"
+  alert_rule_test:
+  # Fast fires at 11m; medium and slow have not yet fired
+  - eval_time: 11m
+    alertname: userJourneyEtcdPeerRoundTripTimeHigh1h5m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdPeerRoundTripTimeHigh1h5m
+        severity: "3"
+        long_window: 1h
+        short_window: 5m
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m)."
+        summary: "etcd peer round-trip time is high for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+  - eval_time: 11m
+    alertname: userJourneyEtcdPeerRoundTripTimeHigh6h30m
+    exp_alerts: []
+  - eval_time: 11m
+    alertname: userJourneyEtcdPeerRoundTripTimeHigh3d
+    exp_alerts: []
+  # Medium fires at 61m
+  - eval_time: 61m
+    alertname: userJourneyEtcdPeerRoundTripTimeHigh6h30m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdPeerRoundTripTimeHigh6h30m
+        severity: "3"
+        long_window: 6h
+        short_window: 30m
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m)."
+        summary: "etcd peer round-trip time is high for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+  - eval_time: 61m
+    alertname: userJourneyEtcdPeerRoundTripTimeHigh3d
+    exp_alerts: []
+  - eval_time: 365m
+    alertname: userJourneyEtcdPeerRoundTripTimeHigh3d
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdPeerRoundTripTimeHigh3d
+        severity: "4"
+        long_window: 3d
+        short_window: 6h
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d)."
+        summary: "etcd peer round-trip time is chronically high for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+
+# Scenario 2: Normal peer RTT — no tiers fire
+- interval: 1m
+  input_series:
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.0001"}'
+    values: "0+50x15"
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.0002"}'
+    values: "0+90x15"
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.0004"}'
+    values: "0+95x15"
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="+Inf"}'
+    values: "0+100x15"
+  alert_rule_test:
+  - eval_time: 11m
+    alertname: userJourneyEtcdPeerRoundTripTimeHigh1h5m
+    exp_alerts: []
+
+# ========================================
+# userJourneyEtcdWALFsyncDurationHigh
+# Threshold: p99 > 50ms
+# Data: le buckets with p99 at 0.064s across all rate windows
+# MWMBR: fast/medium tiers require both short AND long window confirmation
+# Fast  (1h5m):  fires after 5m  -> check at 11m
+# Medium (6h30m): fires after 30m -> check at 61m
+# Slow  (3d):    fires after 6h  -> check at 365m
+# ========================================
+
+# Scenario 1: High WAL fsync duration — all three tiers fire
+- interval: 1m
+  input_series:
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.001"}'
+    values: "0+10x370"
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.002"}'
+    values: "0+20x370"
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.004"}'
+    values: "0+40x370"
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.008"}'
+    values: "0+80x370"
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.016"}'
+    values: "0+150x370"
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.032"}'
+    values: "0+180x370"
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.064"}'
+    values: "0+190x370"
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="+Inf"}'
+    values: "0+200x370"
+  alert_rule_test:
+  # Fast fires at 11m; medium and slow have not yet fired
+  - eval_time: 11m
+    alertname: userJourneyEtcdWALFsyncDurationHigh1h5m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdWALFsyncDurationHigh1h5m
+        severity: "3"
+        long_window: 1h
+        short_window: 5m
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m)."
+        summary: "etcd WAL fsync duration is high for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+  - eval_time: 11m
+    alertname: userJourneyEtcdWALFsyncDurationHigh6h30m
+    exp_alerts: []
+  - eval_time: 11m
+    alertname: userJourneyEtcdWALFsyncDurationHigh3d
+    exp_alerts: []
+  # Medium fires at 61m
+  - eval_time: 61m
+    alertname: userJourneyEtcdWALFsyncDurationHigh6h30m
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdWALFsyncDurationHigh6h30m
+        severity: "3"
+        long_window: 6h
+        short_window: 30m
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m)."
+        summary: "etcd WAL fsync duration is high for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+  - eval_time: 61m
+    alertname: userJourneyEtcdWALFsyncDurationHigh3d
+    exp_alerts: []
+  - eval_time: 365m
+    alertname: userJourneyEtcdWALFsyncDurationHigh3d
+    exp_alerts:
+    - exp_labels:
+        alertname: userJourneyEtcdWALFsyncDurationHigh3d
+        severity: "4"
+        long_window: 3d
+        short_window: 6h
+        instance: etcd-0
+        resource_id: test-hcp-cluster
+        component: hcp
+        exclude_internal_subscriptions: "true"
+      exp_annotations:
+        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d)."
+        summary: "etcd WAL fsync duration is chronically high for test-hcp-cluster etcd-0"
+        runbook_url: https://aka.ms/arohcp-runbook-etcd
+
+# Scenario 2: Normal WAL fsync duration — no tiers fire
+- interval: 1m
+  input_series:
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.001"}'
+    values: "0+100x15"
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.002"}'
+    values: "0+180x15"
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.004"}'
+    values: "0+195x15"
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="+Inf"}'
+    values: "0+200x15"
+  alert_rule_test:
+  - eval_time: 11m
+    alertname: userJourneyEtcdWALFsyncDurationHigh1h5m
+    exp_alerts: []

--- a/observability/alerts/UserJourneyEtcdAvailability-prometheusRule_test.yaml
+++ b/observability/alerts/UserJourneyEtcdAvailability-prometheusRule_test.yaml
@@ -8,9 +8,9 @@ tests:
 # Threshold: p99 > 100ms
 # Data: all le buckets incrementing at constant rates -> p99 always at 0.128s
 # MWMBR: fast/medium tiers require both short AND long window confirmation
-# Fast  (1h5m):  fires after 5m  -> check at 11m
-# Medium (6h30m): fires after 30m -> check at 61m
-# Slow  (3d):    fires after 6h  -> check at 365m
+# Fast  (1h5m):    fires after 5m -> check at 11m
+# Medium (6h30m):  fires after 30m -> check at 61m
+# Slow  (3d/6h):   fires after 3h -> check at 365m
 # ========================================
 
 # Scenario 1: High commit duration — all three tiers fire
@@ -92,7 +92,7 @@ tests:
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d)."
+        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h)."
         summary: "etcd backend commit duration is chronically high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
 
@@ -410,9 +410,9 @@ tests:
 # Threshold: p99 > 100ms
 # Data: many le buckets, p99 at 0.2048s across all rate windows
 # MWMBR: fast/medium tiers require both short AND long window confirmation
-# Fast  (1h5m):  fires after 5m  -> check at 11m
-# Medium (6h30m): fires after 30m -> check at 61m
-# Slow  (3d):    fires after 6h  -> check at 365m
+# Fast  (1h5m):    fires after 5m -> check at 11m
+# Medium (6h30m):  fires after 30m -> check at 61m
+# Slow  (3d/6h):   fires after 3h -> check at 365m
 # ========================================
 
 # Scenario 1: High peer RTT — all three tiers fire
@@ -501,7 +501,7 @@ tests:
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d)."
+        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h)."
         summary: "etcd peer round-trip time is chronically high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
 
@@ -526,9 +526,9 @@ tests:
 # Threshold: p99 > 50ms
 # Data: le buckets with p99 at 0.064s across all rate windows
 # MWMBR: fast/medium tiers require both short AND long window confirmation
-# Fast  (1h5m):  fires after 5m  -> check at 11m
-# Medium (6h30m): fires after 30m -> check at 61m
-# Slow  (3d):    fires after 6h  -> check at 365m
+# Fast  (1h5m):    fires after 5m -> check at 11m
+# Medium (6h30m):  fires after 30m -> check at 61m
+# Slow  (3d/6h):   fires after 3h -> check at 365m
 # ========================================
 
 # Scenario 1: High WAL fsync duration — all three tiers fire
@@ -607,7 +607,7 @@ tests:
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d)."
+        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h)."
         summary: "etcd WAL fsync duration is chronically high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
 

--- a/observability/alerts/UserJourneyEtcdAvailability-prometheusRule_test.yaml
+++ b/observability/alerts/UserJourneyEtcdAvailability-prometheusRule_test.yaml
@@ -10,7 +10,7 @@ tests:
 # MWMBR: fast/medium tiers require both short AND long window confirmation
 # Fast  (1h5m):    fires after 5m -> check at 11m
 # Medium (6h30m):  fires after 30m -> check at 61m
-# Slow  (3d6h):   fires after 3h -> check at 365m
+# Slow  (3d6h):    for: 3h, but checked at 365m so the 6h short window has enough samples
 # ========================================
 
 # Scenario 1: High commit duration — all three tiers fire
@@ -52,6 +52,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m)."
         summary: "etcd backend commit duration is high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdBackendCommitDurationHigh/test-hcp-cluster/etcd-0"
   - eval_time: 11m
     alertname: userJourneyEtcdBackendCommitDurationHigh6h30m
     exp_alerts: []
@@ -75,6 +76,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m)."
         summary: "etcd backend commit duration is high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdBackendCommitDurationHigh/test-hcp-cluster/etcd-0"
   - eval_time: 61m
     alertname: userJourneyEtcdBackendCommitDurationHigh3d6h
     exp_alerts: []
@@ -95,6 +97,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h)."
         summary: "etcd backend commit duration is chronically high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdBackendCommitDurationHigh/test-hcp-cluster/etcd-0"
 
 # Scenario 2: Normal commit duration — no tiers fire
 - interval: 1m
@@ -150,6 +153,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 database in-use ratio is 12.5% (threshold: 25%). Database defragmentation may be needed to reclaim space. Fast burn (1h/5m)."
         summary: "etcd database fragmentation is high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdDatabaseHighFragmentation/test-hcp-cluster/etcd-0"
   - eval_time: 11m
     alertname: userJourneyEtcdDatabaseHighFragmentation6h30m
     exp_alerts: []
@@ -172,6 +176,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 database in-use ratio is 12.5% (threshold: 25%). Database defragmentation may be needed to reclaim space. Medium burn (6h/30m)."
         summary: "etcd database fragmentation is high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdDatabaseHighFragmentation/test-hcp-cluster/etcd-0"
   - eval_time: 61m
     alertname: userJourneyEtcdDatabaseHighFragmentation3d6h
     exp_alerts: []
@@ -191,6 +196,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 database in-use ratio is 12.5% (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d/6h)."
         summary: "etcd database fragmentation is chronically high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdDatabaseHighFragmentation/test-hcp-cluster/etcd-0"
 
 # Scenario 2: Database in-use ratio healthy (no fragmentation) — no tiers fire
 - interval: 1m
@@ -247,6 +253,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 database size is 9GB (threshold: 8GB). Database may need compaction or quota increase. Fast burn (1h/5m)."
         summary: "etcd database size is too large for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdDatabaseSizeExceeded/test-hcp-cluster/etcd-0"
   - eval_time: 11m
     alertname: userJourneyEtcdDatabaseSizeExceeded6h30m
     exp_alerts: []
@@ -269,6 +276,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 database size is 9GB (threshold: 8GB). Database may need compaction or quota increase. Medium burn (6h/30m)."
         summary: "etcd database size is too large for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdDatabaseSizeExceeded/test-hcp-cluster/etcd-0"
   - eval_time: 61m
     alertname: userJourneyEtcdDatabaseSizeExceeded3d6h
     exp_alerts: []
@@ -288,6 +296,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 database size is 9GB (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d/6h)."
         summary: "etcd database size is chronically too large for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdDatabaseSizeExceeded/test-hcp-cluster/etcd-0"
 
 # Scenario 2: Database size below threshold — no tiers fire
 - interval: 1m
@@ -340,6 +349,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 has seen 15 leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Fast burn (1h/5m)."
         summary: "etcd cluster experiencing frequent leader changes for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdFrequentLeaderChanges/test-hcp-cluster/etcd-0"
   - eval_time: 15m
     alertname: userJourneyEtcdFrequentLeaderChanges6h30m
     exp_alerts: []
@@ -362,6 +372,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 has seen 15 leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Medium burn (6h/30m)."
         summary: "etcd cluster experiencing frequent leader changes for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdFrequentLeaderChanges/test-hcp-cluster/etcd-0"
   - eval_time: 61m
     alertname: userJourneyEtcdFrequentLeaderChanges3d6h
     exp_alerts: []
@@ -381,6 +392,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 has seen 15 leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d/6h)."
         summary: "etcd cluster experiencing chronic frequent leader changes for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdFrequentLeaderChanges/test-hcp-cluster/etcd-0"
 
 # Scenario 2: Stable leader — no tiers fire
 - interval: 1m
@@ -412,7 +424,7 @@ tests:
 # MWMBR: fast/medium tiers require both short AND long window confirmation
 # Fast  (1h5m):    fires after 5m -> check at 11m
 # Medium (6h30m):  fires after 30m -> check at 61m
-# Slow  (3d6h):   fires after 3h -> check at 365m
+# Slow  (3d6h):    for: 3h, but checked at 365m so the 6h short window has enough samples
 # ========================================
 
 # Scenario 1: High peer RTT — all three tiers fire
@@ -462,6 +474,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m)."
         summary: "etcd peer round-trip time is high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/test-hcp-cluster/etcd-0"
   - eval_time: 11m
     alertname: userJourneyEtcdPeerRoundTripTimeHigh6h30m
     exp_alerts: []
@@ -485,6 +498,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m)."
         summary: "etcd peer round-trip time is high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/test-hcp-cluster/etcd-0"
   - eval_time: 61m
     alertname: userJourneyEtcdPeerRoundTripTimeHigh3d6h
     exp_alerts: []
@@ -504,6 +518,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h)."
         summary: "etcd peer round-trip time is chronically high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/test-hcp-cluster/etcd-0"
 
 # Scenario 2: Normal peer RTT — no tiers fire
 - interval: 1m
@@ -528,7 +543,7 @@ tests:
 # MWMBR: fast/medium tiers require both short AND long window confirmation
 # Fast  (1h5m):    fires after 5m -> check at 11m
 # Medium (6h30m):  fires after 30m -> check at 61m
-# Slow  (3d6h):   fires after 3h -> check at 365m
+# Slow  (3d6h):    for: 3h, but checked at 365m so the 6h short window has enough samples
 # ========================================
 
 # Scenario 1: High WAL fsync duration — all three tiers fire
@@ -568,6 +583,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m)."
         summary: "etcd WAL fsync duration is high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdWALFsyncDurationHigh/test-hcp-cluster/etcd-0"
   - eval_time: 11m
     alertname: userJourneyEtcdWALFsyncDurationHigh6h30m
     exp_alerts: []
@@ -591,6 +607,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m)."
         summary: "etcd WAL fsync duration is high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdWALFsyncDurationHigh/test-hcp-cluster/etcd-0"
   - eval_time: 61m
     alertname: userJourneyEtcdWALFsyncDurationHigh3d6h
     exp_alerts: []
@@ -610,6 +627,7 @@ tests:
         description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h)."
         summary: "etcd WAL fsync duration is chronically high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
+        correlationId: "userJourneyEtcdWALFsyncDurationHigh/test-hcp-cluster/etcd-0"
 
 # Scenario 2: Normal WAL fsync duration — no tiers fire
 - interval: 1m

--- a/observability/alerts/UserJourneyEtcdAvailability-prometheusRule_test.yaml
+++ b/observability/alerts/UserJourneyEtcdAvailability-prometheusRule_test.yaml
@@ -10,7 +10,7 @@ tests:
 # MWMBR: fast/medium tiers require both short AND long window confirmation
 # Fast  (1h5m):    fires after 5m -> check at 11m
 # Medium (6h30m):  fires after 30m -> check at 61m
-# Slow  (3d/6h):   fires after 3h -> check at 365m
+# Slow  (3d6h):   fires after 3h -> check at 365m
 # ========================================
 
 # Scenario 1: High commit duration — all three tiers fire
@@ -56,7 +56,7 @@ tests:
     alertname: userJourneyEtcdBackendCommitDurationHigh6h30m
     exp_alerts: []
   - eval_time: 11m
-    alertname: userJourneyEtcdBackendCommitDurationHigh3d
+    alertname: userJourneyEtcdBackendCommitDurationHigh3d6h
     exp_alerts: []
   # Medium fires at 61m
   - eval_time: 61m
@@ -76,14 +76,14 @@ tests:
         summary: "etcd backend commit duration is high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
   - eval_time: 61m
-    alertname: userJourneyEtcdBackendCommitDurationHigh3d
+    alertname: userJourneyEtcdBackendCommitDurationHigh3d6h
     exp_alerts: []
   # Slow fires at 365m
   - eval_time: 365m
-    alertname: userJourneyEtcdBackendCommitDurationHigh3d
+    alertname: userJourneyEtcdBackendCommitDurationHigh3d6h
     exp_alerts:
     - exp_labels:
-        alertname: userJourneyEtcdBackendCommitDurationHigh3d
+        alertname: userJourneyEtcdBackendCommitDurationHigh3d6h
         severity: "4"
         long_window: 3d
         short_window: 6h
@@ -123,7 +123,7 @@ tests:
 # Gauge metric: value is 12.5% = 0.125 throughout all tiers
 # Fast  (1h5m):  fires after 5m  -> check at 11m
 # Medium (6h30m): fires after 30m -> check at 61m
-# Slow  (3d):    fires after 6h  -> check at 365m
+# Slow  (3d6h):    fires after 6h  -> check at 365m
 # ========================================
 
 # Scenario 1: Database high fragmentation (low in-use ratio) — all three tiers fire
@@ -154,7 +154,7 @@ tests:
     alertname: userJourneyEtcdDatabaseHighFragmentation6h30m
     exp_alerts: []
   - eval_time: 11m
-    alertname: userJourneyEtcdDatabaseHighFragmentation3d
+    alertname: userJourneyEtcdDatabaseHighFragmentation3d6h
     exp_alerts: []
   - eval_time: 61m
     alertname: userJourneyEtcdDatabaseHighFragmentation6h30m
@@ -173,13 +173,13 @@ tests:
         summary: "etcd database fragmentation is high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
   - eval_time: 61m
-    alertname: userJourneyEtcdDatabaseHighFragmentation3d
+    alertname: userJourneyEtcdDatabaseHighFragmentation3d6h
     exp_alerts: []
   - eval_time: 365m
-    alertname: userJourneyEtcdDatabaseHighFragmentation3d
+    alertname: userJourneyEtcdDatabaseHighFragmentation3d6h
     exp_alerts:
     - exp_labels:
-        alertname: userJourneyEtcdDatabaseHighFragmentation3d
+        alertname: userJourneyEtcdDatabaseHighFragmentation3d6h
         severity: "4"
         long_window: 3d
         short_window: 6h
@@ -188,7 +188,7 @@ tests:
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 database in-use ratio is 12.5% (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d)."
+        description: "test-hcp-cluster etcd instance etcd-0 database in-use ratio is 12.5% (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d/6h)."
         summary: "etcd database fragmentation is chronically high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
 
@@ -222,7 +222,7 @@ tests:
 # Gauge metric: 9GB throughout
 # Fast  (1h5m):  fires after 5m  -> check at 11m
 # Medium (6h30m): fires after 30m -> check at 61m
-# Slow  (3d):    fires after 6h  -> check at 365m
+# Slow  (3d6h):    fires after 6h  -> check at 365m
 # ========================================
 
 # Scenario 1: Database size exceeds 8GB — all three tiers fire
@@ -251,7 +251,7 @@ tests:
     alertname: userJourneyEtcdDatabaseSizeExceeded6h30m
     exp_alerts: []
   - eval_time: 11m
-    alertname: userJourneyEtcdDatabaseSizeExceeded3d
+    alertname: userJourneyEtcdDatabaseSizeExceeded3d6h
     exp_alerts: []
   - eval_time: 61m
     alertname: userJourneyEtcdDatabaseSizeExceeded6h30m
@@ -270,13 +270,13 @@ tests:
         summary: "etcd database size is too large for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
   - eval_time: 61m
-    alertname: userJourneyEtcdDatabaseSizeExceeded3d
+    alertname: userJourneyEtcdDatabaseSizeExceeded3d6h
     exp_alerts: []
   - eval_time: 365m
-    alertname: userJourneyEtcdDatabaseSizeExceeded3d
+    alertname: userJourneyEtcdDatabaseSizeExceeded3d6h
     exp_alerts:
     - exp_labels:
-        alertname: userJourneyEtcdDatabaseSizeExceeded3d
+        alertname: userJourneyEtcdDatabaseSizeExceeded3d6h
         severity: "4"
         long_window: 3d
         short_window: 6h
@@ -285,7 +285,7 @@ tests:
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 database size is 9GB (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d)."
+        description: "test-hcp-cluster etcd instance etcd-0 database size is 9GB (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d/6h)."
         summary: "etcd database size is chronically too large for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
 
@@ -315,7 +315,7 @@ tests:
 # Series: counter increments by 1/min -> at steady state increase([15m]) = 15
 # Fast  (1h5m):  for:5m  — condition true from ~t=4m, fires at ~t=9m  -> check at 15m
 # Medium (6h30m): for:30m — fires at ~t=34m                            -> check at 61m
-# Slow  (3d):    for:6h  — fires at ~t=364m                           -> check at 365m
+# Slow  (3d6h):    for:6h  — fires at ~t=364m                           -> check at 365m
 # ========================================
 
 # Scenario 1: Frequent leader changes — all three tiers fire
@@ -344,7 +344,7 @@ tests:
     alertname: userJourneyEtcdFrequentLeaderChanges6h30m
     exp_alerts: []
   - eval_time: 15m
-    alertname: userJourneyEtcdFrequentLeaderChanges3d
+    alertname: userJourneyEtcdFrequentLeaderChanges3d6h
     exp_alerts: []
   - eval_time: 61m
     alertname: userJourneyEtcdFrequentLeaderChanges6h30m
@@ -363,13 +363,13 @@ tests:
         summary: "etcd cluster experiencing frequent leader changes for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
   - eval_time: 61m
-    alertname: userJourneyEtcdFrequentLeaderChanges3d
+    alertname: userJourneyEtcdFrequentLeaderChanges3d6h
     exp_alerts: []
   - eval_time: 365m
-    alertname: userJourneyEtcdFrequentLeaderChanges3d
+    alertname: userJourneyEtcdFrequentLeaderChanges3d6h
     exp_alerts:
     - exp_labels:
-        alertname: userJourneyEtcdFrequentLeaderChanges3d
+        alertname: userJourneyEtcdFrequentLeaderChanges3d6h
         severity: "4"
         long_window: 3d
         short_window: 6h
@@ -378,7 +378,7 @@ tests:
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 has seen 15 leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d)."
+        description: "test-hcp-cluster etcd instance etcd-0 has seen 15 leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d/6h)."
         summary: "etcd cluster experiencing chronic frequent leader changes for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
 
@@ -412,7 +412,7 @@ tests:
 # MWMBR: fast/medium tiers require both short AND long window confirmation
 # Fast  (1h5m):    fires after 5m -> check at 11m
 # Medium (6h30m):  fires after 30m -> check at 61m
-# Slow  (3d/6h):   fires after 3h -> check at 365m
+# Slow  (3d6h):   fires after 3h -> check at 365m
 # ========================================
 
 # Scenario 1: High peer RTT — all three tiers fire
@@ -466,7 +466,7 @@ tests:
     alertname: userJourneyEtcdPeerRoundTripTimeHigh6h30m
     exp_alerts: []
   - eval_time: 11m
-    alertname: userJourneyEtcdPeerRoundTripTimeHigh3d
+    alertname: userJourneyEtcdPeerRoundTripTimeHigh3d6h
     exp_alerts: []
   # Medium fires at 61m
   - eval_time: 61m
@@ -486,13 +486,13 @@ tests:
         summary: "etcd peer round-trip time is high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
   - eval_time: 61m
-    alertname: userJourneyEtcdPeerRoundTripTimeHigh3d
+    alertname: userJourneyEtcdPeerRoundTripTimeHigh3d6h
     exp_alerts: []
   - eval_time: 365m
-    alertname: userJourneyEtcdPeerRoundTripTimeHigh3d
+    alertname: userJourneyEtcdPeerRoundTripTimeHigh3d6h
     exp_alerts:
     - exp_labels:
-        alertname: userJourneyEtcdPeerRoundTripTimeHigh3d
+        alertname: userJourneyEtcdPeerRoundTripTimeHigh3d6h
         severity: "4"
         long_window: 3d
         short_window: 6h
@@ -528,7 +528,7 @@ tests:
 # MWMBR: fast/medium tiers require both short AND long window confirmation
 # Fast  (1h5m):    fires after 5m -> check at 11m
 # Medium (6h30m):  fires after 30m -> check at 61m
-# Slow  (3d/6h):   fires after 3h -> check at 365m
+# Slow  (3d6h):   fires after 3h -> check at 365m
 # ========================================
 
 # Scenario 1: High WAL fsync duration — all three tiers fire
@@ -572,7 +572,7 @@ tests:
     alertname: userJourneyEtcdWALFsyncDurationHigh6h30m
     exp_alerts: []
   - eval_time: 11m
-    alertname: userJourneyEtcdWALFsyncDurationHigh3d
+    alertname: userJourneyEtcdWALFsyncDurationHigh3d6h
     exp_alerts: []
   # Medium fires at 61m
   - eval_time: 61m
@@ -592,13 +592,13 @@ tests:
         summary: "etcd WAL fsync duration is high for test-hcp-cluster etcd-0"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
   - eval_time: 61m
-    alertname: userJourneyEtcdWALFsyncDurationHigh3d
+    alertname: userJourneyEtcdWALFsyncDurationHigh3d6h
     exp_alerts: []
   - eval_time: 365m
-    alertname: userJourneyEtcdWALFsyncDurationHigh3d
+    alertname: userJourneyEtcdWALFsyncDurationHigh3d6h
     exp_alerts:
     - exp_labels:
-        alertname: userJourneyEtcdWALFsyncDurationHigh3d
+        alertname: userJourneyEtcdWALFsyncDurationHigh3d6h
         severity: "4"
         long_window: 3d
         short_window: 6h

--- a/observability/alerts/UserJourneyEtcdAvailability-prometheusRule_test.yaml
+++ b/observability/alerts/UserJourneyEtcdAvailability-prometheusRule_test.yaml
@@ -48,7 +48,6 @@ tests:
         cluster: test-hcp-cluster
         namespace: test-hcp-namespace
         component: hcp
-        exclude_internal_subscriptions: "true"
       exp_annotations:
         description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m)."
         summary: "etcd backend commit duration is high for test-hcp-cluster test-hcp-namespace"
@@ -73,7 +72,6 @@ tests:
         cluster: test-hcp-cluster
         namespace: test-hcp-namespace
         component: hcp
-        exclude_internal_subscriptions: "true"
       exp_annotations:
         description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m)."
         summary: "etcd backend commit duration is high for test-hcp-cluster test-hcp-namespace"
@@ -95,7 +93,6 @@ tests:
         cluster: test-hcp-cluster
         namespace: test-hcp-namespace
         component: hcp
-        exclude_internal_subscriptions: "true"
       exp_annotations:
         description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h)."
         summary: "etcd backend commit duration is chronically high for test-hcp-cluster test-hcp-namespace"
@@ -151,7 +148,6 @@ tests:
         cluster: test-hcp-cluster
         namespace: test-hcp-namespace
         component: hcp
-        exclude_internal_subscriptions: "true"
       exp_annotations:
         description: "test-hcp-namespace / test-hcp-cluster etcd database in-use ratio is 12.5% (threshold: 25%). Database defragmentation may be needed to reclaim space."
         summary: "etcd database fragmentation is high for test-hcp-cluster test-hcp-namespace"
@@ -208,7 +204,6 @@ tests:
         cluster: test-hcp-cluster
         namespace: test-hcp-namespace
         component: hcp
-        exclude_internal_subscriptions: "true"
       exp_annotations:
         description: "test-hcp-namespace / test-hcp-cluster etcd database size is 9GB (threshold: 7GB). Database may need compaction or quota increase."
         summary: "etcd database size is too large for test-hcp-cluster test-hcp-namespace"
@@ -258,7 +253,6 @@ tests:
         cluster: test-hcp-cluster
         namespace: test-hcp-namespace
         component: hcp
-        exclude_internal_subscriptions: "true"
       exp_annotations:
         description: "test-hcp-namespace / test-hcp-cluster etcd has seen 15 leader changes in the last 15 minutes (threshold: 3). This may indicate network issues or cluster instability."
         summary: "etcd cluster experiencing frequent leader changes for test-hcp-cluster test-hcp-namespace"
@@ -338,7 +332,6 @@ tests:
         cluster: test-hcp-cluster
         namespace: test-hcp-namespace
         component: hcp
-        exclude_internal_subscriptions: "true"
       exp_annotations:
         description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m)."
         summary: "etcd peer round-trip time is high for test-hcp-cluster test-hcp-namespace"
@@ -363,7 +356,6 @@ tests:
         cluster: test-hcp-cluster
         namespace: test-hcp-namespace
         component: hcp
-        exclude_internal_subscriptions: "true"
       exp_annotations:
         description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m)."
         summary: "etcd peer round-trip time is high for test-hcp-cluster test-hcp-namespace"
@@ -384,7 +376,6 @@ tests:
         cluster: test-hcp-cluster
         namespace: test-hcp-namespace
         component: hcp
-        exclude_internal_subscriptions: "true"
       exp_annotations:
         description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h)."
         summary: "etcd peer round-trip time is chronically high for test-hcp-cluster test-hcp-namespace"
@@ -450,7 +441,6 @@ tests:
         cluster: test-hcp-cluster
         namespace: test-hcp-namespace
         component: hcp
-        exclude_internal_subscriptions: "true"
       exp_annotations:
         description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m)."
         summary: "etcd WAL fsync duration is high for test-hcp-cluster test-hcp-namespace"
@@ -475,7 +465,6 @@ tests:
         cluster: test-hcp-cluster
         namespace: test-hcp-namespace
         component: hcp
-        exclude_internal_subscriptions: "true"
       exp_annotations:
         description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m)."
         summary: "etcd WAL fsync duration is high for test-hcp-cluster test-hcp-namespace"
@@ -496,7 +485,6 @@ tests:
         cluster: test-hcp-cluster
         namespace: test-hcp-namespace
         component: hcp
-        exclude_internal_subscriptions: "true"
       exp_annotations:
         description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h)."
         summary: "etcd WAL fsync duration is chronically high for test-hcp-cluster test-hcp-namespace"

--- a/observability/alerts/UserJourneyEtcdAvailability-prometheusRule_test.yaml
+++ b/observability/alerts/UserJourneyEtcdAvailability-prometheusRule_test.yaml
@@ -16,23 +16,23 @@ tests:
 # Scenario 1: High commit duration — all three tiers fire
 - interval: 1m
   input_series:
-  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.001"}'
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.001"}'
     values: "0+10x370"
-  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.002"}'
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.002"}'
     values: "0+20x370"
-  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.004"}'
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.004"}'
     values: "0+30x370"
-  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.008"}'
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.008"}'
     values: "0+40x370"
-  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.016"}'
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.016"}'
     values: "0+60x370"
-  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.032"}'
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.032"}'
     values: "0+80x370"
-  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.064"}'
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.064"}'
     values: "0+90x370"
-  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.128"}'
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.128"}'
     values: "0+95x370"
-  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="+Inf"}'
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="+Inf"}'
     values: "0+100x370"
   alert_rule_test:
   # Fast fires at 11m; medium and slow have not yet fired
@@ -44,15 +44,16 @@ tests:
         severity: "3"
         long_window: 1h
         short_window: 5m
-        instance: etcd-0
-        resource_id: test-hcp-cluster
+        slo: etcd-backend-commit-duration
+        cluster: test-hcp-cluster
+        namespace: test-hcp-namespace
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m)."
-        summary: "etcd backend commit duration is high for test-hcp-cluster etcd-0"
+        description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Fast burn (1h/5m)."
+        summary: "etcd backend commit duration is high for test-hcp-cluster test-hcp-namespace"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdBackendCommitDurationHigh/test-hcp-cluster/etcd-0"
+        correlationId: "userJourneyEtcdBackendCommitDurationHigh/test-hcp-cluster/test-hcp-namespace"
   - eval_time: 11m
     alertname: userJourneyEtcdBackendCommitDurationHigh6h30m
     exp_alerts: []
@@ -68,15 +69,16 @@ tests:
         severity: "3"
         long_window: 6h
         short_window: 30m
-        instance: etcd-0
-        resource_id: test-hcp-cluster
+        slo: etcd-backend-commit-duration
+        cluster: test-hcp-cluster
+        namespace: test-hcp-namespace
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m)."
-        summary: "etcd backend commit duration is high for test-hcp-cluster etcd-0"
+        description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Medium burn (6h/30m)."
+        summary: "etcd backend commit duration is high for test-hcp-cluster test-hcp-namespace"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdBackendCommitDurationHigh/test-hcp-cluster/etcd-0"
+        correlationId: "userJourneyEtcdBackendCommitDurationHigh/test-hcp-cluster/test-hcp-namespace"
   - eval_time: 61m
     alertname: userJourneyEtcdBackendCommitDurationHigh3d6h
     exp_alerts: []
@@ -89,28 +91,29 @@ tests:
         severity: "4"
         long_window: 3d
         short_window: 6h
-        instance: etcd-0
-        resource_id: test-hcp-cluster
+        slo: etcd-backend-commit-duration
+        cluster: test-hcp-cluster
+        namespace: test-hcp-namespace
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h)."
-        summary: "etcd backend commit duration is chronically high for test-hcp-cluster etcd-0"
+        description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile backend commit duration of 0.128s (threshold: 100ms). Slow disk performance may impact write performance. Slow burn (3d/6h)."
+        summary: "etcd backend commit duration is chronically high for test-hcp-cluster test-hcp-namespace"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdBackendCommitDurationHigh/test-hcp-cluster/etcd-0"
+        correlationId: "userJourneyEtcdBackendCommitDurationHigh/test-hcp-cluster/test-hcp-namespace"
 
 # Scenario 2: Normal commit duration — no tiers fire
 - interval: 1m
   input_series:
-  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.001"}'
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy",le="0.001"}'
     values: "0+20x15"
-  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.002"}'
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy",le="0.002"}'
     values: "0+50x15"
-  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.004"}'
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy",le="0.004"}'
     values: "0+80x15"
-  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.008"}'
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy",le="0.008"}'
     values: "0+95x15"
-  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="+Inf"}'
+  - series: 'etcd_disk_backend_commit_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy",le="+Inf"}'
     values: "0+100x15"
   alert_rule_test:
   - eval_time: 11m
@@ -123,298 +126,163 @@ tests:
 # ========================================
 # userJourneyEtcdDatabaseHighFragmentation
 # Threshold: in-use ratio < 25% (high fragmentation)
-# Gauge metric: value is 12.5% = 0.125 throughout all tiers
-# Fast  (1h5m):  fires after 5m  -> check at 11m
-# Medium (6h30m): fires after 30m -> check at 61m
-# Slow  (3d6h):    fires after 6h  -> check at 365m
+# Gauge metric: value is 12.5% = 0.125
+# Single alert: for: 15m -> check at 20m
 # ========================================
 
-# Scenario 1: Database high fragmentation (low in-use ratio) — all three tiers fire
+# Scenario 1: Database high fragmentation (low in-use ratio) — fires
 - interval: 1m
   input_series:
-  - series: 'etcd_mvcc_db_total_size_in_bytes{instance="etcd-0",resource_id="test-hcp-cluster"}'
+  - series: 'etcd_mvcc_db_total_size_in_bytes{cluster="test-hcp-cluster",namespace="test-hcp-namespace"}'
     values: "8000000000+0x370"
-  - series: 'etcd_mvcc_db_total_size_in_use_in_bytes{instance="etcd-0",resource_id="test-hcp-cluster"}'
+  - series: 'etcd_mvcc_db_total_size_in_use_in_bytes{cluster="test-hcp-cluster",namespace="test-hcp-namespace"}'
     values: "1000000000+0x370"
   alert_rule_test:
   - eval_time: 11m
-    alertname: userJourneyEtcdDatabaseHighFragmentation1h5m
+    alertname: userJourneyEtcdDatabaseHighFragmentation
+    exp_alerts: []
+  - eval_time: 20m
+    alertname: userJourneyEtcdDatabaseHighFragmentation
     exp_alerts:
     - exp_labels:
-        alertname: userJourneyEtcdDatabaseHighFragmentation1h5m
+        alertname: userJourneyEtcdDatabaseHighFragmentation
         severity: "3"
-        long_window: 1h
-        short_window: 5m
-        instance: etcd-0
-        resource_id: test-hcp-cluster
+        slo: etcd-database-fragmentation
+        cluster: test-hcp-cluster
+        namespace: test-hcp-namespace
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 database in-use ratio is 12.5% (threshold: 25%). Database defragmentation may be needed to reclaim space. Fast burn (1h/5m)."
-        summary: "etcd database fragmentation is high for test-hcp-cluster etcd-0"
+        description: "test-hcp-namespace / test-hcp-cluster etcd database in-use ratio is 12.5% (threshold: 25%). Database defragmentation may be needed to reclaim space."
+        summary: "etcd database fragmentation is high for test-hcp-cluster test-hcp-namespace"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdDatabaseHighFragmentation/test-hcp-cluster/etcd-0"
-  - eval_time: 11m
-    alertname: userJourneyEtcdDatabaseHighFragmentation6h30m
-    exp_alerts: []
-  - eval_time: 11m
-    alertname: userJourneyEtcdDatabaseHighFragmentation3d6h
-    exp_alerts: []
-  - eval_time: 61m
-    alertname: userJourneyEtcdDatabaseHighFragmentation6h30m
-    exp_alerts:
-    - exp_labels:
-        alertname: userJourneyEtcdDatabaseHighFragmentation6h30m
-        severity: "3"
-        long_window: 6h
-        short_window: 30m
-        instance: etcd-0
-        resource_id: test-hcp-cluster
-        component: hcp
-        exclude_internal_subscriptions: "true"
-      exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 database in-use ratio is 12.5% (threshold: 25%). Database defragmentation may be needed to reclaim space. Medium burn (6h/30m)."
-        summary: "etcd database fragmentation is high for test-hcp-cluster etcd-0"
-        runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdDatabaseHighFragmentation/test-hcp-cluster/etcd-0"
-  - eval_time: 61m
-    alertname: userJourneyEtcdDatabaseHighFragmentation3d6h
-    exp_alerts: []
-  - eval_time: 365m
-    alertname: userJourneyEtcdDatabaseHighFragmentation3d6h
-    exp_alerts:
-    - exp_labels:
-        alertname: userJourneyEtcdDatabaseHighFragmentation3d6h
-        severity: "4"
-        long_window: 3d
-        short_window: 6h
-        instance: etcd-0
-        resource_id: test-hcp-cluster
-        component: hcp
-        exclude_internal_subscriptions: "true"
-      exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 database in-use ratio is 12.5% (threshold: 25%). Database defragmentation may be needed to reclaim space. Slow burn (3d/6h)."
-        summary: "etcd database fragmentation is chronically high for test-hcp-cluster etcd-0"
-        runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdDatabaseHighFragmentation/test-hcp-cluster/etcd-0"
+        correlationId: "userJourneyEtcdDatabaseHighFragmentation/test-hcp-cluster/test-hcp-namespace"
 
-# Scenario 2: Database in-use ratio healthy (no fragmentation) — no tiers fire
+# Scenario 2: Database in-use ratio healthy (no fragmentation) — does not fire
 - interval: 1m
   input_series:
-  - series: 'etcd_mvcc_db_total_size_in_bytes{instance="etcd-1",resource_id="test-hcp-cluster-healthy"}'
+  - series: 'etcd_mvcc_db_total_size_in_bytes{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy"}'
     values: "8000000000+0x15"
-  - series: 'etcd_mvcc_db_total_size_in_use_in_bytes{instance="etcd-1",resource_id="test-hcp-cluster-healthy"}'
+  - series: 'etcd_mvcc_db_total_size_in_use_in_bytes{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy"}'
     values: "6000000000+0x15"
   alert_rule_test:
   - eval_time: 11m
-    alertname: userJourneyEtcdDatabaseHighFragmentation1h5m
+    alertname: userJourneyEtcdDatabaseHighFragmentation
     exp_alerts: []
 
-# Scenario 3: Ratio temporarily low then recovers — fast may fire briefly, medium does not
+# Scenario 3: Ratio temporarily low then recovers — does not fire
 - interval: 1m
   input_series:
-  - series: 'etcd_mvcc_db_total_size_in_bytes{instance="etcd-2",resource_id="test-hcp-cluster-transient"}'
+  - series: 'etcd_mvcc_db_total_size_in_bytes{cluster="test-hcp-cluster",namespace="test-hcp-cluster-transient"}'
     values: "8000000000+0x15"
-  - series: 'etcd_mvcc_db_total_size_in_use_in_bytes{instance="etcd-2",resource_id="test-hcp-cluster-transient"}'
+  - series: 'etcd_mvcc_db_total_size_in_use_in_bytes{cluster="test-hcp-cluster",namespace="test-hcp-cluster-transient"}'
     values: "1000000000 1000000000 6000000000+0x13"
   alert_rule_test:
-  - eval_time: 61m
-    alertname: userJourneyEtcdDatabaseHighFragmentation6h30m
+  - eval_time: 15m
+    alertname: userJourneyEtcdDatabaseHighFragmentation
     exp_alerts: []
 
 # ========================================
 # userJourneyEtcdDatabaseSizeExceeded
-# Threshold: size > 8GB (8000000000 bytes)
+# Threshold: size > 7GB (7000000000 bytes)
 # Gauge metric: 9GB throughout
-# Fast  (1h5m):  fires after 5m  -> check at 11m
-# Medium (6h30m): fires after 30m -> check at 61m
-# Slow  (3d6h):    fires after 6h  -> check at 365m
+# Single alert: for: 15m -> check at 20m
 # ========================================
 
-# Scenario 1: Database size exceeds 8GB — all three tiers fire
+# Scenario 1: Database size exceeds 7GB — fires
 - interval: 1m
   input_series:
-  - series: 'etcd_mvcc_db_total_size_in_bytes{instance="etcd-0",resource_id="test-hcp-cluster"}'
+  - series: 'etcd_mvcc_db_total_size_in_bytes{cluster="test-hcp-cluster",namespace="test-hcp-namespace"}'
     values: "9000000000+0x370"
   alert_rule_test:
   - eval_time: 11m
-    alertname: userJourneyEtcdDatabaseSizeExceeded1h5m
+    alertname: userJourneyEtcdDatabaseSizeExceeded
+    exp_alerts: []
+  - eval_time: 20m
+    alertname: userJourneyEtcdDatabaseSizeExceeded
     exp_alerts:
     - exp_labels:
-        alertname: userJourneyEtcdDatabaseSizeExceeded1h5m
+        alertname: userJourneyEtcdDatabaseSizeExceeded
         severity: "3"
-        long_window: 1h
-        short_window: 5m
-        instance: etcd-0
-        resource_id: test-hcp-cluster
+        slo: etcd-database-size
+        cluster: test-hcp-cluster
+        namespace: test-hcp-namespace
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 database size is 9GB (threshold: 8GB). Database may need compaction or quota increase. Fast burn (1h/5m)."
-        summary: "etcd database size is too large for test-hcp-cluster etcd-0"
+        description: "test-hcp-namespace / test-hcp-cluster etcd database size is 9GB (threshold: 7GB). Database may need compaction or quota increase."
+        summary: "etcd database size is too large for test-hcp-cluster test-hcp-namespace"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdDatabaseSizeExceeded/test-hcp-cluster/etcd-0"
-  - eval_time: 11m
-    alertname: userJourneyEtcdDatabaseSizeExceeded6h30m
-    exp_alerts: []
-  - eval_time: 11m
-    alertname: userJourneyEtcdDatabaseSizeExceeded3d6h
-    exp_alerts: []
-  - eval_time: 61m
-    alertname: userJourneyEtcdDatabaseSizeExceeded6h30m
-    exp_alerts:
-    - exp_labels:
-        alertname: userJourneyEtcdDatabaseSizeExceeded6h30m
-        severity: "3"
-        long_window: 6h
-        short_window: 30m
-        instance: etcd-0
-        resource_id: test-hcp-cluster
-        component: hcp
-        exclude_internal_subscriptions: "true"
-      exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 database size is 9GB (threshold: 8GB). Database may need compaction or quota increase. Medium burn (6h/30m)."
-        summary: "etcd database size is too large for test-hcp-cluster etcd-0"
-        runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdDatabaseSizeExceeded/test-hcp-cluster/etcd-0"
-  - eval_time: 61m
-    alertname: userJourneyEtcdDatabaseSizeExceeded3d6h
-    exp_alerts: []
-  - eval_time: 365m
-    alertname: userJourneyEtcdDatabaseSizeExceeded3d6h
-    exp_alerts:
-    - exp_labels:
-        alertname: userJourneyEtcdDatabaseSizeExceeded3d6h
-        severity: "4"
-        long_window: 3d
-        short_window: 6h
-        instance: etcd-0
-        resource_id: test-hcp-cluster
-        component: hcp
-        exclude_internal_subscriptions: "true"
-      exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 database size is 9GB (threshold: 8GB). Database may need compaction or quota increase. Slow burn (3d/6h)."
-        summary: "etcd database size is chronically too large for test-hcp-cluster etcd-0"
-        runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdDatabaseSizeExceeded/test-hcp-cluster/etcd-0"
+        correlationId: "userJourneyEtcdDatabaseSizeExceeded/test-hcp-cluster/test-hcp-namespace"
 
-# Scenario 2: Database size below threshold — no tiers fire
+# Scenario 2: Database size below threshold — does not fire
 - interval: 1m
   input_series:
-  - series: 'etcd_mvcc_db_total_size_in_bytes{instance="etcd-1",resource_id="test-hcp-cluster-healthy"}'
-    values: "7000000000+0x15"
+  - series: 'etcd_mvcc_db_total_size_in_bytes{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy"}'
+    values: "6000000000+0x15"
   alert_rule_test:
   - eval_time: 11m
-    alertname: userJourneyEtcdDatabaseSizeExceeded1h5m
+    alertname: userJourneyEtcdDatabaseSizeExceeded
     exp_alerts: []
 
-# Scenario 3: Brief spike then drops — medium and slow do not fire
+# Scenario 3: Brief spike then drops — does not fire
 - interval: 1m
   input_series:
-  - series: 'etcd_mvcc_db_total_size_in_bytes{instance="etcd-2",resource_id="test-hcp-cluster-transient"}'
-    values: "7000000000 9000000000 9000000000 7000000000+0x12"
+  - series: 'etcd_mvcc_db_total_size_in_bytes{cluster="test-hcp-cluster",namespace="test-hcp-cluster-transient"}'
+    values: "6000000000 9000000000 9000000000 6000000000+0x12"
   alert_rule_test:
-  - eval_time: 61m
-    alertname: userJourneyEtcdDatabaseSizeExceeded6h30m
+  - eval_time: 15m
+    alertname: userJourneyEtcdDatabaseSizeExceeded
     exp_alerts: []
 
 # ========================================
 # userJourneyEtcdFrequentLeaderChanges
-# Threshold: increase([15m]) > 4
+# Threshold: increase([15m]) > 3
 # Series: counter increments by 1/min -> at steady state increase([15m]) = 15
-# Fast  (1h5m):  for:5m  — condition true from ~t=4m, fires at ~t=9m  -> check at 15m
-# Medium (6h30m): for:30m — fires at ~t=34m                            -> check at 61m
-# Slow  (3d6h):    for:6h  — fires at ~t=364m                           -> check at 365m
+# Single alert: for:5m — condition true early, sustained for 5m -> fires well before 15m, check at 15m
 # ========================================
 
-# Scenario 1: Frequent leader changes — all three tiers fire
+# Scenario 1: Frequent leader changes — fires
 - interval: 1m
   input_series:
-  - series: 'etcd_server_leader_changes_seen_total{instance="etcd-0",resource_id="test-hcp-cluster"}'
+  - series: 'etcd_server_leader_changes_seen_total{cluster="test-hcp-cluster",namespace="test-hcp-namespace"}'
     values: "0+1x370"
   alert_rule_test:
   - eval_time: 15m
-    alertname: userJourneyEtcdFrequentLeaderChanges1h5m
+    alertname: userJourneyEtcdFrequentLeaderChanges
     exp_alerts:
     - exp_labels:
-        alertname: userJourneyEtcdFrequentLeaderChanges1h5m
+        alertname: userJourneyEtcdFrequentLeaderChanges
         severity: "3"
-        long_window: 1h
-        short_window: 5m
-        instance: etcd-0
-        resource_id: test-hcp-cluster
+        slo: etcd-leader-changes
+        cluster: test-hcp-cluster
+        namespace: test-hcp-namespace
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 has seen 15 leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Fast burn (1h/5m)."
-        summary: "etcd cluster experiencing frequent leader changes for test-hcp-cluster etcd-0"
+        description: "test-hcp-namespace / test-hcp-cluster etcd has seen 15 leader changes in the last 15 minutes (threshold: 3). This may indicate network issues or cluster instability."
+        summary: "etcd cluster experiencing frequent leader changes for test-hcp-cluster test-hcp-namespace"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdFrequentLeaderChanges/test-hcp-cluster/etcd-0"
-  - eval_time: 15m
-    alertname: userJourneyEtcdFrequentLeaderChanges6h30m
-    exp_alerts: []
-  - eval_time: 15m
-    alertname: userJourneyEtcdFrequentLeaderChanges3d6h
-    exp_alerts: []
-  - eval_time: 61m
-    alertname: userJourneyEtcdFrequentLeaderChanges6h30m
-    exp_alerts:
-    - exp_labels:
-        alertname: userJourneyEtcdFrequentLeaderChanges6h30m
-        severity: "3"
-        long_window: 6h
-        short_window: 30m
-        instance: etcd-0
-        resource_id: test-hcp-cluster
-        component: hcp
-        exclude_internal_subscriptions: "true"
-      exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 has seen 15 leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Medium burn (6h/30m)."
-        summary: "etcd cluster experiencing frequent leader changes for test-hcp-cluster etcd-0"
-        runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdFrequentLeaderChanges/test-hcp-cluster/etcd-0"
-  - eval_time: 61m
-    alertname: userJourneyEtcdFrequentLeaderChanges3d6h
-    exp_alerts: []
-  - eval_time: 365m
-    alertname: userJourneyEtcdFrequentLeaderChanges3d6h
-    exp_alerts:
-    - exp_labels:
-        alertname: userJourneyEtcdFrequentLeaderChanges3d6h
-        severity: "4"
-        long_window: 3d
-        short_window: 6h
-        instance: etcd-0
-        resource_id: test-hcp-cluster
-        component: hcp
-        exclude_internal_subscriptions: "true"
-      exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 has seen 15 leader changes in the last 15 minutes (threshold: 4). This may indicate network issues or cluster instability. Slow burn (3d/6h)."
-        summary: "etcd cluster experiencing chronic frequent leader changes for test-hcp-cluster etcd-0"
-        runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdFrequentLeaderChanges/test-hcp-cluster/etcd-0"
+        correlationId: "userJourneyEtcdFrequentLeaderChanges/test-hcp-cluster/test-hcp-namespace"
 
-# Scenario 2: Stable leader — no tiers fire
+# Scenario 2: Stable leader — does not fire
 - interval: 1m
   input_series:
-  - series: 'etcd_server_leader_changes_seen_total{instance="etcd-1",resource_id="test-hcp-cluster-healthy"}'
+  - series: 'etcd_server_leader_changes_seen_total{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy"}'
     values: "0 0 0 1 1 1 1 1 1 1 1 1 1 1 1 2"
   alert_rule_test:
   - eval_time: 15m
-    alertname: userJourneyEtcdFrequentLeaderChanges1h5m
-    exp_alerts: []
-  - eval_time: 15m
-    alertname: userJourneyEtcdFrequentLeaderChanges6h30m
+    alertname: userJourneyEtcdFrequentLeaderChanges
     exp_alerts: []
 
-# Scenario 3: Leader changes exactly at threshold — no tiers fire
+# Scenario 3: Leader changes exactly at threshold — does not fire
 - interval: 1m
   input_series:
-  - series: 'etcd_server_leader_changes_seen_total{instance="etcd-2",resource_id="test-hcp-cluster-transient"}'
-    values: "0 0 0 0 0 1 1 1 1 1 2 2 2 2 2 4"
+  - series: 'etcd_server_leader_changes_seen_total{cluster="test-hcp-cluster",namespace="test-hcp-cluster-transient"}'
+    values: "0 0 0 0 0 1 1 1 1 1 2 2 2 2 2 3"
   alert_rule_test:
   - eval_time: 15m
-    alertname: userJourneyEtcdFrequentLeaderChanges1h5m
+    alertname: userJourneyEtcdFrequentLeaderChanges
     exp_alerts: []
 
 # ========================================
@@ -430,31 +298,31 @@ tests:
 # Scenario 1: High peer RTT — all three tiers fire
 - interval: 1m
   input_series:
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0001"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.0001"}'
     values: "0+5x370"
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0002"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.0002"}'
     values: "0+10x370"
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0004"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.0004"}'
     values: "0+15x370"
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0008"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.0008"}'
     values: "0+20x370"
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0016"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.0016"}'
     values: "0+25x370"
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0032"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.0032"}'
     values: "0+30x370"
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0064"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.0064"}'
     values: "0+35x370"
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0128"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.0128"}'
     values: "0+40x370"
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0256"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.0256"}'
     values: "0+50x370"
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.0512"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.0512"}'
     values: "0+70x370"
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.1024"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.1024"}'
     values: "0+90x370"
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.2048"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.2048"}'
     values: "0+95x370"
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="+Inf"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="+Inf"}'
     values: "0+100x370"
   alert_rule_test:
   # Fast fires at 11m; medium and slow have not yet fired
@@ -466,15 +334,16 @@ tests:
         severity: "3"
         long_window: 1h
         short_window: 5m
-        instance: etcd-0
-        resource_id: test-hcp-cluster
+        slo: etcd-peer-round-trip-time
+        cluster: test-hcp-cluster
+        namespace: test-hcp-namespace
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m)."
-        summary: "etcd peer round-trip time is high for test-hcp-cluster etcd-0"
+        description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Fast burn (1h/5m)."
+        summary: "etcd peer round-trip time is high for test-hcp-cluster test-hcp-namespace"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/test-hcp-cluster/etcd-0"
+        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/test-hcp-cluster/test-hcp-namespace"
   - eval_time: 11m
     alertname: userJourneyEtcdPeerRoundTripTimeHigh6h30m
     exp_alerts: []
@@ -490,15 +359,16 @@ tests:
         severity: "3"
         long_window: 6h
         short_window: 30m
-        instance: etcd-0
-        resource_id: test-hcp-cluster
+        slo: etcd-peer-round-trip-time
+        cluster: test-hcp-cluster
+        namespace: test-hcp-namespace
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m)."
-        summary: "etcd peer round-trip time is high for test-hcp-cluster etcd-0"
+        description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Medium burn (6h/30m)."
+        summary: "etcd peer round-trip time is high for test-hcp-cluster test-hcp-namespace"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/test-hcp-cluster/etcd-0"
+        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/test-hcp-cluster/test-hcp-namespace"
   - eval_time: 61m
     alertname: userJourneyEtcdPeerRoundTripTimeHigh3d6h
     exp_alerts: []
@@ -510,26 +380,27 @@ tests:
         severity: "4"
         long_window: 3d
         short_window: 6h
-        instance: etcd-0
-        resource_id: test-hcp-cluster
+        slo: etcd-peer-round-trip-time
+        cluster: test-hcp-cluster
+        namespace: test-hcp-namespace
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h)."
-        summary: "etcd peer round-trip time is chronically high for test-hcp-cluster etcd-0"
+        description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile peer round-trip time of 0.2048s (threshold: 100ms). Network latency between peers may be affecting cluster performance. Slow burn (3d/6h)."
+        summary: "etcd peer round-trip time is chronically high for test-hcp-cluster test-hcp-namespace"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/test-hcp-cluster/etcd-0"
+        correlationId: "userJourneyEtcdPeerRoundTripTimeHigh/test-hcp-cluster/test-hcp-namespace"
 
 # Scenario 2: Normal peer RTT — no tiers fire
 - interval: 1m
   input_series:
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.0001"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy",le="0.0001"}'
     values: "0+50x15"
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.0002"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy",le="0.0002"}'
     values: "0+90x15"
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.0004"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy",le="0.0004"}'
     values: "0+95x15"
-  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="+Inf"}'
+  - series: 'etcd_network_peer_round_trip_time_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy",le="+Inf"}'
     values: "0+100x15"
   alert_rule_test:
   - eval_time: 11m
@@ -549,21 +420,21 @@ tests:
 # Scenario 1: High WAL fsync duration — all three tiers fire
 - interval: 1m
   input_series:
-  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.001"}'
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.001"}'
     values: "0+10x370"
-  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.002"}'
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.002"}'
     values: "0+20x370"
-  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.004"}'
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.004"}'
     values: "0+40x370"
-  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.008"}'
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.008"}'
     values: "0+80x370"
-  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.016"}'
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.016"}'
     values: "0+150x370"
-  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.032"}'
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.032"}'
     values: "0+180x370"
-  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="0.064"}'
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="0.064"}'
     values: "0+190x370"
-  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-0",resource_id="test-hcp-cluster",le="+Inf"}'
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-namespace",le="+Inf"}'
     values: "0+200x370"
   alert_rule_test:
   # Fast fires at 11m; medium and slow have not yet fired
@@ -575,15 +446,16 @@ tests:
         severity: "3"
         long_window: 1h
         short_window: 5m
-        instance: etcd-0
-        resource_id: test-hcp-cluster
+        slo: etcd-wal-fsync-duration
+        cluster: test-hcp-cluster
+        namespace: test-hcp-namespace
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m)."
-        summary: "etcd WAL fsync duration is high for test-hcp-cluster etcd-0"
+        description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Fast burn (1h/5m)."
+        summary: "etcd WAL fsync duration is high for test-hcp-cluster test-hcp-namespace"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdWALFsyncDurationHigh/test-hcp-cluster/etcd-0"
+        correlationId: "userJourneyEtcdWALFsyncDurationHigh/test-hcp-cluster/test-hcp-namespace"
   - eval_time: 11m
     alertname: userJourneyEtcdWALFsyncDurationHigh6h30m
     exp_alerts: []
@@ -599,15 +471,16 @@ tests:
         severity: "3"
         long_window: 6h
         short_window: 30m
-        instance: etcd-0
-        resource_id: test-hcp-cluster
+        slo: etcd-wal-fsync-duration
+        cluster: test-hcp-cluster
+        namespace: test-hcp-namespace
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m)."
-        summary: "etcd WAL fsync duration is high for test-hcp-cluster etcd-0"
+        description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Medium burn (6h/30m)."
+        summary: "etcd WAL fsync duration is high for test-hcp-cluster test-hcp-namespace"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdWALFsyncDurationHigh/test-hcp-cluster/etcd-0"
+        correlationId: "userJourneyEtcdWALFsyncDurationHigh/test-hcp-cluster/test-hcp-namespace"
   - eval_time: 61m
     alertname: userJourneyEtcdWALFsyncDurationHigh3d6h
     exp_alerts: []
@@ -619,26 +492,27 @@ tests:
         severity: "4"
         long_window: 3d
         short_window: 6h
-        instance: etcd-0
-        resource_id: test-hcp-cluster
+        slo: etcd-wal-fsync-duration
+        cluster: test-hcp-cluster
+        namespace: test-hcp-namespace
         component: hcp
         exclude_internal_subscriptions: "true"
       exp_annotations:
-        description: "test-hcp-cluster etcd instance etcd-0 has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h)."
-        summary: "etcd WAL fsync duration is chronically high for test-hcp-cluster etcd-0"
+        description: "test-hcp-namespace / test-hcp-cluster etcd has 99th percentile WAL fsync duration of 0.064s (threshold: 50ms). Slow disk performance may impact cluster stability. Slow burn (3d/6h)."
+        summary: "etcd WAL fsync duration is chronically high for test-hcp-cluster test-hcp-namespace"
         runbook_url: https://aka.ms/arohcp-runbook-etcd
-        correlationId: "userJourneyEtcdWALFsyncDurationHigh/test-hcp-cluster/etcd-0"
+        correlationId: "userJourneyEtcdWALFsyncDurationHigh/test-hcp-cluster/test-hcp-namespace"
 
 # Scenario 2: Normal WAL fsync duration — no tiers fire
 - interval: 1m
   input_series:
-  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.001"}'
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy",le="0.001"}'
     values: "0+100x15"
-  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.002"}'
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy",le="0.002"}'
     values: "0+180x15"
-  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="0.004"}'
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy",le="0.004"}'
     values: "0+195x15"
-  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{instance="etcd-1",resource_id="test-hcp-cluster-healthy",le="+Inf"}'
+  - series: 'etcd_disk_wal_fsync_duration_seconds_bucket{cluster="test-hcp-cluster",namespace="test-hcp-cluster-healthy",le="+Inf"}'
     values: "0+200x15"
   alert_rule_test:
   - eval_time: 11m


### PR DESCRIPTION
### What

HCP etcd availability alerts: https://redhat.atlassian.net/browse/ARO-25981

Adding Prometheus alerts for etcd availability metrics exposed via the SRE metrics set.

Alerts follow the design defined in the ARO HCP Alerting Recommendation ADR.

See https://github.com/openshift-online/architecture/pull/79 for details.

There are 18 etcd availability alerts total defined in 3 separate burn rate tiers.

1. userJourneyEtcdBackendCommitDurationHigh — 99th-percentile etcd disk backend commit duration (etcd_disk_backend_commit_duration_seconds_bucket) exceedi ng 100ms. Flags slow disk performance that could hurt write throughput.

2. userJourneyEtcdDatabaseHighFragmentation — ratio of in-use to total etcd MVCC DB size (etcd_mvcc_db_total_size_in_use_in_bytes / etcd_mvcc_db_total_siz e_in_bytes) dropping below 25%. Flags fragmentation that may need defragmentation to reclaim space.

3. userJourneyEtcdDatabaseSizeExceeded — total etcd MVCC DB size (etcd_mvcc_db_total_size_in_bytes) exceeding 7GB. Flags DBs that may need compaction or a quota increase.

4. userJourneyEtcdFrequentLeaderChanges — more than 3 leader changes in a 15-minute window (increase(etcd_server_leader_changes_seen_total[15m])). Flags p otential network issues or cluster instability.

5. userJourneyEtcdPeerRoundTripTimeHigh — 99th-percentile etcd peer round-trip time (etcd_network_peer_round_trip_time_seconds_bucket) exceeding 100ms. Fl ags network latency between peers affecting cluster performance.

6. userJourneyEtcdWALFsyncDurationHigh — 99th-percentile WAL fsync duration (etcd_disk_wal_fsync_duration_seconds_bucket) exceeding 50ms. Flags slow disk performance affecting cluster stability.

All alerts are configured with component = hcp.

Automated tests that run via make alerts are passing and generated alerts in the bicep files are deployed successfully via make personal-dev-env.

### Why

We are currently lacking alerts for etcd performance degradation scenarios.  Alerts are only being added for the etcd instances in the customer HCP clusters.

### Testing

Automated tests that run via make alerts are passing and generated alerts in the bicep files are deployed successfully via make personal-dev-env and confirmed alerts are firing via Azure Portal.  Screenshots of deployed hcp-etcd-availability rule group and firing and resolved etcd frequent leader change alert below.

<img width="1545" height="797" alt="hcp-etcd-availability-rule-group" src="https://github.com/user-attachments/assets/dcafea51-03da-449f-8bfb-ac2661808b55" />

<img width="1545" height="797" alt="userJourneyEtcdFrequentLeaderChanges-fired" src="https://github.com/user-attachments/assets/49547edd-a6d7-4974-9071-50d995283757" />

<img width="1545" height="797" alt="userJourneyEtcdFrequentLeaderChanges-resolved" src="https://github.com/user-attachments/assets/b8869bdb-7292-4315-90ed-14e45dbd060f" />


Alerts have been tested using the alert-tester tool and the alert thresholds were adjusted based on the results of those tests.

## Alerts under test (bold are updated results for prod data from Aug. 24th - Aug. 31st)

### userJourneyEtcdBackendCommitDurationHigh1h5m

26 firings @ for=5m, 3 @ for=10m, 1 @ for=15m (all 1 grouped/incident each); no firings at for=20m, 30m, or 45m.

**94 firings @ for=5m, 46 @ for=10m, 14 @ for=15m, 6 @ for=20m (all 1 grouped/incident each); no firings at for=30m or 45m.**

### userJourneyEtcdDatabaseHighFragmentation1h5m

26 firings / 13 grouped firings at every tested `for:` value (5m through 45m); 12 firings / 6 grouped firings sustained ≥90% of window at every value (likely permafailing)

**44 firings / 22 grouped @ for=5m; 42/21 @ for=10m; 40/20 @ for=15m and 20m; 36/18 @ for=30m and 45m. No sustained-firing flag this week.**

### userJourneyEtcdDatabaseSizeExceeded1h5m

No usable data at any tested `for:` value.  No etcd database in uksouth returned any series for this metric over the window — every etcd DB stayed well under the 7GB threshold for the time period tested.

### userJourneyEtcdFrequentLeaderChanges1h5m

No usable data at any tested `for:` value.  No leader-change data returned in uksouth for the time period tested.

**1 series returned (1 sample passing the threshold), but no firings at any tested `for:` value — the crossing didn't sustain.**

**Note:** this alert was tested manually by forcing more than four leader changes during a 15 minute period by repeatedly deleting the active leader pod in a test cluster.

### userJourneyEtcdPeerRoundTripTimeHigh1h5m

For 5m: 32 firings, 32 grouped firings (~incidents).  For 10m / 15m / 20m / 30m / 45m no incidents were recorded.

**96 firings @ for=5m, 33 @ for=10m, 13 @ for=15m, 8 @ for=20m, 2 @ for=30m; no firings at for=45m.**

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if dashboards or other UI changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge
