### PR TITLE
Test verify haproxy annotation mechanism for pr6660

### DIFF
--- a/cluster-service/pipeline.yaml
+++ b/cluster-service/pipeline.yaml
@@ -38,6 +38,32 @@ resourceGroups:
       - "unauthorized: authentication required"
       maximumRetryCount: 5
       durationBetweenRetries: 1m
+  - name: mirror-data-plane-haproxy-image
+    action: ImageMirror
+    targetACR:
+      configRef: 'acr.ocp.name'
+    sourceRegistry:
+      configRef: clustersService.dataPlaneHAProxyImage.registry
+    repository:
+      configRef: clustersService.dataPlaneHAProxyImage.repository
+    digest:
+      configRef: clustersService.dataPlaneHAProxyImage.digest
+    pullSecretKeyVault:
+      configRef: global.keyVault.name
+    pullSecretName:
+      configRef: imageSync.ondemandSync.pullSecretName
+    shellIdentity:
+      input:
+        resourceGroup: global
+        step: output
+        name: globalMSIId
+    automatedRetry:
+      errorContainsAny:
+      - "unknown_storage_failure"
+      - "unexpected EOF"
+      - "unauthorized: authentication required"
+      maximumRetryCount: 5
+      durationBetweenRetries: 1m
 - name: kusto
   resourceGroup: '{{ .kusto.rg }}'
   subscription: '{{ .global.subscription.key }}'
@@ -135,6 +161,8 @@ resourceGroups:
       step: output
     - resourceGroup: global
       step: mirror-image
+    - resourceGroup: global
+      step: mirror-data-plane-haproxy-image
     automatedRetry:
       errorContainsAny:
       - "500 Internal Server Error"

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
@@ -8107,6 +8107,7 @@ spec:
         - --log-fields-from-baggage=aro.correlation_id=correlation_id,aro.client.request_id=client_request_id
         
         
+        - --data-plane-ha-proxy-image=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890
         livenessProbe:
           httpGet:
             path: /api/clusters_mgmt/v1

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
@@ -8208,6 +8208,7 @@ spec:
         - --log-fields-from-baggage=aro.correlation_id=correlation_id,aro.client.request_id=client_request_id
         
         
+        - --data-plane-ha-proxy-image=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890
         livenessProbe:
           httpGet:
             path: /api/clusters_mgmt/v1

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_distinct_arm_helper.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_distinct_arm_helper.yaml
@@ -8107,6 +8107,7 @@ spec:
         - --log-fields-from-baggage=aro.correlation_id=correlation_id,aro.client.request_id=client_request_id
         
         
+        - --data-plane-ha-proxy-image=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890
         livenessProbe:
           httpGet:
             path: /api/clusters_mgmt/v1

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_shared_arm_helper.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_shared_arm_helper.yaml
@@ -8107,6 +8107,7 @@ spec:
         - --log-fields-from-baggage=aro.correlation_id=correlation_id,aro.client.request_id=client_request_id
         
         
+        - --data-plane-ha-proxy-image=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890
         livenessProbe:
           httpGet:
             path: /api/clusters_mgmt/v1

--- a/cluster-service/values.yaml
+++ b/cluster-service/values.yaml
@@ -214,7 +214,7 @@ managedIdentitiesDataPlaneAudienceResource: "{{ .msiRp.dataPlaneAudienceResource
 # The image used to override the HAProxy image of the worker node API server proxy.
 # Assembled as an ACR reference so worker nodes pull from the environment-specific ACR, not quay.io.
 # When digest is empty, CS falls back to IMAGE_SHARED_INGRESS_HAPROXY (legacy behavior).
-dataPlaneHAProxyImage: "{{ if .clustersService.dataPlaneHAProxyImage.digest }}{{ .acr.ocp.name }}.azurecr.io/{{ .clustersService.dataPlaneHAProxyImage.repository }}@{{ .clustersService.dataPlaneHAProxyImage.digest }}{{ end }}"
+dataPlaneHAProxyImage: "{{ if .clustersService.dataPlaneHAProxyImage.digest }}{{ .acr.ocp.name }}.{{ .acrDNSSuffix }}/{{ .clustersService.dataPlaneHAProxyImage.repository }}@{{ .clustersService.dataPlaneHAProxyImage.digest }}{{ end }}"
 # The Azure Operator Managed Identities.
 azureOperatorsMI:
   roleSetName: "{{ .clustersService.azureOperatorsManagedIdentities.roleSetName }}"

