### PR TITLE
fix(mgmt-agent): scope node-health success to delegated-NIC pods (AROSLSRE-1979)

### DIFF
--- a/mgmt-agent/pkg/controller/nodehealth/controller_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/controller_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/component-base/metrics/legacyregistry"
 
+	"github.com/Azure/ARO-HCP/mgmt-agent/pkg/controller"
 	"github.com/Azure/ARO-HCP/mgmt-agent/pkg/controller/nodehealth/detectors"
 )
 
@@ -155,7 +156,7 @@ func seedSuccess(t *testing.T, c *Controller, host, name string, ts time.Time) {
 	pod.Spec.Containers = []corev1.Container{{
 		Name: "nic",
 		Resources: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{"aro.openshift.io/swift-nic": resource.MustParse("1")},
+			Limits: corev1.ResourceList{controller.SwiftNICResourceName: resource.MustParse("1")},
 		},
 	}}
 	if err := c.podIndexer.Add(pod); err != nil {

--- a/mgmt-agent/pkg/controller/nodehealth/controller_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -145,10 +146,19 @@ func isWedged(t *testing.T, client *fake.Clientset, name string) bool {
 }
 
 // seedSuccess puts a pod that got a sandbox into the pod cache, which is the
-// only place the success signal is read from.
+// only place the success signal is read from. The pod asks for a delegated NIC,
+// because the SWIFT detector only counts a start as success if the pod actually
+// traversed the path it watches.
 func seedSuccess(t *testing.T, c *Controller, host, name string, ts time.Time) {
 	t.Helper()
-	if err := c.podIndexer.Add(startedPodOn(host, name, ts, false)); err != nil {
+	pod := startedPodOn(host, name, ts, false)
+	pod.Spec.Containers = []corev1.Container{{
+		Name: "nic",
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{"aro.openshift.io/swift-nic": resource.MustParse("1")},
+		},
+	}}
+	if err := c.podIndexer.Add(pod); err != nil {
 		t.Fatalf("add pod: %v", err)
 	}
 }

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/decide_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/decide_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -85,6 +86,20 @@ func stuckPod(pod string, since time.Time) *corev1.Pod {
 	}
 }
 
+// withSwiftNIC marks a pod as one that asked for a SWIFT v2 delegated NIC, which
+// is what makes its start evidence about the delegated-NIC path. Success
+// fixtures that stand for "the node can still attach a NIC" must carry it;
+// fixtures that stand for ordinary overlay traffic must not.
+func withSwiftNIC(p *corev1.Pod) *corev1.Pod {
+	p.Spec.Containers = append(p.Spec.Containers, corev1.Container{
+		Name: "nic",
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{swiftNICResourceName: resource.MustParse("1")},
+		},
+	})
+	return p
+}
+
 // startedPod is a pod whose PodReadyToStartContainers condition transitioned to
 // True at ts: a fresh sandbox, the success signal SuccessAt records. hostNet
 // marks it host-network, which must be excluded since it reaches the condition
@@ -147,7 +162,7 @@ func TestDecide(t *testing.T) {
 			}(),
 			pods: func() []*corev1.Pod {
 				_, p := stuckFailing(3, ago(15*time.Minute))
-				return append(p, startedPod("ok", ago(2*time.Minute), false))
+				return append(p, withSwiftNIC(startedPod("ok", ago(2*time.Minute), false)))
 			}(),
 			want: DecisionHealthy,
 		},
