### PR TITLE
feat: enrich successful operation state with degraded condition

### DIFF
--- a/backend/pkg/controllers/cluster/operations/operation_cluster_create.go
+++ b/backend/pkg/controllers/cluster/operations/operation_cluster_create.go
@@ -383,7 +383,7 @@ func (c *operationClusterCreate) hostedClusterOperationStatus(ctx context.Contex
 	// 1. the hosted cluster is available via condition
 	// 2. the hosted cluster has successfully installed at least one version
 	// 3. the hosted cluster has a control plane endpoint host and port
-	return operationbase.NewOperationState(coreapi.ProvisioningStateSucceeded, ""), nil
+	return operationbase.NewOperationState(coreapi.ProvisioningStateSucceeded, withDegradedSuffix("hosted cluster is available", hostedCluster)), nil
 }
 
 func (c *operationClusterCreate) servingCABundleOperationStatus(ctx context.Context, operation *coreapi.Operation) (*operationbase.OperationState, error) {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-1532

### What

Cluster creation operations can have a `ProvisioningState` of `Succeeded` but still be still have a `Degraded` condition.  This change will add the `Degraded` condition details to the operation state in this scenario for diagnostic purposes.

### Why

Some failures like those observed in https://redhat.atlassian.net/browse/AROSLSRE-1528 will be easier to diagnose if the `Degraded` condition details are always added to the operation state.

### Testing

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
