### PR TITLE
owners: add capz-approvers for CAPZ CI job ownership

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,11 @@
-approvers:
-  - deads2k
-  - stevekuznetsov
-  - geoberle
-  - bennerv
-  - service-lifecycle-global-approvers
-reviewers:
+filters:
+  '.*':
+    approvers:
+      - deads2k
+      - stevekuznetsov
+      - geoberle
+      - bennerv
+      - service-lifecycle-global-approvers
+  '.*capz.*':
+    approvers:
+      - capz-approvers

--- a/OWNERS
+++ b/OWNERS
@@ -6,7 +6,7 @@ filters:
       - geoberle
       - bennerv
       - service-lifecycle-global-approvers
-  # This is targeted at openshift/release.git repo, it doesn't apply to local files
+  # Intended to support autoowners generation in openshift/release; in this repo it will apply to any file paths that match the regex below.
   # See https://github.com/openshift/release/blob/main/ci-operator/config/Azure/ARO-HCP/OWNERS
   '.*capz.*':
     approvers:

--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,8 @@ filters:
       - geoberle
       - bennerv
       - service-lifecycle-global-approvers
+  # This is targeted at openshift/release.git repo, it doesn't apply to local files
+  # See https://github.com/openshift/release/blob/main/ci-operator/config/Azure/ARO-HCP/OWNERS
   '.*capz.*':
     approvers:
       - capz-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -17,6 +17,10 @@ aliases:
   - sclarkso 
   - venkateshsredhat 
   - weherdh
+  capz-approvers:
+  - RadekCap
+  - marek-veber
+  - mzazrivec
   sre-approvers:
   - SudoBrendan
   - ehvs


### PR DESCRIPTION
## Summary

- Adds `capz-approvers` alias (`RadekCap`, `marek-veber`, `mzazrivec`) to `OWNERS_ALIASES`
- Converts root `OWNERS` from SimpleConfig to FullConfig with filters:
  - `.*` — existing SLC approvers (unchanged)
  - `.*capz.*` — capz-approvers

## Why

The `autoowners` tool in openshift/ci-tools regenerates
`openshift/release/ci-operator/config/Azure/ARO-HCP/OWNERS` from this
file. It preserves `filters` blocks and expands aliases, so the
generated file will correctly assign CAPZ team members as approvers for
CAPZ-related CI job configs (e.g. `Azure-ARO-HCP-main__capz-e2e.yaml`).

This means the CAPZ team can approve their own CI changes without
waiting on the SLC team.

Related: https://github.com/openshift/release/pull/83383