### PR TITLE
test: add e2e coverage for HostedCluster deletion after etcd KMS Key Vault removal

### DIFF
--- a/nonlocal-e2e-specs.txt
+++ b/nonlocal-e2e-specs.txt
@@ -10,6 +10,7 @@
   "creates and deletes a GPU nodepool in a single cluster",
   "should allow pods with images from allowed registries and have a valid allowlist",
   "should be able to create an HCP cluster then delete it by deleting the customer resource group",
+  "should be able to delete an HCP cluster after its etcd KMS Key Vault has been removed",
   "should be able to delete an HCP cluster whose managed identities were deleted first",
   "should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings",
   "should confirm the HCP cluster is deleted (not found)",

--- a/test/e2e/cluster_delete_kms_vault.go
+++ b/test/e2e/cluster_delete_kms_vault.go
@@ -1,0 +1,164 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+	"github.com/Azure/ARO-HCP/test/util/verifiers"
+)
+
+// This test is a regression test for AROSLSRE-1167 / AROSLSRE-1709: a
+// HostedCluster deletion deadlocked on prod-uksouth-mgmt-1 after the
+// cluster_delete_cx_rg test (see cluster_delete_cx_rg.go) deleted the
+// customer resource group, which also removed the etcd KMS Key Vault living
+// inside it. With the guest API permanently unavailable, the CAPZ
+// availability-prober blocked the capi-provider manager from ever starting,
+// so AzureMachine finalizers could never clear and deletion hung until an SRE
+// manually removed the finalizers. cluster_delete_cx_rg must keep validating
+// the intended RG-deletion behavior, so this test isolates just the
+// confirmed root cause (the KMS Key Vault disappearing) without touching the
+// customer VNet/subnet, to directly verify the HyperShift escape-hatch fix
+// (DeleteOrphanedMachines/capiProviderUnavailable) recovers automatically.
+var _ = Describe("Customer", func() {
+	It("should be able to delete an HCP cluster after its etcd KMS Key Vault has been removed",
+		labels.RequireNothing,
+		labels.Critical,
+		labels.Positive,
+		labels.MIContainers(1),
+		func(ctx context.Context) {
+			const (
+				customerNetworkSecurityGroupName = "customer-nsg"
+				customerVnetName                 = "customer-vnet"
+				customerVnetSubnetName           = "customer-vnet-subnet1"
+				customerClusterName              = "kms-vault-del-hcp"
+				customerNodePoolName             = "np-1"
+			)
+			tc := framework.NewTestContext()
+
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
+			}
+
+			By("creating the customer resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "cx-rg-kms-vault-del", tc.Location())
+			Expect(err).NotTo(HaveOccurred(), "failed to create customer resource group")
+
+			By("creating cluster parameters")
+			clusterParams := framework.NewDefaultClusterParams20240610()
+			clusterParams.ClusterName = customerClusterName
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.ManagedResourceGroupName = managedResourceGroupName
+
+			By("creating customer resources")
+			clusterParams, err = tc.CreateClusterCustomerResources20240610(ctx,
+				resourceGroup,
+				clusterParams,
+				map[string]interface{}{
+					"customerNsgName":        customerNetworkSecurityGroupName,
+					"customerVnetName":       customerVnetName,
+					"customerVnetSubnetName": customerVnetSubnetName,
+				},
+				TestArtifactsFS,
+				framework.RBACScopeResource,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for cluster %q", customerClusterName)
+			Expect(clusterParams.KeyVaultName).NotTo(BeEmpty(), "expected customer resources to populate an etcd KMS key vault name for cluster %q", customerClusterName)
+
+			By("creating the HCP cluster")
+			err = tc.CreateHCPClusterFromParam20240610(
+				ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				framework.ClusterCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q", customerClusterName)
+
+			hcpClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+
+			By("getting credentials")
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
+				ctx,
+				hcpClient,
+				*resourceGroup.Name,
+				customerClusterName,
+				framework.GetAdminRESTConfigTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for cluster %q", customerClusterName)
+
+			By("ensuring the cluster is viable")
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to verify HCP cluster %q is viable", customerClusterName)
+
+			By("creating a node pool")
+			nodePoolParams := framework.NewDefaultNodePoolParams20240610()
+			nodePoolParams.NodePoolName = customerNodePoolName
+			err = tc.CreateNodePoolFromParam20240610(
+				ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				managedResourceGroupName,
+				customerClusterName,
+				nodePoolParams,
+				framework.NodePoolCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create node pool %q for cluster %q", customerNodePoolName, customerClusterName)
+
+			By("deleting the etcd KMS key vault to make the guest API permanently unavailable")
+			vaultsClient := tc.GetARMKeyVaultClientFactoryOrDie(ctx).NewVaultsClient()
+			_, err = vaultsClient.Delete(ctx, *resourceGroup.Name, clusterParams.KeyVaultName, nil)
+			Expect(err).NotTo(HaveOccurred(), "failed to delete etcd KMS key vault %q for cluster %q", clusterParams.KeyVaultName, customerClusterName)
+
+			By("deleting the HCP cluster and verifying it completes without manual finalizer removal")
+			err = framework.DeleteHCPCluster20240610(ctx, hcpClient, *resourceGroup.Name, customerClusterName, framework.HCPClusterDeletionTimeout)
+			Expect(err).NotTo(HaveOccurred(), "HCP cluster %q deletion must complete automatically without manual finalizer removal even though its etcd KMS key vault was deleted (regression test for AROSLSRE-1167 / AROSLSRE-1709)", customerClusterName)
+
+			By("verifying the cluster resource is deleted (Not Found)")
+			_, err = hcpClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
+			Expect(err).To(HaveOccurred(), "expected an error when getting deleted cluster %q", customerClusterName)
+			var respErr *azcore.ResponseError
+			Expect(errors.As(err, &respErr)).To(BeTrue(), "expected azcore.ResponseError when getting deleted cluster %q, got %v", customerClusterName, err)
+			Expect(respErr.StatusCode).To(Equal(http.StatusNotFound), "expected HTTP 404 when getting deleted cluster %q", customerClusterName)
+
+			// The fix intentionally orphans the AzureMachine k8s object without
+			// deleting the real Azure VM/NIC behind it ("leaving Azure
+			// infrastructure intact" per the fix's own doc comment), since the
+			// guest API is gone and CAPZ can never actually run the cloud
+			// delete. The managed resource group is therefore left holding
+			// live infrastructure that neither the RP's own deprovisioning nor
+			// the standard per-test cleanup will force-delete (it carries a
+			// system-protected deny assignment that the standard cleanup path
+			// treats as "locked" and skips). Force-delete it explicitly here so
+			// the test doesn't leak billable Azure resources.
+			By("force-deleting the orphaned managed resource group")
+			networkClient, err := tc.GetARMNetworkClientFactory(ctx)
+			Expect(err).NotTo(HaveOccurred(), "failed to create ARM network client factory")
+			rgClient := tc.GetARMResourcesClientFactoryOrDie(ctx).NewResourceGroupsClient()
+			err = framework.DeleteResourceGroup(ctx, rgClient, networkClient, managedResourceGroupName, true, 60*time.Minute)
+			Expect(err).NotTo(HaveOccurred(), "failed to force-delete orphaned managed resource group %q left behind by the fix", managedResourceGroupName)
+		})
+})

--- a/test/e2e/cluster_delete_kms_vault.go
+++ b/test/e2e/cluster_delete_kms_vault.go
@@ -48,6 +48,18 @@ var _ = Describe("Customer", func() {
 		labels.Critical,
 		labels.Positive,
 		labels.MIContainers(1),
+		// TODO(AROSLSRE-1709): temporary, remove before merge. The dev presubmit
+		// e2e-parallel job only runs the rp-api-compat-all/parallel suite, which
+		// (in dev) selects on ARO-HCP-RP-API-Compatible || Development-Only. This
+		// test uses ARM templates directly (like cluster_delete_cx_rg.go), so it
+		// is not RP-API-compatible; Development-Only is added solely to get a CI
+		// run on this draft PR since local personal-dev-env validation hit a
+		// shared-subscription public IP quota exhaustion. Removing this label
+		// restores eligibility for the broader integration/stage/prod-e2e-parallel
+		// suites (which exclude Development-Only), matching cluster_delete_cx_rg.go
+		// and cluster_delete_missing_identities.go's unlabeled state — the intended
+		// long-term home for this test, since the original incident was in prod.
+		labels.DevelopmentOnly,
 		func(ctx context.Context) {
 			const (
 				customerNetworkSecurityGroupName = "customer-nsg"

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -78,6 +78,7 @@ type perItOrDescribeTestContext struct {
 	armResourcesClientFactory     *armresources.ClientFactory
 	armSubscriptionsClientFactory *armsubscriptions.ClientFactory
 	armNetworkClientFactory       *armnetwork.ClientFactory
+	armKeyVaultClientFactory      *armkeyvault.ClientFactory
 	graphClient                   *graphutil.Client
 
 	LogDirPath       string
@@ -769,21 +770,12 @@ func (tc *perItOrDescribeTestContext) purgeDeletedKeyVaultsInResourceGroup(ctx c
 	ctx, cancel := context.WithTimeout(ctx, keyVaultPurgeTimeout)
 	defer cancel()
 
-	creds, err := tc.AzureCredential()
+	clientFactory, err := tc.GetARMKeyVaultClientFactory(ctx)
 	if err != nil {
-		ginkgo.GinkgoLogr.Error(err, "unable to purge soft-deleted key vaults: failed to get azure credentials", "resourceGroup", resourceGroupName)
+		ginkgo.GinkgoLogr.Error(err, "unable to purge soft-deleted key vaults: failed to build key vault client factory", "resourceGroup", resourceGroupName)
 		return
 	}
-	subscriptionID, err := tc.SubscriptionID(ctx)
-	if err != nil {
-		ginkgo.GinkgoLogr.Error(err, "unable to purge soft-deleted key vaults: failed to get subscription id", "resourceGroup", resourceGroupName)
-		return
-	}
-	vaultsClient, err := armkeyvault.NewVaultsClient(subscriptionID, creds, tc.perBinaryInvocationTestContext.getClientFactoryOptions())
-	if err != nil {
-		ginkgo.GinkgoLogr.Error(err, "unable to purge soft-deleted key vaults: failed to build key vault client", "resourceGroup", resourceGroupName)
-		return
-	}
+	vaultsClient := clientFactory.NewVaultsClient()
 
 	// Soft-deleted vaults expose their original resource id via VaultID; match
 	// the resource group segment case-insensitively.
@@ -1182,6 +1174,46 @@ func (tc *perItOrDescribeTestContext) getARMComputeClientFactoryUnlocked(ctx con
 	tc.armComputeClientFactory = clientFactory
 
 	return tc.armComputeClientFactory, nil
+}
+
+func (tc *perItOrDescribeTestContext) GetARMKeyVaultClientFactoryOrDie(ctx context.Context) *armkeyvault.ClientFactory {
+	return Must(tc.GetARMKeyVaultClientFactory(ctx))
+}
+
+func (tc *perItOrDescribeTestContext) GetARMKeyVaultClientFactory(ctx context.Context) (*armkeyvault.ClientFactory, error) {
+	tc.contextLock.RLock()
+	if tc.armKeyVaultClientFactory != nil {
+		defer tc.contextLock.RUnlock()
+		return tc.armKeyVaultClientFactory, nil
+	}
+	tc.contextLock.RUnlock()
+
+	tc.contextLock.Lock()
+	defer tc.contextLock.Unlock()
+
+	return tc.getARMKeyVaultClientFactoryUnlocked(ctx)
+}
+
+func (tc *perItOrDescribeTestContext) getARMKeyVaultClientFactoryUnlocked(ctx context.Context) (*armkeyvault.ClientFactory, error) {
+	if tc.armKeyVaultClientFactory != nil {
+		return tc.armKeyVaultClientFactory, nil
+	}
+
+	creds, err := tc.perBinaryInvocationTestContext.getAzureCredentials()
+	if err != nil {
+		return nil, err
+	}
+	subscriptionID, err := tc.getSubscriptionIDUnlocked(ctx)
+	if err != nil {
+		return nil, err
+	}
+	clientFactory, err := armkeyvault.NewClientFactory(subscriptionID, creds, tc.perBinaryInvocationTestContext.getClientFactoryOptions())
+	if err != nil {
+		return nil, err
+	}
+	tc.armKeyVaultClientFactory = clientFactory
+
+	return tc.armKeyVaultClientFactory, nil
 }
 
 func (tc *perItOrDescribeTestContext) getSubscriptionIDUnlocked(ctx context.Context) (string, error) {


### PR DESCRIPTION
[AROSLSRE-1709](https://redhat.atlassian.net/browse/AROSLSRE-1709)

### What

Adds a new permanent e2e regression test, `test/e2e/cluster_delete_kms_vault.go`:
creates an HCP cluster + node pool, deletes **only the etcd KMS Key Vault**
(not the customer resource group), then deletes the HCP cluster and asserts
it completes automatically within `HCPClusterDeletionTimeout` (25 min)
without manual finalizer removal.

Also adds a `GetARMKeyVaultClientFactory`/`OrDie` accessor to the test
framework (`test/util/framework/per_test_framework.go`), following the
existing ARM client-factory pattern (mirrors `GetARMComputeClientFactory`),
since no management-plane Key Vault client was previously exposed on the test
context. The existing `purgeDeletedKeyVaultsInResourceGroup` helper is
refactored to reuse this new accessor instead of constructing its own client
inline.

`nonlocal-e2e-specs.txt` regenerated via `make record-nonlocal-e2e` to include
the new spec.

### Why

AROSLSRE-1167's RCA confirmed a real `HostedCluster` deletion deadlock on
`prod-uksouth-mgmt-1`: the existing `cluster_delete_cx_rg` test deleted a
customer resource group (as designed) which also removed the etcd KMS Key
Vault living inside it. With the guest API permanently unavailable, the CAPZ
`availability-prober` blocked the `capi-provider` manager from ever starting,
so `AzureMachine` finalizers could never clear and deletion hung for weeks
until an SRE manually removed finalizers on 2026-06-11.

`AROSLSRE-1709` tracks the preventive HyperShift fix
(`openshift/hypershift#9403`, `DeleteOrphanedMachines`/
`capiProviderUnavailable`) and its acceptance criteria explicitly require
verifying this scenario recovers automatically without manual finalizer
removal, **while keeping `cluster_delete_cx_rg`'s RG-deletion behavior
intact** (it must keep validating its own, different intended behavior).
This PR closes that specific coverage gap by isolating just the confirmed
etcd KMS Key Vault trigger, rather than the whole customer RG.

### Testing

- [x] E2E tests
- Build/`go vet`/`golangci-lint` all pass locally for the changed packages.
- **Not yet verified end-to-end against the fix.** I ran this twice against a
  personal dev env with the patched `openshift/hypershift#9403` HyperShift
  operator image, but both runs failed during ordinary cluster creation
  (before ever reaching the Key Vault deletion step) due to the shared EA
  subscription's public IPv4 quota being fully exhausted (1000/1000) by
  concurrent usage from other teams — an unrelated, external environment
  constraint, not a defect in this test or the fix. Opening as **Draft**
  specifically to verify via `e2e-parallel` in CI, which should confirm:
  1. the test passes with the fix present, and
  2. it fails clearly (hangs to the 25-min `HCPClusterDeletionTimeout`, per
     the fix's own doc comment about what it prevents) without it — happy to
     paste CI logs here once available, including the operator's
     `"orphaning azuremachine stuck in deletion"` / `"capi-provider
     unavailable"` log line as direct proof the new code path fires.

### Special notes for your reviewer

- The fix intentionally leaves real Azure VM/NIC infrastructure in the
  managed resource group intact when it orphans a stuck `AzureMachine` (see
  the fix's own doc comment) — the standard per-test cleanup won't
  force-delete a deny-assignment-locked managed RG full of live VMs, so this
  test explicitly force-deletes the managed RG itself in its final step
  rather than relying on `DeferCleanup`.
- Per [AROSLSRE-1709](https://redhat.atlassian.net/browse/AROSLSRE-1709)'s explicit non-goals, `cluster_delete_cx_rg.go` is
  untouched — this is additive coverage, not a replacement.