### PR TITLE
fix(e2e): use subscription home tenant locally (AROSLSRE-1988)

### DIFF
--- a/internal/apitesting/coreapitesting/testhelpers.go
+++ b/internal/apitesting/coreapitesting/testhelpers.go
@@ -38,7 +38,7 @@ import (
 const (
 	TestLocation                                = "westus3"
 	TestAPIVersion                              = "2024-06-10-preview"
-	TestTenantID                                = "00000000-0000-0000-0000-000000000000"
+	TestTenantID                                = "33333333-3333-3333-3333-333333333333"
 	TestSubscriptionID                          = "11111111-1111-1111-1111-111111111111"
 	TestAltSubscriptionID                       = "22222222-2222-2222-2222-222222222222"
 	TestResourceGroupName                       = "testResourceGroup"

--- a/internal/validation/validate_subscription.go
+++ b/internal/validation/validate_subscription.go
@@ -26,6 +26,8 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
 )
 
+const emptyTenantID = "00000000-0000-0000-0000-000000000000"
+
 func ValidateSubscriptionCreate(ctx context.Context, newObj *coreapi.Subscription) field.ErrorList {
 	op := operation.Operation{Type: operation.Create}
 	return validateSubscription(ctx, op, newObj, nil)
@@ -50,6 +52,14 @@ func validateSubscription(ctx context.Context, op operation.Operation, newObj, o
 	}
 
 	//Properties       *SubscriptionProperties `json:"properties"`
+	if newObj.Properties != nil && newObj.Properties.TenantId != nil {
+		tenantIDPath := field.NewPath("properties").Child("tenantId")
+		errs = append(errs, validate.RequiredValue(ctx, op, tenantIDPath, newObj.Properties.TenantId, nil)...)
+		if *newObj.Properties.TenantId == emptyTenantID {
+			errs = append(errs, field.Invalid(tenantIDPath, *newObj.Properties.TenantId, "must not be the all-zero tenant ID"))
+		}
+	}
+
 	//LastUpdated int `json:"-"`
 
 	return errs

--- a/internal/validation/validate_subscription.go
+++ b/internal/validation/validate_subscription.go
@@ -26,6 +26,8 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
 )
 
+// emptyTenantID is the all-zero GUID sentinel, distinct from the empty string
+// case also validated below.
 const emptyTenantID = "00000000-0000-0000-0000-000000000000"
 
 func ValidateSubscriptionCreate(ctx context.Context, newObj *coreapi.Subscription) field.ErrorList {

--- a/internal/validation/validate_subscription_comprehensive_test.go
+++ b/internal/validation/validate_subscription_comprehensive_test.go
@@ -54,6 +54,32 @@ func TestValidateSubscriptionCreate(t *testing.T) {
 			expectErrors: []utils.ExpectedError{},
 		},
 		{
+			name: "empty tenant ID",
+			subscription: func() *coreapi.Subscription {
+				s := createValidSubscription()
+				s.Properties = &coreapi.SubscriptionProperties{
+					TenantId: ptr.To(""),
+				}
+				return s
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "Required value", FieldPath: "properties.tenantId"},
+			},
+		},
+		{
+			name: "all-zero tenant ID",
+			subscription: func() *coreapi.Subscription {
+				s := createValidSubscription()
+				s.Properties = &coreapi.SubscriptionProperties{
+					TenantId: ptr.To(emptyTenantID),
+				}
+				return s
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "must not be the all-zero tenant ID", FieldPath: "properties.tenantId"},
+			},
+		},
+		{
 			name: "valid subscription - all valid states",
 			subscription: func() *coreapi.Subscription {
 				s := createValidSubscription()

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/basic-external-auth-operation-external-auth.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/basic-external-auth-operation-external-auth.json
@@ -14,7 +14,7 @@
 		"request": "Create",
 		"startTime": "2025-12-05T20:30:10.966609337Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/create-with-tags-operation.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/create-with-tags-operation.json
@@ -14,7 +14,7 @@
 		"request": "Create",
 		"startTime": "2025-12-05T20:29:59.734335781Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/immutability-operation-for-node-pool.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/immutability-operation-for-node-pool.json
@@ -14,7 +14,7 @@
 		"request": "Create",
 		"startTime": "2025-12-05T20:30:25.067364685Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/operation-3-new.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/01-load-initial/operation-3-new.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/37332504-70b3-4796-9af6-301a5d47d127",
 		"startTime": "2025-12-05T20:30:25.067364685Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/basic-external-auth-operation-external-auth.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/basic-external-auth-operation-external-auth.json
@@ -14,7 +14,7 @@
 		"request": "Create",
 		"startTime": "2025-12-05T20:30:10.966609337Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/create-with-tags-operation.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/create-with-tags-operation.json
@@ -14,7 +14,7 @@
 		"request": "Create",
 		"startTime": "2025-12-05T20:29:59.734335781Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/immutability-operation-for-node-pool.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/immutability-operation-for-node-pool.json
@@ -14,7 +14,7 @@
 		"request": "Create",
 		"startTime": "2025-12-05T20:30:25.067364685Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/operation-3-new.json
+++ b/test-integration/frontend/artifacts/DatabaseCRUD/UntypedCRUD/basic/05-untypedListRecursive-subscription/operation-3-new.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/f52dfea2-47ee-4396-8006-4a27d47d59c5/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/37332504-70b3-4796-9af6-301a5d47d127",
 		"startTime": "2025-12-05T20:30:25.067364685Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/request/03-listActiveOperations-request-credentials/operation-request-credential.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/request/03-listActiveOperations-request-credentials/operation-request-credential.json
@@ -10,5 +10,5 @@
 	"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/00000000-0000-0000-0000-000000000000",
 	"startTime": "2025-01-01T00:00:00Z",
 	"status": "Accepted",
-	"tenantId": "00000000-0000-0000-0000-000000000000"
+	"tenantId": "33333333-3333-3333-3333-333333333333"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke/03-listActiveOperations-revoke-credentials/operation-revoke-credentials.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/AdminCredentials/revoke/03-listActiveOperations-revoke-credentials/operation-revoke-credentials.json
@@ -10,5 +10,5 @@
 	"resourceId": "/subscriptions/0465bc32-c654-41b8-8d87-9815d7abe8f6/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/00000000-0000-0000-0000-000000000000",
 	"startTime": "2025-01-01T00:00:00Z",
 	"status": "Accepted",
-	"tenantId": "00000000-0000-0000-0000-000000000000"
+	"tenantId": "33333333-3333-3333-3333-333333333333"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/04-cosmosCompare-confirm-content/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/04-cosmosCompare-confirm-content/operation-cluster-create-with-tags-create.json
@@ -20,7 +20,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/07-listActiveOperations-cluster-create/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-current/07-listActiveOperations-cluster-create/operation-cluster-create-with-tags-create.json
@@ -11,5 +11,5 @@
 	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/07314510-beb6-4379-902a-ab6452603265",
 	"startTime": "2025-12-19T20:41:44.99062756Z",
 	"status": "Accepted",
-	"tenantId": "00000000-0000-0000-0000-000000000000"
+	"tenantId": "33333333-3333-3333-3333-333333333333"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-create-canceled.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-create-canceled.json
@@ -8,7 +8,7 @@
 		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster",
 		"request": "Create",
 		"status": "Canceled",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-cluster-operation/03-cosmosCompare-final-state/operation-cluster-delete.json
@@ -4,7 +4,7 @@
 		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster",
 		"request": "Delete",
 		"status": "Deleting",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": true,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/07-cosmosCompare-final-state/operation-cluster-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/07-cosmosCompare-final-state/operation-cluster-create.json
@@ -4,7 +4,7 @@
 		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster",
 		"request": "Create",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/07-cosmosCompare-final-state/operation-cluster-delete.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/07-cosmosCompare-final-state/operation-cluster-delete.json
@@ -4,7 +4,7 @@
 		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster",
 		"request": "Delete",
 		"status": "Deleting",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": true,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/07-cosmosCompare-final-state/operation-nodepool-create-canceled.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/delete-with-pending-nodepool-operation/07-cosmosCompare-final-state/operation-nodepool-create-canceled.json
@@ -8,7 +8,7 @@
 		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/test-cluster/nodePools/test-nodepool",
 		"request": "Create",
 		"status": "Canceled",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/experimental-features/00-httpCreate-subscription-with-afec/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/experimental-features/00-httpCreate-subscription-with-afec/subscription.json
@@ -6,7 +6,7 @@
 				"state": "Registered"
 			}
 		],
