### PR TITLE
fix: decrease timeout for kms key rotation e2e

### DIFF
--- a/test/e2e/kms_key_rotation.go
+++ b/test/e2e/kms_key_rotation.go
@@ -31,9 +31,10 @@ import (
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
 )
 
-// UpdateTimeout of a cluster + the etcd re-encryption timeout
-// To check the p99 in the future and adjust times
-const HCPClusterReencryptionUpgradeTimeout = framework.UpdateHCPClusterTimeout + 20*time.Minute
+// HCPClusterReencryptionUpgradeTimeout is the cluster update timeout plus additional time for etcd re-encryption.
+// p99 across dev/stg/prod is 18m 29s (2026-09-01, 30d window).
+// The total timeout should be 23m = p99 + ~20% buffer.
+const HCPClusterReencryptionUpgradeTimeout = framework.UpdateHCPClusterTimeout + 13*time.Minute
 
 var _ = Describe("Customer", func() {
 	It("should be able to rotate KMS key for a cluster with version >= 4.22",


### PR DESCRIPTION
### What

Decrease the timeout for e2e kms key rotation from 30 minutes to 23 minutes.

### Why

When this test was added there was not a confidence of the time that it usually takes to perform the re-encryption. I have analyzed the data from the different tests (e2e-parallel and the slow ones).

I have used the following query, that gets the status when the controller finally picks the operation and stores it in CosmosDB, after calculate the different states from the different components.

```
database('ServiceLogs').table('backendLogs')
| where timestamp between (ago(30d) .. now())
| where container_name == 'aro-hcp-backend'
| where log.controller_name endswith 'update'
| where resource_group has 'kms-key-rotate'
| where log.msg has 'Updating operation status'
| project timestamp, operation_id, resource_id = tostring(log.resource_id), status = tostring(log.newStatus), resource_type = tostring(log.resourceType), log.controller_name
| summarize
    updating_time = minif(timestamp, status == 'Updating'),
    succeeded_time    = minif(timestamp, status == 'Succeeded')
    by operation_id
| where isnotempty(updating_time) and isnotempty(succeeded_time)
| extend duration = succeeded_time - updating_time
| summarize
    count  = count(),
    avg    = avg(duration),
    p50    = percentile(duration, 50),
    p90    = percentile(duration, 90),
    p95    = percentile(duration, 95),
    p99    = percentile(duration, 99),
    p999   = percentile(duration, 99.9),
    p9999  = percentile(duration, 99.99)
```

Slow test are not significant as they have 25, and 50 elements. e2e-parallel test run  3,529 re-encryption tests. And the results for this was:

| count | avg | p50 | p90 | p95 | p99 | p999 |
|---|---|---|---|---|---|---|
| 3,529 | 16m 04s | 16m 00s | 17m 19s | 17m 41s | 18m 29s | 22m 47s |

Selecting the p99 18m 29s . With ~20% buffer → ~22m. Rounding up → 23 minutes is the calculation to choose 23 minutes.

### Testing

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

