### PR TITLE
fix(test): bump ClusterCreationTimeout to reduce CI pain from slow CS provisioning (AROSLSRE-1990)

### DIFF
--- a/test/util/framework/constants.go
+++ b/test/util/framework/constants.go
@@ -20,7 +20,13 @@ import "time"
 
 // Provisioning timeouts
 const (
-	ClusterCreationTimeout      = 20 * time.Minute
+	// ClusterCreationTimeout is temporarily raised from 20m as a stop-gap while
+	// Cluster Service provisioning latency is being investigated (CS steps run
+	// strictly serially today and recent telemetry shows several steps, e.g.
+	// DNS and RBAC role assignment on the MRG, taking noticeably longer than
+	// their historical p50/p90). Revisit and re-tune once the CS-side latency
+	// work lands; see test/e2e/README.md#updating-e2e-timeouts.
+	ClusterCreationTimeout      = 30 * time.Minute
 	NodePoolCreationTimeout     = 20 * time.Minute
 	ExternalAuthCreationTimeout = 15 * time.Minute
 	GetAdminRESTConfigTimeout   = 10 * time.Minute


### PR DESCRIPTION
Jira: [AROSLSRE-1990](https://redhat.atlassian.net/browse/AROSLSRE-1990)

### What

Raises the shared E2E `ClusterCreationTimeout` constant from 20 minutes to 30
minutes in `test/util/framework/constants.go`. No other logic changes.

### Why

Recent telemetry (analysis shared in the `external-wg-aro-hcp` Slack channel
by Steve Kuznetsov) shows Cluster Service's provisioning steps run strictly
serially, and several steps, DNS, RBAC role assignment on the managed
resource group, and egress/public-IP provisioning, are currently taking
noticeably longer than their historical p50/p90. Clusters that fail to reach
`Succeeded` in time show DNS alone taking roughly 60s longer at p50 than
succeeding clusters.

This is causing otherwise-healthy clusters to be flagged as CI failures
purely because provisioning didn't finish inside the current 20 minute
window, adding noise/pain to CI independent of any real product regression.

This is an interim mitigation while the underlying CS latency is addressed
separately (see [#6784](https://github.com/Azure/ARO-HCP/pull/6784), and a
proposal from Steve Kuznetsov to move CS provisioning to ARM deployment
stacks). It should be revisited and re-tuned from real p99 data once that
work lands, per `test/e2e/README.md#updating-e2e-timeouts`.

### Testing

- `go build ./util/...` in `test/` succeeds.
- No new test behavior; only a shared timeout constant changed, consumed by
  existing E2E cluster-creation flows across the suite.

### Special notes for your reviewer

Scoped to a single constant per `test/e2e/README.md#updating-e2e-timeouts`
("change only the constant in constants.go"). Follow-up work to retune this
from Kusto p99 data, and to fix the underlying CS latency, is tracked
separately (not part of this PR).

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
