### PR TITLE
fix(dev-infrastructure): add shared identity RBAC drift check script

### DIFF
--- a/dev-infrastructure/scripts/verify-shared-identity-rbac.sh
+++ b/dev-infrastructure/scripts/verify-shared-identity-rbac.sh
@@ -45,7 +45,10 @@ roleNames() {
         | sort -u
 }
 
-REFERENCE_ROLES=$(roleNames "${REFERENCE_OBJECT_ID}")
+if ! REFERENCE_ROLES=$(roleNames "${REFERENCE_OBJECT_ID}"); then
+    echo "Error: failed to query role assignments for reference identity ${REFERENCE_OBJECT_ID}; cannot establish a baseline." >&2
+    exit 2
+fi
 
 if [ -z "${REFERENCE_ROLES}" ]; then
     echo "Error: reference identity ${REFERENCE_OBJECT_ID} has no role assignments at /subscriptions/${SUBSCRIPTION_ID}; refusing to use it as a baseline." >&2
@@ -58,7 +61,11 @@ echo "${REFERENCE_ROLES}" | sed 's/^/  - /'
 DRIFT_FOUND=0
 
 for objectId in "${TARGET_OBJECT_IDS[@]}"; do
-    TARGET_ROLES=$(roleNames "${objectId}")
+    if ! TARGET_ROLES=$(roleNames "${objectId}"); then
+        echo "ERROR: failed to query role assignments for ${objectId}; treating as drift" >&2
+        DRIFT_FOUND=1
+        continue
+    fi
 
     MISSING_ROLES=$(comm -23 <(echo "${REFERENCE_ROLES}") <(echo "${TARGET_ROLES}"))
 

