### PR TITLE
feat(hcpctl): add Kusto-backed oc-adm-inspect and wire it into must-g…

### DIFF
--- a/test/cmd/aro-hcp-tests/custom-link-tools/options.go
+++ b/test/cmd/aro-hcp-tests/custom-link-tools/options.go
@@ -435,10 +435,16 @@ func getPerTestMustGatherCommands(timingInfo map[string]timing.TimingInfo, subsc
 			continue
 		}
 		rg := ti.ResourceGroupNames[0]
+		// Prefer the subscription the test actually ran in; fall back to the global
+		// flag when the timing metadata predates per-test subscription capture.
+		testSubscriptionID := ti.SubscriptionID
+		if testSubscriptionID == "" {
+			testSubscriptionID = subscriptionID
+		}
 		cmd := fmt.Sprintf(`hcpctl must-gather query --kusto %s --region %s --timestamp-min '%s' --timestamp-max '%s' --resource-group %s --subscription-id %s`,
 			kusto.KustoName, kusto.KustoRegion,
 			ti.StartTime.Format(time.DateTime), ti.EndTime.Format(time.DateTime),
-			rg, subscriptionID)
+			rg, testSubscriptionID)
 		rows = append(rows, TestCommandRow{
 			TestName: testName,
 			Command:  cmd,

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -1346,6 +1346,7 @@ func (tc *perItOrDescribeTestContext) commitTimingMetadata(ctx context.Context) 
 		tc.recordDeploymentOperationsUnlocked(resourceGroupName, deploymentName, operations)
 	}
 
+	tc.timingMetadata.SubscriptionID = subscriptionID
 	tc.timingMetadata.FinishedAt = time.Now().Format(time.RFC3339)
 	encoded, err := yaml.Marshal(tc.timingMetadata)
 	if err != nil {

--- a/test/util/timing/timewindow.go
+++ b/test/util/timing/timewindow.go
@@ -55,6 +55,7 @@ type TimingInfo struct {
 	TestStartTime      time.Time
 	CleanupStartTime   time.Time
 	ResourceGroupNames []string
+	SubscriptionID     string
 	Steps              []StepTimingMetadata
 }
 
@@ -183,6 +184,7 @@ func LoadTestTimingInfo(ctx context.Context, dir string) (map[string]TimingInfo,
 			TestStartTime:      testStartTime,
 			CleanupStartTime:   finishedAt,
 			ResourceGroupNames: rgNames,
+			SubscriptionID:     tm.SubscriptionID,
 			Steps:              tm.Steps,
 		}
 		return nil

--- a/tooling/hcpctl/cmd/must-gather/cmd.go
+++ b/tooling/hcpctl/cmd/must-gather/cmd.go
@@ -22,6 +22,7 @@ var ServicesLogDirectory = "service"
 var HostedControlPlaneLogDirectory = "hosted-control-plane"
 var CustomLogsDirectory = "custom"
 var InfraLogDirectory = "cluster"
+var OCAdmInspectDirectory = "oc-adm-inspect"
 
 var OptionsOutputFile = "options.json"
 

--- a/tooling/hcpctl/cmd/must-gather/query_cmd.go
+++ b/tooling/hcpctl/cmd/must-gather/query_cmd.go
@@ -16,11 +16,15 @@ package mustgather
 
 import (
 	"context"
+	"errors"
+	"path/filepath"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/kusto"
 	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/mustgather"
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/ocadminspect"
 )
 
 func newQueryCommand() (*cobra.Command, error) {
@@ -64,5 +68,36 @@ func (opts *CompletedQueryOptions) RunQuery(ctx context.Context) error {
 		QueryOptions:               &opts.QueryOptions,
 	}, false)
 
-	return gatherer.GatherLogs(ctx)
+	logger.Info("gathering must-gather logs", "output", opts.OutputPath)
+	gatherErr := gatherer.GatherLogs(ctx)
+
+	// For every HCP cluster discovered in the resource group, oc-adm-inspect the
+	// hosted-cluster namespace (which pulls in the paired control-plane namespace)
+	// on the management cluster that hosts it.
+	var inspectErr error
+	if !opts.SkipOCAdmInspect {
+		inspectErr = opts.runOCAdmInspect(ctx)
+	}
+
+	if err := errors.Join(gatherErr, inspectErr); err != nil {
+		logger.Error(err, "must-gather finished with errors; partial content may have been written", "output", opts.OutputPath)
+		return err
+	}
+	logger.Info("must-gather complete; content written", "output", opts.OutputPath)
+	return nil
+}
+
+// runOCAdmInspect runs the Kusto-backed oc-adm-inspect for every cluster in the
+// resource group, writing under <output>/oc-adm-inspect.
+func (opts *CompletedQueryOptions) runOCAdmInspect(ctx context.Context) error {
+	logger := logr.FromContextOrDiscard(ctx)
+
+	factory, err := kusto.NewQueryFactory()
+	if err != nil {
+		return err
+	}
+	outputPath := filepath.Join(opts.OutputPath, OCAdmInspectDirectory)
+	writer := ocadminspect.NewFilesystemWriter(outputPath)
+	logger.Info("running oc-adm-inspect for clusters in the resource group", "output", outputPath, "clusterIDs", opts.QueryOptions.ClusterIds)
+	return ocadminspect.InspectResourceGroupManagementNamespaces(ctx, opts.QueryClient, factory, opts.QueryOptions, writer, opts.QueryOptions.ClusterIds)
 }

--- a/tooling/hcpctl/cmd/must-gather/query_options.go
+++ b/tooling/hcpctl/cmd/must-gather/query_options.go
@@ -40,6 +40,7 @@ type RawQueryOptions struct {
 	SkipKubernetesEventsLogs   bool     // Skip Kubernetes events logs
 	CollectSystemdLogs         bool     // Collect Systemd logs
 	SkipCustomLogs             bool     // Skip Custom logs
+	SkipOCAdmInspect           bool     // Skip per-cluster oc-adm-inspect of hosted-cluster namespaces
 }
 
 // DefaultQueryOptions returns a new RawQueryOptions struct initialized with sensible defaults.
@@ -64,6 +65,7 @@ func BindQueryOptions(opts *RawQueryOptions, cmd *cobra.Command) error {
 	cmd.Flags().BoolVar(&opts.SkipKubernetesEventsLogs, "skip-kubernetes-events-logs", opts.SkipKubernetesEventsLogs, "Do not gather Kubernetes events logs")
 	cmd.Flags().BoolVar(&opts.CollectSystemdLogs, "collect-systemd-logs", opts.CollectSystemdLogs, "Collect Systemd logs")
 	cmd.Flags().BoolVar(&opts.SkipCustomLogs, "skip-custom-logs", opts.SkipCustomLogs, "Skip Custom logs")
+	cmd.Flags().BoolVar(&opts.SkipOCAdmInspect, "skip-oc-adm-inspect", opts.SkipOCAdmInspect, "Skip per-cluster oc-adm-inspect of hosted-cluster and control-plane namespaces")
 	cmd.MarkFlagsMutuallyExclusive("subscription-id", "resource-id")
 	cmd.MarkFlagsMutuallyExclusive("resource-group", "resource-id")
 

--- a/tooling/hcpctl/cmd/oc-adm-inspect/cmd.go
+++ b/tooling/hcpctl/cmd/oc-adm-inspect/cmd.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ocadminspectcmd provides the `hcpctl oc-adm-inspect` command: a
+// Kusto-backed equivalent of `oc adm inspect` that reconstructs a namespace's
+// resources, events, and pod logs at a past point in time.
+package ocadminspectcmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/ocadminspect"
+)
+
+// NewCommand builds the oc-adm-inspect command.
+func NewCommand(group string) (*cobra.Command, error) {
+	opts := DefaultOptions()
+	cmd := &cobra.Command{
+		Use:     "oc-adm-inspect [ns/<name> ...]",
+		Short:   "Reconstruct namespace state, events, and pod logs at a point in time from Kusto",
+		GroupID: group,
+		Long: `oc-adm-inspect is a Kusto-backed equivalent of "oc adm inspect".
+
+Given a management or service cluster, one or more namespaces, and a time window
+(--timestamp-min/--timestamp-max, matching must-gather), it reconstructs from
+telemetry, as of --timestamp-max:
+  - the state of every resource in the namespace (kubernetesResourceSnapshots),
+    excluding resources that were actually deleted by then (a Delete event, or a
+    deletionTimestamp past its grace period),
+  - the namespace's Kubernetes events in the window (kubernetesEvents), and
+  - the container logs for the namespace's pods in the window (containerLogs).
+
+Namespaces like kube-system require specifying the cluster. When inspecting a
+hosted-cluster namespace the paired control-plane namespace is added automatically,
+and vice versa. If no cluster is given, the clusters active in the window are
+listed so you can pick one.`,
+		Example: `  hcpctl oc-adm-inspect -n kube-system --management-cluster mgmt-1 --timestamp-min "2026-08-31 11:00:00" --timestamp-max "2026-08-31 12:00:00" --kusto hcp-stg-uk-2 --region uksouth
+  hcpctl oc-adm-inspect ns/ocm-arohcpstg-2abc --management-cluster mgmt-1 --timestamp-min "2026-08-31 11:00:00" --timestamp-max "2026-08-31 12:00:00" --kusto hcp-stg-uk-2 --region uksouth`,
+		Args:             cobra.ArbitraryArgs,
+		SilenceUsage:     true,
+		SilenceErrors:    true,
+		TraverseChildren: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return opts.Run(cmd.Context(), args)
+		},
+	}
+	if err := BindOptions(opts, cmd); err != nil {
+		return nil, err
+	}
+	return cmd, nil
+}
+
+// Inspect runs the discovery-or-inspect flow against the completed options.
+func (o *CompletedOptions) Inspect(ctx context.Context) error {
+	logger := logr.FromContextOrDiscard(ctx)
+	defer func() {
+		if err := o.kustoClient.Close(); err != nil {
+			logger.Error(err, "failed to close Kusto client")
+		}
+	}()
+
+	// No cluster specified: discover which clusters were active and tell the user.
+	if o.ClusterName == "" {
+		clusters, err := ocadminspect.DiscoverActiveClusters(ctx, o.kustoClient, o.factory, o.baseOptions)
+		if err != nil {
+			return fmt.Errorf("no --management-cluster/--service-cluster given and failed to discover active clusters: %w", err)
+		}
+		return fmt.Errorf("no --management-cluster or --service-cluster specified\n\n%s", clusterOptionsMessage(clusters, o.TimestampMax))
+	}
+
+	inspector := ocadminspect.NewInspector(o.kustoClient, o.factory, o.baseOptions, o.ClusterName, o.writer)
+
+	namespaces, err := inspector.ExpandWithPairedNamespaces(ctx, o.Namespaces)
+	if err != nil {
+		return fmt.Errorf("failed to pair hosted-cluster/control-plane namespaces: %w", err)
+	}
+
+	logger.Info("inspecting namespaces",
+		"cluster", o.ClusterName,
+		"namespaces", strings.Join(namespaces, ","),
+		"timestamp", o.TimestampMax.Format(time.RFC3339),
+		"output", o.OutputPath,
+	)
+	if err := inspector.InspectNamespaces(ctx, namespaces); err != nil {
+		return err
+	}
+	logger.Info("wrote inspect output", "path", o.OutputPath)
+	return nil
+}
+
+// clusterOptionsMessage renders the discovered clusters, split into management and
+// service clusters, so the user can re-run with the right flag.
+func clusterOptionsMessage(clusters []string, timestamp time.Time) string {
+	if len(clusters) == 0 {
+		return fmt.Sprintf("no clusters were active around %s; widen the --timestamp-min/--timestamp-max window", timestamp.Format(time.RFC3339))
+	}
+	var management, service []string
+	for _, cluster := range clusters {
+		if ocadminspect.IsManagementCluster(cluster) {
+			management = append(management, cluster)
+		} else {
+			service = append(service, cluster)
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "clusters active around %s:\n", timestamp.Format(time.RFC3339))
+	if len(management) > 0 {
+		b.WriteString("\n  management clusters (pass --management-cluster <name>):\n")
+		for _, cluster := range management {
+			fmt.Fprintf(&b, "    %s\n", cluster)
+		}
+	}
+	if len(service) > 0 {
+		b.WriteString("\n  service clusters (pass --service-cluster <name>):\n")
+		for _, cluster := range service {
+			fmt.Fprintf(&b, "    %s\n", cluster)
+		}
+	}
+	return b.String()
+}

--- a/tooling/hcpctl/cmd/oc-adm-inspect/options.go
+++ b/tooling/hcpctl/cmd/oc-adm-inspect/options.go
@@ -1,0 +1,219 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocadminspectcmd
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/kusto"
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/ocadminspect"
+)
+
+// namespacePattern matches a valid Kubernetes namespace name (an RFC 1123 label:
+// lowercase alphanumerics and '-', starting and ending alphanumeric, up to 63
+// chars). It rejects path separators and traversal (e.g. "../"), so a namespace
+// is safe to use as an on-disk path segment.
+var namespacePattern = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$`)
+
+// RawOptions is the unvalidated CLI configuration for oc-adm-inspect.
+type RawOptions struct {
+	Kusto             string
+	Region            string
+	SubscriptionID    string
+	ResourceGroup     string
+	Namespaces        []string
+	TimestampMin      time.Time
+	TimestampMax      time.Time
+	ManagementCluster string
+	ServiceCluster    string
+	OutputPath        string
+	QueryTimeout      time.Duration
+	Limit             int
+}
+
+// DefaultOptions returns RawOptions with sensible defaults. The time-window
+// defaults mirror must-gather (last 24h).
+func DefaultOptions() *RawOptions {
+	return &RawOptions{
+		TimestampMin: time.Now().Add(-24 * time.Hour),
+		TimestampMax: time.Now(),
+		QueryTimeout: 5 * time.Minute,
+		Limit:        -1,
+		OutputPath:   fmt.Sprintf("oc-adm-inspect-%s", time.Now().Format("20060102-150405")),
+	}
+}
+
+// BindOptions wires the cobra flags. The time-window flags match must-gather
+// exactly (--timestamp-min / --timestamp-max, "YYYY-MM-DD HH:MM:SS" layout).
+func BindOptions(opts *RawOptions, cmd *cobra.Command) error {
+	cmd.Flags().StringVar(&opts.Kusto, "kusto", opts.Kusto, "Azure Data Explorer cluster name (required)")
+	cmd.Flags().StringVar(&opts.Region, "region", opts.Region, "Azure Data Explorer cluster region (required)")
+	cmd.Flags().StringVar(&opts.SubscriptionID, "subscription-id", opts.SubscriptionID, "subscription ID (optional, recorded for context)")
+	cmd.Flags().StringVar(&opts.ResourceGroup, "resource-group", opts.ResourceGroup, "resource group (optional, recorded for context)")
+	cmd.Flags().StringArrayVarP(&opts.Namespaces, "namespace", "n", opts.Namespaces, "namespace to inspect (repeatable; also accepts positional ns/<name> args)")
+	cmd.Flags().TimeVar(&opts.TimestampMin, "timestamp-min", opts.TimestampMin, []string{time.DateTime}, "start of the window to search for the latest resource snapshots and logs")
+	cmd.Flags().TimeVar(&opts.TimestampMax, "timestamp-max", opts.TimestampMax, []string{time.DateTime}, "point in time to reconstruct state at (also the end of the search window)")
+	cmd.Flags().StringVar(&opts.ManagementCluster, "management-cluster", opts.ManagementCluster, "management cluster to inspect (the telemetry 'cluster' name)")
+	cmd.Flags().StringVar(&opts.ServiceCluster, "service-cluster", opts.ServiceCluster, "service cluster to inspect (the telemetry 'cluster' name)")
+	cmd.Flags().StringVar(&opts.OutputPath, "output-path", opts.OutputPath, "path to write the gathered data")
+	cmd.Flags().DurationVar(&opts.QueryTimeout, "query-timeout", opts.QueryTimeout, "timeout for query execution")
+	cmd.Flags().IntVar(&opts.Limit, "limit", opts.Limit, "limit the number of rows per query (-1 for no limit)")
+
+	cmd.MarkFlagsMutuallyExclusive("management-cluster", "service-cluster")
+	for _, flag := range []string{"kusto", "region"} {
+		if err := cmd.MarkFlagRequired(flag); err != nil {
+			return fmt.Errorf("failed to mark %s as required: %w", flag, err)
+		}
+	}
+	return nil
+}
+
+// ValidatedOptions is a RawOptions that passed validation.
+type ValidatedOptions struct {
+	*RawOptions
+
+	KustoEndpoint *url.URL
+	Namespaces    []string
+	ClusterName   string // empty when neither management- nor service-cluster was given
+}
+
+// Validate checks the inputs and normalizes namespaces. The reconstruction time
+// is TimestampMax; TimestampMin is the lookback floor for snapshots and logs.
+func (o *RawOptions) Validate(ctx context.Context, args []string) (*ValidatedOptions, error) {
+	if o.Kusto == "" {
+		return nil, fmt.Errorf("--kusto is required")
+	}
+	if o.Region == "" {
+		return nil, fmt.Errorf("--region is required")
+	}
+	kustoEndpoint, err := kusto.KustoEndpoint(o.Kusto, o.Region)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kusto endpoint: %w", err)
+	}
+
+	if o.QueryTimeout < 30*time.Second {
+		return nil, fmt.Errorf("--query-timeout must be at least 30 seconds")
+	}
+	if o.QueryTimeout > 30*time.Minute {
+		return nil, fmt.Errorf("--query-timeout cannot exceed 30 minutes")
+	}
+	if o.TimestampMin.After(o.TimestampMax) {
+		return nil, fmt.Errorf("--timestamp-min cannot be after --timestamp-max")
+	}
+
+	namespaces := normalizeNamespaces(append(append([]string{}, o.Namespaces...), args...))
+	if len(namespaces) == 0 {
+		return nil, fmt.Errorf("at least one namespace is required (use --namespace or a positional ns/<name> argument)")
+	}
+	for _, namespace := range namespaces {
+		if !namespacePattern.MatchString(namespace) {
+			return nil, fmt.Errorf("invalid namespace %q: must be a valid Kubernetes namespace name (RFC 1123 label; this also rejects path separators and traversal)", namespace)
+		}
+	}
+
+	clusterName := o.ManagementCluster
+	if clusterName == "" {
+		clusterName = o.ServiceCluster
+	}
+
+	return &ValidatedOptions{
+		RawOptions:    o,
+		KustoEndpoint: kustoEndpoint,
+		Namespaces:    namespaces,
+		ClusterName:   clusterName,
+	}, nil
+}
+
+// CompletedOptions is fully initialized and ready to run.
+type CompletedOptions struct {
+	*ValidatedOptions
+
+	kustoClient *kusto.Client
+	factory     *kusto.QueryFactory
+	baseOptions kusto.QueryOptions
+	writer      ocadminspect.Writer
+}
+
+// Complete builds the Kusto client, query factory, base query options, and writer.
+func (o *ValidatedOptions) Complete(ctx context.Context) (*CompletedOptions, error) {
+	kustoClient, err := kusto.NewClient(o.KustoEndpoint, o.QueryTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kusto client: %w", err)
+	}
+	factory, err := kusto.NewQueryFactory()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create query factory: %w", err)
+	}
+
+	baseOptions := kusto.NewQueryOptions()
+	baseOptions.SubscriptionId = o.SubscriptionID
+	baseOptions.ResourceGroupName = o.ResourceGroup
+	baseOptions.TimestampMin = o.TimestampMin
+	baseOptions.TimestampMax = o.TimestampMax
+	baseOptions.Limit = o.Limit
+
+	return &CompletedOptions{
+		ValidatedOptions: o,
+		kustoClient:      kustoClient,
+		factory:          factory,
+		baseOptions:      baseOptions,
+		writer:           ocadminspect.NewFilesystemWriter(o.OutputPath),
+	}, nil
+}
+
+// Run is the RunE entry point: Validate -> Complete -> Inspect.
+func (o *RawOptions) Run(ctx context.Context, args []string) error {
+	validated, err := o.Validate(ctx, args)
+	if err != nil {
+		return err
+	}
+	completed, err := validated.Complete(ctx)
+	if err != nil {
+		return err
+	}
+	return completed.Inspect(ctx)
+}
+
+// normalizeNamespaces strips ns/ and namespace/ prefixes, trims, and de-duplicates
+// while preserving order.
+func normalizeNamespaces(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		name := strings.TrimSpace(value)
+		for _, prefix := range []string{"namespace/", "ns/"} {
+			if strings.HasPrefix(name, prefix) {
+				name = strings.TrimPrefix(name, prefix)
+				break
+			}
+		}
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out
+}

--- a/tooling/hcpctl/cmd/oc-adm-inspect/options_test.go
+++ b/tooling/hcpctl/cmd/oc-adm-inspect/options_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocadminspectcmd
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestNormalizeNamespaces(t *testing.T) {
+	got := normalizeNamespaces([]string{"kube-system", "ns/ocm-stg-abc", "namespace/foo", " bar ", "kube-system", ""})
+	want := []string{"kube-system", "ocm-stg-abc", "foo", "bar"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("normalizeNamespaces = %v, want %v", got, want)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	ctx := context.Background()
+	min := time.Date(2026, 9, 1, 18, 31, 35, 0, time.UTC)
+	max := time.Date(2026, 9, 1, 19, 37, 9, 0, time.UTC)
+
+	base := func() *RawOptions {
+		o := DefaultOptions()
+		o.Kusto = "hcp-dev-us-2"
+		o.Region = "eastus2"
+		o.TimestampMin = min
+		o.TimestampMax = max
+		return o
+	}
+
+	t.Run("missing namespace errors", func(t *testing.T) {
+		if _, err := base().Validate(ctx, nil); err == nil {
+			t.Errorf("expected error when no namespace is given")
+		}
+	})
+
+	t.Run("missing cluster is allowed (deferred to discovery)", func(t *testing.T) {
+		o := base()
+		o.Namespaces = []string{"kube-system"}
+		v, err := o.Validate(ctx, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v.ClusterName != "" {
+			t.Errorf("expected empty ClusterName, got %q", v.ClusterName)
+		}
+	})
+
+	t.Run("timestamp-min after timestamp-max errors", func(t *testing.T) {
+		o := base()
+		o.Namespaces = []string{"kube-system"}
+		o.TimestampMin = max
+		o.TimestampMax = min
+		if _, err := o.Validate(ctx, nil); err == nil {
+			t.Errorf("expected error when timestamp-min is after timestamp-max")
+		}
+	})
+
+	t.Run("cluster and window pass through", func(t *testing.T) {
+		o := base()
+		o.Namespaces = []string{"kube-system"}
+		o.ManagementCluster = "aro-hcp-mgmt-1"
+		v, err := o.Validate(ctx, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if v.ClusterName != "aro-hcp-mgmt-1" {
+			t.Errorf("ClusterName = %q, want aro-hcp-mgmt-1", v.ClusterName)
+		}
+		if !v.TimestampMax.Equal(max) || !v.TimestampMin.Equal(min) {
+			t.Errorf("window = [%v..%v], want [%v..%v]", v.TimestampMin, v.TimestampMax, min, max)
+		}
+	})
+
+	t.Run("rejects path-traversal / invalid namespaces", func(t *testing.T) {
+		for _, ns := range []string{"../etc", "a/b", "..", "Kube-System"} {
+			o := base()
+			o.Namespaces = []string{ns}
+			if _, err := o.Validate(ctx, nil); err == nil {
+				t.Errorf("expected error for invalid namespace %q", ns)
+			}
+		}
+	})
+
+	t.Run("positional args are treated as namespaces", func(t *testing.T) {
+		o := base()
+		v, err := o.Validate(ctx, []string{"ns/ocm-stg-abc"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(v.Namespaces, []string{"ocm-stg-abc"}) {
+			t.Errorf("Namespaces = %v, want [ocm-stg-abc]", v.Namespaces)
+		}
+	})
+}

--- a/tooling/hcpctl/main.go
+++ b/tooling/hcpctl/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Azure/ARO-HCP/tooling/hcpctl/cmd/kubelogin"
 	"github.com/Azure/ARO-HCP/tooling/hcpctl/cmd/mc"
 	mustgather "github.com/Azure/ARO-HCP/tooling/hcpctl/cmd/must-gather"
+	ocadminspectcmd "github.com/Azure/ARO-HCP/tooling/hcpctl/cmd/oc-adm-inspect"
 	"github.com/Azure/ARO-HCP/tooling/hcpctl/cmd/sc"
 	"github.com/Azure/ARO-HCP/tooling/hcpctl/cmd/snapshot"
 	"github.com/Azure/ARO-HCP/tooling/hcpctl/cmd/version"
@@ -95,6 +96,7 @@ and hosted control plane services for operational and emergency scenarios.`,
 		sc.NewCommand,
 		hcp.NewCommand,
 		mustgather.NewCommand,