-		"tenantId": "00000000-0000-0000-0000-000000000000"
+		"tenantId": "33333333-3333-3333-3333-333333333333"
 	},
 	"registrationDate": "2025-12-19T19:53:15+00:00",
 	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/experimental-features/06-httpReplace-subscription-keep-afec/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/experimental-features/06-httpReplace-subscription-keep-afec/subscription.json
@@ -6,7 +6,7 @@
 				"state": "Registered"
 			}
 		],
-		"tenantId": "00000000-0000-0000-0000-000000000000"
+		"tenantId": "33333333-3333-3333-3333-333333333333"
 	},
 	"registrationDate": "2025-12-19T19:53:15+00:00",
 	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/01-load-old-data/hcpoperationstatuses_Create_90b2322c-2c26-47ca-b6f9-d9b1a8385cbc.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/01-load-old-data/hcpoperationstatuses_Create_90b2322c-2c26-47ca-b6f9-d9b1a8385cbc.json
@@ -20,7 +20,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/90b2322c-2c26-47ca-b6f9-d9b1a8385cbc",
 		"startTime": "2026-01-05T18:29:58.181047849Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/04-listActiveOperations-cluster-create/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/read-old-data/04-listActiveOperations-cluster-create/operation-cluster-create-with-tags-create.json
@@ -11,5 +11,5 @@
 	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/07314510-beb6-4379-902a-ab6452603265",
 	"startTime": "2025-12-19T20:41:44.99062756Z",
 	"status": "Accepted",
