### PR TITLE
fix(e2e): run workload identity test pod as non-root with writable HOME

### DIFF
--- a/test/e2e/oidc_issuer_workload_identity.go
+++ b/test/e2e/oidc_issuer_workload_identity.go
@@ -59,7 +59,7 @@ func newWITestPodWithWebhook(namespace string) *corev1.Pod {
 					Name:  "azure-cli",
 					Image: "mcr.microsoft.com/azure-cli:latest",
 					SecurityContext: &corev1.SecurityContext{
-						RunAsUser:                to.Ptr(int64(0)),
+						RunAsNonRoot:             to.Ptr(true),
 						AllowPrivilegeEscalation: to.Ptr(false),
 						SeccompProfile: &corev1.SeccompProfile{
 							Type: corev1.SeccompProfileTypeRuntimeDefault,
@@ -75,6 +75,12 @@ func newWITestPodWithWebhook(namespace string) *corev1.Pod {
 							-t "$AZURE_TENANT_ID" \
 							--allow-no-subscriptions
 					`},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "HOME",
+							Value: "/tmp",
+						},
+					},
 				},
 			},
 		},
@@ -122,7 +128,7 @@ func newWITestPodWithManualInjection(namespace, clientID, tenantID string) *core
 					Name:  "azure-cli",
 					Image: "mcr.microsoft.com/azure-cli:latest",
 					SecurityContext: &corev1.SecurityContext{
-						RunAsUser:                to.Ptr(int64(0)),
+						RunAsNonRoot:             to.Ptr(true),
 						AllowPrivilegeEscalation: to.Ptr(false),
 						SeccompProfile: &corev1.SeccompProfile{
 							Type: corev1.SeccompProfileTypeRuntimeDefault,
@@ -150,6 +156,10 @@ func newWITestPodWithManualInjection(namespace, clientID, tenantID string) *core
 						{
 							Name:  "AZURE_FEDERATED_TOKEN_FILE",
 							Value: tokenPath,
+						},
+						{
+							Name:  "HOME",
+							Value: "/tmp",
 						},
 					},
 					VolumeMounts: []corev1.VolumeMount{

--- a/test/util/verifiers/fips.go
+++ b/test/util/verifiers/fips.go
@@ -28,6 +28,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 )
 
 type verifyFIPSEnabledImpl struct{}
@@ -108,6 +110,19 @@ func checkNodeFIPSMode(ctx context.Context, kubeClient *kubernetes.Clientset, no
 					Name:    "fips-check",
 					Image:   "mcr.microsoft.com/azurelinux/distroless/debug:3.0",
 					Command: []string{"busybox", "cat", "/proc/sys/crypto/fips_enabled"},
+					Env: []corev1.EnvVar{
+						{Name: "HOME", Value: "/tmp"},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						RunAsNonRoot:             to.Ptr(true),
+						AllowPrivilegeEscalation: to.Ptr(false),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-29411

### What

The OIDC issuer workload identity test hardcoded RunAsUser: 0 on the azure-cli test pod's container. Namespaces that sync their Pod Security "enforce" label to "restricted" reject this outright with:

    violates PodSecurity "restricted:latest": runAsNonRoot != true,
    runAsUser=0

The test already waited for the openshift.io/sa.scc.uid-range namespace annotation before creating the pod, indicating the original intent was to let OpenShift assign a non-root UID from that range rather than force root. Replace RunAsUser: 0 with RunAsNonRoot: true in both pod builders (webhook and manual-injection variants).

With that fixed, the pod is admitted but the mcr.microsoft.com/azure-cli image's default $HOME (/root) is not writable by the SCC-assigned non-root UID, so `az login` fails to create its config/token cache and the container keeps restarting under RestartPolicy: OnFailure without ever reaching Succeeded. Set HOME=/tmp on the container to give it a writable home directory

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
