### PR TITLE
fix(ci): purge E2E Entra identities from deleted items (AROSLSRE-1982)

### DIFF
--- a/docs/ci/cleanup.md
+++ b/docs/ci/cleanup.md
@@ -35,6 +35,18 @@ In the normal public-cloud flow, test cleanup:
 2. waits for managed resource groups to disappear
 3. finishes cleaning up test-owned leftovers such as the customer resource group, app registrations, and leased identities
 
+When the tests use app-only CI credentials, test-created app registrations are
+permanently removed rather than left in Entra's deleted-items container. The
+framework records both the application object ID and the associated
+service-principal object ID. It soft-deletes and purges the service principal
+first, then does the same for the application. If a purge fails, cleanup
+restores that object so a later run can rediscover and retry it. Purging only
+the application is insufficient because its service principal remains
+independently recoverable and continues consuming directory quota. Local runs
+using delegated user credentials retain the standard soft-delete behavior
+because permanent deletion requires elevated directory permissions that
+ordinary application owners may not have.
+
 This path is not just background hygiene. Cleanup failures are treated as test signal.
 
 ### Targeted environment teardown
@@ -86,7 +98,7 @@ Its job is to keep subscriptions healthy over time, not to prove that a single t
 Today that periodic layer includes:
 
 - expired test resource-group cleanup
-- expired app-registration cleanup
+- expired app-registration and service-principal cleanup, including permanent deletion
 - Kusto role-assignment cleanup
 - `cleanup-sweeper` jobs for policy-driven resource-group cleanup and shared leftovers
 
@@ -168,7 +180,8 @@ This is implemented in:
 At the end of a test, the framework cleans:
 
 - resource groups created by the test context
-- app registrations created by the test
+- app registrations and associated service principals created by the test,
+  including both objects in Entra's deleted-items container
 - leased identity leftovers
 
 There are two cleanup modes in the framework:
@@ -203,6 +216,16 @@ There are two broad styles of periodic cleanup:
 
 - test-oriented cleanup jobs, such as expired resource groups and old test identities
 - `cleanup-sweeper` jobs, which are meant for policy-driven resource-group cleanup and shared leftovers
+
+The expired app-registration job resolves the active service principal before
+deleting each owned `aro-hcp-e2e-*` application. It then permanently deletes
+both objects after Entra exposes them in `directory/deletedItems`, preventing
+the hourly cleanup from moving quota pressure from active objects into the
+30-day recycle bin.
+
+This flow prevents new buildup. Existing objects already in the recycle bin
+require a separate, explicitly scoped purge because the ownership query only
+returns active applications.
 
 The important point is that all of these are background hygiene jobs. They are there to keep shared environments healthy and reduce accumulation over time.
 