-	"tenantId": "00000000-0000-0000-0000-000000000000"
+	"tenantId": "33333333-3333-3333-3333-333333333333"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/05-cosmosCompare-ending-content/operation-cluster-create-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/05-cosmosCompare-ending-content/operation-cluster-create-create-with-tags.json
@@ -15,7 +15,7 @@
 		"resourceId": null,
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/05-cosmosCompare-ending-content/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/create-current/05-cosmosCompare-ending-content/operation-externalauth-create-default.json
@@ -20,7 +20,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/ea807c13-7e15-43d4-b760-69ef7e31d273",
 		"startTime": "2026-01-09T18:30:03.439824696Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -20,7 +20,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/9696fbeb-0e78-4a32-a3fd-a6e987c2a015",
 		"startTime": "2026-01-09T18:32:10.15007222Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/01-load-old-data/operation-externalauth-create-default.json
@@ -20,7 +20,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-cluster-create-create-with-tags.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-cluster-create-create-with-tags.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/9696fbeb-0e78-4a32-a3fd-a6e987c2a015",
 		"startTime": "2026-01-09T18:32:10.15007222Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-externalauth-create-default.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-externalauth-update-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/read-old-data/09-cosmosCompare-confirm-update/operation-externalauth-update-default.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4d8d4875-5233-4987-8b14-a26e177b8e20",
 		"startTime": "2026-01-09T18:44:19.757910778Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/99-cosmosCompare-ending-content/operation-cluster-create-example-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/99-cosmosCompare-ending-content/operation-cluster-create-example-cluster.json
@@ -4,7 +4,7 @@
 		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/example-cluster",
 		"request": "Create",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/99-cosmosCompare-ending-content/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/second-external-auth-rejected/99-cosmosCompare-ending-content/operation-externalauth-create-default.json
@@ -4,7 +4,7 @@
 		"externalId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/example-cluster/externalAuths/default",
 		"request": "Create",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-create-basicnodepool.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-create-nodepool-02.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/01-load-old-data/operation-externalauth-create-default.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-cluster-create-with-tags-create.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-create-basicnodepool.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-create-nodepool-02.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/migrate-old-data/99-cosmosCompare-confirm-migration/operation-externalauth-create-default.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-create-basicnodepool.json
@@ -20,7 +20,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-create-nodepool-02.json
@@ -20,7 +20,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/01-load-old-data/operation-externalauth-create-default.json
@@ -20,7 +20,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-cluster-create-with-tags-create.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-create-basicnodepool.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-create-nodepool-02.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-externalauth-create-default.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Migration/read-new-data/18-cosmosCompare-confirm/operation-externalauth-create-default.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/5dce3cac-e09b-4ef5-803c-cb8f17b3a552",
 		"startTime": "2026-01-09T18:32:10.835814057Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-listActiveOperations-cluster-create/operation-nodepool-create-basic-nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-listActiveOperations-cluster-create/operation-nodepool-create-basic-nodepool.json
