### PR TITLE
fix(validation): Validate an exact cluster version is specified when passing nightly channels

### DIFF
--- a/internal/admission/admit_cluster.go
+++ b/internal/admission/admit_cluster.go
@@ -687,7 +687,7 @@ func admitClusterVersionID(_ context.Context, admissionContext *ClusterAdmission
 	}
 	// on nightlies and candidates, we don't wait for the target version to show up. We trust these people to
 	// know what they're doing.
-	if newObj.ChannelGroup == "nightly" || newObj.ChannelGroup == "candidate" {
+	if newObj.ChannelGroup == metadataapi.ChannelGroupNightly || newObj.ChannelGroup == metadataapi.ChannelGroupCandidate {
 		return nil
 	}
 

--- a/internal/api/metadataapi/utils.go
+++ b/internal/api/metadataapi/utils.go
@@ -53,11 +53,24 @@ var AllowControlPlaneNodePoolMajorVersionSkew = map[string][]string{
 	"4.23": {"5.1", "5.2"},
 }
 
+// OpenShift version update channel groups.
+const (
+	ChannelGroupStable    = "stable"
+	ChannelGroupFast      = "fast"
+	ChannelGroupCandidate = "candidate"
+	// ChannelGroupNightly builds are published to the CI releasestream API rather
+	// than the Cincinnati graph API used for version selection, so a nightly
+	// version cannot be resolved from a bare major.minor and must be pinned to a
+	// full major.minor.patch (see validateVersionProfile and the control plane
+	// desired version controller).
+	ChannelGroupNightly = "nightly"
+)
+
 // AllowedChannelGroups is the set ARO-HCP allows to use for customer purposes
-var AllowedChannelGroups = sets.New("stable", "fast")
+var AllowedChannelGroups = sets.New(ChannelGroupStable, ChannelGroupFast)
 
 // AllowedChannelGroupsWithExperimentalFlag is the set the service allows to use when using the Experimental Feature AFEC flag
-var AllowedChannelGroupsWithExperimentalFlag = sets.New("stable", "fast", "candidate", "nightly")
+var AllowedChannelGroupsWithExperimentalFlag = sets.New(ChannelGroupStable, ChannelGroupFast, ChannelGroupCandidate, ChannelGroupNightly)
 
 // NextMinorReleaseLine returns the next OpenShift minor release line after v as
 // major.minor.0 (patch and pre-release metadata cleared).

--- a/internal/validation/hcpopenshiftcluster_test.go
+++ b/internal/validation/hcpopenshiftcluster_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blang/semver/v4"
+
 	"k8s.io/apimachinery/pkg/api/operation"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -480,10 +482,32 @@ func TestClusterValidate(t *testing.T) {
 			},
 		},
 		{
-			name: "ChannelGroup nightly is allowed with experimental flag",
+			// A bare "<major>.<minor>" with no exact pin is what the object looks
+			// like post-mutation when the customer did not supply a full version.
+			name: "ChannelGroup nightly without a full version is rejected with experimental flag",
 			resource: func() *coreapi.HCPOpenShiftCluster {
 				r := coreapitesting.MinimumValidClusterTestCase()
 				r.CustomerProperties.Version.ChannelGroup = "nightly"
+				return r
+			}(),
+			opOptions: testFeatureOptions(metadataapi.FeatureExperimentalReleaseFeatures),
+			expectErrors: []utils.ExpectedError{
+				{
+					Message:   "must be specified as MAJOR.MINOR.PATCH (optionally with a pre-release, e.g. a nightly build suffix) when channelGroup is \"nightly\"",
+					FieldPath: "customerProperties.version.id",
+				},
+			},
+		},
+		{
+			// Post-mutation shape for a full nightly version.id: version.id is
+			// reduced to its release line and the exact build is pinned on
+			// ExperimentalFeatures. The validator maps the pin back and accepts it.
+			name: "ChannelGroup nightly with a mapped exact version is allowed with experimental flag",
+			resource: func() *coreapi.HCPOpenShiftCluster {
+				r := coreapitesting.MinimumValidClusterTestCase()
+				r.CustomerProperties.Version.ChannelGroup = "nightly"
+				exact := semver.MustParse("4.20.0-0.nightly-2026-08-05-123456")
+				r.ServiceProviderProperties.ExperimentalFeatures.ControlPlaneExactVersion = &exact
 				return r
 			}(),
 			opOptions:    testFeatureOptions(metadataapi.FeatureExperimentalReleaseFeatures),

--- a/internal/validation/validate_cluster.go
+++ b/internal/validation/validate_cluster.go
@@ -97,6 +97,10 @@ func ValidateCluster(ctx context.Context, op operation.Operation, newCluster, ol
 	// Private KAS requires OpenShift >= 4.22 (HyperShift gained private API server support in 4.22).
 	errs = append(errs, validatePrivateKASRequiresMinimumVersion(ctx, op, newCluster, oldCluster)...)
 
+	// Nightly installs must resolve to a full version; this needs both the customer
+	// version profile and the service-provider exact pin, so it lives at cluster level.
+	errs = append(errs, validateNightlyChannelRequiresFullVersion(ctx, op, newCluster, oldCluster)...)
+
 	// there are pieces of clusterProperties that are dependent upon values in .identity
 	errs = append(errs, validateOperatorAuthenticationAgainstIdentities(ctx, op, newCluster, oldCluster)...)
 
@@ -151,6 +155,55 @@ func validatePrivateKASRequiresMinimumVersion(_ context.Context, _ operation.Ope
 		)}
 	}
 
