### PR TITLE
feat: add bounded workload metrics to CI observability for ephemeral environments

### DIFF
--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -184,6 +184,7 @@ ARO HCP CI is split across this repository and the OpenShift CI configuration in
 ### [CI Operations](operations.md)
 
 - [Inspecting Runs](operations.md#inspecting-runs)
+- [Post-Job Observability Artifacts](operations.md#post-job-observability-artifacts)
 - [Modifying CI Configuration](operations.md#modifying-ci-configuration)
 - [Troubleshooting](operations.md#troubleshooting)
 - [Job Stuck Pending](operations.md#job-stuck-pending)

--- a/docs/ci/operations.md
+++ b/docs/ci/operations.md
@@ -23,6 +23,28 @@ Useful signals include:
 - GitHub checks status on the PR
 - Slack notifications in [`#forum-ocp-testplatform`](https://redhat.enterprise.slack.com/archives/CBN38N3MW) for build-farm-side failures and repeated issues
 
+### Post-Job Observability Artifacts
+
+For DEV E2E runs, open the artifacts for the
+`aro-hcp-gather-observability` post-step before looking for a separate Grafana
+dashboard. The step runs before environment deletion and queries only the
+run's bounded time window from the regional Azure Monitor workspaces.
+
+- `observability-summary.html` contains fired-alert details and the selected
+  Frontend, Backend, Fleet, Maestro, service-container, and management-cluster
+  charts. Use the service-workload charts to identify the highest CPU and
+  memory consumers and the running pod count during the failure window, then
+  correlate their cluster, namespace, pod, and container labels with the test
+  logs.
+- `alerts.json` contains the alert data used by the summary.
+- `junit_alerts.xml` records unexpected fired alerts as test failures for Prow.
+
+The uploaded summary preserves the selected chart samples after the ephemeral
+environment is deleted, subject to OpenShift CI artifact retention. It is not a
+raw cross-run metrics store. The chart descriptions and copyable PromQL are the
+source of truth for interpreting each signal; the maintained query catalog is
+[`queries.yaml`](../../test/cmd/aro-hcp-tests/gather-observability/queries.yaml).
+
 ## Modifying CI Configuration
 
 ARO HCP Prow job definitions are maintained in `openshift/release`, not in this repository. The generated job manifests under `ci-operator/jobs/Azure/ARO-HCP/` are outputs and should not be edited directly.

--- a/test/cmd/aro-hcp-tests/gather-observability/chart_test.go
+++ b/test/cmd/aro-hcp-tests/gather-observability/chart_test.go
@@ -834,8 +834,9 @@ func TestLoadQueriesConfigEmbedded(t *testing.T) {
 	// that attached Maestro's queries to the CosmosDB panel and dropped the
 	// Maestro Metrics panel entirely).
 	wantQuery := map[string]string{
-		"CosmosDB Metrics": "RU Consumption vs Provisioned",
-		"Maestro Metrics":  "REST API Request Rate by Status",
+		"CosmosDB Metrics":         "RU Consumption vs Provisioned",
+		"Maestro Metrics":          "REST API Request Rate by Status",
+		"Service Workload Metrics": "Top 20 Container CPU Usage",
 	}
 	for panelTitle, queryTitle := range wantQuery {
 		p, ok := byTitle[panelTitle]

--- a/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
@@ -320,6 +320,57 @@ panels:
     unit: /s
     workspace: svc
     step: "60s"
+- title: "Service Workload Metrics"
+  queries:
+  - title: "Top 20 Container CPU Usage"
+    description: "Twenty highest CPU-consuming service containers at each point in the CI run window, measured in CPU cores. The namespace scope matches the service memory resource alerts. This bounded chart is for failure triage and does not define a CI threshold."
+    query: |
+      topk(20,
+        sum by (cluster, namespace, pod, container) (
+          max without (prometheus_replica) (
+            rate(container_cpu_usage_seconds_total{
+              container!="",
+              container!="POD",
+              namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|arobit|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"
+            }[5m])
+          )
+        )
+      )
+    unit: cores
+    workspace: svc
+    step: "60s"
+  - title: "Top 20 Container Memory Working Set"
+    description: "Twenty highest memory-working-set service containers at each point in the CI run window. The namespace scope matches the service memory resource alerts. This bounded chart is for failure triage and does not define a CI threshold."
+    query: |
+      topk(20,
+        max by (cluster, namespace, pod, container) (
+          max without (prometheus_replica) (
+            container_memory_working_set_bytes{
+              container!="",
+              container!="POD",
+              namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|arobit|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate"
+            }
+          )
+        )
+      )
+    unit: bytes
+    workspace: svc
+    step: "60s"
+  - title: "Running Service Pods by Namespace"
+    description: "Running pod count for each monitored service namespace and cluster during the CI run window. This low-cardinality chart shows workload density; use the MC pod-capacity chart to determine whether that density is exhausting node capacity."
+    query: |
+      count by (cluster, namespace) (
+        max by (cluster, namespace, pod) (
+          kube_pod_status_phase{
+            job="kube-state-metrics",
+            namespace=~"aro-hcp|aro-hcp-admin-api|aro-hcp-exporter|arobit|clusters-service|fleet|kube-applier|maestro|mgmt-agent|prometheus|secret-sync-controller|sessiongate",
+            phase="Running"
+          } == 1
+        )
+      )
+    unit: pods
+    workspace: svc
+    step: "60s"
 - title: "MC AKS Metrics"
   queries:
   - title: "MC User Node Count by Phase"


### PR DESCRIPTION
Relates to [ARO-27596](https://redhat.atlassian.net/browse/ARO-27596).

## Why

PR #5623 proposed remote-writing every ephemeral CI time series into a shared workspace. It was closed after reviewers raised cardinality, scale, ownership, and unclear-use concerns and pointed to the existing `gather-observability` post-step instead.

The supported path now captures alerts and selected high-level node metrics before teardown, but it does not show which service workloads consumed the resources or service pod density during the failure window.

## What

- add bounded top-20 service-container CPU and memory-working-set charts
- add running service pod counts by cluster and namespace
- query only the existing regional `svc` workspace over the CI run window, with the established HA-replica deduplication pattern
- document how to find and interpret the persisted Prow artifacts

Frontend request volume and management-cluster CPU, memory, disk, and pod capacity are already covered by the existing Frontend and MC AKS panels, so this change does not duplicate them.

## Design boundaries

This creates no AMW, DCR, DCE, remote-write configuration, CI labels, publisher identity, Grafana data source/dashboard, pipeline step, dependency, or new ingestion path. The selected samples live in `observability-summary.html` subject to OpenShift CI artifact retention; raw metrics are not retained as a cross-run store. Alert policy is unchanged.

## Validation

- [x] `go test ./cmd/aro-hcp-tests/gather-observability`
- [x] `go vet ./cmd/aro-hcp-tests/gather-observability`
- [x] `make verify-yamlfmt`
- [x] `git diff --check`
- [x] attach a live DEV/Prow artifact screenshot before marking ready for review
- [x] presubmit CI

## Screenhots of new tab with meterics

<img width="1708" height="1085" alt="Screenshot From 2026-09-02 12-42-38" src="https://github.com/user-attachments/assets/d7461a74-087c-4cbb-9161-5ab7e3b25f61" />


<img width="1708" height="1085" alt="Screenshot From 2026-09-02 12-42-26" src="https://github.com/user-attachments/assets/3f354518-a073-4b43-b4ea-90acb5f65b4b" />


<img width="1708" height="1085" alt="Screenshot From 2026-09-02 12-42-38" src="https://github.com/user-attachments/assets/6fa1ce16-353a-4fd8-a074-3981948a3c5c" />


`make verify` was also attempted. Generation completed without a diff, but the local run could not download the pre-existing `github.com/keybase/go-keychain` test dependency because sandbox network access to `proxy.golang.org` is disabled.