--- a/internal/graph/util/applications.go
+++ b/internal/graph/util/applications.go
@@ -151,7 +151,7 @@ func (c *Client) UpdateApplicationRedirectUris(ctx context.Context, appID string
 func (c *Client) DeleteApplication(ctx context.Context, appID string) error {
 	err := c.graphClient.Applications().ByApplicationId(appID).Delete(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("delete application: %w", err)
+		return fmt.Errorf("delete application: %w", odataErrorWithDiagnostics(err))
 	}
 	return nil
 }

--- a/internal/graph/util/directory_objects.go
+++ b/internal/graph/util/directory_objects.go
@@ -1,0 +1,229 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+
+	"github.com/Azure/ARO-HCP/internal/graph/graphsdk/models/odataerrors"
+)
+
+const (
+	deletedItemPollInterval       = time.Second
+	deletedItemPropagationTimeout = 30 * time.Second
+	deletedItemRestoreTimeout     = 30 * time.Second
+)
+
+// ApplicationCleanupTarget identifies an application registration and its
+// associated service principal by their directory object IDs.
+type ApplicationCleanupTarget struct {
+	ApplicationObjectID      string
+	ServicePrincipalObjectID string
+}
+
+// CleanupApplications removes application registrations and their associated
+// service principals, permanently when the caller uses app-only credentials.
+func (c *Client) CleanupApplications(ctx context.Context, targets []ApplicationCleanupTarget) error {
+	var errs []error
+	for _, target := range targets {
+		if err := c.DeleteApplicationPermanently(ctx, target); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// DeleteApplicationPermanently removes the service principal first, then the
+// application, and purges both objects from deletedItems.
+func (c *Client) DeleteApplicationPermanently(ctx context.Context, target ApplicationCleanupTarget) error {
+	if target.ApplicationObjectID == "" {
+		return fmt.Errorf("application object ID is required")
+	}
+
+	if c.isUser {
+		err := c.DeleteApplication(ctx, target.ApplicationObjectID)
+		if isODataStatus(err, http.StatusNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		logr.FromContextOrDiscard(ctx).V(1).Info(
+			"Skipping permanent deletion because delegated credentials may not have deletedItems permissions",
+			"applicationObjectID", target.ApplicationObjectID,
+			"servicePrincipalObjectID", target.ServicePrincipalObjectID,
+		)
+		return nil
+	}
+
+	if target.ServicePrincipalObjectID != "" {
+		servicePrincipalWasDeleted := true
+		if err := c.DeleteServicePrincipal(ctx, target.ServicePrincipalObjectID); err != nil {
+			if !isODataStatus(err, http.StatusNotFound) {
+				return err
+			}
+			servicePrincipalWasDeleted = false
+		}
+
+		if err := c.permanentlyDeleteDirectoryObject(
+			ctx,
+			target.ServicePrincipalObjectID,
+			deletedItemPollInterval,
+			deletedItemPropagationTimeout,
+			servicePrincipalWasDeleted,
+		); err != nil {
+			purgeErr := fmt.Errorf("purge service principal %q: %w", target.ServicePrincipalObjectID, err)
+			if restoreErr := c.restoreDeletedDirectoryObject(ctx, target.ServicePrincipalObjectID); restoreErr != nil {
+				return errors.Join(
+					purgeErr,
+					fmt.Errorf("restore service principal %q after failed purge: %w", target.ServicePrincipalObjectID, restoreErr),
+				)
+			}
+			return purgeErr
+		}
+	}
+
+	applicationWasDeleted := true
+	if err := c.DeleteApplication(ctx, target.ApplicationObjectID); err != nil {
+		if !isODataStatus(err, http.StatusNotFound) {
+			return err
+		}
+		applicationWasDeleted = false
+	}
+
+	if err := c.permanentlyDeleteDirectoryObject(
+		ctx,
+		target.ApplicationObjectID,
+		deletedItemPollInterval,
+		deletedItemPropagationTimeout,
+		applicationWasDeleted,
+	); err != nil {
+		purgeErr := fmt.Errorf("purge application %q: %w", target.ApplicationObjectID, err)
+		if restoreErr := c.restoreDeletedDirectoryObject(ctx, target.ApplicationObjectID); restoreErr != nil {
+			return errors.Join(
+				purgeErr,
+				fmt.Errorf("restore application %q after failed purge: %w", target.ApplicationObjectID, restoreErr),
+			)
+		}
+		return purgeErr
+	}
+
+	return nil
+}
+
+func (c *Client) restoreDeletedDirectoryObject(ctx context.Context, objectID string) error {
+	restoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), deletedItemRestoreTimeout)
+	defer cancel()
+
+	requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(
+		abstractions.POST,
+		"{+baseurl}/directory/deletedItems/{directoryObjectId}/restore",
+		map[string]string{
+			"baseurl":           c.graphClient.RequestAdapter.GetBaseUrl(),
+			"directoryObjectId": objectID,
+		},
+	)
+	requestInfo.Headers.TryAdd("Accept", "application/json")
+
+	err := c.graphClient.RequestAdapter.SendNoContent(
+		restoreCtx,
+		requestInfo,
+		abstractions.ErrorMappings{
+			"XXX": odataerrors.CreateODataErrorFromDiscriminatorValue,
+		},
+	)
+	if err != nil {
+		return odataErrorWithDiagnostics(err)
+	}
+	return nil
+}
+
+func (c *Client) permanentlyDeleteDirectoryObject(
+	ctx context.Context,
+	objectID string,
+	pollInterval time.Duration,
+	propagationTimeout time.Duration,
+	requireAppearance bool,
+) error {
+	if objectID == "" {
+		return fmt.Errorf("directory object ID is required")
+	}
+
+	purgeCtx, cancel := context.WithTimeout(ctx, propagationTimeout)
+	defer cancel()
+
+	sawNotFound := false
+	for {
+		requestInfo := abstractions.NewRequestInformationWithMethodAndUrlTemplateAndPathParameters(
+			abstractions.DELETE,
+			"{+baseurl}/directory/deletedItems/{directoryObjectId}",
+			map[string]string{
+				"baseurl":           c.graphClient.RequestAdapter.GetBaseUrl(),
+				"directoryObjectId": objectID,
+			},
+		)
+		requestInfo.Headers.TryAdd("Accept", "application/json")
+
+		err := c.graphClient.RequestAdapter.SendNoContent(
+			purgeCtx,
+			requestInfo,
+			abstractions.ErrorMappings{
+				"XXX": odataerrors.CreateODataErrorFromDiscriminatorValue,
+			},
+		)
+		if err == nil {
+			return nil
+		}
+		if purgeCtx.Err() != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if sawNotFound && !requireAppearance {
+				return nil
+			}
+			return fmt.Errorf("directory object did not appear in deletedItems before timeout: %w", purgeCtx.Err())
+		}
+		if !isODataStatus(err, http.StatusNotFound) {
+			return odataErrorWithDiagnostics(err)
+		}
+		sawNotFound = true
+
+		timer := time.NewTimer(pollInterval)
+		select {
+		case <-purgeCtx.Done():
+			timer.Stop()
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if !requireAppearance {
+				return nil
+			}
+			return fmt.Errorf("directory object did not appear in deletedItems before timeout: %w", purgeCtx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+func isODataStatus(err error, statusCode int) bool {
+	var odataErr *odataerrors.ODataError
+	return errors.As(err, &odataErr) && odataErr.ResponseStatusCode == statusCode
+}

--- a/internal/graph/util/directory_objects_test.go
+++ b/internal/graph/util/directory_objects_test.go
@@ -1,0 +1,336 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+	"time"
+
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+	kiotahttp "github.com/microsoft/kiota-http-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Azure/ARO-HCP/internal/graph/graphsdk"
+)
+
+type noAuthProvider struct{}
+
+func (*noAuthProvider) AuthenticateRequest(
+	context.Context,
+	*abstractions.RequestInformation,
+	map[string]interface{},
+) error {
+	return nil
+}
+
+func newTestGraphClient(t *testing.T, server *httptest.Server) *Client {
+	t.Helper()
+
+	adapter, err := kiotahttp.NewNetHttpRequestAdapterWithParseNodeFactoryAndSerializationWriterFactoryAndHttpClient(
+		&noAuthProvider{},
+		nil,
+		nil,
+		server.Client(),
+	)
+	require.NoError(t, err)
+	adapter.SetBaseUrl(server.URL)
+
+	return &Client{
+		graphClient: graphsdk.NewGraphBaseServiceClient(adapter, nil),
+	}
+}
+
+func writeGraphError(t *testing.T, writer http.ResponseWriter, statusCode int) {
+	t.Helper()
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(statusCode)
+	_, err := fmt.Fprintf(
+		writer,
+		`{"error":{"code":"Request_ResourceNotFound","message":"status %d"}}`,
+		statusCode,
+	)
+	require.NoError(t, err)
+}
+
+func TestDeleteApplicationPermanentlyPurgesApplicationAndServicePrincipal(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests = append(requests, request.Method+" "+request.URL.Path)
+		switch request.URL.Path {
+		case "/applications/app-object",
+			"/servicePrincipals/sp-object",
+			"/directory/deletedItems/app-object",
+			"/directory/deletedItems/sp-object":
+			writer.WriteHeader(http.StatusNoContent)
+		default:
+			writeGraphError(t, writer, http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestGraphClient(t, server)
+	err := client.DeleteApplicationPermanently(context.Background(), ApplicationCleanupTarget{
+		ApplicationObjectID:      "app-object",
+		ServicePrincipalObjectID: "sp-object",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"DELETE /servicePrincipals/sp-object",
+		"DELETE /directory/deletedItems/sp-object",
+		"DELETE /applications/app-object",
+		"DELETE /directory/deletedItems/app-object",
+	}, requests)
+}
+
+func TestPermanentlyDeleteDirectoryObjectRetriesPropagationNotFound(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		attempts++
+		if attempts < 3 {
+			writeGraphError(t, writer, http.StatusNotFound)
+			return
+		}
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := newTestGraphClient(t, server)
+	err := client.permanentlyDeleteDirectoryObject(
+		context.Background(),
+		"app-object",
+		time.Millisecond,
+		time.Second,
+		true,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 3, attempts)
+}
+
+func TestPermanentlyDeleteDirectoryObjectReturnsNonNotFoundError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writeGraphError(t, writer, http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	client := newTestGraphClient(t, server)
+	err := client.permanentlyDeleteDirectoryObject(
+		context.Background(),
+		"app-object",
+		time.Millisecond,
+		time.Second,
+		true,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 403")
+}
+
+func TestDeleteApplicationPermanentlyResumesWhenApplicationIsAlreadyDeleted(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests = append(requests, request.Method+" "+request.URL.Path)
+		if request.URL.Path == "/applications/app-object" || request.URL.Path == "/servicePrincipals/sp-object" {
+			writeGraphError(t, writer, http.StatusNotFound)
+			return
+		}
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := newTestGraphClient(t, server)
+	err := client.DeleteApplicationPermanently(context.Background(), ApplicationCleanupTarget{
+		ApplicationObjectID:      "app-object",
+		ServicePrincipalObjectID: "sp-object",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"DELETE /servicePrincipals/sp-object",
+		"DELETE /directory/deletedItems/sp-object",
+		"DELETE /applications/app-object",
+		"DELETE /directory/deletedItems/app-object",
+	}, requests)
+}
+
+func TestDeleteApplicationPermanentlyPreservesApplicationWhenServicePrincipalPurgeFails(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests = append(requests, request.Method+" "+request.URL.Path)
+		switch request.URL.Path {
+		case "/servicePrincipals/sp-object":
+			writer.WriteHeader(http.StatusNoContent)
+		case "/directory/deletedItems/sp-object":
+			writeGraphError(t, writer, http.StatusForbidden)
+		case "/directory/deletedItems/sp-object/restore":
+			writer.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", request.Method, request.URL.Path)
+			writer.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestGraphClient(t, server)
+	err := client.DeleteApplicationPermanently(context.Background(), ApplicationCleanupTarget{
+		ApplicationObjectID:      "app-object",
+		ServicePrincipalObjectID: "sp-object",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "purge service principal")
+	assert.Equal(t, []string{
+		"DELETE /servicePrincipals/sp-object",
+		"DELETE /directory/deletedItems/sp-object",
+		"POST /directory/deletedItems/sp-object/restore",
+	}, requests)
+}
+
+func TestDeleteApplicationPermanentlyRestoresApplicationWhenPurgeFails(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests = append(requests, request.Method+" "+request.URL.Path)
+		switch request.Method + " " + request.URL.Path {
+		case "DELETE /servicePrincipals/sp-object",
+			"DELETE /directory/deletedItems/sp-object",
+			"DELETE /applications/app-object":
+			writer.WriteHeader(http.StatusNoContent)
+		case "DELETE /directory/deletedItems/app-object":
+			writeGraphError(t, writer, http.StatusForbidden)
+		case "POST /directory/deletedItems/app-object/restore":
+			writer.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected request: %s %s", request.Method, request.URL.Path)
+			writer.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestGraphClient(t, server)
+	err := client.DeleteApplicationPermanently(context.Background(), ApplicationCleanupTarget{
+		ApplicationObjectID:      "app-object",
+		ServicePrincipalObjectID: "sp-object",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "purge application")
+	assert.Equal(t, []string{
+		"DELETE /servicePrincipals/sp-object",
+		"DELETE /directory/deletedItems/sp-object",
+		"DELETE /applications/app-object",
+		"DELETE /directory/deletedItems/app-object",
+		"POST /directory/deletedItems/app-object/restore",
+	}, requests)
+}
+
+func TestDeleteApplicationPermanentlyWithDelegatedCredentialsOnlySoftDeletes(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests = append(requests, request.Method+" "+request.URL.Path)
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := newTestGraphClient(t, server)
+	client.isUser = true
+	err := client.DeleteApplicationPermanently(context.Background(), ApplicationCleanupTarget{
+		ApplicationObjectID:      "app-object",
+		ServicePrincipalObjectID: "sp-object",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"DELETE /applications/app-object",
+	}, requests)
+}
+
+func TestPermanentlyDeleteDirectoryObjectTreatsAbsentObjectAsAlreadyPurged(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writeGraphError(t, writer, http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := newTestGraphClient(t, server)
+	err := client.permanentlyDeleteDirectoryObject(
+		context.Background(),
+		"app-object",
+		time.Millisecond,
+		5*time.Millisecond,
+		false,
+	)
+	require.NoError(t, err)
+}
+
+func TestRestoreDeletedDirectoryObjectSurvivesCanceledOperationContext(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests++
+		require.Equal(t, http.MethodPost, request.Method)
+		require.Equal(t, "/directory/deletedItems/app-object/restore", request.URL.Path)
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := newTestGraphClient(t, server)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := client.restoreDeletedDirectoryObject(ctx, "app-object")
+	require.NoError(t, err)
+	assert.Equal(t, 1, requests)
+}
+
+func TestGetServicePrincipalByAppID(t *testing.T) {
+	const appID = "11111111-2222-3333-4444-555555555555"
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		require.Equal(t, http.MethodGet, request.Method)
+		require.Equal(t, "/servicePrincipals", request.URL.Path)
+		assert.Equal(t, "appId eq '"+appID+"'", request.URL.Query().Get("$filter"))
+		assert.True(t, slices.Contains(request.URL.Query()["$select"], "id,appId"))
+
+		writer.Header().Set("Content-Type", "application/json")
+		_, err := fmt.Fprint(
+			writer,
+			`{"value":[{"id":"sp-object","appId":"`+appID+`"}]}`,
+		)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client := newTestGraphClient(t, server)
+	servicePrincipal, err := client.GetServicePrincipalByAppID(context.Background(), appID)
+	require.NoError(t, err)
+	require.NotNil(t, servicePrincipal)
+	assert.Equal(t, "sp-object", servicePrincipal.ID)
+	assert.Equal(t, appID, servicePrincipal.AppID)
+}
+
+func TestGetServicePrincipalByAppIDReturnsNilWhenMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		_, err := fmt.Fprint(writer, `{"value":[]}`)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client := newTestGraphClient(t, server)
+	servicePrincipal, err := client.GetServicePrincipalByAppID(
+		context.Background(),
+		"11111111-2222-3333-4444-555555555555",
+	)
+	require.NoError(t, err)
+	assert.Nil(t, servicePrincipal)
+}

--- a/internal/graph/util/serviceprincipal.go
+++ b/internal/graph/util/serviceprincipal.go
@@ -18,7 +18,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+
 	"github.com/Azure/ARO-HCP/internal/graph/graphsdk/models"
+	"github.com/Azure/ARO-HCP/internal/graph/graphsdk/serviceprincipals"
 )
 
 // ServicePrincipal represents a Microsoft Entra service principal
@@ -44,4 +47,46 @@ func (c *Client) CreateServicePrincipal(ctx context.Context, appId string) (*Ser
 		ID:    *createdSp.GetId(),
 		AppID: *createdSp.GetAppId(),
 	}, nil
+}
+
+// DeleteServicePrincipal soft-deletes a service principal.
+func (c *Client) DeleteServicePrincipal(ctx context.Context, servicePrincipalID string) error {
+	err := c.graphClient.ServicePrincipals().ByServicePrincipalId(servicePrincipalID).Delete(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("delete service principal: %w", odataErrorWithDiagnostics(err))
+	}
+	return nil
+}
+
+// GetServicePrincipalByAppID returns the service principal associated with an
+// application ID. A nil result means no active service principal exists.
+func (c *Client) GetServicePrincipalByAppID(ctx context.Context, appID string) (*ServicePrincipal, error) {
+	response, err := c.graphClient.ServicePrincipals().Get(ctx, &serviceprincipals.ServicePrincipalsRequestBuilderGetRequestConfiguration{
+		QueryParameters: &serviceprincipals.ServicePrincipalsRequestBuilderGetQueryParameters{
+			Filter: to.Ptr(fmt.Sprintf("appId eq '%s'", appID)),
+			Select: []string{"id", "appId"},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get service principal for appId %q: %w", appID, odataErrorWithDiagnostics(err))
+	}
+
+	values := response.GetValue()
+	if len(values) == 0 {
+		return nil, nil
+	}
+	if len(values) > 1 {
+		return nil, fmt.Errorf("found %d service principals for appId %q", len(values), appID)
+	}
+
+	value := values[0]
+	if value.GetId() == nil || value.GetAppId() == nil {
+		return nil, fmt.Errorf("service principal for appId %q has an incomplete response", appID)
+	}
+
+	servicePrincipal := &ServicePrincipal{
+		ID:    *value.GetId(),
+		AppID: *value.GetAppId(),
+	}
+	return servicePrincipal, nil
 }

--- a/test/util/cleanup/appregistrations/run.go
+++ b/test/util/cleanup/appregistrations/run.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/Azure/ARO-HCP/test/util/framework"
+	graphutil "github.com/Azure/ARO-HCP/internal/graph/util"
 )
 
 func (o *Options) Run(ctx context.Context) error {
@@ -37,12 +37,28 @@ func (o *Options) Run(ctx context.Context) error {
 		return nil
 	}
 
-	appObjectIDs := make([]string, 0, len(expiredApps))
+	targets := make([]graphutil.ApplicationCleanupTarget, 0, len(expiredApps))
 	for _, app := range expiredApps {
-		logger.Info("Found expired app registration", "clientID", app.AppID, "objectID", app.ID, "displayName", app.DisplayName)
-		if !o.DryRun {
-			appObjectIDs = append(appObjectIDs, app.ID)
+		servicePrincipal, err := o.GraphClient.GetServicePrincipalByAppID(ctx, app.AppID)
+		if err != nil {
+			return fmt.Errorf("failed to resolve service principal for app registration %q: %w", app.ID, err)
 		}
+
+		target := graphutil.ApplicationCleanupTarget{
+			ApplicationObjectID: app.ID,
+		}
+		if servicePrincipal != nil {
+			target.ServicePrincipalObjectID = servicePrincipal.ID
+		}
+		targets = append(targets, target)
+
+		logger.Info(
+			"Found expired app registration",
+			"clientID", app.AppID,
+			"applicationObjectID", app.ID,
+			"servicePrincipalObjectID", target.ServicePrincipalObjectID,
+			"displayName", app.DisplayName,
+		)
 	}
 
 	if o.DryRun {
@@ -50,11 +66,11 @@ func (o *Options) Run(ctx context.Context) error {
 		return nil
 	}
 
-	logger.Info("Deleting owned expired app registrations", "count", len(appObjectIDs))
-	if err := framework.CleanupAppRegistrations(ctx, o.GraphClient, appObjectIDs); err != nil {
-		return fmt.Errorf("failed to delete app registrations: %w", err)
+	logger.Info("Deleting and purging owned expired app registrations", "count", len(targets))
+	if err := o.GraphClient.CleanupApplications(ctx, targets); err != nil {
+		return fmt.Errorf("failed to delete and purge app registrations: %w", err)
 	}
 
-	logger.Info("All expired app registrations successfully deleted", "count", len(appObjectIDs))
+	logger.Info("All expired app registrations and service principals successfully purged", "count", len(targets))
 	return nil
 }

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -67,7 +67,7 @@ type perItOrDescribeTestContext struct {
 
 	contextLock                   sync.RWMutex
 	knownResourceGroups           []string
-	knownAppRegistrationIDs       []string
+	knownAppRegistrations         []graphutil.ApplicationCleanupTarget
 	createdRoleAssignmentIDs      []string
 	subscriptionID                string
 	clientFactory20240610         *hcpsdk20240610preview.ClientFactory
@@ -263,8 +263,8 @@ func (tc *perItOrDescribeTestContext) deleteCreatedResources(ctx context.Context
 	}
 
 	tc.contextLock.RLock()
-	resourceGroupNames := tc.knownResourceGroups
-	appRegistrations := tc.knownAppRegistrationIDs
+	resourceGroupNames := slices.Clone(tc.knownResourceGroups)
+	appRegistrations := slices.Clone(tc.knownAppRegistrations)
 	tc.contextLock.RUnlock()
 	ginkgo.GinkgoLogr.Info("deleting created resources")
 
@@ -280,9 +280,9 @@ func (tc *perItOrDescribeTestContext) deleteCreatedResources(ctx context.Context
 		}
 	}
 
-	err = CleanupAppRegistrations(ctx, graphClient, appRegistrations)
+	err = graphClient.CleanupApplications(ctx, appRegistrations)
 	if err != nil {
-		ginkgo.GinkgoLogr.Error(err, "at least one app registration failed to delete")
+		ginkgo.GinkgoLogr.Error(err, "at least one app registration failed to delete and purge")
 	}
 
 	ginkgo.GinkgoLogr.Info("finished deleting created resources")
@@ -1010,29 +1010,23 @@ func (tc *perItOrDescribeTestContext) NewAppRegistrationWithServicePrincipal(ctx
 		return nil, nil, fmt.Errorf("failed to create app registration: %w", err)
 	}
 
-	func() {
-		tc.contextLock.Lock()
-		defer tc.contextLock.Unlock()
-		// Track the ObjectIDs as that's what operations are performed against, not AppID
-		tc.knownAppRegistrationIDs = append(tc.knownAppRegistrationIDs, app.ID)
-	}()
+	tc.contextLock.Lock()
+	targetIndex := len(tc.knownAppRegistrations)
+	tc.knownAppRegistrations = append(tc.knownAppRegistrations, graphutil.ApplicationCleanupTarget{
+		ApplicationObjectID: app.ID,
+	})
+	tc.contextLock.Unlock()
 
 	sp, err := graphClient.CreateServicePrincipal(ctx, app.AppID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create service principal: %w", err)
 	}
 
-	return app, sp, nil
-}
+	tc.contextLock.Lock()
+	tc.knownAppRegistrations[targetIndex].ServicePrincipalObjectID = sp.ID
+	tc.contextLock.Unlock()
 
-func CleanupAppRegistrations(ctx context.Context, graphClient *graphutil.Client, appRegistrationIDs []string) error {
-	var errs []error
-	for _, currAppID := range appRegistrationIDs {
-		if err := graphClient.DeleteApplication(ctx, currAppID); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return errors.Join(errs...)
+	return app, sp, nil
 }
 
 func (tc *perItOrDescribeTestContext) GetARMResourcesClientFactoryOrDie(ctx context.Context) *armresources.ClientFactory {


### PR DESCRIPTION
[AROSLSRE-1982](https://redhat.atlassian.net/browse/AROSLSRE-1982)

### What

Permanently remove E2E application registrations and their associated service principals from Entra deleted items when cleanup runs with app-only CI credentials.

Both strict per-test teardown and the hourly expired-application job now track or resolve the two directory object IDs, delete and purge the service principal first, then delete and purge the application. Cleanup retries deleted-item propagation and attempts bounded restoration after a partial failure. Delegated local-user cleanup retains normal soft-delete behavior.

### Why

Deleting an application through Microsoft Graph only soft-deletes it and its service principal. Thousands of recoverable `aro-hcp-e2e-*` identities accumulated in the shared tenant, consumed directory quota, and prevented development cluster creation.

Purging only the application is insufficient because the service principal remains independently recoverable and continues contributing to quota usage.

### Testing

- `GOTOOLCHAIN=go1.25.7 make lint`
- `cd internal && GOTOOLCHAIN=go1.25.7 go test ./graph/util`
- `cd test && GOTOOLCHAIN=go1.25.7 go test ./util/cleanup/appregistrations ./util/framework`
- `cd test && GOTOOLCHAIN=go1.25.7 go build ./cmd/aro-hcp-tests`
- `GOTOOLCHAIN=go1.25.7 make verify-json-format verify-gomega-assertions verify-mi-containers verify-schema`
- `GOTOOLCHAIN=go1.25.7 make generate` and `make yamlfmt` produced no changes

### Special notes for your reviewer

This prevents new recycle-bin buildup. Existing deleted objects require a separate, explicitly scoped one-time purge because the ownership query used by the periodic job returns only active applications.

Review focus: @hlipsig @rvazquez

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if dashboards or other UI changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge

If E2E tests are included:

- [x] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [x] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
