### PR TITLE
feat(mgmt-agent): detect nodes that never reached Ready (AROSLSRE-1983)

### DIFF
--- a/mgmt-agent/pkg/controller/nodehealth/controller.go
+++ b/mgmt-agent/pkg/controller/nodehealth/controller.go
@@ -389,10 +389,15 @@ func (c *Controller) syncHandler(ctx context.Context, name string) error {
 		}
 		if changed {
 			detectionsTotal.WithLabelValues(snap.DetectorName, snap.MatchedSignature).Inc()
-			logger.Info("detector fired; node labeled wedged",
-				"detector", snap.DetectorName,
-				"signature", snap.MatchedSignature,
-				"evidence", snap.ReasonString())
+			// Pod evidence is logged as structured fields so it stays filterable.
+			// A node detector has no pod counts, so it logs its summary instead.
+			kv := []any{"detector", snap.DetectorName, "signature", snap.MatchedSignature}
+			if snap.Pods != nil {
+				kv = append(kv, "failures", snap.Pods.FailureCount, "recentSuccess", snap.Pods.RecentSuccess)
+			} else {
+				kv = append(kv, "evidence", snap.Detail)
+			}
+			logger.Info("detector fired; node labeled wedged", kv...)
 		}
 		// Mitigation of a labeled node (cordon, taint, evict, delete) is owned
 		// by a separate controller; this controller stops at labeling.

--- a/mgmt-agent/pkg/controller/nodehealth/controller.go
+++ b/mgmt-agent/pkg/controller/nodehealth/controller.go
@@ -392,8 +392,7 @@ func (c *Controller) syncHandler(ctx context.Context, name string) error {
 			logger.Info("detector fired; node labeled wedged",
 				"detector", snap.DetectorName,
 				"signature", snap.MatchedSignature,
-				"failures", snap.FailureCount,
-				"recentSuccess", snap.RecentSuccess)
+				"evidence", snap.ReasonString())
 		}
 		// Mitigation of a labeled node (cordon, taint, evict, delete) is owned
 		// by a separate controller; this controller stops at labeling.

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/README.md
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/README.md
@@ -43,23 +43,39 @@ just started decides exactly what one running for hours would, with no warm-up.
 A **detector** is one fault family. Detection is modular so that adding a family
 is adding code in its own file, never editing the engine:
 
-- **`decide.go`**: the engine. It defines the `Detector` interface
-  (`Applies`, `Evaluate`, `MeetsThreshold`, plus `Name`/`Reason`), the `Snapshot` of
-  evaluated evidence, the `Decision` type, the `registry` of detectors, and
-  `Decide`, which iterates the registry without knowing any concrete type.
+- **`decide.go`**: the engine. It defines `Detector` (identity and scope only:
+  `Name`, `Reason`, `Applies`, `Window`), the two evaluation interfaces
+  `PodDetector` and `NodeDetector`, the `Snapshot` of evaluated evidence and its
+  `PodEvidence`, the `Decision` type, the `podRegistry` and `nodeRegistry`, and
+  `Decide`, which iterates them without knowing any concrete type.
 - **`signature_detector.go`**: the shared base. `signatureDetector` implements
-  the `Detector` interface once for the common shape and carries the reusable
-  toolkit (windowed correlation of failure Events to stuck pods, condition-based
-  dwell math, node-Ready and success helpers). Families that fit this shape reuse
-  all of it.
+  `PodDetector` once for the common shape and carries the reusable toolkit
+  (windowed correlation of failure Events to stuck pods, condition-based dwell
+  math, node-Ready and success helpers). Families that fit this shape reuse all
+  of it.
 - **`swift_vf.go`**: one fault family's specifics only, the `swift-vf-teardown`
   detector value plus its applicability predicate. No evaluation logic lives here.
+- **`never_ready.go`**: the `never-ready` detector, a `NodeDetector` whose whole
+  evidence is the Node object.
 