--- a/cluster-service/values.yaml
+++ b/cluster-service/values.yaml
@@ -212,9 +212,9 @@ databasePort: "5432"
 # The name of the managed identities data plane audience resource.
 managedIdentitiesDataPlaneAudienceResource: "{{ .msiRp.dataPlaneAudienceResource }}"
 # The image used to override the HAProxy image of the worker node API server proxy.
-# If set to an empty string, either the environment variable IMAGE_SHARED_INGRESS_HAPROXY or the default shared ingress image will be used.
-# If given a value, it must be a valid image reference.
-dataPlaneHAProxyImage: "{{ .clustersService.dataPlaneHAProxyImage }}"
+# Assembled as an ACR reference so worker nodes pull from the environment-specific ACR, not quay.io.
+# When digest is empty, CS falls back to IMAGE_SHARED_INGRESS_HAPROXY (legacy behavior).
+dataPlaneHAProxyImage: "{{ if .clustersService.dataPlaneHAProxyImage.digest }}{{ .acr.ocp.name }}.azurecr.io/{{ .clustersService.dataPlaneHAProxyImage.repository }}@{{ .clustersService.dataPlaneHAProxyImage.digest }}{{ end }}"
 # The Azure Operator Managed Identities.
 azureOperatorsMI:
   roleSetName: "{{ .clustersService.azureOperatorsManagedIdentities.roleSetName }}"

--- a/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
+++ b/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
@@ -8107,6 +8107,7 @@ spec:
         - --log-fields-from-baggage=aro.correlation_id=correlation_id,aro.client.request_id=client_request_id
         
         
+        - --data-plane-ha-proxy-image=arohcpocpdev.azurecr.io/redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main@sha256:1234567890
         livenessProbe:
           httpGet:
             path: /api/clusters_mgmt/v1

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1238,8 +1238,7 @@
           ]
         },
         "dataPlaneHAProxyImage": {
-          "type": "string",
-          "description": "A valid image reference used for overriding the HAProxy image of the worker node API server proxy. If set to an empty string, either the environment variable IMAGE_SHARED_INGRESS_HAPROXY or the default shared ingress image will be used."
+          "$ref": "#/definitions/containerImage"
         }
       },
       "additionalProperties": false,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1102,7 +1102,7 @@ defaults:
     dataPlaneHAProxyImage:
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
-      digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+      digest: sha256:d443537f72ec48b2078d24de9852c3369c68c60c06ac82d51c472b2144d41309
     postgres:
       name: "arohcp-{{ .ctx.environment }}-dbcs-{{ .ctx.regionShort }}" # [globally-unique]
       deploy: true

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1097,7 +1097,12 @@ defaults:
     environment: "arohcp{{ .ctx.environment }}"
     denyAssignments: "disabled"
     # The image used to override the HAProxy image of the worker node API server proxy.
-    dataPlaneHAProxyImage: ""
+    # Defaults to matching sharedIngressImage so the decoupled image starts identical.
+    # Override only `digest` per-region in sdp-pipelines overlays when regions need pinning.
+    dataPlaneHAProxyImage:
+      registry: quay.io
+      repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
+      digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
     postgres:
       name: "arohcp-{{ .ctx.environment }}-dbcs-{{ .ctx.regionShort }}" # [globally-unique]
       deploy: true

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -171,7 +171,10 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
-  dataPlaneHAProxyImage: ""
+  dataPlaneHAProxyImage:
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcpci00

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -172,7 +172,7 @@ clustersService:
   batchProcesses: ""
   batchProcessesDryRun: true
   dataPlaneHAProxyImage:
