### PR TITLE
feat: support templated config rendering in E2E tests

### DIFF
--- a/test/E2ELocal.mk
+++ b/test/E2ELocal.mk
@@ -30,6 +30,10 @@ e2e-local/run-test: $(ARO_HCP_TESTS)
 	export FRONTEND_ADDRESS=$${FRONTEND_ADDRESS:-http://localhost:8443}; \
 	export ADMIN_API_ADDRESS=$${ADMIN_API_ADDRESS:-http://localhost:8444}; \
 	export ARTIFACT_DIR="$(E2E_ARTIFACT_DIR)"; \
+	export ARO_HCP_CONFIG_FILE="$(CONFIG_FILE)"; \
+	export CLOUD="$(ARO_HCP_CLOUD)"; \
+	export DEPLOY_ENV="$(DEPLOY_ENV)"; \
+	export REGION="$${LOCATION:-${REGION}}"; \
 	$(ARO_HCP_TESTS) run-test "$$TEST_NAME"
 .PHONY: e2e-local/run-test
 

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 
+	"github.com/Azure/ARO-HCP/test/util/config"
 	"github.com/Azure/ARO-HCP/test/util/integration"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/log"
@@ -32,8 +33,30 @@ var (
 )
 
 func setup(ctx context.Context) error {
-	// Use GinkgoLabelFilter to determine if the test should load the e2e setup file
 	labelFilter := GinkgoLabelFilter()
+
+	// Load templated configuration
+	opts := config.ConfigOptions{
+		ConfigFile:         os.Getenv("ARO_HCP_CONFIG_FILE"),
+		ConfigFileOverride: os.Getenv("ARO_HCP_CONFIG_FILE_OVERRIDE"),
+		Cloud:              os.Getenv("CLOUD"),
+		DeployEnv:          os.Getenv("DEPLOY_ENV"),
+		Region:             os.Getenv("REGION"),
+	}
+
+	requiresConfig := strings.Contains(labelFilter, labels.RequiresConfig[0])
+	if requiresConfig && opts.ConfigFile == "" {
+		return fmt.Errorf("test requires config but ARO_HCP_CONFIG_FILE is not set")
+	}
+
+	// Only fail if a config file is explicitly supplied but fails to render
+	if opts.ConfigFile != "" {
+		if err := config.LoadConfig(opts); err != nil {
+			return fmt.Errorf("failed to load service config: %w", err)
+		}
+	}
+
+	// Use GinkgoLabelFilter to determine if the test should load the e2e setup file
 	if strings.Contains(labelFilter, labels.RequireNothing[0]) ||
 		strings.Contains(labelFilter, labels.UpgradeInPlace[0]) {
 		// Skip loading the e2esetup file

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -44,9 +44,16 @@ func setup(ctx context.Context) error {
 		Region:             os.Getenv("REGION"),
 	}
 
+	if opts.ConfigFileOverride != "" && opts.ConfigFile == "" {
+		return fmt.Errorf("ARO_HCP_CONFIG_FILE_OVERRIDE is set but ARO_HCP_CONFIG_FILE is not set")
+	}
+
 	requiresConfig := strings.Contains(labelFilter, labels.RequiresConfig[0])
 	if requiresConfig && opts.ConfigFile == "" {
 		return fmt.Errorf("test requires config but ARO_HCP_CONFIG_FILE is not set")
+	}
+	if requiresConfig && (opts.Cloud == "" || opts.DeployEnv == "" || opts.Region == "") {
+		return fmt.Errorf("test requires config but CLOUD/DEPLOY_ENV/REGION are not all set (CLOUD=%q, DEPLOY_ENV=%q, REGION=%q)", opts.Cloud, opts.DeployEnv, opts.Region)
 	}
 
 	// Only fail if a config file is explicitly supplied but fails to render

--- a/test/testdata/config/config.yaml
+++ b/test/testdata/config/config.yaml
@@ -1,0 +1,16 @@
+$schema: ../../../config/config.schema.json
+defaults:
+  test:
+    property: "base_value"
+    cloud: "{{ .ctx.cloud }}"
+    env: "{{ .ctx.environment }}"
+    region: "{{ .ctx.region }}"
+clouds:
+  public:
+    environments:
+      dev:
+        defaults: {}
+        regions:
+          uksouth:
+            test:
+              region_prop: "region_base"

--- a/test/testdata/config/override.yaml
+++ b/test/testdata/config/override.yaml
@@ -1,0 +1,12 @@
+$schema: ../../../config/config.schema.json
+defaults:
+  test:
+    property: "override_value"
+clouds:
+  public:
+    environments:
+      dev:
+        regions:
+          uksouth:
+            test:
+              region_prop: "region_override"

--- a/test/util/config/config.go
+++ b/test/util/config/config.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/test/util/config/config.go
+++ b/test/util/config/config.go
@@ -66,6 +66,10 @@ func LoadConfig(opts ConfigOptions) error {
 		return fmt.Errorf("failed to get config resolver: %w", err)
 	}
 
+	if resolver == nil {
+		return fmt.Errorf("resolver is nil!")
+	}
+
 	// 4. Evaluate region specific overrides/values and expose globally
 	ServiceConfig, err = resolver.GetRegionConfiguration(opts.Region)
 	return err

--- a/test/util/config/config.go
+++ b/test/util/config/config.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/Azure/ARO-Tools/config"
+	"github.com/Azure/ARO-Tools/config/types"
+)
+
+var ServiceConfig types.Configuration
+
+type ConfigOptions struct {
+	ConfigFile         string
+	ConfigFileOverride string
+	Cloud              string
+	DeployEnv          string
+	Region             string
+}
+
+// LoadConfig creates a provider, resolves values, and populates ServiceConfig
+func LoadConfig(opts ConfigOptions) error {
+	var provider config.ConfigProvider
+	var err error
+
+	// 1. Merge files if override is provided, or just read the base file
+	if opts.ConfigFileOverride != "" {
+		schemaBaseDir := filepath.Dir(opts.ConfigFile)
+		mergedConfigData, err := types.MergeRawConfigurationFiles(schemaBaseDir, []string{opts.ConfigFile, opts.ConfigFileOverride})
+		if err != nil {
+			return fmt.Errorf("failed to merge config files: %w", err)
+		}
+		provider, err = config.NewConfigProviderFromData(mergedConfigData, schemaBaseDir)
+	} else {
+		provider, err = config.NewConfigProvider(opts.ConfigFile)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to create config provider: %w", err)
+	}
+
+	// 2. Supply replacements for templated values (e.g. {{ .ctx.region }})
+	replacements := config.ConfigReplacements{
+		CloudReplacement:       opts.Cloud,
+		EnvironmentReplacement: opts.DeployEnv,
+		RegionReplacement:      opts.Region,
+		// Add StampReplacement or RegionShortReplacement if your tests require stamp-scoped values
+	}
+
+	// 3. Resolve
+	resolver, err := provider.GetResolver(&replacements)
+	if err != nil {
+		return fmt.Errorf("failed to get config resolver: %w", err)
+	}
+
+	// 4. Evaluate region specific overrides/values and expose globally
+	ServiceConfig, err = resolver.GetRegionConfiguration(opts.Region)
+	return err
+}

--- a/test/util/config/config_test.go
+++ b/test/util/config/config_test.go
@@ -1,0 +1,49 @@
+package config_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/Azure/ARO-HCP/test/util/config"
+)
+
+func TestLoadConfig(t *testing.T) {
+	opts := config.ConfigOptions{
+		ConfigFile:         filepath.Join("..", "..", "testdata", "config", "config.yaml"),
+		ConfigFileOverride: filepath.Join("..", "..", "testdata", "config", "override.yaml"),
+		Cloud:              "public",
+		DeployEnv:          "dev",
+		Region:             "uksouth",
+	}
+
+	err := config.LoadConfig(opts)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	val, err := config.ServiceConfig.GetByPath("test.property")
+	if err != nil {
+		t.Fatalf("Failed to get test.property: %v", err)
+	}
+	fmt.Println(val)
+	if val.(string) != "override_value" {
+		t.Errorf("Expected 'override_value', got '%v'", val)
+	}
+
+	val2, err := config.ServiceConfig.GetByPath("test.cloud")
+	if err != nil {
+		t.Fatalf("Failed to get test.cloud: %v", err)
+	}
+	if val2.(string) != "public" {
+		t.Errorf("Expected 'public', got '%v'", val2)
+	}
+
+	val3, err := config.ServiceConfig.GetByPath("test.region_prop")
+	if err != nil {
+		t.Fatalf("Failed to get test.region_prop: %v", err)
+	}
+	if val3.(string) != "region_override" {
+		t.Errorf("Expected 'region_override', got '%v'", val3)
+	}
+}

--- a/test/util/config/config_test.go
+++ b/test/util/config/config_test.go
@@ -1,7 +1,6 @@
 package config_test
 
 import (
-	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -26,24 +25,36 @@ func TestLoadConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get test.property: %v", err)
 	}
-	fmt.Println(val)
-	if val.(string) != "override_value" {
-		t.Errorf("Expected 'override_value', got '%v'", val)
+	valStr, ok := val.(string)
+	if !ok {
+		t.Fatalf("Expected string, got %T", val)
+	}
+
+	if valStr != "override_value" {
+		t.Errorf("Expected 'override_value', got '%v'", valStr)
 	}
 
 	val2, err := config.ServiceConfig.GetByPath("test.cloud")
+	val2Str, ok := val2.(string)
+	if !ok {
+		t.Fatalf("Expected string, got %T", val2)
+	}
 	if err != nil {
 		t.Fatalf("Failed to get test.cloud: %v", err)
 	}
-	if val2.(string) != "public" {
+	if val2Str != "public" {
 		t.Errorf("Expected 'public', got '%v'", val2)
 	}
 
 	val3, err := config.ServiceConfig.GetByPath("test.region_prop")
+	val3Str, ok := val3.(string)
+	if !ok {
+		t.Fatalf("Expected string, got %T", val3)
+	}
 	if err != nil {
 		t.Fatalf("Failed to get test.region_prop: %v", err)
 	}
-	if val3.(string) != "region_override" {
+	if val3Str != "region_override" {
 		t.Errorf("Expected 'region_override', got '%v'", val3)
 	}
 }

--- a/test/util/labels/labels.go
+++ b/test/util/labels/labels.go
@@ -58,6 +58,8 @@ var (
 	DevelopmentOnly  = ginkgo.Label("Development-Only")
 	IntegrationOnly  = ginkgo.Label("Integration-Only")
 	StageAndProdOnly = ginkgo.Label("Stage-And-Prod-Only")
+	// RequiresConfig marks a test as requiring templated configuration
+	RequiresConfig = ginkgo.Label("RequiresConfig")
 	// A test case is ARO-HCP-RP-API-Compatible if it doesn't use ARM API (eg.
 	// ARM templates) to communicate with ARO HCP RP, so that it can run
 	// against either ARO HCP RP or ARM endpoint.


### PR DESCRIPTION
### What

- Add `test/util/config` to load/resolve configs via `ARO-Tools` (matches templatize logic).                                             - Update test setup to read `ARO_HCP_CONFIG_FILE`, `CLOUD`, `DEPLOY_ENV`, and `REGION`.
- Introduce `RequiresConfig` Ginkgo label to enable asserting if config is set.
- Wire required env vars into `test/E2ELocal.mk`.


https://redhat.atlassian.net/browse/AROSLSRE-1869


### Why

- Want to test infra created during e2e tests. to do this, we need to get the e2e specific configuration values from the config file. Hence we need to render the configuration file

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