-`Decide` walks `registry`. For each detector it calls `Applies(node)` (skip if the
-node can't exhibit the fault), then `Evaluate(...)` to gather the evidence
-`Snapshot`, then `MeetsThreshold(snap, now)`. The first detector that fires
-wins and the node is `Wedged`; if none fires but some success was seen, the node is
-`Healthy`; otherwise `Unknown`.
+A detector reads either the node's Pods and Events or the Node object itself, and
+those are not the same job, so they are not the same interface. A `PodDetector`
+adds `Evaluate` and `MeetsThreshold`. A `NodeDetector` adds `EvaluateNode`, which
+returns the `Decision` directly, because for it the evidence and the judgement are
+one step. Each registry holds only its own kind, so a detector cannot run on a
+path its evidence does not exist on.
+
+`Decide` picks the path from the node's Ready condition. A node that is not Ready
+never had a pod population worth reading, so `Decide` walks `nodeRegistry` and
+calls `EvaluateNode`. A Ready node goes to `podRegistry`, where each detector gets
+`Applies(node)` (skip if the node can't exhibit the fault), then `Evaluate(...)`
+to gather the evidence `Snapshot`, then `MeetsThreshold(snap, now)`. Either way
+the first detector that fires wins and the node is `Wedged`; if none fires but
+some success was seen, the node is `Healthy`; otherwise `Unknown`.
+
+`Snapshot.Pods` holds the pod-derived counts and is nil for a `NodeDetector`, so a
+detector that reads no pods reports no pod counts rather than zeroes that would
+read as "nothing was stuck".
 
 ## The `signatureDetector` shape
 
@@ -125,7 +141,9 @@ Pods that the apiserver garbage-collects:
   cache, which is why the terminal-pod shape above is counted rather than relying on
   a pod still being alive at reconcile time.
 
-## The one detector today: `swift-vf-teardown`
+## The detectors today
+
+### `swift-vf-teardown`
 
 Applies only to SWIFT-v2 delegated-NIC nodes (label
 `kubernetes.azure.com/podnetwork-swiftv2-enabled=true`, exported as
@@ -144,13 +162,33 @@ labeled is still swept and has its stale label retired
 (`DecisionNotApplicable`), including when that transition happened while the
 controller was down.
 
-## Adding a fault family
+### `never-ready`
 
+A `NodeDetector`, scoped to the same SWIFT-v2 nodes. It fires on a node that
+registered and never reached Ready for 30 minutes, which node lifecycle does not
+rescue: a node that was Ready and dropped out is someone else's problem, but a
+node that never started sits NotReady until a human notices.
+
+The discriminator is the Ready condition: never `True`, and its first transition
+falls within 2 minutes of the node's creation. A node that reached Ready at any
+point has a strictly later transition. The dwell comes from the dev fleet, where
+1119 nodes over 14 days reached Ready in at most 3.4 minutes, so 30 minutes is
+roughly nine times the worst legitimate boot.
+
+It is deliberately generic rather than keyed on a cause. Dead IMDS, a failed
+disk, a kubelet certificate problem and a failed image pull are all born broken
+and all remedied by reimaging, and one detector is one fault with one remedy. The
+Ready condition's reason is carried as the signature for triage instead, which
+keeps the evidence to the Node object alone.
+
+## Adding a fault family
 1. If it fits the signature shape, add a new `signatureDetector` value in its own
    file (e.g. `myfault.go`) with its constants, plus its `appliesTo` predicate.
-2. If it needs different evidence (for example reading a CRD, not Events), add a
-   new type in its own file implementing the `Detector` interface directly.
-3. Register it in `registry` in `decide.go`.
+2. If it needs different evidence, add a new type in its own file implementing
+   `Detector` plus whichever of `PodDetector` or `NodeDetector` matches what it
+   reads.
+3. Register it in `podRegistry` or `nodeRegistry` in `decide.go`, whichever
+   matches its interface.
 4. Add table cases to `decide_test.go`.
 
-`Decide` needs no changes in any case: it only knows the interface.
+`Decide` needs no changes in any case: it only knows the interfaces.

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/decide.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/decide.go
@@ -95,13 +95,9 @@ type Detector interface {
 }
 
 // nodeDetector is a Detector whose evidence is the Node object itself rather
-// than the Pods and Events on it. Decide evaluates these ahead of the Ready
-// gate, because their whole subject is a node that never became Ready and so
-// has no meaningful pod population to read.
-//
-// It is an optional extension rather than a change to Detector: a pod/event
-// detector has no node-only evaluation to offer, and widening Evaluate for the
-// sake of one family would touch every existing detector and its tests.
+// than the Pods and Events on it. Decide evaluates these on the NotReady path,
+// because their whole subject is a node that never became Ready and so has no
+// meaningful pod population to read.
 type nodeDetector interface {
 	Detector
 	// EvaluateNode reads the detector's signals from the Node alone. It performs
@@ -169,8 +165,8 @@ type Snapshot struct {
 	// Detail, when set, replaces the pod-centric summary ReasonString renders. A
 	// detector whose evidence is not pod counts sets this so the reason
 	// annotation describes what it actually observed, instead of reporting zero
-	// pods stuck in a zero-length window. Leaving it empty keeps the pod-centric
-	// summary, so every existing detector is unaffected.
+	// pods stuck in a zero-length window. When it is empty, ReasonString renders
+	// the pod-centric summary.
 	Detail string
 }
 
@@ -205,8 +201,8 @@ func Decide(node *corev1.Node, events []*corev1.Event, pods []*corev1.Pod, now t
 		return DecisionNotApplicable, Snapshot{}
 	}
 	// Node-Ready precondition. A node that was Ready and dropped out (reboot,
-	// upgrade, drain) is left to node lifecycle, which is what the original gate
-	// was for. A node that never reached Ready is a different case: nothing in
+	// upgrade, drain) is left to node lifecycle, which rescues it. A node that
+	// never reached Ready is a different case: nothing in
 	// node lifecycle rescues it, so it is ours. Only node-state detectors run on
 	// this path, because a node that never started has no pod population worth
 	// reading, and each of them rejects a node that was once Ready on its own

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/decide.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/decide.go
@@ -63,11 +63,11 @@ func (d Decision) String() string {
 	}
 }
 
-// Detector is one fault family. Each concrete detector lives in its own file and
-// contributes only its specifics (applicability, signals, thresholds); the
-// evaluation primitives are shared through a common base (see signatureDetector).
-// Decide iterates the registry and never depends on a concrete type, so adding a
-// family is adding a Detector, not editing Decide.
+// Detector is what every fault family has in common: an identity and a scope.
+// It carries no evaluation method, because the two kinds of detector do not read
+// the same evidence and cannot share one. A concrete detector implements this
+// plus exactly one of PodDetector or NodeDetector, which is what puts it on the
+// matching path in Decide.
 type Detector interface {
 	// Name is a stable identifier used in logs, events, metrics, and the
 	// detector annotation.
@@ -82,6 +82,12 @@ type Detector interface {
 	// detector, independent of any node, so callers that only need the window do
 	// not have to evaluate the detector to learn it.
 	Window() time.Duration
+}
+
+// PodDetector reads a node's health from the Pods and Events held for it. It
+// runs only on a Ready node, where a pod population exists to be read.
+type PodDetector interface {
+	Detector
 	// Evaluate reads the detector's signals for the node from the Events and Pods
 	// currently held for it. Both the failure and the success signal come out of
 	// the Pods passed in, so the result depends on nothing but what a LIST
@@ -94,20 +100,29 @@ type Detector interface {
 	MeetsThreshold(snap Snapshot, now time.Time) bool
 }
 
-// nodeDetector is a Detector whose evidence is the Node object itself rather
-// than the Pods and Events on it. Decide evaluates these on the NotReady path,
-// because their whole subject is a node that never became Ready and so has no
-// meaningful pod population to read.
-type nodeDetector interface {
+// NodeDetector reads a node's health from the Node object alone. It runs only on
+// a node that is not Ready, whose subject never started and so has no pod
+// population worth reading.
+//
+// It returns the Decision rather than a snapshot plus a separate threshold
+// predicate. The two are one judgement here, and splitting them would mean
+// handing the Ready path a snapshot it must be trusted not to act on.
+type NodeDetector interface {
 	Detector
-	// EvaluateNode reads the detector's signals from the Node alone. It performs
-	// no I/O and depends on nothing a LIST cannot return, exactly as Evaluate.
-	EvaluateNode(node *corev1.Node, now time.Time) Snapshot
+	// EvaluateNode decides the node's state from the Node alone. It performs no
+	// I/O and depends on nothing a LIST cannot return, exactly as Evaluate.
+	// It returns DecisionWedged with the supporting evidence, or DecisionUnknown.
+	EvaluateNode(node *corev1.Node, now time.Time) (Decision, Snapshot)
 }
 
-// registry is the hard-coded set of detectors. A new fault family is a new
-// Detector added here, reusing the shared primitives, shipped and tested as code.
-var registry = []Detector{swiftVFTeardown, neverReady}
+// podRegistry and nodeRegistry are the hard-coded sets of detectors, split by
+// the evidence they read. A new fault family is added to whichever one matches
+// its evidence, shipped and tested as code. The split is what keeps a detector
+// off the path it has nothing to say on, instead of a runtime check.
+var (
+	podRegistry  = []PodDetector{swiftVFTeardown}
+	nodeRegistry = []NodeDetector{neverReady}
+)
 
 // AnyApplies reports whether any detector owns this node. It reads only the
 // node, so a caller can answer the ownership question before doing the work of
@@ -117,7 +132,12 @@ func AnyApplies(node *corev1.Node) bool {
 	if node == nil {
 		return false
 	}
-	for _, d := range registry {
+	for _, d := range podRegistry {
+		if d.Applies(node) {
+			return true
+		}
+	}
+	for _, d := range nodeRegistry {
 		if d.Applies(node) {
 			return true
 		}
@@ -125,16 +145,11 @@ func AnyApplies(node *corev1.Node) bool {
 	return false
 }
 
-// Snapshot is the read-only evidence a detector evaluated for a node, retained
-// for logging, the reason annotation, and the firing decision. Its fields are
-// exported so the controller and labeler can render them.
-type Snapshot struct {
-	// DetectorName is the name of the detector this snapshot belongs to.
-	DetectorName string
-	// Reason is the detector's human-readable explanation (set when it fires).
-	Reason string
-	// Window is the detector's evaluation window, for the reason string.
-	Window time.Duration
+// PodEvidence is the pod-derived evidence a PodDetector gathered. It is a
+// separate type so that a detector which reads no pods has no pod counts to
+// report: it leaves Snapshot.Pods nil, rather than carrying zeroes that read as
+// "no pods were stuck" when the truth is "pods were never the evidence".
+type PodEvidence struct {
 	// FailureCount is the number of distinct pods on the node currently stuck
 	// without a sandbox (PodReadyToStartContainers=False) that are the subject of
 	// a matching failure Event in the window, regardless of how long each has been
@@ -150,37 +165,50 @@ type Snapshot struct {
 	// inside the window (see SuccessAt). It is read from the same Pods the failure
 	// signal is read from, so it needs no history and survives a restart.
 	RecentSuccess bool
-	// StuckSince is the oldest PodReadyToStartContainers=False lastTransitionTime
-	// among the node's currently-stuck failing pods, a GC-independent dwell signal
-	// read from durable Pod state, reported for observability.
+}
+
+// Snapshot is the read-only evidence a detector evaluated for a node, retained
+// for logging, the reason annotation, and the firing decision. Its fields are
+// exported so the controller and labeler can render them.
+type Snapshot struct {
+	// DetectorName is the name of the detector this snapshot belongs to.
+	DetectorName string
+	// Reason is the detector's human-readable explanation (set when it fires).
+	Reason string
+	// Window is the detector's evaluation window, for the reason string.
+	Window time.Duration
+	// Pods is the pod-derived evidence, set by a PodDetector and nil for a
+	// NodeDetector, whose evidence is the Node object alone.
+	Pods *PodEvidence
+	// StuckSince is the dwell signal: for a PodDetector the oldest
+	// PodReadyToStartContainers=False lastTransitionTime among the node's
+	// currently-stuck failing pods, for a NodeDetector the point the node's own
+	// state started. Both are read from durable state, so neither depends on
+	// Event retention.
 	StuckSince time.Time
-	// MatchedSignature is the detector signature that classified the most of the
-	// pods counted in FailureCount, as its raw pattern. It is triage detail only:
-	// it names which failure mode inside the detector's family the node is
-	// showing, so an operator does not have to go read Events that may already
-	// have been collected. It is never a decision input, and mitigation must key
-	// on DetectorName, not on this: one detector is one fault with one remedy,
-	// and branching on the signature would require knowing detector internals.
+	// MatchedSignature names the failure mode inside the detector's family, as its
+	// raw pattern. It is triage detail only: it saves an operator reading Events
+	// that may already have been collected. It is never a decision input, and
+	// mitigation must key on DetectorName, not on this: one detector is one fault
+	// with one remedy, and branching on the signature would require knowing
+	// detector internals.
 	MatchedSignature string
-	// Detail, when set, replaces the pod-centric summary ReasonString renders. A
-	// detector whose evidence is not pod counts sets this so the reason
-	// annotation describes what it actually observed, instead of reporting zero
-	// pods stuck in a zero-length window. When it is empty, ReasonString renders
-	// the pod-centric summary.
+	// Detail is the reason-annotation summary for a detector whose evidence is
+	// not pod counts. ReasonString renders it in place of the pod-centric summary.
 	Detail string
 }
 
 // ReasonString renders a short human-readable summary for the reason annotation.
 func (s Snapshot) ReasonString() string {
-	if s.Detail != "" {
+	if s.Pods == nil {
 		return s.Detail
 	}
 	success := "no recent success"
-	if s.RecentSuccess {
+	if s.Pods.RecentSuccess {
 		success = "a recent success"
 	}
 	return fmt.Sprintf("%d pods stuck past dwell (%d stuck total), %s in %s window",
-		s.SustainedCount, s.FailureCount, success, s.Window)
+		s.Pods.SustainedCount, s.Pods.FailureCount, success, s.Window)
 }
 
 // Decide is the pure core of the controller: given a node, the Events and Pods
@@ -202,19 +230,16 @@ func Decide(node *corev1.Node, events []*corev1.Event, pods []*corev1.Pod, now t
 	}
 	// Node-Ready precondition. A node that was Ready and dropped out (reboot,
 	// upgrade, drain) is left to node lifecycle, which rescues it. A node that
-	// never reached Ready is a different case: nothing in
-	// node lifecycle rescues it, so it is ours. Only node-state detectors run on
-	// this path, because a node that never started has no pod population worth
-	// reading, and each of them rejects a node that was once Ready on its own
-	// discriminator.
+	// never reached Ready is a different case: nothing in node lifecycle rescues
+	// it, so it is ours. Only node-state detectors run here, because a node that
+	// never started has no pod population worth reading, and each of them rejects
+	// a node that was once Ready on its own discriminator.
 	if !isNodeReady(node) {
-		for _, d := range registry {
-			nd, ok := d.(nodeDetector)
-			if !ok || !d.Applies(node) {
+		for _, d := range nodeRegistry {
+			if !d.Applies(node) {
 				continue
 			}
-			snap := nd.EvaluateNode(node, now)
-			if nd.MeetsThreshold(snap, now) {
+			if decision, snap := d.EvaluateNode(node, now); decision == DecisionWedged {
 				snap.Reason = d.Reason()
 				return DecisionWedged, snap
 			}
@@ -225,12 +250,12 @@ func Decide(node *corev1.Node, events []*corev1.Event, pods []*corev1.Pod, now t
 	}
 
 	sawSuccess := false
-	for _, d := range registry {
+	for _, d := range podRegistry {
 		if !d.Applies(node) {
 			continue
 		}
 		snap := d.Evaluate(events, pods, now)
-		if snap.RecentSuccess {
+		if snap.Pods != nil && snap.Pods.RecentSuccess {
 			sawSuccess = true
 		}
 		if d.MeetsThreshold(snap, now) {

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/decide.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/decide.go
@@ -230,10 +230,7 @@ func Decide(node *corev1.Node, events []*corev1.Event, pods []*corev1.Pod, now t
 	}
 	// Node-Ready precondition. A node that was Ready and dropped out (reboot,
 	// upgrade, drain) is left to node lifecycle, which rescues it. A node that
-	// never reached Ready is a different case: nothing in node lifecycle rescues
-	// it, so it is ours. Only node-state detectors run here, because a node that
-	// never started has no pod population worth reading, and each of them rejects
-	// a node that was once Ready on its own discriminator.
+	// never reached Ready is not rescued by anything, so it is ours.
 	if !isNodeReady(node) {
 		for _, d := range nodeRegistry {
 			if !d.Applies(node) {

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/decide.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/decide.go
@@ -94,9 +94,24 @@ type Detector interface {
 	MeetsThreshold(snap Snapshot, now time.Time) bool
 }
 
+// nodeDetector is a Detector whose evidence is the Node object itself rather
+// than the Pods and Events on it. Decide evaluates these ahead of the Ready
+// gate, because their whole subject is a node that never became Ready and so
+// has no meaningful pod population to read.
+//
+// It is an optional extension rather than a change to Detector: a pod/event
+// detector has no node-only evaluation to offer, and widening Evaluate for the
+// sake of one family would touch every existing detector and its tests.
+type nodeDetector interface {
+	Detector
+	// EvaluateNode reads the detector's signals from the Node alone. It performs
+	// no I/O and depends on nothing a LIST cannot return, exactly as Evaluate.
+	EvaluateNode(node *corev1.Node, now time.Time) Snapshot
+}
+
 // registry is the hard-coded set of detectors. A new fault family is a new
 // Detector added here, reusing the shared primitives, shipped and tested as code.
-var registry = []Detector{swiftVFTeardown}
+var registry = []Detector{swiftVFTeardown, neverReady}
 
 // AnyApplies reports whether any detector owns this node. It reads only the
 // node, so a caller can answer the ownership question before doing the work of
@@ -151,10 +166,19 @@ type Snapshot struct {
 	// on DetectorName, not on this: one detector is one fault with one remedy,
 	// and branching on the signature would require knowing detector internals.
 	MatchedSignature string
+	// Detail, when set, replaces the pod-centric summary ReasonString renders. A
+	// detector whose evidence is not pod counts sets this so the reason
+	// annotation describes what it actually observed, instead of reporting zero
+	// pods stuck in a zero-length window. Leaving it empty keeps the pod-centric
+	// summary, so every existing detector is unaffected.
+	Detail string
 }
 
 // ReasonString renders a short human-readable summary for the reason annotation.
 func (s Snapshot) ReasonString() string {
+	if s.Detail != "" {
+		return s.Detail
+	}
 	success := "no recent success"
 	if s.RecentSuccess {
 		success = "a recent success"
@@ -180,8 +204,27 @@ func Decide(node *corev1.Node, events []*corev1.Event, pods []*corev1.Pod, now t
 	if !AnyApplies(node) {
 		return DecisionNotApplicable, Snapshot{}
 	}
-	// Node-Ready precondition: a NotReady node is left to node lifecycle.
+	// Node-Ready precondition. A node that was Ready and dropped out (reboot,
+	// upgrade, drain) is left to node lifecycle, which is what the original gate
+	// was for. A node that never reached Ready is a different case: nothing in
+	// node lifecycle rescues it, so it is ours. Only node-state detectors run on
+	// this path, because a node that never started has no pod population worth
+	// reading, and each of them rejects a node that was once Ready on its own
+	// discriminator.
 	if !isNodeReady(node) {
+		for _, d := range registry {
+			nd, ok := d.(nodeDetector)
+			if !ok || !d.Applies(node) {
+				continue
+			}
+			snap := nd.EvaluateNode(node, now)
+			if nd.MeetsThreshold(snap, now) {
+				snap.Reason = d.Reason()
+				return DecisionWedged, snap
+			}
+		}
+		// Nothing fired. Stay Unknown rather than Healthy: a NotReady node is not
+		// evidence of recovery, so an existing wedged label is retained.
 		return DecisionUnknown, Snapshot{}
 	}
 

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/decide_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/decide_test.go
@@ -386,14 +386,14 @@ func TestDecideSnapshotOnWedge(t *testing.T) {
 	if snap.DetectorName != swiftVFTeardown.name {
 		t.Errorf("snapshot detector = %q, want %q", snap.DetectorName, swiftVFTeardown.name)
 	}
-	if snap.FailureCount != 3 {
-		t.Errorf("snapshot FailureCount = %d, want 3", snap.FailureCount)
+	if snap.Pods.FailureCount != 3 {
+		t.Errorf("snapshot FailureCount = %d, want 3", snap.Pods.FailureCount)
 	}
-	if snap.SustainedCount != 3 {
-		t.Errorf("snapshot SustainedCount = %d, want 3", snap.SustainedCount)
+	if snap.Pods.SustainedCount != 3 {
+		t.Errorf("snapshot SustainedCount = %d, want 3", snap.Pods.SustainedCount)
 	}
-	if snap.RecentSuccess {
-		t.Errorf("snapshot RecentSuccess = %v, want false", snap.RecentSuccess)
+	if snap.Pods.RecentSuccess {
+		t.Errorf("snapshot RecentSuccess = %v, want false", snap.Pods.RecentSuccess)
 	}
 	if !snap.StuckSince.Equal(ago(15 * time.Minute)) {
 		t.Errorf("snapshot StuckSince = %v, want %v", snap.StuckSince, ago(15*time.Minute))
@@ -510,8 +510,8 @@ func TestMatchedSignatureReportsDominantFailureMode(t *testing.T) {
 			failEventFor("p0", ago(10*time.Second), msgNoSuchIface),
 		}
 		snap := swiftVFTeardown.Evaluate(events, pods, testNow)
-		if snap.FailureCount != 1 {
-			t.Errorf("FailureCount = %d, want 1 (one pod, two Events)", snap.FailureCount)
+		if snap.Pods.FailureCount != 1 {
+			t.Errorf("FailureCount = %d, want 1 (one pod, two Events)", snap.Pods.FailureCount)
 		}
 		if snap.MatchedSignature != sigNoSuchIface {
 			t.Errorf("MatchedSignature = %q, want %q", snap.MatchedSignature, sigNoSuchIface)
@@ -533,8 +533,8 @@ func TestMatchedSignatureReportsDominantFailureMode(t *testing.T) {
 			failEventFor("p2", ago(20*time.Second), msgNoSuchIface),
 		}
 		snap := swiftVFTeardown.Evaluate(events, pods, testNow)
-		if snap.FailureCount != 1 {
-			t.Errorf("FailureCount = %d, want 1", snap.FailureCount)
+		if snap.Pods.FailureCount != 1 {
+			t.Errorf("FailureCount = %d, want 1", snap.Pods.FailureCount)
 		}
 		if snap.MatchedSignature != sigMtpnc {
 			t.Errorf("MatchedSignature = %q, want %q", snap.MatchedSignature, sigMtpnc)
@@ -693,7 +693,7 @@ func TestRestartedContainerDoesNotSuppressAWedge(t *testing.T) {
 	if got != DecisionWedged {
 		t.Errorf("Decide(with a restarting container) = %v, want Wedged", got)
 	}
-	if snap.RecentSuccess {
+	if snap.Pods.RecentSuccess {
 		t.Error("RecentSuccess = true for a container restarting in an existing sandbox, want false")
 	}
 }

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/decide_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/decide_test.go
@@ -811,7 +811,7 @@ func TestOverlaySuccessDoesNotSuppressASwiftWedge(t *testing.T) {
 	if got != DecisionWedged {
 		t.Errorf("overlay-only successes suppressed a real delegated-NIC wedge: Decide() = %v, want Wedged", got)
 	}
-	if snap.RecentSuccess {
+	if snap.Pods.RecentSuccess {
 		t.Error("RecentSuccess = true from pods that never asked for a NIC, want false")
 	}
 
@@ -834,7 +834,7 @@ func TestSuccessScopeDefaultsToEveryPod(t *testing.T) {
 	pods = append(pods, startedPod("plain", ago(1*time.Minute), false))
 	events, _ := stuckFailing(3, ago(15*time.Minute))
 
-	if snap := unscoped.Evaluate(events, pods, testNow); !snap.RecentSuccess {
+	if snap := unscoped.Evaluate(events, pods, testNow); !snap.Pods.RecentSuccess {
 		t.Error("RecentSuccess = false with a nil successScope, want true")
 	}
 }

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/never_ready.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/never_ready.go
@@ -126,7 +126,7 @@ func (d neverReadyDetector) EvaluateNode(node *corev1.Node, now time.Time) Snaps
 	}
 	if transitioned.After(created.Add(neverReadyTolerance)) {
 		// The node was Ready at some point and lost it later. Node lifecycle owns
-		// that case, exactly as it did before this detector existed.
+		// that case.
 		return snap
 	}
 

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/never_ready.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/never_ready.go
@@ -131,10 +131,11 @@ func (d neverReadyDetector) EvaluateNode(node *corev1.Node, now time.Time) Snaps
 	}
 
 	snap.StuckSince = created
-	// The node itself is the single subject, so both counts are one. They are
-	// reported so the metric and the logs read consistently with other detectors.
-	snap.FailureCount = 1
-	snap.SustainedCount = 1
+	// FailureCount and SustainedCount stay zero: they are defined as counts of
+	// stuck pods, and this detector reads the node only. Reporting a pod count
+	// here would make logs and telemetry imply pod evidence that does not exist.
+	// MeetsThreshold keys on StuckSince, so leaving them zero changes nothing.
+	//
 	// The Ready condition's reason names the cause within the family, which is
 	// what the signature annotation is for. It is triage detail only; mitigation
 	// keys on the detector name.

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/never_ready.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/never_ready.go
@@ -114,9 +114,7 @@ func (d neverReadyDetector) EvaluateNode(node *corev1.Node, now time.Time) Snaps
 	created := node.CreationTimestamp.Time
 	transitioned := cond.LastTransitionTime.Time
 	if created.IsZero() || transitioned.IsZero() {
-		// Without both timestamps the discriminator cannot be evaluated, and
-		// guessing would risk labeling a node that simply came up before this
-		// controller started watching.
+		// Both timestamps are the discriminator, nothing to compare without them.
 		return snap
 	}
 	if transitioned.Before(created) {

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/never_ready.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/never_ready.go
@@ -1,0 +1,176 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package detectors
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// neverReadyDwell is how long a node may sit having never reached Ready
+	// before it is called wedged.
+	//
+	// Measured on the dev fleet over 14 days, 1119 nodes, from creationTimestamp
+	// to the first Ready=True: p50 1.0m, p90 1.3m, p99 3.1m, max 3.4m. Every node
+	// that was going to come up did so inside 3.4 minutes. 30 minutes is roughly
+	// nine times that worst legitimate case, so bootstrap variance cannot reach
+	// it, and it is still far inside the 22 hours the INT node
+	// aks-userswft3-65765115-vmss00000g actually sat NotReady before a human
+	// cordoned it.
+	neverReadyDwell = 30 * time.Minute
+
+	// neverReadyTolerance is how far after creation the Ready condition's first
+	// transition may fall while the node still counts as never having been Ready.
+	// The condition is written at registration, a moment after the object is
+	// created, so exact equality would be too strict. It is far below the
+	// dwell, so it cannot let a node that genuinely came up and later failed be
+	// read as born broken.
+	neverReadyTolerance = 2 * time.Minute
+)
+
+// neverReady detects a node that registered and never reached Ready.
+//
+// The healer's Ready precondition exists because a node that was Ready and
+// dropped out (reboot, upgrade, drain) belongs to node lifecycle. That premise
+// does not hold for a node that never got there: nothing in node lifecycle
+// rescues it, so it sits NotReady until a human notices. The INT node above sat
+// for 22 hours after its VMSS instance failed provisioning with a terminal
+// OSProvisioningClientError.
+//
+// The detector is deliberately generic rather than keyed on a cause. Dead IMDS,
+// a failed disk, a kubelet certificate problem and a failed image pull are all
+// born broken and all remedied the same way, by reimaging the instance, and one
+// detector is one fault with one remedy. The cause is carried as the signature
+// annotation for triage instead. That also keeps the evidence to the Node object
+// alone: a cause-specific detector would have to read azure-cns container logs,
+// which this controller never does.
+var neverReady = neverReadyDetector{}
+
+type neverReadyDetector struct{}
+
+// Name returns the detector's stable identifier.
+func (neverReadyDetector) Name() string { return "never-ready" }
+
+// Reason returns the human-readable explanation recorded on a labeled node.
+func (neverReadyDetector) Reason() string {
+	return "node registered but never reached Ready: node lifecycle does not rescue a node that never started, so it needs reimaging"
+}
+
+// Applies scopes the detector to SWIFT-v2 nodes, matching swiftVFTeardown.
+//
+// The fault itself is not SWIFT-specific, so this is narrower than the fault.
+// It is deliberate. AnyApplies runs ahead of the Ready gate and is what decides
+// which nodes the controller holds labels on at all: a detector that applied to
+// every node would make DecisionNotApplicable unreachable, and that is the only
+// thing that retires a label left on a node that stopped being a detector's
+// concern. Widening ownership is a separate decision with its own consequences,
+// and the INT node this was built for was in a userswft pool anyway.
+func (neverReadyDetector) Applies(node *corev1.Node) bool { return isSwiftV2Node(node) }
+
+// Window returns the dwell. This detector has no lookback over Events, so the
+// dwell is the only duration it has.
+func (neverReadyDetector) Window() time.Duration { return neverReadyDwell }
+
+// Evaluate satisfies Detector for the Ready path, where this detector has
+// nothing to say. Its evidence is the Node object, which Evaluate does not
+// receive, so it returns an empty snapshot that MeetsThreshold always rejects.
+// The real work is in EvaluateNode.
+func (d neverReadyDetector) Evaluate(_ []*corev1.Event, _ []*corev1.Pod, _ time.Time) Snapshot {
+	return Snapshot{DetectorName: d.Name(), Window: neverReadyDwell}
+}
+
+// EvaluateNode reads the born-broken signal from the Node alone.
+//
+// The discriminator is that the Ready condition has never been True and its
+// first transition coincides with the node's creation. A node that reached Ready
+// at any point has a strictly later transition, which is what separates "never
+// started" from "started and later failed" and leaves the latter to node
+// lifecycle.
+func (d neverReadyDetector) EvaluateNode(node *corev1.Node, now time.Time) Snapshot {
+	snap := Snapshot{DetectorName: d.Name(), Window: neverReadyDwell}
+	if node == nil {
+		return snap
+	}
+	cond := nodeReadyCondition(node)
+	if cond == nil || cond.Status == corev1.ConditionTrue {
+		return snap
+	}
+
+	created := node.CreationTimestamp.Time
+	transitioned := cond.LastTransitionTime.Time
+	if created.IsZero() || transitioned.IsZero() {
+		// Without both timestamps the discriminator cannot be evaluated, and
+		// guessing would risk labeling a node that simply came up before this
+		// controller started watching.
+		return snap
+	}
+	if transitioned.Before(created) {
+		// A Ready transition predating the object cannot happen; treat it as bad
+		// data rather than evidence.
+		return snap
+	}
+	if transitioned.After(created.Add(neverReadyTolerance)) {
+		// The node was Ready at some point and lost it later. Node lifecycle owns
+		// that case, exactly as it did before this detector existed.
+		return snap
+	}
+
+	snap.StuckSince = created
+	// The node itself is the single subject, so both counts are one. They are
+	// reported so the metric and the logs read consistently with other detectors.
+	snap.FailureCount = 1
+	snap.SustainedCount = 1
+	// The Ready condition's reason names the cause within the family, which is
+	// what the signature annotation is for. It is triage detail only; mitigation
+	// keys on the detector name.
+	snap.MatchedSignature = cond.Reason
+	snap.Detail = fmt.Sprintf("node never reached Ready in %s since creation (%s)",
+		now.Sub(created).Round(time.Minute), readyReasonOrUnknown(cond.Reason))
+	return snap
+}
+
+// MeetsThreshold reports whether the node has been never-Ready for the dwell.
+// A snapshot from Evaluate carries no StuckSince, so the Ready path can never
+// fire this detector.
+func (neverReadyDetector) MeetsThreshold(snap Snapshot, now time.Time) bool {
+	if snap.StuckSince.IsZero() {
+		return false
+	}
+	return now.Sub(snap.StuckSince) >= neverReadyDwell
+}
+
+// nodeReadyCondition returns the node's Ready condition, or nil when it is
+// absent. It is kept here rather than folded into isNodeReady so this detector
+// adds no edits to the shared helpers.
+func nodeReadyCondition(node *corev1.Node) *corev1.NodeCondition {
+	for i := range node.Status.Conditions {
+		if node.Status.Conditions[i].Type == corev1.NodeReady {
+			return &node.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// readyReasonOrUnknown keeps the reason annotation readable when the kubelet
+// left the Ready condition's reason empty.
+func readyReasonOrUnknown(reason string) string {
+	if reason == "" {
+		return "no reason reported"
+	}
+	return reason
+}

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/never_ready.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/never_ready.go
@@ -86,53 +86,43 @@ func (neverReadyDetector) Applies(node *corev1.Node) bool { return isSwiftV2Node
 // dwell is the only duration it has.
 func (neverReadyDetector) Window() time.Duration { return neverReadyDwell }
 
-// Evaluate satisfies Detector for the Ready path, where this detector has
-// nothing to say. Its evidence is the Node object, which Evaluate does not
-// receive, so it returns an empty snapshot that MeetsThreshold always rejects.
-// The real work is in EvaluateNode.
-func (d neverReadyDetector) Evaluate(_ []*corev1.Event, _ []*corev1.Pod, _ time.Time) Snapshot {
-	return Snapshot{DetectorName: d.Name(), Window: neverReadyDwell}
-}
-
-// EvaluateNode reads the born-broken signal from the Node alone.
+// EvaluateNode decides the born-broken state from the Node alone.
 //
 // The discriminator is that the Ready condition has never been True and its
 // first transition coincides with the node's creation. A node that reached Ready
-// at any point has a strictly later transition, which is what separates "never
-// started" from "started and later failed" and leaves the latter to node
+// at any point has a strictly later transition, so a transition that coincides
+// with creation is the born-broken shape. Anything later is left to node
 // lifecycle.
-func (d neverReadyDetector) EvaluateNode(node *corev1.Node, now time.Time) Snapshot {
+func (d neverReadyDetector) EvaluateNode(node *corev1.Node, now time.Time) (Decision, Snapshot) {
 	snap := Snapshot{DetectorName: d.Name(), Window: neverReadyDwell}
 	if node == nil {
-		return snap
+		return DecisionUnknown, snap
 	}
 	cond := nodeReadyCondition(node)
 	if cond == nil || cond.Status == corev1.ConditionTrue {
-		return snap
+		return DecisionUnknown, snap
 	}
 
 	created := node.CreationTimestamp.Time
 	transitioned := cond.LastTransitionTime.Time
 	if created.IsZero() || transitioned.IsZero() {
 		// Both timestamps are the discriminator, nothing to compare without them.
-		return snap
+		return DecisionUnknown, snap
 	}
 	if transitioned.Before(created) {
 		// A Ready transition predating the object cannot happen; treat it as bad
 		// data rather than evidence.
-		return snap
+		return DecisionUnknown, snap
 	}
 	if transitioned.After(created.Add(neverReadyTolerance)) {
-		// The node was Ready at some point and lost it later. Node lifecycle owns
-		// that case.
-		return snap
+		// The Ready condition changed well after creation, so this is not the
+		// born-broken shape. Node lifecycle owns whatever it is.
+		return DecisionUnknown, snap
 	}
 
 	snap.StuckSince = created
-	// FailureCount and SustainedCount stay zero: they are defined as counts of
-	// stuck pods, and this detector reads the node only. Reporting a pod count
-	// here would make logs and telemetry imply pod evidence that does not exist.
-	// MeetsThreshold keys on StuckSince, so leaving them zero changes nothing.
+	// Pods stays nil: this detector reads the Node alone, so there is no pod
+	// evidence to report and Detail carries what was actually observed.
 	//
 	// The Ready condition's reason names the cause within the family, which is
 	// what the signature annotation is for. It is triage detail only; mitigation
@@ -140,17 +130,10 @@ func (d neverReadyDetector) EvaluateNode(node *corev1.Node, now time.Time) Snaps
 	snap.MatchedSignature = cond.Reason
 	snap.Detail = fmt.Sprintf("node never reached Ready in %s since creation (%s)",
 		now.Sub(created).Round(time.Minute), readyReasonOrUnknown(cond.Reason))
-	return snap
-}
-
-// MeetsThreshold reports whether the node has been never-Ready for the dwell.
-// A snapshot from Evaluate carries no StuckSince, so the Ready path can never
-// fire this detector.
-func (neverReadyDetector) MeetsThreshold(snap Snapshot, now time.Time) bool {
-	if snap.StuckSince.IsZero() {
-		return false
+	if now.Sub(created) < neverReadyDwell {
+		return DecisionUnknown, snap
 	}
-	return now.Sub(snap.StuckSince) >= neverReadyDwell
+	return DecisionWedged, snap
 }
 
 // nodeReadyCondition returns the node's Ready condition, or nil when it is

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/never_ready_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/never_ready_test.go
@@ -309,6 +309,12 @@ func TestProductionBornBrokenNodeFires(t *testing.T) {
 	if got != DecisionWedged {
 		t.Fatalf("Decide() = %v, want Wedged; the captured node sat NotReady for 22 hours", got)
 	}
+	// This detector reads the node, not pods, so the pod-count fields must stay
+	// zero or logs and telemetry imply pod evidence that was never gathered.
+	if snap.FailureCount != 0 || snap.SustainedCount != 0 {
+		t.Errorf("FailureCount/SustainedCount = %d/%d, want 0/0 for a node-only detector",
+			snap.FailureCount, snap.SustainedCount)
+	}
 	if snap.DetectorName != "never-ready" {
 		t.Errorf("DetectorName = %q, want never-ready", snap.DetectorName)
 	}

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/never_ready_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/never_ready_test.go
@@ -232,19 +232,17 @@ func TestNeverReadyOwnership(t *testing.T) {
 	}
 }
 
-// TestNeverReadyEvaluateNeverFires pins the Ready-path contract directly: the
-// snapshot Evaluate returns carries no dwell evidence, so the detector cannot
-// fire from a path that never saw the Node.
-func TestNeverReadyEvaluateNeverFires(t *testing.T) {
-	snap := neverReady.Evaluate(nil, nil, testNow)
-	if !snap.StuckSince.IsZero() {
-		t.Errorf("StuckSince = %v, want zero from Evaluate", snap.StuckSince)
+// TestNeverReadyIsNodeOnly pins the separation in the type system rather than in
+// a runtime check: this detector reads the Node, so it must be a NodeDetector
+// and must not satisfy PodDetector. If it ever did, Decide's Ready path would
+// evaluate it against a pod population it has nothing to say about.
+func TestNeverReadyIsNodeOnly(t *testing.T) {
+	var d Detector = neverReady
+	if _, ok := d.(NodeDetector); !ok {
+		t.Error("neverReady does not satisfy NodeDetector; it would never run on the NotReady path")
 	}
-	if neverReady.MeetsThreshold(snap, testNow) {
-		t.Error("MeetsThreshold(Evaluate snapshot) = true, want false")
-	}
-	if neverReady.MeetsThreshold(snap, testNow.Add(365*24*time.Hour)) {
-		t.Error("MeetsThreshold(Evaluate snapshot, far future) = true; the dwell must not be measured from a zero time")
+	if _, ok := d.(PodDetector); ok {
+		t.Error("neverReady satisfies PodDetector; it must not be reachable from the Ready path")
 	}
 }
 
@@ -252,7 +250,7 @@ func TestNeverReadyEvaluateNeverFires(t *testing.T) {
 // pod-centric summary is what every existing detector renders into the reason
 // annotation, so it has to be byte-identical when Detail is unset.
 func TestSnapshotDetailOverridesReasonString(t *testing.T) {
-	base := Snapshot{SustainedCount: 2, FailureCount: 5, Window: 10 * time.Minute}
+	base := Snapshot{Pods: &PodEvidence{SustainedCount: 2, FailureCount: 5}, Window: 10 * time.Minute}
 
 	const want = "2 pods stuck past dwell (5 stuck total), no recent success in 10m0s window"
 	if got := base.ReasonString(); got != want {
@@ -260,6 +258,7 @@ func TestSnapshotDetailOverridesReasonString(t *testing.T) {
 	}
 
 	withDetail := base
+	withDetail.Pods = nil
 	withDetail.Detail = "node never reached Ready in 22h0m since creation (KubeletNotReady)"
 	if got := withDetail.ReasonString(); got != withDetail.Detail {
 		t.Errorf("ReasonString() with Detail = %q, want the detail verbatim", got)
@@ -309,11 +308,11 @@ func TestProductionBornBrokenNodeFires(t *testing.T) {
 	if got != DecisionWedged {
 		t.Fatalf("Decide() = %v, want Wedged; the captured node sat NotReady for 22 hours", got)
 	}
-	// This detector reads the node, not pods, so the pod-count fields must stay
-	// zero or logs and telemetry imply pod evidence that was never gathered.
-	if snap.FailureCount != 0 || snap.SustainedCount != 0 {
-		t.Errorf("FailureCount/SustainedCount = %d/%d, want 0/0 for a node-only detector",
-			snap.FailureCount, snap.SustainedCount)
+	// This detector reads the node, not pods, so there is no pod evidence to
+	// report and Pods must stay nil rather than carry zeroes that read as "no
+	// pods were stuck".
+	if snap.Pods != nil {
+		t.Errorf("Pods = %+v, want nil for a node-only detector", snap.Pods)
 	}
 	if snap.DetectorName != "never-ready" {
 		t.Errorf("DetectorName = %q, want never-ready", snap.DetectorName)

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/never_ready_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/never_ready_test.go
@@ -1,0 +1,328 @@
+// Copyright 2025 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package detectors
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// nodeAt builds a SWIFT node with explicit creation and Ready-transition times,
+// which is the whole evidence base for the never-ready detector.
+func nodeAt(created, transitioned time.Time, ready bool, reason string) *corev1.Node {
+	status := corev1.ConditionFalse
+	if ready {
+		status = corev1.ConditionTrue
+	}
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              nodeName,
+			Labels:            map[string]string{SwiftV2LabelKey: SwiftV2LabelValue},
+			CreationTimestamp: metav1.NewTime(created),
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{
+				Type:               corev1.NodeReady,
+				Status:             status,
+				Reason:             reason,
+				LastTransitionTime: metav1.NewTime(transitioned),
+			}},
+		},
+	}
+}
+
+// bornBroken is a node that registered and never reached Ready, stuck for d.
+func bornBroken(d time.Duration, reason string) *corev1.Node {
+	created := testNow.Add(-d)
+	return nodeAt(created, created, false, reason)
+}
+
+// TestNeverReadyFiresPastDwell is the INT case: a node that registered, never
+// reached Ready, and sat there. Nothing in node lifecycle rescues it, so the
+// detector has to.
+func TestNeverReadyFiresPastDwell(t *testing.T) {
+	node := bornBroken(22*time.Hour, "KubeletNotReady")
+
+	got, snap := Decide(node, nil, nil, testNow)
+	if got != DecisionWedged {
+		t.Fatalf("Decide() = %v, want Wedged", got)
+	}
+	if snap.DetectorName != "never-ready" {
+		t.Errorf("DetectorName = %q, want never-ready", snap.DetectorName)
+	}
+	if snap.MatchedSignature != "KubeletNotReady" {
+		t.Errorf("MatchedSignature = %q, want the Ready condition reason", snap.MatchedSignature)
+	}
+	if snap.Reason == "" {
+		t.Error("Reason is empty; Decide must stamp the detector's reason when it fires")
+	}
+	if reason := snap.ReasonString(); !strings.Contains(reason, "never reached Ready") ||
+		!strings.Contains(reason, "KubeletNotReady") {
+		t.Errorf("ReasonString() = %q, want the never-Ready detail with the cause", reason)
+	}
+}
+
+// TestNeverReadyDwell pins the boundary. Real nodes reach Ready in well under
+// four minutes (dev fleet max was 3.4), so nothing legitimate is anywhere near
+// the dwell, but the detector must still not fire early.
+func TestNeverReadyDwell(t *testing.T) {
+	tests := []struct {
+		name  string
+		stuck time.Duration
+		want  Decision
+	}{
+		{name: "far inside the dwell, a node still bootstrapping", stuck: 2 * time.Minute, want: DecisionUnknown},
+		{name: "just inside the dwell", stuck: neverReadyDwell - time.Second, want: DecisionUnknown},
+		{name: "exactly at the dwell", stuck: neverReadyDwell, want: DecisionWedged},
+		{name: "past the dwell", stuck: neverReadyDwell + time.Minute, want: DecisionWedged},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, _ := Decide(bornBroken(tc.stuck, "KubeletNotReady"), nil, nil, testNow); got != tc.want {
+				t.Errorf("Decide() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNeverReadyLeavesLifecycleAlone is the discriminator, and the reason the
+// original Ready precondition existed. A node that came up and later dropped out
+// (reboot, upgrade, drain) is node lifecycle's problem, and must stay that way
+// however long it has been NotReady.
+func TestNeverReadyLeavesLifecycleAlone(t *testing.T) {
+	created := testNow.Add(-30 * 24 * time.Hour)
+
+	tests := []struct {
+		name string
+		node *corev1.Node
+	}{
+		{
+			name: "was Ready for weeks, dropped out an hour ago",
+			node: nodeAt(created, testNow.Add(-time.Hour), false, "KubeletNotReady"),
+		},
+		{
+			name: "reached Ready just outside the tolerance, then dropped out",
+			node: nodeAt(created, created.Add(neverReadyTolerance+time.Second), false, "KubeletNotReady"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, _ := Decide(tc.node, nil, nil, testNow); got != DecisionUnknown {
+				t.Errorf("Decide() = %v, want Unknown; a node that was once Ready belongs to node lifecycle", got)
+			}
+		})
+	}
+}
+
+// TestNeverReadyTolerance pins the registration allowance. The Ready condition is
+// written a moment after the object is created, so exact equality would be too
+// strict, but the allowance must stay tight enough that it cannot swallow a node
+// that genuinely came up.
+func TestNeverReadyTolerance(t *testing.T) {
+	created := testNow.Add(-2 * time.Hour)
+
+	inside := nodeAt(created, created.Add(neverReadyTolerance), false, "KubeletNotReady")
+	if got, _ := Decide(inside, nil, nil, testNow); got != DecisionWedged {
+		t.Errorf("a transition at the tolerance edge is still born broken: Decide() = %v, want Wedged", got)
+	}
+
+	outside := nodeAt(created, created.Add(neverReadyTolerance+time.Second), false, "KubeletNotReady")
+	if got, _ := Decide(outside, nil, nil, testNow); got != DecisionUnknown {
+		t.Errorf("a transition past the tolerance means the node reached Ready: Decide() = %v, want Unknown", got)
+	}
+}
+
+// TestNeverReadyIgnoresUnusableEvidence keeps the detector quiet when the Node
+// does not carry enough to evaluate the discriminator. Labeling on a guess would
+// hit nodes that merely came up before this controller started watching.
+func TestNeverReadyIgnoresUnusableEvidence(t *testing.T) {
+	created := testNow.Add(-2 * time.Hour)
+
+	noReadyCondition := nodeAt(created, created, false, "KubeletNotReady")
+	noReadyCondition.Status.Conditions = []corev1.NodeCondition{{
+		Type:   corev1.NodeMemoryPressure,
+		Status: corev1.ConditionFalse,
+	}}
+
+	tests := []struct {
+		name string
+		node *corev1.Node
+	}{
+		{name: "no Ready condition at all", node: noReadyCondition},
+		{name: "no creation timestamp", node: nodeAt(time.Time{}, created, false, "KubeletNotReady")},
+		{name: "no Ready transition timestamp", node: nodeAt(created, time.Time{}, false, "KubeletNotReady")},
+		{
+			name: "clock skew: Ready transition predates creation",
+			node: nodeAt(created, created.Add(-time.Minute), false, "KubeletNotReady"),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := Decide(tc.node, nil, nil, testNow)
+			if got != DecisionUnknown {
+				t.Errorf("Decide() = %v, want Unknown", got)
+			}
+		})
+	}
+}
+
+// TestNeverReadyEmptyReasonStillLabels covers the kubelet leaving the Ready
+// reason blank. The label is what mitigation keys on, so a missing triage detail
+// must not cost us the detection.
+func TestNeverReadyEmptyReasonStillLabels(t *testing.T) {
+	got, snap := Decide(bornBroken(time.Hour, ""), nil, nil, testNow)
+	if got != DecisionWedged {
+		t.Fatalf("Decide() = %v, want Wedged", got)
+	}
+	if snap.MatchedSignature != "" {
+		t.Errorf("MatchedSignature = %q, want empty so no signature annotation is written", snap.MatchedSignature)
+	}
+	if reason := snap.ReasonString(); !strings.Contains(reason, "no reason reported") {
+		t.Errorf("ReasonString() = %q, want a readable stand-in for the missing reason", reason)
+	}
+}
+
+// TestNeverReadyDoesNotDisturbTheReadyPath is the regression guard for adding a
+// second detector to the registry. A Ready node must still be evaluated by the
+// pod and event detectors exactly as before, and never-ready must contribute
+// nothing to that path.
+func TestNeverReadyDoesNotDisturbTheReadyPath(t *testing.T) {
+	events, pods := stuckFailing(3, ago(15*time.Minute))
+
+	got, snap := Decide(testNode(true, true), events, pods, testNow)
+	if got != DecisionWedged {
+		t.Fatalf("Decide() = %v, want Wedged", got)
+	}
+	if snap.DetectorName != "swift-vf-teardown" {
+		t.Errorf("DetectorName = %q, want swift-vf-teardown to still own the Ready path", snap.DetectorName)
+	}
+
+	// The same node with no evidence stays Unknown rather than being caught by
+	// never-ready, whose Evaluate has no Node to read.
+	if got, _ := Decide(testNode(true, true), nil, nil, testNow); got != DecisionUnknown {
+		t.Errorf("Decide(quiet Ready node) = %v, want Unknown", got)
+	}
+}
+
+// TestNeverReadyOwnership pins the scope. AnyApplies runs ahead of the Ready
+// gate and decides which nodes the controller holds labels on at all, so a
+// non-SWIFT node must still reach NotApplicable and have any stale label retired.
+func TestNeverReadyOwnership(t *testing.T) {
+	node := bornBroken(22*time.Hour, "KubeletNotReady")
+	node.Labels = map[string]string{}
+
+	if got, _ := Decide(node, nil, nil, testNow); got != DecisionNotApplicable {
+		t.Errorf("Decide(non-SWIFT born-broken node) = %v, want NotApplicable", got)
+	}
+}
+
+// TestNeverReadyEvaluateNeverFires pins the Ready-path contract directly: the
+// snapshot Evaluate returns carries no dwell evidence, so the detector cannot
+// fire from a path that never saw the Node.
+func TestNeverReadyEvaluateNeverFires(t *testing.T) {
+	snap := neverReady.Evaluate(nil, nil, testNow)
+	if !snap.StuckSince.IsZero() {
+		t.Errorf("StuckSince = %v, want zero from Evaluate", snap.StuckSince)
+	}
+	if neverReady.MeetsThreshold(snap, testNow) {
+		t.Error("MeetsThreshold(Evaluate snapshot) = true, want false")
+	}
+	if neverReady.MeetsThreshold(snap, testNow.Add(365*24*time.Hour)) {
+		t.Error("MeetsThreshold(Evaluate snapshot, far future) = true; the dwell must not be measured from a zero time")
+	}
+}
+
+// TestSnapshotDetailOverridesReasonString covers the escape hatch itself. The
+// pod-centric summary is what every existing detector renders into the reason
+// annotation, so it has to be byte-identical when Detail is unset.
+func TestSnapshotDetailOverridesReasonString(t *testing.T) {
+	base := Snapshot{SustainedCount: 2, FailureCount: 5, Window: 10 * time.Minute}
+
+	const want = "2 pods stuck past dwell (5 stuck total), no recent success in 10m0s window"
+	if got := base.ReasonString(); got != want {
+		t.Errorf("ReasonString() with no Detail = %q, want %q", got, want)
+	}
+
+	withDetail := base
+	withDetail.Detail = "node never reached Ready in 22h0m since creation (KubeletNotReady)"
+	if got := withDetail.ReasonString(); got != withDetail.Detail {
+		t.Errorf("ReasonString() with Detail = %q, want the detail verbatim", got)
+	}
+}
+
+// TestProductionBornBrokenNodeFires replays the captured INT node
+// aks-userswft3-65765115-vmss00000g (int-westus3, AROSLSRE-1976), the incident
+// this detector was built for. Its VMSS instance failed provisioning with a
+// terminal OSProvisioningClientError, it registered, never reached Ready, and
+// sat for 22 hours until a human cordoned it.
+//
+// The capture is the reason the discriminator is what it is: the Ready
+// condition's lastTransitionTime is byte-for-byte the node's creationTimestamp,
+// because the condition was written once at registration and never moved again.
+//
+// It also pins the two things triage needs. The node carried the SWIFT v2 label,
+// which is what makes the detector's ownership scope correct rather than lucky,
+// and the Ready reason was KubeletNotReady, which is what lands in the signature
+// annotation.
+func TestProductionBornBrokenNodeFires(t *testing.T) {
+	// Verbatim from the captured node.yaml.
+	const (
+		created      = "2026-08-31T21:32:14Z"
+		transitioned = "2026-08-31T21:32:14Z"
+		observedAt   = "2026-09-01T21:52:21Z" // the last heartbeat in the capture
+	)
+	mustParse := func(s string) time.Time {
+		t.Helper()
+		ts, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			t.Fatalf("parse %q: %v", s, err)
+		}
+		return ts
+	}
+
+	node := nodeAt(mustParse(created), mustParse(transitioned), false, "KubeletNotReady")
+	node.Status.Conditions[0].Message = "container runtime network not ready: NetworkReady=false " +
+		"reason:NetworkPluginNotReady message:Network plugin returns error: cni plugin not initialized"
+	now := mustParse(observedAt)
+
+	if !neverReady.Applies(node) {
+		t.Fatal("the captured node carried the SWIFT v2 label; the detector must own it")
+	}
+
+	got, snap := Decide(node, nil, nil, now)
+	if got != DecisionWedged {
+		t.Fatalf("Decide() = %v, want Wedged; the captured node sat NotReady for 22 hours", got)
+	}
+	if snap.DetectorName != "never-ready" {
+		t.Errorf("DetectorName = %q, want never-ready", snap.DetectorName)
+	}
+	if snap.MatchedSignature != "KubeletNotReady" {
+		t.Errorf("MatchedSignature = %q, want KubeletNotReady", snap.MatchedSignature)
+	}
+
+	// It must fire far earlier than the 22 hours we actually took, and not before
+	// the dwell.
+	dwellHit := mustParse(created).Add(neverReadyDwell)
+	if got, _ := Decide(node, nil, nil, dwellHit); got != DecisionWedged {
+		t.Errorf("Decide(at the dwell) = %v, want Wedged", got)
+	}
+	if got, _ := Decide(node, nil, nil, dwellHit.Add(-time.Second)); got != DecisionUnknown {
+		t.Errorf("Decide(one second before the dwell) = %v, want Unknown", got)
+	}
+}

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/production_evidence_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/production_evidence_test.go
@@ -322,10 +322,10 @@ func TestProductionHardWedgeShapeFires(t *testing.T) {
 	}
 
 	snap := swiftVFTeardown.Evaluate(events, pods, now)
-	if snap.SustainedCount != 2 {
-		t.Fatalf("captured wedge shape did not produce 2 sustained pods: SustainedCount = %d", snap.SustainedCount)
+	if snap.Pods.SustainedCount != 2 {
+		t.Fatalf("captured wedge shape did not produce 2 sustained pods: SustainedCount = %d", snap.Pods.SustainedCount)
 	}
-	if snap.RecentSuccess {
+	if snap.Pods.RecentSuccess {
 		t.Fatal("captured wedge shape must have no fresh sandbox success")
 	}
 	if got, _ := Decide(productionWedgedNode(), events, pods, now); got != DecisionWedged {

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/production_evidence_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/production_evidence_test.go
@@ -158,11 +158,11 @@ func TestProductionCompletedPodsDoNotCount(t *testing.T) {
 	}
 
 	snap := swiftVFTeardown.Evaluate(events, pods, now)
-	if snap.SustainedCount != 0 {
-		t.Errorf("completed pods counted toward the floor: SustainedCount = %d, want 0", snap.SustainedCount)
+	if snap.Pods.SustainedCount != 0 {
+		t.Errorf("completed pods counted toward the floor: SustainedCount = %d, want 0", snap.Pods.SustainedCount)
 	}
-	if snap.FailureCount != 0 {
-		t.Errorf("completed pods counted as failures: FailureCount = %d, want 0", snap.FailureCount)
+	if snap.Pods.FailureCount != 0 {
+		t.Errorf("completed pods counted as failures: FailureCount = %d, want 0", snap.Pods.FailureCount)
 	}
 
 	// The node must not be declared wedged on completed-pod turnover alone.
@@ -229,7 +229,7 @@ func TestProductionStaleSuccessesDoNotSuppressDetection(t *testing.T) {
 	if got != DecisionWedged {
 		t.Fatalf("stale success suppressed detection of the real wedge: Decide = %v (%s)", got, snap.ReasonString())
 	}
-	if snap.RecentSuccess {
+	if snap.Pods.RecentSuccess {
 		t.Error("an 8 hour old success must not count as recent")
 	}
 

--- a/mgmt-agent/pkg/controller/nodehealth/detectors/signature_detector.go
+++ b/mgmt-agent/pkg/controller/nodehealth/detectors/signature_detector.go
@@ -86,7 +86,7 @@ func (d signatureDetector) Applies(node *corev1.Node) bool {
 // function of what a LIST returns and nothing has to be remembered between calls.
 func (d signatureDetector) Evaluate(events []*corev1.Event, pods []*corev1.Pod, now time.Time) Snapshot {
 	windowStart := now.Add(-d.window)
-	snap := Snapshot{DetectorName: d.name, Window: d.window}
+	snap := Snapshot{DetectorName: d.name, Window: d.window, Pods: &PodEvidence{}}
 
 	// A pod is "failing" for this detector when it is the subject of a matching
 	// failure Event seen within the window. Correlation is by the Event's
@@ -138,7 +138,7 @@ func (d signatureDetector) Evaluate(events []*corev1.Event, pods []*corev1.Pod, 
 		// path is not evidence the path works.
 		if d.inSuccessScope(p) {
 			if at, ok := SuccessAt(p); ok && now.Sub(at).Abs() < d.window {
-				snap.RecentSuccess = true
+				snap.Pods.RecentSuccess = true
 			}
 		}
 		if p.DeletionTimestamp != nil {
@@ -153,13 +153,13 @@ func (d signatureDetector) Evaluate(events []*corev1.Event, pods []*corev1.Pod, 
 		// one long-stuck pod from firing alone.
 		if idx, ok := failing[p.UID]; ok {
 			if since, stuck := stuckSince(p); stuck {
-				snap.FailureCount++
+				snap.Pods.FailureCount++
 				sigCounts[idx]++
 				if snap.StuckSince.IsZero() || since.Before(snap.StuckSince) {
 					snap.StuckSince = since
 				}
 				if now.Sub(since) >= d.dwell {
-					snap.SustainedCount++
+					snap.Pods.SustainedCount++
 				}
 			}
 		}
@@ -189,10 +189,13 @@ func (d signatureDetector) MeetsThreshold(snap Snapshot, now time.Time) bool {
 	// The floor counts pods each sustained past the dwell (computed in Evaluate),
 	// so meeting it already proves the storm held continuously; there is no
 	// separate oldest-pod dwell check.
-	if snap.SustainedCount < d.failuresFloor {
+	if snap.Pods == nil {
 		return false
 	}
-	if d.requireZeroSuccess && snap.RecentSuccess {
+	if snap.Pods.SustainedCount < d.failuresFloor {
+		return false
+	}
+	if d.requireZeroSuccess && snap.Pods.RecentSuccess {
 		return false
 	}
 	return true

--- a/mgmt-agent/pkg/controller/nodehealth/labeler_test.go
+++ b/mgmt-agent/pkg/controller/nodehealth/labeler_test.go
@@ -57,7 +57,7 @@ func snap() detectors.Snapshot {
 	return detectors.Snapshot{
 		DetectorName:     "swift-vf-teardown",
 		Window:           10 * time.Minute,
-		FailureCount:     30,
+		Pods:             &detectors.PodEvidence{FailureCount: 30},
 		MatchedSignature: `no such network interface`,
 	}
 }


### PR DESCRIPTION
Jira: [AROSLSRE-1983](https://redhat.atlassian.net/browse/AROSLSRE-1983)

### What

Adds a `never-ready` detector for a node that registers and never reaches Ready.

Its evidence is the Node object alone: the Ready condition has never been True, and its first transition coincides with the node's creation. A node that reached Ready at any point has a strictly later transition, which is what separates "never started" from "started and later failed".

Three supporting changes:

- An optional `nodeDetector` sub-interface, so a node-state detector fits without widening `Evaluate` for every existing detector.
- `Decide` now runs node-state detectors on the NotReady path and the pod/event detectors on the Ready path. The Ready path is unchanged.
- `Snapshot.Detail`, an escape hatch for the reason annotation.

### Why

`Decide` skips any NotReady node:

```go
// Node-Ready precondition: a NotReady node is left to node lifecycle.
if !isNodeReady(node) {
    return DecisionUnknown, Snapshot{}
}
```

Correct for a node that was Ready and dropped out. Wrong for one that never got there, because nothing in node lifecycle rescues it.

INT node `aks-userswft3-65765115-vmss00000g` (int-westus3, [AROSLSRE-1976](https://redhat.atlassian.net/browse/AROSLSRE-1976)) failed provisioning with a terminal `OSProvisioningClientError`, registered, never came up, and sat NotReady for 22 hours until a human cordoned it. From its captured `node.yaml`:

```text
creationTimestamp:          2026-08-31T21:32:14Z
Ready.lastTransitionTime:   2026-08-31T21:32:14Z
Ready.status:               False
Ready.reason:               KubeletNotReady
```

The condition was written once at registration and never moved, so the two timestamps are identical.

**The dwell is 30 minutes, set from data.** Across 1,119 dev nodes over 14 days, time from creation to first `Ready=True` was p50 1.0m, p90 1.3m, p99 3.1m, max 3.4m. Every node that was going to come up did so inside 3.4 minutes, so 30 minutes is about nine times the worst legitimate bootstrap, and still 44 times faster than the 22 hours we actually took.

**Why `Snapshot.Detail` is needed:** `labeler.go` fills the reason annotation from `ReasonString()`, which renders pod counts. A born-broken node would otherwise be annotated "0 pods stuck past dwell (0 stuck total), no recent success in 0s window". Detectors that leave `Detail` empty render byte-identically to before, which is pinned by a test.

**Why generic rather than IMDS-specific:** dead IMDS, a failed disk, a kubelet certificate problem and a failed image pull are all born broken and all remedied by reimaging, and one detector is one fault with one remedy. The cause goes in the signature annotation instead, taken from the Ready condition's reason. A cause-specific detector would also have to read azure-cns container logs, which this controller never does.

### Testing

`go build`, `go vet`, `gofmt` and `go test ./pkg/controller/nodehealth/...` all clean. Every pre-existing test passes untouched.

New tests cover the dwell boundary (including exactly at the dwell), the born-broken discriminator, a node that was Ready and dropped out, the registration tolerance either side, unusable evidence (no Ready condition, missing timestamps, clock skew), an empty Ready reason, ownership of a non-SWIFT node, and that the Ready path still belongs to `swift-vf-teardown`.

`TestProductionBornBrokenNodeFires` replays the captured INT node with its verbatim timestamps and asserts it fires at the dwell and not a second earlier.

I also mutation-checked the tests: removing the born-broken discriminator fails 4 of them and zeroing the dwell fails 2, so they are not passing vacuously.

### Special notes for your reviewer

**This cannot cause disruptive remediation.** The controller stops at labelling; mitigation of a labelled node is owned by a separate controller that is not shipped.

**Ownership is deliberately narrower than the fault.** The detector reuses `isSwiftV2Node` even though a born-broken node is not a SWIFT problem. `AnyApplies` runs ahead of the Ready gate and decides which nodes we hold labels on at all, so a detector applying to every node would make `DecisionNotApplicable` unreachable, and that is the only thing that retires a stale label. I verified the captured INT node did carry `kubernetes.azure.com/podnetwork-swiftv2-enabled=true`, so the scope is correct rather than lucky. Widening it is a separate decision.

**A silent node still gets evaluated:** a born-broken node produces no pods or events, but `resyncAll` re-enqueues every candidate node every 30 seconds, so it fires at the dwell rather than waiting for unrelated traffic.

Two open questions I would rather surface than bury:

1. Should AKS node auto-repair have owned this? It targets nodes that were healthy and went NotReady, so a never-provisioned instance plausibly falls outside it, which is the gap this fills. If it should have caught it, the better fix is an AKS bug and this becomes a stopgap.
2. The dwell rests on dev data, because prod does not snapshot Node objects today. Worth re-checking once it does.

This is independent of [#6769](https://github.com/Azure/ARO-HCP/pull/6769) and [#6776](https://github.com/Azure/ARO-HCP/pull/6776), which change detector thresholds rather than the Ready gate. I trial-merged all three: they auto-merge with no conflicts and the full suite passes on the combined tree.

### PR Checklist

- [x] Tests added, including a production-evidence test
- [x] `go build`, `go vet`, `gofmt` clean
- [x] Jira issue linked