--- a/dev-infrastructure/scripts/verify-shared-identity-rbac.sh
+++ b/dev-infrastructure/scripts/verify-shared-identity-rbac.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Detects RBAC drift on shared HCP service principals (first-party, arm-helper,
+# msi-mock, etc.) by comparing each target identity's subscription-scope role
+# assignments against a known-good reference identity.
+#
+# Background: AROSLSRE-1994 - three INT shared service principals were
+# recreated (new object IDs) after being hard-deleted, but the recreation
+# skipped the RBAC assignment step. The gap went undetected for roughly a day
+# because nothing checked that a recreated identity actually has its expected
+# roles. This script is meant to be run periodically (e.g. from a Prow
+# periodic job, alongside cleanup-sweeper) so that a repeat of this failure
+# mode is caught within hours instead of days.
+#
+# Usage:
+#   verify-shared-identity-rbac.sh <subscription-id> <reference-object-id> <target-object-id> [<target-object-id> ...]
+#
+# Exit code is non-zero if any target is missing one or more of the reference
+# identity's role assignments. A per-identity summary is printed to stdout in
+# all cases.
+
+set -euo pipefail
+
+if [ "$#" -lt 3 ]; then
+    echo "Usage: $0 <subscription-id> <reference-object-id> <target-object-id> [<target-object-id> ...]" >&2
+    exit 2
+fi
+
+SUBSCRIPTION_ID=$1
+REFERENCE_OBJECT_ID=$2
+shift 2
+TARGET_OBJECT_IDS=("$@")
+
+# roleNames returns the sorted, de-duplicated list of role definition names
+# assigned to $1 at subscription scope, one per line.
+roleNames() {
+    local objectId=$1
+    az role assignment list \
+        --subscription "${SUBSCRIPTION_ID}" \
+        --assignee-object-id "${objectId}" \
+        --scope "/subscriptions/${SUBSCRIPTION_ID}" \
+        --query "[].roleDefinitionName" \
+        -o tsv \
+        --only-show-errors \
+        | sort -u
+}
+
+REFERENCE_ROLES=$(roleNames "${REFERENCE_OBJECT_ID}")
+
+if [ -z "${REFERENCE_ROLES}" ]; then
+    echo "Error: reference identity ${REFERENCE_OBJECT_ID} has no role assignments at /subscriptions/${SUBSCRIPTION_ID}; refusing to use it as a baseline." >&2
+    exit 2
+fi
+
+echo "Reference identity ${REFERENCE_OBJECT_ID} roles:"
+echo "${REFERENCE_ROLES}" | sed 's/^/  - /'
+
+DRIFT_FOUND=0
+
+for objectId in "${TARGET_OBJECT_IDS[@]}"; do
+    TARGET_ROLES=$(roleNames "${objectId}")
+
+    MISSING_ROLES=$(comm -23 <(echo "${REFERENCE_ROLES}") <(echo "${TARGET_ROLES}"))
+
+    if [ -z "${TARGET_ROLES}" ]; then
+        echo "MISSING RBAC: ${objectId} has zero role assignments at /subscriptions/${SUBSCRIPTION_ID} (expected: $(echo "${REFERENCE_ROLES}" | tr '\n' ',' | sed 's/,$//'))"
+        DRIFT_FOUND=1
+    elif [ -n "${MISSING_ROLES}" ]; then
+        echo "MISSING RBAC: ${objectId} is missing role(s): $(echo "${MISSING_ROLES}" | tr '\n' ',' | sed 's/,$//')"
+        DRIFT_FOUND=1
+    else
+        echo "OK: ${objectId} has all expected roles"
+    fi
+done
+
+exit "${DRIFT_FOUND}"

--- a/dev-infrastructure/scripts/verify-shared-identity-rbac.sh
+++ b/dev-infrastructure/scripts/verify-shared-identity-rbac.sh
@@ -62,7 +62,7 @@ DRIFT_FOUND=0
 
 for objectId in "${TARGET_OBJECT_IDS[@]}"; do
     if ! TARGET_ROLES=$(roleNames "${objectId}"); then
-        echo "ERROR: failed to query role assignments for ${objectId}; treating as drift" >&2
+        echo "ERROR: ${objectId} failed to query role assignments; treating as drift"
         DRIFT_FOUND=1
         continue
     fi

--- a/docs/ops/verify-shared-identity-rbac.md
+++ b/docs/ops/verify-shared-identity-rbac.md
@@ -1,0 +1,63 @@
+# Verify Shared Identity RBAC
+
+## Background
+
+[AROSLSRE-1994](https://redhat.atlassian.net/browse/AROSLSRE-1994): three INT shared service
+principals (`aro-hcp-int-fp`, `aro-hcp-int-arm-helper`, `aro-hcp-int-msi-mock`) were hard-deleted
+and recreated with new object IDs, but the recreation skipped assigning their subscription-scope
+RBAC (`Contributor` and `Role Based Access Control Administrator`). The gap went undetected for
+roughly a day, causing a sustained flood of `AuthorizationFailed` errors in Clusters Service logs
+and blocking cluster create/delete in INT.
+
+This mirrors the related incident [AROSLSRE-1969](https://redhat.atlassian.net/browse/AROSLSRE-1969)
+(DEV mock identities soft-deleted by the `cleanup-sweeper` `shared-leftovers` job, fixed in
+[PR #6762](https://github.com/Azure/ARO-HCP/pull/6762)). That fix prevents the sweeper from
+prematurely deleting RBAC for a soft-deleted-but-recoverable principal; it does not detect the case
+handled here, where an identity is recreated (new object ID) and RBAC is simply never (re)applied.
+
+## What this checks
+
+`dev-infrastructure/scripts/verify-shared-identity-rbac.sh` compares a target identity's
+subscription-scope role assignments against a known-good reference identity in the same
+subscription. Any target missing one or more of the reference identity's roles (including having
+zero role assignments at all) is reported and the script exits non-zero.
+
+## Usage
+
+```bash
+dev-infrastructure/scripts/verify-shared-identity-rbac.sh \
+  <subscription-id> \
+  <reference-object-id> \
+  <target-object-id> [<target-object-id> ...]
+```
+
+Example, using the healthy `aro-hcp-int-cs-arm-helper` identity as the reference for the three
+identities involved in AROSLSRE-1994:
+
+```bash
+dev-infrastructure/scripts/verify-shared-identity-rbac.sh \
+  64f0619f-ebc2-4156-9d91-c4c781de7e54 \
+  dfcca0f7-a439-45e8-9284-9a2b876d605a \
+  e02ddacf-108f-4f1b-914b-1aee78fd4cb2 \
+  3fcba429-5bf0-40b1-bd4e-efc8136390a3 \
+  6096f642-63a0-4dd6-958d-715a87f33535
+```
+
+Requires an `az` session with at least read access to role assignments on the target subscription
+(`Microsoft.Authorization/roleAssignments/read`).
+
+## Recommended usage
+
+Run this daily per environment (DEV/INT/STG/PROD) against each environment's shared first-party,
+ARM-helper, and MSI-mock identities, alerting to the environment's on-call channel on a non-zero
+exit code. This closes the detection gap that let AROSLSRE-1994 go unnoticed for a day; see
+AROSLSRE-1995 for the tracked follow-up to wire this into a periodic job.
+
+This script only detects drift; it does not repair it. To fix a detected gap, re-run the
+create/reset flow for the affected identity and re-apply the missing role assignments, for example:
+
+```bash
+az role assignment create --subscription <subscription-id> \
+  --assignee-object-id <object-id> --assignee-principal-type ServicePrincipal \
+  --role Contributor --scope /subscriptions/<subscription-id>
+```

--- a/docs/ops/verify-shared-identity-rbac.md
+++ b/docs/ops/verify-shared-identity-rbac.md
@@ -31,16 +31,16 @@ dev-infrastructure/scripts/verify-shared-identity-rbac.sh \
   <target-object-id> [<target-object-id> ...]
 ```
 
-Example, using the healthy `aro-hcp-int-cs-arm-helper` identity as the reference for the three
-identities involved in AROSLSRE-1994:
+Example, using a known-healthy identity (e.g. `aro-hcp-int-cs-arm-helper`) as the reference for a
+set of target identities to check:
 
 ```bash
 dev-infrastructure/scripts/verify-shared-identity-rbac.sh \
-  64f0619f-ebc2-4156-9d91-c4c781de7e54 \
-  dfcca0f7-a439-45e8-9284-9a2b876d605a \
-  e02ddacf-108f-4f1b-914b-1aee78fd4cb2 \
-  3fcba429-5bf0-40b1-bd4e-efc8136390a3 \
-  6096f642-63a0-4dd6-958d-715a87f33535
+  <subscription-id> \
+  <reference-object-id> \
+  <target-object-id-1> \
+  <target-object-id-2> \
+  <target-object-id-3>
 ```
 
 Requires an `az` session with at least read access to role assignments on the target subscription


### PR DESCRIPTION
## Why

[AROSLSRE-1994](https://redhat.atlassian.net/browse/AROSLSRE-1994): three INT shared service principals (`aro-hcp-int-fp`, `aro-hcp-int-arm-helper`, `aro-hcp-int-msi-mock`) were hard-deleted and recreated with new object IDs, but the recreation skipped assigning their subscription-scope RBAC (`Contributor` + `Role Based Access Control Administrator`). The gap went undetected for roughly a day, causing a sustained flood of `AuthorizationFailed` errors in Clusters Service logs and blocking cluster create/delete in INT.

This is related to [AROSLSRE-1969](https://redhat.atlassian.net/browse/AROSLSRE-1969) (fixed in #6762), which addressed a different bug in the same incident family: the `cleanup-sweeper` `shared-leftovers` job deleting RBAC prematurely for soft-deleted-but-recoverable principals. That fix does not cover this case, where RBAC is simply never (re)created after an identity is recreated from scratch.

## What

Adds `dev-infrastructure/scripts/verify-shared-identity-rbac.sh`, which compares a target identity's subscription-scope role assignments against a known-good reference identity and exits non-zero if any role is missing (including the zero-role-assignments case that caused this incident). Also adds `docs/ops/verify-shared-identity-rbac.md` documenting the background and usage.

Manually verified against the live INT subscription:
- Against the (now-fixed) three identities from [AROSLSRE-1994](https://redhat.atlassian.net/browse/AROSLSRE-1994), using the healthy `aro-hcp-int-cs-arm-helper` as reference: reports `OK` for all three, exit 0.
- Against an identity with no subscription-scope RBAC (`aro-hcp-frontend`, by design): reports `MISSING RBAC`, exit 1.

This is a detection-only script; it does not repair drift. Wiring it into a periodic job (per environment, alerting on-call) is tracked separately in [AROSLSRE-1995](https://redhat.atlassian.net/browse/AROSLSRE-1995).

## Non-goals

- No change to `cleanup-sweeper` itself.
- No new Prow periodic job in this PR (tracked in [AROSLSRE-1995](https://redhat.atlassian.net/browse/AROSLSRE-1995)).