### PR TITLE
test: demonstrate ACM policy image override

### DIFF
--- a/acm/multicluster-engine-config.values.yaml
+++ b/acm/multicluster-engine-config.values.yaml
@@ -1,5 +1,9 @@
 global:
   registryOverride: "{{ .acr.svc.name }}.azurecr.io/acm-d-cache"
+  # Temporary per-component pin. This value is merged into the policy subchart
+  # and takes precedence over its bundle-derived imageOverrides default.
+  imageOverrides:
+    governance_policy_propagator: "governance-policy-propagator-rhel9@sha256:af38ee1695978c68234762d9208c8369fbba623ed5a5c1dd180a64a5c161f34a"
 finalizeMceJobImage: "{{ .aksCommandRuntime.image.registry }}/{{ .aksCommandRuntime.image.repository }}@{{ .aksCommandRuntime.image.digest }}"
 localCluster:
   kubeApiUrl: https://kubernetes.default.svc


### PR DESCRIPTION
## Why

Demonstrate a durable per-component ACM policy-image pin without changing the bundle-derived defaults.

## How it works

The ACM unpack flow regenerates the policy subchart defaults at acm/deploy/helm/multicluster-engine-config/charts/policy/values.yaml from the ACM operator bundle manifest. It does not modify acm/multicluster-engine-config.values.yaml.

The ACM pipeline deploy-mce-config Helm step deploys the multicluster-engine-config parent chart using acm/multicluster-engine-config.values.yaml as its values file. Helm merges global values into the policy subchart. This change adds global.imageOverrides.governance_policy_propagator in that parent values file, which takes precedence over the regenerated child-chart default.

The governance-policy-propagator template constructs its workload image from global.registryOverride plus global.imageOverrides.governance_policy_propagator. Consequently, the rendered deployment uses the specified previous digest from the service-cluster acm-d-cache registry. Other policy component image defaults still come from the ACM bundle.

## Scope and caveat

This is deliberately a global management-cluster pin and applies to every deployment using this values file. The image reference is injected by the Helm release, but rollout also requires the prior digest to remain available in the acm-d-cache ACR repository.

## Validation

- make update-helm-fixtures
- Rendered the MCE config chart with the parent values and confirmed that the governance-policy-propagator workload resolves to the override digest.