@@ -11,7 +11,7 @@
 	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7c3de93c-ff5d-4865-a177-291549ba8020",
 	"startTime": "2025-12-19T21:03:42.649357713Z",
 	"status": "Accepted",
-	"tenantId": "00000000-0000-0000-0000-000000000000",
+	"tenantId": "33333333-3333-3333-3333-333333333333",
 	"usesNewClusterDeletionApproach": false,
 	"usesNewExternalAuthDeletionApproach": false,
 	"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-listActiveOperations-cluster-create/operation-nodepool-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/06-listActiveOperations-cluster-create/operation-nodepool-create-nodepool-02.json
@@ -11,7 +11,7 @@
 	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/c1216e33-a694-4a65-a504-d821c30dc67c",
 	"startTime": "2025-12-19T21:03:42.924755264Z",
 	"status": "Accepted",
-	"tenantId": "00000000-0000-0000-0000-000000000000",
+	"tenantId": "33333333-3333-3333-3333-333333333333",
 	"usesNewClusterDeletionApproach": false,
 	"usesNewExternalAuthDeletionApproach": false,
 	"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/07-cosmosCompare-confirm-content/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/create-current/07-cosmosCompare-confirm-content/operation-cluster-create-with-tags-create.json
@@ -20,7 +20,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/locations/fake-location/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/experimental-features/00-httpCreate-subscription-with-afec/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/experimental-features/00-httpCreate-subscription-with-afec/subscription.json
@@ -6,7 +6,7 @@
 				"state": "Registered"
 			}
 		],
-		"tenantId": "00000000-0000-0000-0000-000000000000"
+		"tenantId": "33333333-3333-3333-3333-333333333333"
 	},
 	"registrationDate": "2025-12-19T19:53:15+00:00",
 	"resourceId": "/subscriptions/a1b2c3d4-0000-0000-0000-afec00000000",

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-cluster-create-with-tags-create.json
@@ -15,7 +15,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/7a4ed07a-47a1-4efb-966a-93a6316522a0",
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-basicnodepool.json
@@ -20,7 +20,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/01-load-old-data/operation-create-nodepool-02.json
@@ -20,7 +20,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-listActiveOperations-node-create/operation-nodepool-create-basicnodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-listActiveOperations-node-create/operation-nodepool-create-basicnodepool.json
@@ -11,5 +11,5 @@
 	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/cdfb496e-6e70-4022-9f8d-b0dacf6d2ff5",
 	"startTime": "2026-01-08T20:04:05.054190978Z",
 	"status": "Accepted",
-	"tenantId": "00000000-0000-0000-0000-000000000000"
+	"tenantId": "33333333-3333-3333-3333-333333333333"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-listActiveOperations-node-create/operation-nodepool-create-nodepool02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/04-listActiveOperations-node-create/operation-nodepool-create-nodepool02.json
@@ -11,5 +11,5 @@
 	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/4067756a-fcc1-4732-a211-d785d888203c",
 	"startTime": "2026-01-08T20:04:05.330050272Z",
 	"status": "Accepted",
-	"tenantId": "00000000-0000-0000-0000-000000000000"
+	"tenantId": "33333333-3333-3333-3333-333333333333"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-cluster.json
@@ -15,7 +15,7 @@
 		"resourceId": null,
 		"startTime": "2025-12-19T19:59:30.714826736Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-02.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-02.json
@@ -15,7 +15,7 @@
 		"resourceId": null,
 		"startTime": "2026-01-08T20:04:05.330050272Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-basic.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-create-nodepool-basic.json
@@ -15,7 +15,7 @@
 		"resourceId": null,
 		"startTime": "2026-01-08T20:04:05.054190978Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-update-nodepool-basic.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/read-old-data/09-cosmosCompare-confirm-update/operation-update-nodepool-basic.json
@@ -15,7 +15,7 @@
 		"resourceId": null,
 		"startTime": "2026-01-08T20:09:32.571015378Z",
 		"status": "Accepted",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/version-update/10-listActiveOperations-version-update/operation.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/version-update/10-listActiveOperations-version-update/operation.json
@@ -11,5 +11,5 @@
 	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/00000000-0000-0000-0000-000000000000",
 	"startTime": "2025-12-19T21:03:42.649357713Z",
 	"status": "Accepted",
-	"tenantId": "00000000-0000-0000-0000-000000000000"
+	"tenantId": "33333333-3333-3333-3333-333333333333"
 }