@@ -226,7 +241,7 @@ func TestDecide(t *testing.T) {
 		{
 			name: "recovery: a started pod, no stuck pods",
 			node: testNode(true, true),
-			pods: []*corev1.Pod{startedPod("ok", ago(1*time.Minute), false)},
+			pods: []*corev1.Pod{withSwiftNIC(startedPod("ok", ago(1*time.Minute), false))},
 			want: DecisionHealthy,
 		},
 		{
@@ -283,7 +298,7 @@ func TestDecide(t *testing.T) {
 			}(),
 			pods: func() []*corev1.Pod {
 				_, p := stuckFailing(3, ago(15*time.Minute))
-				return append(p, startedPod("stale", ago(30*time.Minute), false))
+				return append(p, withSwiftNIC(startedPod("stale", ago(30*time.Minute), false)))
 			}(),
 			want: DecisionWedged,
 		},
@@ -684,9 +699,13 @@ func TestRestartedContainerDoesNotSuppressAWedge(t *testing.T) {
 }
 
 // TestFinishedPodInWindowPreventsAFalseWedge is the reason the finished-pod path
-// exists: on a low-churn node the only thing that started recently may be a
-// CronJob pod that has already completed. It is still real proof the node can
-// build a sandbox, so it must suppress the wedge exactly as a running pod does.
+// exists: on a low-churn node the only thing that started recently may be a pod
+// that has already completed. It is still real proof the node can build a
+// sandbox, so it must suppress the wedge exactly as a running pod does.
+//
+// The pod has to be one that asked for a delegated NIC. A completed pod that
+// only ever used the overlay proves nothing about the path this detector
+// watches; see TestOverlaySuccessDoesNotSuppressASwiftWedge.
 func TestFinishedPodInWindowPreventsAFalseWedge(t *testing.T) {
 	events, pods := stuckFailing(3, ago(15*time.Minute))
 
@@ -694,7 +713,7 @@ func TestFinishedPodInWindowPreventsAFalseWedge(t *testing.T) {
 		t.Fatalf("precondition: Decide() = %v, want Wedged", got)
 	}
 
-	withJob := append(pods, completedPod("cronjob", ago(3*time.Minute), false))
+	withJob := append(pods, withSwiftNIC(completedPod("router-job", ago(3*time.Minute), false)))
 	if got, _ := Decide(testNode(true, true), events, withJob, testNow); got != DecisionHealthy {
 		t.Errorf("a finished pod inside the window must rule out a wedge: Decide() = %v, want Healthy", got)
 	}
@@ -703,5 +722,119 @@ func TestFinishedPodInWindowPreventsAFalseWedge(t *testing.T) {
 	withOldJob := append(pods, completedPod("old-cronjob", ago(45*time.Minute), false))
 	if got, _ := Decide(testNode(true, true), events, withOldJob, testNow); got != DecisionWedged {
 		t.Errorf("a finished pod outside the window must not rule out a wedge: Decide() = %v, want Wedged", got)
+	}
+}
+
+// TestPodRequestsSwiftNIC pins how a pod is recognised as needing a delegated
+// NIC. Extended resources are schedulable only as a limit and the kubelet mirrors
+// the limit into requests, so both fields have to be read, on init containers as
+// well as regular ones.
+func TestPodRequestsSwiftNIC(t *testing.T) {
+	nic := corev1.ResourceList{swiftNICResourceName: resource.MustParse("1")}
+	cpu := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}
+
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{name: "nil pod", pod: nil, want: false},
+		{name: "no containers", pod: &corev1.Pod{}, want: false},
+		{
+			name: "limit on a regular container",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
+				{Name: "c", Resources: corev1.ResourceRequirements{Limits: nic}},
+			}}},
+			want: true,
+		},
+		{
+			name: "request on a regular container",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
+				{Name: "c", Resources: corev1.ResourceRequirements{Requests: nic}},
+			}}},
+			want: true,
+		},
+		{
+			name: "limit on an init container",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{InitContainers: []corev1.Container{
+				{Name: "i", Resources: corev1.ResourceRequirements{Limits: nic}},
+			}}},
+			want: true,
+		},
+		{
+			name: "only unrelated resources",
+			pod: &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{
+				{Name: "c", Resources: corev1.ResourceRequirements{Limits: cpu, Requests: cpu}},
+			}}},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := podRequestsSwiftNIC(tc.pod); got != tc.want {
+				t.Errorf("podRequestsSwiftNIC() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOverlaySuccessDoesNotSuppressASwiftWedge is the partial-wedge case, and the
+// reason successScope exists.
+//
+// A mgmt node runs almost all of its pods on the ordinary overlay, which keeps
+// working while the delegated-NIC path is dead. Counting those starts as success
+// lets a node that cannot attach a single NIC look healthy for as long as it
+// keeps scheduling ordinary pods, which on a busy mgmt node is forever.
+//
+// Pinned to CI node aks-userswft2-17575576-vmss000003 on 2026-09-01, where 8
+// router pods across 7 hosted control planes hung for 16 minutes on
+// dhcp-discover timeouts while the node created 110 other pods and brought 107
+// of them to Running.
+func TestOverlaySuccessDoesNotSuppressASwiftWedge(t *testing.T) {
+	events, pods := stuckFailing(3, ago(15*time.Minute))
+
+	if got, _ := Decide(testNode(true, true), events, pods, testNow); got != DecisionWedged {
+		t.Fatalf("precondition: Decide() = %v, want Wedged", got)
+	}
+
+	// The overlay is healthy throughout: a steady stream of ordinary pods reaches
+	// a fresh sandbox well inside the window. None of them asked for a NIC.
+	overlay := pods
+	for i := 0; i < 20; i++ {
+		overlay = append(overlay, startedPod(fmt.Sprintf("overlay%d", i), ago(1*time.Minute), false))
+	}
+	// A completed overlay pod is the same story on a low-churn node.
+	overlay = append(overlay, completedPod("cronjob", ago(3*time.Minute), false))
+
+	got, snap := Decide(testNode(true, true), events, overlay, testNow)
+	if got != DecisionWedged {
+		t.Errorf("overlay-only successes suppressed a real delegated-NIC wedge: Decide() = %v, want Wedged", got)
+	}
+	if snap.RecentSuccess {
+		t.Error("RecentSuccess = true from pods that never asked for a NIC, want false")
+	}
+
+	// One pod that did ask for a NIC and got one is real proof the path works, and
+	// must still rule the wedge out.
+	recovered := append(overlay, withSwiftNIC(startedPod("router", ago(1*time.Minute), false)))
+	if got, _ := Decide(testNode(true, true), events, recovered, testNow); got != DecisionHealthy {
+		t.Errorf("a delegated-NIC success must rule out the wedge: Decide() = %v, want Healthy", got)
+	}
+}
+
+// TestSuccessScopeDefaultsToEveryPod pins the zero value: a detector that does
+// not set a scope keeps counting every pod, so adding the field cannot silently
+// change a detector that did not opt in.
+func TestSuccessScopeDefaultsToEveryPod(t *testing.T) {
+	unscoped := swiftVFTeardown
+	unscoped.successScope = nil
+
+	_, pods := stuckFailing(3, ago(15*time.Minute))
+	pods = append(pods, startedPod("plain", ago(1*time.Minute), false))
+	events, _ := stuckFailing(3, ago(15*time.Minute))
+
+	if snap := unscoped.Evaluate(events, pods, testNow); !snap.RecentSuccess {
+		t.Error("RecentSuccess = false with a nil successScope, want true")
 	}
 }

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/drift_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/drift_test.go
@@ -1,0 +1,17 @@
+package detectors
+
+import (
+	"testing"
+
+	"github.com/Azure/ARO-HCP/mgmt-agent/pkg/controller"
+)
+
+// TestSwiftNICResourceNameMatchesController pins the local copy of the extended
+// resource name to the one the mgmt-agent advertises on the node. This package
+// keeps its own copy so it does not depend on the controller package, so nothing
+// but this test stops the two drifting apart.
+func TestSwiftNICResourceNameMatchesController(t *testing.T) {
+	if got, want := string(swiftNICResourceName), string(controller.SwiftNICResourceName); got != want {
+		t.Errorf("swiftNICResourceName = %q, controller.SwiftNICResourceName = %q; they must stay equal", got, want)
+	}
+}

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/drift_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/drift_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package detectors
 
 import (

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/production_evidence_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/production_evidence_test.go
@@ -225,7 +225,7 @@ func TestProductionStaleSuccessesDoNotSuppressDetection(t *testing.T) {
 	// far outside the 10 minute window. It is still sitting in the LIST, exactly
 	// as it was on the real node, because the pod is still running.
 	staleSuccess := now.Add(-500*time.Minute - 36*time.Second)
-	got, snap := Decide(node, events, append(pods, startedPod("long-running", staleSuccess, false)), now)
+	got, snap := Decide(node, events, append(pods, withSwiftNIC(startedPod("long-running", staleSuccess, false))), now)
 	if got != DecisionWedged {
 		t.Fatalf("stale success suppressed detection of the real wedge: Decide = %v (%s)", got, snap.ReasonString())
 	}
@@ -238,7 +238,7 @@ func TestProductionStaleSuccessesDoNotSuppressDetection(t *testing.T) {
 	// as Healthy and returns an empty snapshot on that path, so the decision is
 	// the assertion here.
 	freshSuccess := now.Add(-2 * time.Minute)
-	if got, _ = Decide(node, events, append(pods, startedPod("just-started", freshSuccess, false)), now); got != DecisionHealthy {
+	if got, _ = Decide(node, events, append(pods, withSwiftNIC(startedPod("just-started", freshSuccess, false))), now); got != DecisionHealthy {
 		t.Errorf("a success inside the window must rule out a hard wedge: Decide = %v, want %v", got, DecisionHealthy)
 	}
 }
@@ -262,7 +262,7 @@ func TestFutureDatedSuccessDoesNotSuppressDetection(t *testing.T) {
 	// A success stamped an hour into the future by a skewed kubelet clock. It is
 	// not evidence the node can attach a NIC now, so it must not rule out a wedge.
 	future := now.Add(1 * time.Hour)
-	if got, _ := Decide(node, events, append(pods, startedPod("skewed", future, false)), now); got != DecisionWedged {
+	if got, _ := Decide(node, events, append(pods, withSwiftNIC(startedPod("skewed", future, false))), now); got != DecisionWedged {
 		t.Errorf("a future-dated success suppressed detection of a real wedge: Decide = %v, want %v", got, DecisionWedged)
 	}
 }

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/signature_detector.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/signature_detector.go
@@ -56,6 +56,12 @@ type signatureDetector struct {
 	// load-bearing discriminator between a hard-wedge (zero successes, VF gone)
 	// and a flap (some successes, VF present).
 	requireZeroSuccess bool
+	// successScope narrows which pods may serve as success evidence. A nil scope
+	// counts every pod, which is right for a fault that breaks a node's only pod
+	// network. A fault that breaks one of several networking paths needs the
+	// scope, because pods that never travel the broken path keep starting
+	// normally and would otherwise mask it forever. See swiftVFTeardown.
+	successScope func(*corev1.Pod) bool
 }
 
 // Name returns the detector's stable identifier.
@@ -125,8 +131,15 @@ func (d signatureDetector) Evaluate(events []*corev1.Event, pods []*corev1.Pod, 
 		// Success is read from every pod the LIST returns, including one that is
 		// terminating: a pod that got a sandbox proves the node could build one,
 		// and that stays true while it is being torn down.
-		if at, ok := SuccessAt(p); ok && now.Sub(at).Abs() < d.window {
-			snap.RecentSuccess = true
+		//
+		// When the detector sets a successScope, only pods inside it are read.
+		// A success proves the node can build the kind of sandbox that pod
+		// needed, and nothing more, so a pod that never exercises the broken
+		// path is not evidence the path works.
+		if d.inSuccessScope(p) {
+			if at, ok := SuccessAt(p); ok && now.Sub(at).Abs() < d.window {
+				snap.RecentSuccess = true
+			}
 		}
 		if p.DeletionTimestamp != nil {
 			continue
@@ -183,6 +196,12 @@ func (d signatureDetector) MeetsThreshold(snap Snapshot, now time.Time) bool {
 		return false
 	}
 	return true
+}
+
+// inSuccessScope reports whether a pod may serve as success evidence for this
+// detector. A detector with no scope accepts every pod.
+func (d signatureDetector) inSuccessScope(p *corev1.Pod) bool {
+	return d.successScope == nil || d.successScope(p)
 }
 
 // matchSignature returns the index of the first of the detector's signature

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/swift_vf.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/swift_vf.go
@@ -33,6 +33,12 @@ const (
 	// reasonFailedCreatePodSandBox is the kubelet Event reason emitted when a pod
 	// sandbox cannot be created. It is the failure signal for the SWIFT wedge.
 	reasonFailedCreatePodSandBox = "FailedCreatePodSandBox"
+
+	// swiftNICResourceName is the extended resource a pod requests to be given a
+	// SWIFT v2 delegated NIC. It mirrors controller.SwiftNICResourceName, which
+	// the mgmt-agent advertises on the node; the two are pinned equal by test so
+	// this package stays free of a dependency on the controller package.
+	swiftNICResourceName corev1.ResourceName = "aro.openshift.io/swift-nic"
 )
 
 // swiftVFTeardown detects the SWIFT v2 delegated-NIC teardown wedge: on a
@@ -56,6 +62,39 @@ var swiftVFTeardown = signatureDetector{
 	window:             10 * time.Minute,
 	dwell:              10 * time.Minute,
 	requireZeroSuccess: true,
+	successScope:       podRequestsSwiftNIC,
+}
+
+// podRequestsSwiftNIC reports whether a pod asks for a SWIFT v2 delegated NIC,
+// which is what makes its start evidence about the delegated-NIC path.
+//
+// Only these pods traverse the path this detector watches. A mgmt node runs the
+// overwhelming majority of its pods on the ordinary overlay, which keeps working
+// while the delegated-NIC path is dead, so counting them as success lets a node
+// that cannot attach a single NIC look healthy indefinitely. Observed on CI node
+// aks-userswft2-17575576-vmss000003 on 2026-09-01: 8 router pods across 7 hosted
+// control planes hung for 16 minutes on dhcp-discover timeouts while the node
+// created 110 other pods and brought 107 of them to Running.
+//
+// Extended resources are only schedulable when requested as a limit, and the
+// kubelet copies the limit into requests, so either field carrying the resource
+// means the pod needed a NIC.
+func podRequestsSwiftNIC(p *corev1.Pod) bool {
+	if p == nil {
+		return false
+	}
+	for _, containers := range [][]corev1.Container{p.Spec.InitContainers, p.Spec.Containers} {
+		for i := range containers {
+			res := containers[i].Resources
+			if _, ok := res.Limits[swiftNICResourceName]; ok {
+				return true
+			}
+			if _, ok := res.Requests[swiftNICResourceName]; ok {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func isSwiftV2Node(node *corev1.Node) bool {


### PR DESCRIPTION
Jira: [AROSLSRE-1979](https://redhat.atlassian.net/browse/AROSLSRE-1979)

### What

Adds a `successScope` to `signatureDetector` and sets it on `swiftVFTeardown`, so only a pod that requests `aro.openshift.io/swift-nic` counts as success evidence for the SWIFT wedge detector.

A nil scope counts every pod, which is the existing behaviour, so no other detector changes.

### Why

The detector uses `requireZeroSuccess`: any pod that got a sandbox in the last 10 minutes rules out a wedge. On a management node that is almost always true, because nearly every pod runs on the ordinary overlay, and the overlay keeps working while the delegated-NIC path is dead.

So a node that cannot attach a single NIC never got labelled, for as long as it kept scheduling ordinary pods. On a busy mgmt node that is forever.

CI node `aks-userswft2-17575576-vmss000003` on 2026-09-01, from prow build [2094847592197263360](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/6660/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2094847592197263360):

```text
18:39:49 -> 18:55:52   204 dhcp-discover timeouts, 8 router pods, 7 hosted control planes
same window            110 pods created on the node, 107 reached Running
```

Every other node in that cluster saw 1-6 of those events and recovered in seconds. This one was stuck for 16 minutes and the detector stayed quiet, because those 107 overlay starts read as success.

This follows the same logic `SuccessAt` already applies to host-network pods: a pod that never travels the broken path is not evidence the path works. It just extends it one step, from "did it use a pod network at all" to "did it use the pod network this detector watches".

### Testing

`go test ./pkg/controller/nodehealth/...` passes, plus `go vet` and `gofmt`.

New tests:

- `TestOverlaySuccessDoesNotSuppressASwiftWedge` reproduces the CI case: stuck delegated-NIC pods plus a stream of overlay starts must still read Wedged, and a single delegated-NIC success must still rule it out.
- `TestPodRequestsSwiftNIC` covers limits, requests, init containers, unrelated resources and nil.
- `TestSuccessScopeDefaultsToEveryPod` pins that a detector without a scope is unchanged.
- `TestSwiftNICResourceNameMatchesController` pins the local resource-name constant to `controller.SwiftNICResourceName`.

Existing success fixtures now carry the NIC request via a `withSwiftNIC` helper, so each test states whether its success is a delegated-NIC one. The uksouth production evidence test still passes unchanged in intent.

### Special notes for your reviewer

This detector is label-only today. `labeler.go` applies `node-health.aro-hcp.azure.com/status=wedged` and annotations, and mitigation of a labelled node is owned by a separate controller that is not shipped. So making the detector fire in a case where it previously stayed quiet cannot cause disruptive remediation, it only changes what gets labelled.

The trade-off worth reviewing: for this detector `requireZeroSuccess` now effectively reduces to "3 or more pods stuck on swift signatures past the dwell", since the common case is that no delegated-NIC pod succeeds during a wedge. I think that is the right reading of the signal, and the label being non-disruptive today makes it a safe place to find out.

One thing worth correcting from the original thread: the `NodeCapacityExceeded` on the MTPNC was not the cause. It lasted 12 milliseconds, went Ready with a valid IP, and appears in zero `FailedCreatePodSandBox` messages cluster-wide. The node was wedged on dhcp discover.

### PR Checklist

- [x] Tests added or updated
- [x] `go build`, `go vet`, `gofmt` clean
- [x] Jira issue linked