-    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    digest: sha256:d443537f72ec48b2078d24de9852c3369c68c60c06ac82d51c472b2144d41309
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -171,7 +171,10 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
-  dataPlaneHAProxyImage: ""
+  dataPlaneHAProxyImage:
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcpci01

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -172,7 +172,7 @@ clustersService:
   batchProcesses: ""
   batchProcessesDryRun: true
   dataPlaneHAProxyImage:
-    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    digest: sha256:d443537f72ec48b2078d24de9852c3369c68c60c06ac82d51c472b2144d41309
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -171,7 +171,10 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
-  dataPlaneHAProxyImage: ""
+  dataPlaneHAProxyImage:
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcpcspr

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -172,7 +172,7 @@ clustersService:
   batchProcesses: ""
   batchProcessesDryRun: true
   dataPlaneHAProxyImage:
-    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    digest: sha256:d443537f72ec48b2078d24de9852c3369c68c60c06ac82d51c472b2144d41309
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -171,7 +171,10 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
-  dataPlaneHAProxyImage: ""
+  dataPlaneHAProxyImage:
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcpdev

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -172,7 +172,7 @@ clustersService:
   batchProcesses: ""
   batchProcessesDryRun: true
   dataPlaneHAProxyImage:
-    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    digest: sha256:d443537f72ec48b2078d24de9852c3369c68c60c06ac82d51c472b2144d41309
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -171,7 +171,10 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
-  dataPlaneHAProxyImage: ""
+  dataPlaneHAProxyImage:
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcpperf

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -172,7 +172,7 @@ clustersService:
   batchProcesses: ""
   batchProcessesDryRun: true
   dataPlaneHAProxyImage:
-    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    digest: sha256:d443537f72ec48b2078d24de9852c3369c68c60c06ac82d51c472b2144d41309
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -171,7 +171,10 @@ clustersService:
     tlsCertificatesIssuer: Self
   batchProcesses: ""
   batchProcessesDryRun: true
-  dataPlaneHAProxyImage: ""
+  dataPlaneHAProxyImage:
+    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    registry: quay.io
+    repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled
   deployDebugJobs: false
   environment: arohcppers

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -172,7 +172,7 @@ clustersService:
   batchProcesses: ""
   batchProcessesDryRun: true
   dataPlaneHAProxyImage:
-    digest: sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
+    digest: sha256:d443537f72ec48b2078d24de9852c3369c68c60c06ac82d51c472b2144d41309
     registry: quay.io
     repository: redhat-user-workloads/crt-redhat-acm-tenant/hypershift-shared-ingress-main
   denyAssignments: disabled


### PR DESCRIPTION
:white_check_mark: Option D — Branch ready, PR needs manual creation

The optionD workspace completed successfully:

• Branch: test-verify-haproxy-annotation-mechanism on redhat-chai-bot/Azure_ARO-HCP
• Old digest (sharedIngressHAProxyImage / fallback): sha256:5e22710fe440869655329ecc0ef57b4ae15f4ef96e74a8904b1e6fafc0d87678
• New digest (dataPlaneHAProxyImage / annotation path): sha256:d443537f72ec48b2078d24de9852c3369c68c60c06ac82d51c472b2144d41309
• Found via skopeo inspect on tag 028227b537668d525d909c1d189d483deccb4006 from the same quay.io repo
• Ran make materialize to regenerate 6 rendered config files under config/rendered/dev/
• Committed as 5be07228a

How to observe the result:
- If the annotation mechanism works → router pods on worker nodes will pull sha256:d443537f... (the new digest)
- If the annotation is NOT working → router pods use the fallback IMAGE_SHARED_INGRESS_HAPROXY which still points to sha256:5e22710... (the old digest)
- If the image mirror fails or the new digest is incompatible → you'll see ImagePullBackOff instead of scheduling errors, which also proves the mechanism is active

I couldn't open the PR from a DM (requires peer approval). You can create it directly:
Open the test PR on GitHub

I'd recommend opening it as a draft so it's clear this is a verification test, not for merge.

The optionB workspace (Kusto investigation) is still running — I'll report those results as soon as it completes.

[ARO Engineering] AI-generated. Review for accuracy.