--- a/test-integration/frontend/artifacts/FrontendCRUD/Operations/read-new-data/01-load-new-data/operation.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Operations/read-new-data/01-load-new-data/operation.json
@@ -16,7 +16,7 @@
 		"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/providers/Microsoft.RedHatOpenShift/hcpOperationStatuses/ab5d298a-2267-432a-ad71-313bbdae0349",
 		"startTime": "2026-01-08T19:02:35.73640117Z",
 		"status": "Succeeded",
-		"tenantId": "00000000-0000-0000-0000-000000000000",
+		"tenantId": "33333333-3333-3333-3333-333333333333",
 		"usesNewClusterDeletionApproach": false,
 		"usesNewExternalAuthDeletionApproach": false,
 		"usesNewNodePoolDeletionApproach": false

--- a/test/E2ELocal.mk
+++ b/test/E2ELocal.mk
@@ -15,6 +15,8 @@ LOCAL_FRONTEND_PORT ?= 8443
 LOCAL_ADMIN_API_PORT ?= 8444
 AROHCP_ENV ?= development
 CUSTOMER_SUBSCRIPTION ?= $$(az account show --output tsv --query 'name')
+AZURE_HOME_TENANT_ID ?= $$(az account show --output tsv --query 'homeTenantId')
+EMPTY_TENANT_ID := 00000000-0000-0000-0000-000000000000
 ifndef E2E_ARTIFACT_DIR
   E2E_ARTIFACT_DIR := $(shell mktemp -d)
 endif
@@ -25,7 +27,7 @@ e2e-local/run-test: $(ARO_HCP_TESTS)
 	export LOCATION="$${LOCATION:-${REGION}}"; \
 	export AROHCP_ENV="development"; \
 	export CUSTOMER_SUBSCRIPTION="$$(az account show --output tsv --query 'name')"; \
-	export AZURE_TENANT_ID="$$(az account show --output tsv --query 'tenantId')"; \
+	export AZURE_TENANT_ID="$(AZURE_HOME_TENANT_ID)"; \
 	export SKIP_CERT_VERIFICATION=$${SKIP_CERT_VERIFICATION:-false}; \
 	export FRONTEND_ADDRESS=$${FRONTEND_ADDRESS:-http://localhost:8443}; \
 	export ADMIN_API_ADDRESS=$${ADMIN_API_ADDRESS:-http://localhost:8444}; \
@@ -79,7 +81,11 @@ e2e-local/gather-observability: $(ARO_HCP_TESTS) $(TEMPLATIZE)
 
 .e2e-local/setup:
 	SUBSCRIPTION_ID="$$(az account show --query id --output tsv)"; \
-	TENANT_ID="$$(az account show --query tenantId --output tsv)"; \
+	TENANT_ID="$(AZURE_HOME_TENANT_ID)"; \
+	if [[ -z "$${TENANT_ID}" || "$${TENANT_ID}" == "$(EMPTY_TENANT_ID)" ]]; then \
+		echo "Azure subscription home tenant ID is missing or invalid; refusing to overwrite the local RP subscription registration."; \
+		exit 1; \
+	fi; \
 	curl --silent --show-error --include \
 		--insecure \
 		--request PUT \


### PR DESCRIPTION
[AROSLSRE-1988](https://redhat.atlassian.net/browse/AROSLSRE-1988)

### What

- Use the selected subscription's `homeTenantId` for local E2E subscription registration and `AZURE_TENANT_ID`.
- Refuse to overwrite the local RP subscription registration when the home tenant is empty or all-zero.
- Reject empty and all-zero tenant IDs at the subscription API validation boundary.

### Why

`az account show --query tenantId` identifies the active Azure CLI authentication tenant, which can differ from the tenant that owns a cross-tenant subscription. A personal DEV environment was registered first with the Microsoft tenant and later with the all-zero tenant, causing clusters-service credential failures during cluster provisioning and deletion.

### Testing

- `go test ./internal/validation ./frontend/pkg/frontend`
- `make lint GO=/Users/rael/go/bin/go1.25.7`
- Exercised `.e2e-local/setup` with a fake Azure CLI/curl boundary:
  - the subscription PUT contains the selected `homeTenantId`
  - empty and all-zero tenant IDs fail before the PUT

### Special notes for your reviewer

The affected `pers-usw3nshn-svc` subscription registration has already been repaired with its owning tenant. Existing clusters-service records created while the registration was corrupt are not mutated by this change and must be recreated.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