+		ocadminspectcmd.NewCommand,
 		datadumptogit.NewCommand,
 		snapshot.NewCommand,
 	}

--- a/tooling/hcpctl/pkg/kusto/query.go
+++ b/tooling/hcpctl/pkg/kusto/query.go
@@ -138,8 +138,13 @@ type TemplateData struct {
 	ClusterIds         string
 	FilterClusterName  string
 	HCPNamespacePrefix string
-	SplitByPod         bool
-	OrderBy            string
+	// Namespace is the Kubernetes namespace to scope a query to (e.g. an
+	// oc-adm-inspect resource/event/log query). Single quotes are escaped for safe
+	// embedding inside a single-quoted KQL string literal; the template supplies
+	// the surrounding quotes (e.g. '{{.Namespace}}').
+	Namespace  string
+	SplitByPod bool
+	OrderBy    string
 }
 
 type TemplateDataOptions func(*TemplateData)
@@ -177,6 +182,12 @@ func WithHCPNamespacePrefix(hcpNamespacePrefix string) TemplateDataOptions {
 func WithClusterName(clusterName string) TemplateDataOptions {
 	return func(d *TemplateData) {
 		d.ClusterName = kqlEscStr(clusterName)
+	}
+}
+
+func WithNamespace(namespace string) TemplateDataOptions {
+	return func(d *TemplateData) {
+		d.Namespace = kqlEscStr(namespace)
 	}
 }
 

--- a/tooling/hcpctl/pkg/kusto/query_definitions.go
+++ b/tooling/hcpctl/pkg/kusto/query_definitions.go
@@ -35,10 +35,13 @@ type QueryChild struct {
 type QueryType string
 
 const (
-	QueryTypeServices           QueryType = "services"
-	QueryTypeHostedControlPlane QueryType = "hosted-control-plane"
-	QueryTypeInternal           QueryType = "must-gather-internal"
-	QueryTypeKubernetesEvents   QueryType = "kubernetes-events"
-	QueryTypeSystemdLogs        QueryType = "systemd-logs"
-	QueryTypeCustomLogs         QueryType = "custom-logs"
+	QueryTypeServices             QueryType = "services"
+	QueryTypeHostedControlPlane   QueryType = "hosted-control-plane"
+	QueryTypeInternal             QueryType = "must-gather-internal"
+	QueryTypeKubernetesEvents     QueryType = "kubernetes-events"
+	QueryTypeSystemdLogs          QueryType = "systemd-logs"
+	QueryTypeCustomLogs           QueryType = "custom-logs"
+	QueryTypeOCAdmInspectResource QueryType = "oc-adm-inspect-resource"
+	QueryTypeOCAdmInspectEvents   QueryType = "oc-adm-inspect-events"
+	QueryTypeOCAdmInspectLogs     QueryType = "oc-adm-inspect-logs"
 )

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/active_clusters.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/active_clusters.kql.gotmpl
@@ -1,0 +1,15 @@
+{{- /*
+Lists the distinct cluster names seen in backend logs for the resource group in
+the lookback window ending at the requested timestamp. backendLogs.cluster_name is
+mapped from the backend's hcp_cluster_name log field. resource_group is matched
+case-insensitively (=~) because the forwarder may upper-case it. Used to tell the
+user which clusters are available when they did not specify one.
+*/ -}}
+backendLogs
+| where timestamp between ({{ .TimestampMin }} .. {{ .TimestampMax }})
+{{- if .ResourceGroupName}}
+| where resource_group =~ '{{.ResourceGroupName}}'
+{{- end}}
+| where isnotempty(cluster_name)
+| distinct cluster_name
+| order by cluster_name asc

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/container_logs.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/container_logs.kql.gotmpl
@@ -1,0 +1,17 @@
+{{- /*
+Container logs for every pod in a namespace on the management/service cluster,
+from the lookback floor up to the requested timestamp (TimestampMax). Ordered so
+each pod/container's lines can be written in chronological order, mirroring the
+current.log files oc adm inspect writes per container.
+*/ -}}
+{{- if .NoTruncation}}set notruncation;
+{{end -}}
+containerLogs
+| where timestamp between ({{ .TimestampMin }} .. {{ .TimestampMax }})
+| where cluster == '{{.ClusterName}}'
+| where namespace_name == '{{.Namespace}}'
+| project timestamp, log, cluster, namespace_name, container_name, pod_name
+| order by pod_name asc, container_name asc, timestamp asc
+{{- if gt .Limit 0}}
+| limit {{.Limit}}
+{{- end}}

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/container_logs_hcp.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/container_logs_hcp.kql.gotmpl
@@ -1,0 +1,20 @@
+{{- /*
+Container logs for a namespace from the HostedControlPlaneLogs database, where the
+per-cluster hosted control plane pod logs (kube-apiserver, etcd,
+control-plane-operator, etc.) live. Unlike the ServiceLogs container logs, these
+are NOT filtered by the management cluster's `cluster` column — that column does
+not carry the management cluster name here — so the control-plane namespace name
+(globally unique, it embeds the cluster id) is the scope. Paired with the
+ServiceLogs container logs so a namespace's pod logs are captured wherever the
+forwarder routed them.
+*/ -}}
+{{- if .NoTruncation}}set notruncation;
+{{end -}}
+containerLogs
+| where timestamp between ({{ .TimestampMin }} .. {{ .TimestampMax }})
+| where namespace_name == '{{.Namespace}}'
+| project timestamp, log, cluster, namespace_name, container_name, pod_name
+| order by pod_name asc, container_name asc, timestamp asc
+{{- if gt .Limit 0}}
+| limit {{.Limit}}
+{{- end}}

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/events.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/events.kql.gotmpl
@@ -1,0 +1,16 @@
+{{- /*
+Kubernetes API events for a namespace on the management/service cluster, up to
+the requested timestamp. Mirrors the events oc adm inspect writes under
+namespaces/<ns>/core/events.yaml.
+*/ -}}
+{{- if .NoTruncation}}set notruncation;
+{{end -}}
+kubernetesEvents
+| where timestamp between ({{ .TimestampMin }} .. {{ .TimestampMax }})
+| where cluster == '{{.ClusterName}}'
+| where eventNamespace == '{{.Namespace}}'
+| project timestamp, firstSeen, lastSeen, count, kubeEventType, reason, objectKind, objectApiVersion, objectName, sourceComponent, message
+| order by timestamp {{.OrderBy}}
+{{- if gt .Limit 0}}
+| limit {{.Limit}}
+{{- end}}

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/namespaces.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/namespaces.kql.gotmpl
@@ -1,0 +1,18 @@
+{{- /*
+Distinct namespaces present on a management cluster within the window. When
+cluster ids are supplied, restricts to namespaces that embed one of them: both a
+hosted-cluster namespace (ocm-<env>-<cid>) and its control-plane namespace
+(ocm-<env>-<cid>-<name>) contain the cluster id, so this finds all namespaces
+belonging to those clusters without querying HostedCluster objects. Without
+cluster ids it lists every namespace on the cluster (used to pair a requested
+namespace with its hosted/control-plane counterpart).
+*/ -}}
+kubernetesResourceSnapshots
+| where timestamp between ({{ .TimestampMin }} .. {{ .TimestampMax }})
+| where cluster == '{{.ClusterName}}'
+| where isnotempty(namespace)
+{{- if .ClusterIds}}
+| where namespace has_any ({{.ClusterIds}})
+{{- end}}
+| distinct namespace
+| order by namespace asc

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/resource_snapshots.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/resource_snapshots.kql.gotmpl
@@ -1,0 +1,26 @@
+{{- /*
+Reconstructs the state of every resource in a namespace as of the requested
+timestamp (TimestampMax) from the management cluster's resource snapshots. For
+each object (identified by apiVersion/kind/namespace/name/uid) it keeps the most
+recent snapshot at or before the timestamp, then drops objects that were actually
+deleted by then: either the latest event was a Delete, or the object carried a
+deletionTimestamp whose graceful-deletion deadline (deletionTimestamp +
+deletionGracePeriodSeconds) had already elapsed. Objects mid-termination whose
+grace period has not yet expired are kept, because they still existed.
+*/ -}}
+{{- if .NoTruncation}}set notruncation;
+{{end -}}
+kubernetesResourceSnapshots
+| where timestamp between ({{ .TimestampMin }} .. {{ .TimestampMax }})
+| where cluster == '{{.ClusterName}}'
+| where namespace == '{{.Namespace}}' or (objectKind == 'Namespace' and name == '{{.Namespace}}')
+| summarize arg_max(timestamp, event, object) by apiVersion, objectKind, namespace, name, uid
+| where event != 'Delete'
+| extend deletionTimestamp = todatetime(object.metadata.deletionTimestamp)
+| extend gracePeriodSeconds = coalesce(tolong(object.metadata.deletionGracePeriodSeconds), 0)
+| where isnull(deletionTimestamp) or datetime_add('second', gracePeriodSeconds, deletionTimestamp) > {{ .TimestampMax }}
+| project timestamp, apiVersion, objectKind, namespace, name, uid, object
+| order by objectKind asc, name asc
+{{- if gt .Limit 0}}
+| limit {{.Limit}}
+{{- end}}

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/queries.yaml
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/queries.yaml
@@ -2,6 +2,30 @@
   queryType: kubernetes-events
   database: ServiceLogs
   templatePath: templates/builtin/infra/kubernetes_events.kql.gotmpl
+- name: ocAdmInspectResources
+  queryType: oc-adm-inspect-resource
+  database: ServiceLogs
+  templatePath: templates/builtin/oc-adm-inspect/resource_snapshots.kql.gotmpl
+- name: ocAdmInspectEvents
+  queryType: oc-adm-inspect-events
+  database: ServiceLogs
+  templatePath: templates/builtin/oc-adm-inspect/events.kql.gotmpl
+- name: ocAdmInspectContainerLogs
+  queryType: oc-adm-inspect-logs
+  database: ServiceLogs
+  templatePath: templates/builtin/oc-adm-inspect/container_logs.kql.gotmpl
+- name: ocAdmInspectHostedControlPlaneLogs
+  queryType: oc-adm-inspect-logs
+  database: HostedControlPlaneLogs
+  templatePath: templates/builtin/oc-adm-inspect/container_logs_hcp.kql.gotmpl
+- name: ocAdmInspectActiveClusters
+  queryType: must-gather-internal
+  database: ServiceLogs
+  templatePath: templates/builtin/oc-adm-inspect/active_clusters.kql.gotmpl
+- name: ocAdmInspectNamespaces
+  queryType: must-gather-internal
+  database: ServiceLogs
+  templatePath: templates/builtin/oc-adm-inspect/namespaces.kql.gotmpl
 - name: systemdLogs
   queryType: systemd-logs
   database: ServiceLogs

--- a/tooling/hcpctl/pkg/ocadminspect/inspect.go
+++ b/tooling/hcpctl/pkg/ocadminspect/inspect.go
@@ -1,0 +1,536 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ocadminspect implements a Kusto-backed equivalent of `oc adm inspect`:
+// given a management/service cluster, a namespace, and a point in time, it
+// reconstructs the state of every resource in that namespace (from
+// kubernetesResourceSnapshots), the namespace's Kubernetes events (from
+// kubernetesEvents), and the container logs for the namespace's pods up to that
+// time (from containerLogs), writing them to disk in an oc-adm-inspect-style
+// layout. Unlike `oc adm inspect`, it queries historical telemetry rather than a
+// live cluster, so it can inspect a namespace as it existed at a past timestamp.
+package ocadminspect
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/kusto"
+)
+
+// Builtin query definition names (registered in pkg/kusto/templates/builtin/queries.yaml).
+const (
+	resourcesQueryName      = "ocAdmInspectResources"
+	eventsQueryName         = "ocAdmInspectEvents"
+	activeClustersQueryName = "ocAdmInspectActiveClusters"
+	namespacesQueryName     = "ocAdmInspectNamespaces"
+)
+
+// containerLogSourceQueries are the container-log queries run per namespace, one
+// per database: pods in management-cluster namespaces log to ServiceLogs, while
+// hosted control plane pods log to HostedControlPlaneLogs. Both are queried and
+// merged so a namespace's logs are captured wherever the forwarder routed them.
+var containerLogSourceQueries = []string{
+	"ocAdmInspectContainerLogs",          // ServiceLogs
+	"ocAdmInspectHostedControlPlaneLogs", // HostedControlPlaneLogs
+}
+
+// ManagementClusterNameMarker is the substring that distinguishes a management
+// cluster name from a service cluster name in the `cluster` telemetry column.
+const ManagementClusterNameMarker = "mgmt"
+
+// QueryExecutor is the subset of the Kusto query client the inspector needs. It
+// is satisfied by *mustgather.QueryClient.
+type QueryExecutor interface {
+	ExecutePreconfiguredQuery(ctx context.Context, query kusto.Query, outputChannel chan<- kusto.TaggedRow) (*kusto.QueryResult, error)
+}
+
+// Resource is a single Kubernetes object reconstructed as of the requested time.
+type Resource struct {
+	APIVersion string
+	Kind       string
+	Namespace  string
+	Name       string
+	// Object is the full Kubernetes object as stored in the snapshot.
+	Object map[string]any
+}
+
+// LogLine is one container log line with its Kusto timestamp.
+type LogLine struct {
+	Timestamp string
+	// Log is the log payload (typically a map with a "log" string, matching the
+	// containerLogs projection).
+	Log any
+}
+
+// Writer persists what the inspector gathers for a namespace. Implementations
+// choose the on-disk layout.
+type Writer interface {
+	// WriteResources writes all resources gathered for a namespace.
+	WriteResources(ctx context.Context, namespace string, resources []Resource) error
+	// WriteEvents writes the namespace's Kubernetes events (each event is a
+	// column->value map from the events query).
+	WriteEvents(ctx context.Context, namespace string, events []map[string]any) error
+	// WriteContainerLog writes the log lines for a single pod container.
+	WriteContainerLog(ctx context.Context, namespace, pod, container string, lines []LogLine) error
+	// NamespaceOutputPath returns a human-readable location (e.g. a directory
+	// path) where the namespace's content is written, for logging. It may be
+	// empty for writers that have no such location.
+	NamespaceOutputPath(namespace string) string
+}
+
+// Inspector gathers namespace state from Kusto for a single management/service
+// (infra) cluster at a fixed time window.
+type Inspector struct {
+	exec        QueryExecutor
+	factory     *kusto.QueryFactory
+	baseOptions kusto.QueryOptions
+	clusterName string
+	writer      Writer
+}
+
+// NewInspector builds an Inspector. clusterName is the infra (management or
+// service) cluster name that appears in the telemetry `cluster` column;
+// baseOptions supplies the time window (TimestampMin/Max) and Limit.
+func NewInspector(exec QueryExecutor, factory *kusto.QueryFactory, baseOptions kusto.QueryOptions, clusterName string, writer Writer) *Inspector {
+	return &Inspector{
+		exec:        exec,
+		factory:     factory,
+		baseOptions: baseOptions,
+		clusterName: clusterName,
+		writer:      writer,
+	}
+}
+
+// InspectNamespaces gathers and writes the state, events, and container logs for
+// each namespace. Failures for one namespace do not abort the others; the joined
+// error is returned at the end.
+func (i *Inspector) InspectNamespaces(ctx context.Context, namespaces []string) error {
+	logger := logr.FromContextOrDiscard(ctx)
+	var errs []error
+	for _, namespace := range namespaces {
+		logger.Info("running oc-adm-inspect for namespace",
+			"cluster", i.clusterName,
+			"namespace", namespace,
+			"output", i.writer.NamespaceOutputPath(namespace),
+		)
+		if err := i.inspectResources(ctx, namespace); err != nil {
+			errs = append(errs, fmt.Errorf("failed to inspect resources in %q: %w", namespace, err))
+		}
+		if err := i.inspectEvents(ctx, namespace); err != nil {
+			errs = append(errs, fmt.Errorf("failed to inspect events in %q: %w", namespace, err))
+		}
+		if err := i.inspectContainerLogs(ctx, namespace); err != nil {
+			errs = append(errs, fmt.Errorf("failed to inspect container logs in %q: %w", namespace, err))
+		}
+	}
+	return joinErrors(errs)
+}
+
+func (i *Inspector) inspectResources(ctx context.Context, namespace string) error {
+	rows, err := i.runNamespaceQuery(ctx, resourcesQueryName, namespace)
+	if err != nil {
+		return err
+	}
+	resources := make([]Resource, 0, len(rows))
+	for _, row := range rows {
+		object, _ := row["object"].(map[string]any)
+		resources = append(resources, Resource{
+			APIVersion: asString(row["apiVersion"]),
+			Kind:       asString(row["objectKind"]),
+			Namespace:  asString(row["namespace"]),
+			Name:       asString(row["name"]),
+			Object:     object,
+		})
+	}
+	return i.writer.WriteResources(ctx, namespace, resources)
+}
+
+func (i *Inspector) inspectEvents(ctx context.Context, namespace string) error {
+	rows, err := i.runNamespaceQuery(ctx, eventsQueryName, namespace)
+	if err != nil {
+		return err
+	}
+	return i.writer.WriteEvents(ctx, namespace, rows)
+}
+
+func (i *Inspector) inspectContainerLogs(ctx context.Context, namespace string) error {
+	type podContainer struct{ pod, container string }
+	byContainer := make(map[podContainer][]LogLine)
+
+	var errs []error
+	// Query every container-log source (ServiceLogs + HostedControlPlaneLogs) and
+	// merge, so control-plane pod logs are captured alongside management-cluster
+	// namespace logs.
+	for _, defName := range containerLogSourceQueries {
+		rows, err := i.runNamespaceQuery(ctx, defName, namespace)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to query container logs (%s): %w", defName, err))
+			continue
+		}
+		for _, row := range rows {
+			key := podContainer{pod: asString(row["pod_name"]), container: asString(row["container_name"])}
+			byContainer[key] = append(byContainer[key], LogLine{
+				Timestamp: asString(row["timestamp"]),
+				Log:       row["log"],
+			})
+		}
+	}
+
+	// Write deterministically: pods/containers in sorted order, each container's
+	// lines re-sorted by timestamp since they may come from two merged sources.
+	keys := make([]podContainer, 0, len(byContainer))
+	for key := range byContainer {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(a, b int) bool {
+		if keys[a].pod != keys[b].pod {
+			return keys[a].pod < keys[b].pod
+		}
+		return keys[a].container < keys[b].container
+	})
+	for _, key := range keys {
+		lines := byContainer[key]
+		sort.SliceStable(lines, func(a, b int) bool { return lines[a].Timestamp < lines[b].Timestamp })
+		if err := i.writer.WriteContainerLog(ctx, namespace, key.pod, key.container, lines); err != nil {
+			errs = append(errs, fmt.Errorf("failed to write logs for pod %q container %q: %w", key.pod, key.container, err))
+		}
+	}
+	return joinErrors(errs)
+}
+
+// ExpandWithPairedNamespaces returns the requested namespaces plus, for any that
+// is a hosted-cluster namespace or a control-plane namespace on this cluster, its
+// paired counterpart. It discovers the cluster's namespaces and pairs them by the
+// hosted/control-plane prefix relationship (control-plane = <hostedNamespace>-<name>).
+// Ordering is deterministic (sorted) and duplicates removed.
+func (i *Inspector) ExpandWithPairedNamespaces(ctx context.Context, requested []string) ([]string, error) {
+	clusterNamespaces, err := i.DiscoverNamespaces(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return pairNamespaces(requested, clusterNamespaces), nil
+}
+
+// hostedClusterNamespacePrefix is the prefix of hosted-cluster and control-plane
+// namespaces (ocm-<env>-<cid>[-<name>]). Pairing is restricted to namespaces with
+// this prefix so unrelated namespaces that merely share a name prefix (e.g.
+// "kube-system" and "kube-system-x") are never paired.
+const hostedClusterNamespacePrefix = "ocm-"
+
+// pairNamespaces returns the requested namespaces plus, for any that is a
+// hosted-cluster namespace or a control-plane namespace among clusterNamespaces,
+// its counterpart. A control-plane namespace is <hostedNamespace>-<name>, so the
+// two are paired when one is the other with a trailing "-<suffix>". Only namespaces
+// with the hosted-cluster prefix are considered, so unrelated namespaces that share
+// a name prefix are not falsely paired. Deterministic, de-duplicated. Pure function.
+func pairNamespaces(requested, clusterNamespaces []string) []string {
+	set := make(map[string]struct{}, len(requested))
+	for _, ns := range requested {
+		set[ns] = struct{}{}
+	}
+	for _, ns := range requested {
+		if !strings.HasPrefix(ns, hostedClusterNamespacePrefix) {
+			continue
+		}
+		for _, other := range clusterNamespaces {
+			if other == "" || other == ns || !strings.HasPrefix(other, hostedClusterNamespacePrefix) {
+				continue
+			}
+			// other is ns's control-plane namespace, or ns is other's.
+			if strings.HasPrefix(other, ns+"-") || strings.HasPrefix(ns, other+"-") {
+				set[other] = struct{}{}
+			}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for ns := range set {
+		if ns != "" {
+			out = append(out, ns)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// DiscoverNamespaces returns the distinct namespaces on this cluster in the time
+// window. When clusterIDs is non-empty it restricts to namespaces that embed one
+// of those cluster IDs (both the hosted-cluster namespace ocm-<env>-<cid> and its
+// control-plane namespace ocm-<env>-<cid>-<name> contain the cid), which is how
+// the namespaces for a resource group's clusters are found.
+func (i *Inspector) DiscoverNamespaces(ctx context.Context, clusterIDs []string) ([]string, error) {
+	logger := logr.FromContextOrDiscard(ctx)
+	def, err := i.factory.GetBuiltinQueryDefinition(namespacesQueryName)
+	if err != nil {
+		return nil, err
+	}
+	data := kusto.NewTemplateDataFromOptions(i.baseOptions,
+		kusto.WithClusterName(i.clusterName),
+		kusto.WithClusterIds(clusterIDs),
+	)
+	queries, err := i.factory.Build(*def, data)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := runQuery(ctx, i.exec, queries[0])
+	if err != nil {
+		return nil, err
+	}
+	namespaces := make([]string, 0, len(rows))
+	for _, row := range rows {
+		if namespace := asString(row["namespace"]); namespace != "" {
+			namespaces = append(namespaces, namespace)
+		}
+	}
+	logger.Info("oc-adm-inspect: discovered namespaces",
+		"cluster", i.clusterName,
+		"namespaces", namespaces,
+	)
+	return namespaces, nil
+}
+
+// DiscoverActiveClusters returns the distinct cluster names seen in backend logs
+// in the time window, for telling the user which clusters are available when they
+// did not specify one. It does not require a cluster to be set, so it is a package
+// function rather than an Inspector method.
+func DiscoverActiveClusters(ctx context.Context, exec QueryExecutor, factory *kusto.QueryFactory, baseOptions kusto.QueryOptions) ([]string, error) {
+	def, err := factory.GetBuiltinQueryDefinition(activeClustersQueryName)
+	if err != nil {
+		return nil, err
+	}
+	queries, err := factory.Build(*def, kusto.NewTemplateDataFromOptions(baseOptions))
+	if err != nil {
+		return nil, err
+	}
+	rows, err := runQuery(ctx, exec, queries[0])
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{}, len(rows))
+	clusters := make([]string, 0, len(rows))
+	for _, row := range rows {
+		clusterName := clusterNameFromNameOrResourceID(asString(row["cluster_name"]))
+		if clusterName == "" {
+			continue
+		}
+		if _, ok := seen[clusterName]; ok {
+			continue
+		}
+		seen[clusterName] = struct{}{}
+		clusters = append(clusters, clusterName)
+	}
+	sort.Strings(clusters)
+	return clusters, nil
+}
+
+// clusterNameFromNameOrResourceID returns the cluster name from a value that may
+// be either a bare cluster name or a full ARM resource ID (whose last path
+// segment is the cluster name).
+func clusterNameFromNameOrResourceID(nameOrID string) string {
+	if idx := strings.LastIndex(nameOrID, "/"); idx >= 0 {
+		return nameOrID[idx+1:]
+	}
+	return nameOrID
+}
+
+// IsManagementCluster reports whether an infra cluster name denotes a management
+// cluster (as opposed to a service cluster).
+func IsManagementCluster(clusterName string) bool {
+	return strings.Contains(clusterName, ManagementClusterNameMarker)
+}
+
+// DiscoverResourceGroupClusterIDs returns the HCP cluster IDs (the `cid` column)
+// that have Cluster Service logs scoped to baseOptions' subscription/resource
+// group, using the shared "clusterId" discovery query.
+func DiscoverResourceGroupClusterIDs(ctx context.Context, exec QueryExecutor, factory *kusto.QueryFactory, baseOptions kusto.QueryOptions) ([]string, error) {
+	return discoverDistinctColumn(ctx, exec, factory, baseOptions, "clusterId", "cid")
+}
+
+// DiscoverResourceGroupClusterNames returns the infra (management/service)
+// cluster names that emitted logs for baseOptions' subscription/resource group in
+// the time window, using the shared "clusterNamesSvc"/"clusterNamesHcp" queries.
+func DiscoverResourceGroupClusterNames(ctx context.Context, exec QueryExecutor, factory *kusto.QueryFactory, baseOptions kusto.QueryOptions) ([]string, error) {
+	seen := make(map[string]struct{})
+	var names []string
+	for _, defName := range []string{"clusterNamesSvc", "clusterNamesHcp"} {
+		values, err := discoverDistinctColumn(ctx, exec, factory, baseOptions, defName, "cluster")
+		if err != nil {
+			return nil, err
+		}
+		for _, value := range values {
+			if _, ok := seen[value]; ok {
+				continue
+			}
+			seen[value] = struct{}{}
+			names = append(names, value)
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// InspectResourceGroupManagementNamespaces inspects, for every HCP cluster in
+// baseOptions' resource group, its namespaces (the hosted-cluster namespace and
+// its control-plane namespace, discovered by matching the cluster id embedded in
+// the namespace name) on whichever management cluster hosts it. This is the entry
+// point the must-gather command uses. Per-cluster failures are collected and
+// returned together so one bad cluster does not abort the rest.
+//
+// clusterIDs, when non-empty, are the cluster IDs to inspect (wired from
+// must-gather's --cluster-id); when empty they are discovered from the resource
+// group's Cluster Service logs.
+func InspectResourceGroupManagementNamespaces(ctx context.Context, exec QueryExecutor, factory *kusto.QueryFactory, baseOptions kusto.QueryOptions, writer Writer, clusterIDs []string) error {
+	logger := logr.FromContextOrDiscard(ctx)
+
+	if len(clusterIDs) == 0 {
+		discovered, err := DiscoverResourceGroupClusterIDs(ctx, exec, factory, baseOptions)
+		if err != nil {
+			return fmt.Errorf("failed to discover cluster IDs: %w", err)
+		}
+		clusterIDs = discovered
+	}
+	logger.Info("oc-adm-inspect: cluster IDs to inspect", "clusterIDs", clusterIDs)
+	if len(clusterIDs) == 0 {
+		logger.Info("no HCP clusters discovered in resource group; skipping oc-adm-inspect",
+			"resourceGroup", baseOptions.ResourceGroupName,
+		)
+		return nil
+	}
+
+	clusterNames, err := DiscoverResourceGroupClusterNames(ctx, exec, factory, baseOptions)
+	if err != nil {
+		return fmt.Errorf("failed to discover infra cluster names: %w", err)
+	}
+	logger.Info("oc-adm-inspect: discovered infra cluster names", "clusterNames", clusterNames)
+
+	var errs []error
+	for _, clusterName := range clusterNames {
+		if !IsManagementCluster(clusterName) {
+			continue
+		}
+		inspector := NewInspector(exec, factory, baseOptions, clusterName, writer)
+		namespaces, err := inspector.DiscoverNamespaces(ctx, clusterIDs)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to discover namespaces on %q: %w", clusterName, err))
+			continue
+		}
+		if len(namespaces) == 0 {
+			continue
+		}
+		logger.Info("oc-adm-inspect: discovered namespaces for resource group clusters",
+			"managementCluster", clusterName, "namespaceCount", len(namespaces))
+		if err := inspector.InspectNamespaces(ctx, namespaces); err != nil {
+			errs = append(errs, fmt.Errorf("failed to inspect namespaces on %q: %w", clusterName, err))
+		}
+	}
+	return joinErrors(errs)
+}
+
+// discoverDistinctColumn runs a builtin discovery query and returns the distinct
+// non-empty string values of one column.
+func discoverDistinctColumn(ctx context.Context, exec QueryExecutor, factory *kusto.QueryFactory, baseOptions kusto.QueryOptions, defName, column string) ([]string, error) {
+	def, err := factory.GetBuiltinQueryDefinition(defName)
+	if err != nil {
+		return nil, err
+	}
+	queries, err := factory.Build(*def, kusto.NewTemplateDataFromOptions(baseOptions))
+	if err != nil {
+		return nil, err
+	}
+	rows, err := runQuery(ctx, exec, queries[0])
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{}, len(rows))
+	var values []string
+	for _, row := range rows {
+		value := asString(row[column])
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func (i *Inspector) runNamespaceQuery(ctx context.Context, defName, namespace string) ([]map[string]any, error) {
+	def, err := i.factory.GetBuiltinQueryDefinition(defName)
+	if err != nil {
+		return nil, err
+	}
+	data := kusto.NewTemplateDataFromOptions(i.baseOptions,
+		kusto.WithClusterName(i.clusterName),
+		kusto.WithNamespace(namespace),
+	)
+	queries, err := i.factory.Build(*def, data)
+	if err != nil {
+		return nil, err
+	}
+	return runQuery(ctx, i.exec, queries[0])
+}
+
+// runQuery executes a single query and returns each row as a column->value map,
+// parsing dynamic columns (e.g. the snapshot `object`) into nested structures.
+func runQuery(ctx context.Context, exec QueryExecutor, query kusto.Query) ([]map[string]any, error) {
+	outputChannel := make(chan kusto.TaggedRow)
+	var rows []map[string]any
+
+	group := new(errgroup.Group)
+	group.Go(func() error {
+		for tagged := range outputChannel {
+			rows = append(rows, rowToMap(tagged))
+		}
+		return nil
+	})
+
+	_, queryErr := exec.ExecutePreconfiguredQuery(ctx, query, outputChannel)
+	close(outputChannel)
+
+	if err := group.Wait(); err != nil {
+		return nil, fmt.Errorf("failed to process query results: %w", err)
+	}
+	if queryErr != nil {
+		return nil, fmt.Errorf("failed to execute query %q: %w", query.GetName(), queryErr)
+	}
+	return rows, nil
+}
+
+func asString(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func joinErrors(errs []error) error {
+	switch len(errs) {
+	case 0:
+		return nil
+	case 1:
+		return errs[0]
+	default:
+		msgs := make([]string, 0, len(errs))
+		for _, err := range errs {
+			msgs = append(msgs, err.Error())
+		}
+		return fmt.Errorf("%d errors: %s", len(errs), strings.Join(msgs, "; "))
+	}
+}

--- a/tooling/hcpctl/pkg/ocadminspect/inspect_test.go
+++ b/tooling/hcpctl/pkg/ocadminspect/inspect_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocadminspect
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/kusto"
+)
+
+func TestClusterNameFromNameOrResourceID(t *testing.T) {
+	tests := map[string]string{
+		"cluster-candidate-4-20-xz2crd": "cluster-candidate-4-20-xz2crd",
+		"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/my-cluster": "my-cluster",
+		"": "",
+	}
+	for input, want := range tests {
+		if got := clusterNameFromNameOrResourceID(input); got != want {
+			t.Errorf("clusterNameFromNameOrResourceID(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestIsManagementCluster(t *testing.T) {
+	tests := map[string]bool{
+		"aro-hcp-mgmt-1": true,
+		"hcpmgmtuks1":    true,
+		"aro-hcp-svc-1":  false,
+		"svc-cluster":    false,
+	}
+	for name, want := range tests {
+		if got := IsManagementCluster(name); got != want {
+			t.Errorf("IsManagementCluster(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestPairNamespaces(t *testing.T) {
+	// The namespaces present on the cluster: a hosted-cluster namespace, its
+	// control-plane namespace (hosted + "-<name>"), and an unrelated cluster's pair.
+	clusterNamespaces := []string{
+		"kube-system",
+		"kube-system-audit", // shares a prefix with kube-system but is not an ocm- namespace
+		"ocm-arohcpci01-2sicoll",
+		"ocm-arohcpci01-2sicoll-u0y8w2y6",
+		"ocm-arohcpci01-otherdef",
+		"ocm-arohcpci01-otherdef-x9",
+	}
+	tests := []struct {
+		name      string
+		requested []string
+		want      []string
+	}{
+		{
+			name:      "hosted pulls in control plane",
+			requested: []string{"ocm-arohcpci01-2sicoll"},
+			want:      []string{"ocm-arohcpci01-2sicoll", "ocm-arohcpci01-2sicoll-u0y8w2y6"},
+		},
+		{
+			name:      "control plane pulls in hosted",
+			requested: []string{"ocm-arohcpci01-2sicoll-u0y8w2y6"},
+			want:      []string{"ocm-arohcpci01-2sicoll", "ocm-arohcpci01-2sicoll-u0y8w2y6"},
+		},
+		{
+			// kube-system must not pair with kube-system-audit: only ocm- namespaces pair.
+			name:      "non-ocm namespace with shared prefix is not paired",
+			requested: []string{"kube-system"},
+			want:      []string{"kube-system"},
+		},
+		{
+			name:      "does not cross-pair different clusters",
+			requested: []string{"ocm-arohcpci01-2sicoll"},
+			want:      []string{"ocm-arohcpci01-2sicoll", "ocm-arohcpci01-2sicoll-u0y8w2y6"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := pairNamespaces(tc.requested, clusterNamespaces)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("pairNamespaces(%v) = %v, want %v", tc.requested, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRenderedResourceQuery verifies the resource-snapshot template renders KQL
+// that scopes by cluster + namespace + time and excludes actually-deleted objects.
+func TestRenderedResourceQuery(t *testing.T) {
+	factory, err := kusto.NewQueryFactory()
+	if err != nil {
+		t.Fatalf("failed to build query factory: %v", err)
+	}
+	def, err := factory.GetBuiltinQueryDefinition("ocAdmInspectResources")
+	if err != nil {
+		t.Fatalf("failed to get query definition: %v", err)
+	}
+	baseOptions := kusto.NewQueryOptions()
+	data := kusto.NewTemplateDataFromOptions(baseOptions,
+		kusto.WithClusterName("aro-hcp-mgmt-1"),
+		kusto.WithNamespace("kube-system"),
+	)
+	queries, err := factory.Build(*def, data)
+	if err != nil {
+		t.Fatalf("failed to build query: %v", err)
+	}
+	rendered := queries[0].GetQuery().String()
+
+	for _, want := range []string{
+		"kubernetesResourceSnapshots",
+		"cluster == 'aro-hcp-mgmt-1'",
+		"namespace == 'kube-system'",
+		"event != 'Delete'",
+		"deletionTimestamp",
+		"deletionGracePeriodSeconds",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered resource query missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestRenderedContainerLogsQuery(t *testing.T) {
+	factory, err := kusto.NewQueryFactory()
+	if err != nil {
+		t.Fatalf("failed to build query factory: %v", err)
+	}
+	def, err := factory.GetBuiltinQueryDefinition("ocAdmInspectContainerLogs")
+	if err != nil {
+		t.Fatalf("failed to get query definition: %v", err)
+	}
+	data := kusto.NewTemplateDataFromOptions(kusto.NewQueryOptions(),
+		kusto.WithClusterName("aro-hcp-mgmt-1"),
+		kusto.WithNamespace("ocm-stg-abc"),
+	)
+	queries, err := factory.Build(*def, data)
+	if err != nil {
+		t.Fatalf("failed to build query: %v", err)
+	}
+	rendered := queries[0].GetQuery().String()
+	for _, want := range []string{"containerLogs", "namespace_name == 'ocm-stg-abc'", "cluster == 'aro-hcp-mgmt-1'"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered container logs query missing %q:\n%s", want, rendered)
+		}
+	}
+}

--- a/tooling/hcpctl/pkg/ocadminspect/row.go
+++ b/tooling/hcpctl/pkg/ocadminspect/row.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocadminspect
+
+import (
+	"encoding/json"
+
+	"github.com/Azure/azure-kusto-go/azkustodata/types"
+
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/kusto"
+)
+
+// rowToMap converts a Kusto row into a column-name -> value map. Dynamic columns
+// (e.g. the snapshot `object`) are JSON-decoded into nested Go structures; all
+// other columns are rendered as strings.
+func rowToMap(tagged kusto.TaggedRow) map[string]any {
+	row := tagged.Row
+	columns := row.Columns()
+	values := row.Values()
+
+	result := make(map[string]any, len(columns))
+	for idx, col := range columns {
+		if idx >= len(values) {
+			break
+		}
+		value := values[idx]
+		if value.GetType() == types.Dynamic {
+			if raw, ok := value.GetValue().([]byte); ok {
+				var parsed any
+				if err := json.Unmarshal(raw, &parsed); err == nil {
+					result[col.Name()] = parsed
+					continue
+				}
+			}
+		}
+		result[col.Name()] = value.String()
+	}
+	return result
+}

--- a/tooling/hcpctl/pkg/ocadminspect/writer.go
+++ b/tooling/hcpctl/pkg/ocadminspect/writer.go
@@ -1,0 +1,242 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocadminspect
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// FilesystemWriter writes gathered namespace state to disk in a layout that
+// mirrors `oc adm inspect`:
+//
+//	<root>/namespaces/<ns>/<ns>.yaml                                    (the Namespace object)
+//	<root>/namespaces/<ns>/<group>/<resource>.yaml                      (one List per resource kind, e.g. core/pods.yaml)
+//	<root>/namespaces/<ns>/pods/<pod>/<pod>.yaml                        (each pod object; pods also appear in core/pods.yaml)
+//	<root>/namespaces/<ns>/pods/<pod>/<container>/<container>/logs/current.log   (container logs)
+//	<root>/namespaces/<ns>/core/events.yaml                             (kubernetes events)
+//
+// where <group> is the API group ("core" for the core group) and <resource> is
+// the pluralized kind. Resource files are v1 List objects and every YAML file is
+// prefixed with a "---" document separator, matching oc adm inspect. The doubled
+// <container>/<container> segment and the pods/<pod>/<pod>.yaml pod placement
+// also match oc adm inspect's on-disk layout.
+type FilesystemWriter struct {
+	root string
+}
+
+var _ Writer = (*FilesystemWriter)(nil)
+
+// NewFilesystemWriter returns a writer rooted at root. All paths are created
+// under root/namespaces/<ns>/...
+func NewFilesystemWriter(root string) *FilesystemWriter {
+	return &FilesystemWriter{root: root}
+}
+
+func (w *FilesystemWriter) namespaceDir(namespace string) string {
+	return filepath.Join(w.root, "namespaces", namespace)
+}
+
+// NamespaceOutputPath returns the directory a namespace's content is written to.
+func (w *FilesystemWriter) NamespaceOutputPath(namespace string) string {
+	return w.namespaceDir(namespace)
+}
+
+// ensureWithinRoot rejects a target path that resolves outside the writer's root.
+// Namespace/pod/container names ultimately come from user input or telemetry, so
+// this is a defense-in-depth guard against path traversal (e.g. a "../" segment)
+// escaping the output directory, in addition to the input validation done by the
+// caller.
+func (w *FilesystemWriter) ensureWithinRoot(path string) error {
+	rel, err := filepath.Rel(w.root, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("refusing to write outside output root %q: %s", w.root, path)
+	}
+	return nil
+}
+
+// WriteResources writes the Namespace object to <ns>/<ns>.yaml, each Pod object
+// individually to pods/<pod>/<pod>.yaml, and every kind (pods included) into a v1
+// List file at <group>/<resource>.yaml, mirroring oc adm inspect.
+func (w *FilesystemWriter) WriteResources(_ context.Context, namespace string, resources []Resource) error {
+	var errs []error
+	byFile := make(map[string][]Resource)
+	for _, resource := range resources {
+		// The namespace object itself is written at <ns>/<ns>.yaml, not into a list.
+		if resource.Kind == "Namespace" && resource.Name == namespace {
+			path := filepath.Join(w.namespaceDir(namespace), namespace+".yaml")
+			if err := w.writeObjectFile(path, resource.Object); err != nil {
+				errs = append(errs, err)
+			}
+			continue
+		}
+		// Pods are written individually and also collected into core/pods.yaml.
+		if resource.Kind == "Pod" && resource.Name != "" {
+			path := filepath.Join(w.namespaceDir(namespace), "pods", resource.Name, resource.Name+".yaml")
+			if err := w.writeObjectFile(path, resource.Object); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		group := apiGroup(resource.APIVersion)
+		fileKey := filepath.Join(group, resourcePlural(resource.Kind)+".yaml")
+		byFile[fileKey] = append(byFile[fileKey], resource)
+	}
+
+	for fileKey, group := range byFile {
+		sort.Slice(group, func(a, b int) bool { return group[a].Name < group[b].Name })
+		if err := w.writeListFile(filepath.Join(w.namespaceDir(namespace), fileKey), group); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return joinErrors(errs)
+}
+
+// writeListFile writes the resources as a single v1 List object.
+func (w *FilesystemWriter) writeListFile(path string, resources []Resource) error {
+	items := make([]any, 0, len(resources))
+	for _, resource := range resources {
+		items = append(items, resource.Object)
+	}
+	return w.writeObjectFile(path, map[string]any{
+		"apiVersion": "v1",
+		"kind":       "List",
+		"items":      items,
+	})
+}
+
+// writeObjectFile marshals obj to YAML and writes it with a leading "---"
+// document separator, creating parent directories as needed.
+func (w *FilesystemWriter) writeObjectFile(path string, obj any) error {
+	if err := w.ensureWithinRoot(path); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("failed to create directory for %s: %w", path, err)
+	}
+	data, err := yaml.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("failed to marshal object for %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, append([]byte("---\n"), data...), 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", path, err)
+	}
+	return nil
+}
+
+// WriteEvents writes the namespace's events to core/events.yaml as a YAML
+// sequence of the projected event fields. Like the resource files it is written
+// through writeObjectFile, so it carries the same leading "---" separator.
+func (w *FilesystemWriter) WriteEvents(_ context.Context, namespace string, events []map[string]any) error {
+	if len(events) == 0 {
+		return nil
+	}
+	path := filepath.Join(w.namespaceDir(namespace), "core", "events.yaml")
+	return w.writeObjectFile(path, events)
+}
+
+// WriteContainerLog writes one container's log lines to
+// pods/<pod>/<container>/<container>/logs/current.log (the doubled container
+// segment matches oc adm inspect).
+func (w *FilesystemWriter) WriteContainerLog(_ context.Context, namespace, pod, container string, lines []LogLine) error {
+	if pod == "" || container == "" || len(lines) == 0 {
+		return nil
+	}
+	path := filepath.Join(w.namespaceDir(namespace), "pods", pod, container, container, "logs", "current.log")
+	if err := w.ensureWithinRoot(path); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("failed to create directory for %s: %w", path, err)
+	}
+	var buf strings.Builder
+	for _, line := range lines {
+		buf.WriteString(renderLogLine(line.Log))
+		buf.WriteString("\n")
+	}
+	if err := os.WriteFile(path, []byte(buf.String()), 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", path, err)
+	}
+	return nil
+}
+
+// apiGroup returns the API group from an apiVersion string ("apps/v1" -> "apps",
+// "v1" -> "core").
+func apiGroup(apiVersion string) string {
+	if idx := strings.Index(apiVersion, "/"); idx > 0 {
+		return apiVersion[:idx]
+	}
+	return "core"
+}
+
+// irregularResourcePlurals maps a lowercased Kind to its resource (plural) name
+// where the naive rules below would be wrong. oc derives this from discovery; the
+// snapshot telemetry only carries the Kind, so we approximate.
+var irregularResourcePlurals = map[string]string{
+	"endpoints": "endpoints", // already plural
+}
+
+// resourcePlural approximates the plural resource name for a Kind (e.g. "Pod" ->
+// "pods", "NetworkPolicy" -> "networkpolicies", "Ingress" -> "ingresses"), used
+// for the list file names. It is an approximation of the discovery-derived
+// resource name oc uses, sufficient for the file layout.
+func resourcePlural(kind string) string {
+	lower := strings.ToLower(kind)
+	if lower == "" {
+		return ""
+	}
+	if plural, ok := irregularResourcePlurals[lower]; ok {
+		return plural
+	}
+	switch {
+	case strings.HasSuffix(lower, "s"), strings.HasSuffix(lower, "x"),
+		strings.HasSuffix(lower, "ch"), strings.HasSuffix(lower, "sh"):
+		return lower + "es"
+	case strings.HasSuffix(lower, "y") && len(lower) > 1 && !isVowel(lower[len(lower)-2]):
+		return lower[:len(lower)-1] + "ies"
+	default:
+		return lower + "s"
+	}
+}
+
+func isVowel(b byte) bool {
+	switch b {
+	case 'a', 'e', 'i', 'o', 'u':
+		return true
+	}
+	return false
+}
+
+// renderLogLine renders a container log payload: a plain string is emitted as-is
+// (the common case for containerLogs), anything structured is rendered compactly.
+func renderLogLine(log any) string {
+	switch v := log.(type) {
+	case string:
+		return strings.TrimRight(v, "\n")
+	case nil:
+		return ""
+	default:
+		data, err := yaml.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		return strings.TrimRight(string(data), "\n")
+	}
+}

--- a/tooling/hcpctl/pkg/ocadminspect/writer_test.go
+++ b/tooling/hcpctl/pkg/ocadminspect/writer_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocadminspect
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestApiGroup(t *testing.T) {
+	tests := map[string]string{
+		"v1":                              "core",
+		"apps/v1":                         "apps",
+		"hypershift.openshift.io/v1beta1": "hypershift.openshift.io",
+		"":                                "core",
+	}
+	for apiVersion, want := range tests {
+		if got := apiGroup(apiVersion); got != want {
+			t.Errorf("apiGroup(%q) = %q, want %q", apiVersion, got, want)
+		}
+	}
+}
+
+func TestRenderLogLine(t *testing.T) {
+	if got := renderLogLine("hello\n"); got != "hello" {
+		t.Errorf("renderLogLine(string) = %q, want %q", got, "hello")
+	}
+	if got := renderLogLine(nil); got != "" {
+		t.Errorf("renderLogLine(nil) = %q, want empty", got)
+	}
+	if got := renderLogLine(map[string]any{"msg": "hi"}); !strings.Contains(got, "hi") {
+		t.Errorf("renderLogLine(map) = %q, want it to contain the value", got)
+	}
+}
+
+func TestResourcePlural(t *testing.T) {
+	tests := map[string]string{
+		"Pod":           "pods",
+		"ConfigMap":     "configmaps",
+		"Service":       "services",
+		"Endpoints":     "endpoints",
+		"Ingress":       "ingresses",
+		"NetworkPolicy": "networkpolicies",
+		"Deployment":    "deployments",
+		"HostedCluster": "hostedclusters",
+		"EgressQoS":     "egressqoses",
+		"Namespace":     "namespaces",
+	}
+	for kind, want := range tests {
+		if got := resourcePlural(kind); got != want {
+			t.Errorf("resourcePlural(%q) = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+func TestFilesystemWriter_Layout(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	w := NewFilesystemWriter(root)
+	const ns = "kube-system"
+
+	resources := []Resource{
+		// The Namespace object is cluster-scoped (empty namespace field) but named ns.
+		{APIVersion: "v1", Kind: "Namespace", Namespace: "", Name: ns, Object: map[string]any{"apiVersion": "v1", "kind": "Namespace", "metadata": map[string]any{"name": ns}}},
+		{APIVersion: "v1", Kind: "ConfigMap", Namespace: ns, Name: "coredns", Object: map[string]any{"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "coredns"}}},
+		{APIVersion: "v1", Kind: "Pod", Namespace: ns, Name: "coredns-abc", Object: map[string]any{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]any{"name": "coredns-abc"}}},
+	}
+	if err := w.WriteResources(ctx, ns, resources); err != nil {
+		t.Fatalf("WriteResources: %v", err)
+	}
+	if err := w.WriteEvents(ctx, ns, []map[string]any{{"reason": "Started", "message": "started container"}}); err != nil {
+		t.Fatalf("WriteEvents: %v", err)
+	}
+	if err := w.WriteContainerLog(ctx, ns, "coredns-abc", "coredns", []LogLine{{Timestamp: "t0", Log: "log line one"}}); err != nil {
+		t.Fatalf("WriteContainerLog: %v", err)
+	}
+
+	// Namespace object: namespaces/<ns>/<ns>.yaml (leading --- separator).
+	assertFileContains(t, filepath.Join(root, "namespaces", ns, ns+".yaml"), "kind: Namespace")
+	assertFileContains(t, filepath.Join(root, "namespaces", ns, ns+".yaml"), "---")
+	// Non-pod resource List: namespaces/<ns>/core/configmaps.yaml
+	assertFileContains(t, filepath.Join(root, "namespaces", ns, "core", "configmaps.yaml"), "kind: List")
+	assertFileContains(t, filepath.Join(root, "namespaces", ns, "core", "configmaps.yaml"), "name: coredns")
+	// Pods appear in the core/pods.yaml List...
+	assertFileContains(t, filepath.Join(root, "namespaces", ns, "core", "pods.yaml"), "name: coredns-abc")
+	// ...and individually at pods/<pod>/<pod>.yaml.
+	assertFileContains(t, filepath.Join(root, "namespaces", ns, "pods", "coredns-abc", "coredns-abc.yaml"), "kind: Pod")
+	// Events: namespaces/<ns>/core/events.yaml, with the same "---" prefix as other files.
+	assertFileContains(t, filepath.Join(root, "namespaces", ns, "core", "events.yaml"), "started container")
+	assertFileContains(t, filepath.Join(root, "namespaces", ns, "core", "events.yaml"), "---")
+	// Container log with doubled container segment.
+	assertFileContains(t, filepath.Join(root, "namespaces", ns, "pods", "coredns-abc", "coredns", "coredns", "logs", "current.log"), "log line one")
+}
+
+func TestFilesystemWriter_RejectsPathTraversal(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	w := NewFilesystemWriter(root)
+
+	// A traversal namespace must not write outside the root.
+	if err := w.WriteContainerLog(ctx, "../../evil", "pod", "ctr", []LogLine{{Log: "x"}}); err == nil {
+		t.Errorf("expected WriteContainerLog to reject a path-traversal namespace")
+	}
+	if err := w.WriteResources(ctx, "../../evil", []Resource{
+		{APIVersion: "v1", Kind: "ConfigMap", Name: "c", Object: map[string]any{"kind": "ConfigMap"}},
+	}); err == nil {
+		t.Errorf("expected WriteResources to reject a path-traversal namespace")
+	}
+	// Nothing should have been created outside the root.
+	if entries, _ := os.ReadDir(filepath.Dir(root)); len(entries) > 0 {
+		for _, e := range entries {
+			if e.Name() == "evil" {
+				t.Errorf("path traversal wrote outside the output root: %s", e.Name())
+			}
+		}
+	}
+}
+
+func assertFileContains(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected file %s: %v", path, err)
+	}
+	if !strings.Contains(string(data), want) {
+		t.Errorf("file %s missing %q; got:\n%s", path, want, string(data))
+	}
+}

--- a/tooling/hcpctl/testdata/zz_fixture_TestTemplateDataOptions.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestTemplateDataOptions.yaml
@@ -5,6 +5,7 @@ ClusterNames: '''cluster-a'', ''cluster-b'''
 FilterClusterName: ""
 HCPNamespacePrefix: ocm-arohcp
 Limit: 100
+Namespace: ""
 NoTruncation: false
 OrderBy: asc
 ResourceGroupName: rg

--- a/tooling/hcpctl/testdata/zz_fixture_TestTemplateDataOptions_NoTruncation.yaml
+++ b/tooling/hcpctl/testdata/zz_fixture_TestTemplateDataOptions_NoTruncation.yaml
@@ -5,6 +5,7 @@ ClusterNames: ''''''
 FilterClusterName: ""
 HCPNamespacePrefix: ""
 Limit: 0
+Namespace: ""
 NoTruncation: true
 OrderBy: asc
 ResourceGroupName: ""

--- a/tooling/utilitytypes/timing/types.go
+++ b/tooling/utilitytypes/timing/types.go
@@ -19,6 +19,13 @@ type SpecTimingMetadata struct {
 	StartedAt  string   `json:"startedAt"`
 	FinishedAt string   `json:"finishedAt"`
 
+	// SubscriptionID is the Azure subscription the test ran its resources in.
+	// Unlike Resource.SubscriptionID (which is omitted from artifacts), this is
+	// serialized on purpose so the per-test must-gather links can target the right
+	// subscription; tests run in per-test subscriptions, so a single shared value
+	// would be wrong.
+	SubscriptionID string `json:"subscriptionID,omitempty"`
+
 	Steps []StepTimingMetadata `json:"steps,omitempty"`
 
 	// Deployments holds deployment operation metadata by resource group and deployment name


### PR DESCRIPTION
…ather

Adds `hcpctl oc-adm-inspect`, a Kusto-backed equivalent of `oc adm inspect` that reconstructs a namespace's state at a past point in time instead of querying a live cluster:

- Resources from kubernetesResourceSnapshots (latest snapshot per object at or before the timestamp), excluding objects that were actually deleted by then (a Delete event, or deletionTimestamp + deletionGracePeriodSeconds elapsed).
- Kubernetes events from kubernetesEvents for the namespace up to the timestamp.
- Container logs from containerLogs up to the timestamp, querying both the ServiceLogs database (management-cluster namespaces) and the HostedControlPlaneLogs database (hosted control plane pods) and merging them.

Behavior:
- Accepts namespaces via -n or positional ns/<name> args, a --timestamp, a --lookback window, and --management-cluster/--service-cluster (the telemetry `cluster` name). Namespaces like kube-system require specifying the cluster.
- If no cluster is given, discovers the clusters active in the window and lists them (split into management vs service) so the user can re-run.
- Inspecting a hosted-cluster namespace automatically adds the paired control-plane namespace and vice versa, derived from HostedCluster snapshots.
- Output mirrors oc adm inspect: namespaces/<ns>/<group>/<kind>.yaml, pods/<pod>/<pod>.yaml, pods/<pod>/<container>/<container>/logs/current.log, and core/events.yaml.

must-gather `query` now runs oc-adm-inspect for every HCP cluster discovered in the resource group, inspecting each cluster's hosted-cluster and control-plane namespaces on the management cluster hosting it, under <output>/oc-adm-inspect (skippable with --skip-oc-adm-inspect).


/hold  for me to read and review.