### PR TITLE
fix: handle empty timestamps in JUnit report generation

### DIFF
--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -551,6 +551,16 @@ func runGraph(ctx context.Context, logger logr.Logger, executionGraph *graph.Gra
 			suite := suites.Suites[0]
 			for id, info := range timing {
 				thisLogger := logger.WithValues("id", id.String())
+				// Skip steps that were never started or finished (empty timestamps).
+				// This typically happens when a step was queued but not executed due to
+				// earlier failures or context cancellation. Without this check, time.Parse()
+				// would fail with: parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"
+				if info.StartedAt == "" || info.FinishedAt == "" {
+					thisLogger.Info("Skipping JUnit report entry for step that was not executed",
+						"state", info.State, "preempted", info.Preempted,
+						"startedAt", info.StartedAt, "finishedAt", info.FinishedAt)
+					continue
+				}
 				startedAt, err := time.Parse(time.RFC3339, info.StartedAt)
 				if err != nil {
 					thisLogger.Error(err, "error parsing started at")


### PR DESCRIPTION
When generating JUnit reports, skip steps that were never started or finished (empty StartedAt/FinishedAt timestamps) instead of attempting to parse them. This prevents "parsing time \"\" as \"2006-01-02T15:04:05Z07:00\"" errors for steps that were queued but not executed due to earlier failures or preemptions.

Steps are initialized with empty ExecutionInfo{} structs, and if a step is queued but never starts (or starts but is preempted before finishing), the timestamp fields remain empty strings. Previously this caused time.Parse() to fail with a cryptic error referencing Go's reference date format.

<!-- Link to Jira issue -->

### What

Makes the source of the failure clear.

### Why

To reduce time to troubleshoot Prow failures. 

### Testing

This is a fix to a test, test ran locally without issues.
### Special notes for your reviewer

Doesn't fix an underlying CI issue, but will make it easier to spot the real problem.

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