+	return nil
+}
+
+// validateNightlyChannelRequiresFullVersion enforces that a cluster in the
+// "nightly" channel group resolves to a full "<major>.<minor>.<patch>" version.
+// Nightly builds are published to the CI releasestream API rather than the
+// Cincinnati graph the control plane desired version controller resolves
+// against, so the controller cannot derive a nightly build from a bare
+// "<major>.<minor>" and would leave the cluster wedged in provisioning.
+//
+// Admission mutation runs before validation: for a full version.id (or an
+// exact-version tag) it moves the exact version onto
+// ServiceProviderProperties.ExperimentalFeatures.ControlPlaneExactVersion and
+// reduces version.id to its "<major>.<minor>" release line. This validator
+// therefore maps that internal exact pin back to the external version.id it
+// represents and validates the mapped value, so a nightly install is accepted
+// only when the effective version.id is a full version.
+func validateNightlyChannelRequiresFullVersion(_ context.Context, op operation.Operation, newCluster, _ *coreapi.HCPOpenShiftCluster) field.ErrorList {
+	// Nightly is only selectable with the experimental feature; without it the
+	// channelGroup enum already rejects the request, so skip here to avoid a
+	// duplicate error.
+	if !op.HasOption(metadataapi.FeatureExperimentalReleaseFeatures) {
+		return nil
+	}
+	if newCluster.CustomerProperties.Version.ChannelGroup != metadataapi.ChannelGroupNightly {
+		return nil
+	}
+
+	// Map the internal exact pin back to the external version.id it represents:
+	// when a full version was supplied, mutation moved it to
+	// ControlPlaneExactVersion and reduced version.id to its release line.
+	effectiveVersionID := newCluster.CustomerProperties.Version.ID
+	if exact := newCluster.ServiceProviderProperties.ExperimentalFeatures.ControlPlaneExactVersion; exact != nil {
+		effectiveVersionID = exact.String()
+	}
+	if len(effectiveVersionID) == 0 {
+		// A missing version.id is reported by the required-value check.
+		return nil
+	}
+
+	// Strict semver parsing accepts a full "<major>.<minor>.<patch>" (optionally
+	// with a pre-release such as the nightly build suffix) while rejecting a bare
+	// "<major>.<minor>".
+	if _, err := semver.Parse(effectiveVersionID); err != nil {
+		return field.ErrorList{field.Invalid(
+			field.NewPath("customerProperties", "version", "id"), effectiveVersionID,
+			"must be specified as MAJOR.MINOR.PATCH (optionally with a pre-release, e.g. a nightly build suffix) when channelGroup is \"nightly\"",
+		)}
+	}
 	return nil
 }
 

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-nightly-with-full-version/00-httpCreate-subscription-with-afec/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-nightly-with-full-version/00-httpCreate-subscription-with-afec/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-nightly-with-full-version/00-httpCreate-subscription-with-afec/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-nightly-with-full-version/00-httpCreate-subscription-with-afec/subscription.json
@@ -1,0 +1,14 @@
+{
+	"properties": {
+		"registeredFeatures": [
+			{
+				"name": "Microsoft.RedHatOpenShift/ExperimentalReleaseFeatures",
+				"state": "Registered"
+			}
+		],
+		"tenantId": "33333333-3333-3333-3333-333333333333"
+	},
+	"registrationDate": "2025-12-19T19:53:15+00:00",
+	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"state": "Registered"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-nightly-with-full-version/01-httpCreate-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-nightly-with-full-version/01-httpCreate-cluster/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nightly-full-version"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-nightly-with-full-version/01-httpCreate-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-nightly-with-full-version/01-httpCreate-cluster/cluster.json
@@ -1,0 +1,50 @@
+{
+	"identity": {
+		"type": "UserAssigned",
+		"userAssignedIdentities": {}
+	},
+	"name": "nightly-full-version",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"clusterImageRegistry": {
+			"state": "Disabled"
+		},
+		"console": {},
+		"dns": {},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "encryptionKeyName",
+							"vaultName": "keyVaultName",
+							"version": "2024-12-01-preview"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-resource-group-name",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"version": {
+			"channelGroup": "nightly",
+			"id": "4.20.0-0.nightly-2026-08-05-123456"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-nightly-without-full-version/00-httpCreate-subscription-with-afec/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-nightly-without-full-version/00-httpCreate-subscription-with-afec/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-nightly-without-full-version/00-httpCreate-subscription-with-afec/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-nightly-without-full-version/00-httpCreate-subscription-with-afec/subscription.json
@@ -1,0 +1,14 @@
+{
+	"properties": {
+		"registeredFeatures": [
+			{
+				"name": "Microsoft.RedHatOpenShift/ExperimentalReleaseFeatures",
+				"state": "Registered"
+			}
+		],
+		"tenantId": "33333333-3333-3333-3333-333333333333"
+	},
+	"registrationDate": "2025-12-19T19:53:15+00:00",
+	"resourceId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7",
+	"state": "Registered"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-nightly-without-full-version/01-httpCreate-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-nightly-without-full-version/01-httpCreate-cluster/00-key.json
@@ -1,0 +1,3 @@
+{
+	"resourceID": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/reject-nightly-no-full-version"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-nightly-without-full-version/01-httpCreate-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-nightly-without-full-version/01-httpCreate-cluster/cluster.json
@@ -1,0 +1,50 @@
+{
+	"identity": {
+		"type": "UserAssigned",
+		"userAssignedIdentities": {}
+	},
+	"name": "reject-nightly-no-full-version",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"clusterImageRegistry": {
+			"state": "Disabled"
+		},
+		"console": {},
+		"dns": {},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "encryptionKeyName",
+							"vaultName": "keyVaultName",
+							"version": "2024-12-01-preview"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-resource-group-name",
+			"networkSecurityGroupId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/6b690bec-0c16-4ecb-8f67-781caf40bba7/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"version": {
+			"channelGroup": "nightly",
+			"id": "4.20"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-nightly-without-full-version/01-httpCreate-cluster/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/Cluster/create-reject-nightly-without-full-version/01-httpCreate-cluster/expected-error.txt
@@ -1,0 +1,5 @@
+{
+    "code": "InvalidRequestContent",
+    "message": "Invalid value: \"4.20\": must be specified as MAJOR.MINOR.PATCH (optionally with a pre-release, e.g. a nightly build suffix) when channelGroup is \"nightly\"",
+    "target": "properties.version.id"
+  }


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Requires an exact cluster version when nightly channel is specified for clusters.

### Why

https://github.com/Azure/ARO-HCP/pull/6538/changes#diff-c85735cdffdb78eb1070b2d4cf9b78a882cda824695fc27719cd73a04b8ecf46R209-R213 results in a failure to resolve the control plane version if the nightly channel is used and we don't specify the exact version we want to install.  

### Testing

Unit tests and integration tests. 

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
