### PR TITLE
fix(int): update aro-hcp-int-msi-mock identity to new principal

### DIFF
--- a/backend/testdata/zz_fixture_TestHelmTemplate_backend_clstr_scoped_identities_role_set_name_public.yaml
+++ b/backend/testdata/zz_fixture_TestHelmTemplate_backend_clstr_scoped_identities_role_set_name_public.yaml
@@ -191,9 +191,9 @@ spec:
         - "--insecure-azure-managed-identity-mock-certificate-bundle-path"
         - "/secrets/backend-service-key-vault/mi-mock-cert-bundle"
         - "--insecure-azure-managed-identity-mock-client-id"
-        - "e8723db7-9b9e-46a4-9f7d-64d75c3534f0"
+        - "f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a"
         - "--insecure-azure-managed-identity-mock-principal-id"
-        - "d6b62dfa-87f5-49b3-bbcb-4a687c4faa96"
+        - "6096f642-63a0-4dd6-958d-715a87f33535"
         - "--insecure-azure-managed-identity-mock-tenant-id"
         - "64dc69e4-d083-49fc-9569-ebece1dd1408"
         # ARM Permissions Manager Identity flags. They should only be set in ARO-HCP environments where Microsoft's First Party Application (FPA) integration is not available.

--- a/backend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_backend_dev.yaml
+++ b/backend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_backend_dev.yaml
@@ -191,9 +191,9 @@ spec:
         - "--insecure-azure-managed-identity-mock-certificate-bundle-path"
         - "/secrets/backend-service-key-vault/mi-mock-cert-bundle"
         - "--insecure-azure-managed-identity-mock-client-id"
-        - "e8723db7-9b9e-46a4-9f7d-64d75c3534f0"
+        - "f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a"
         - "--insecure-azure-managed-identity-mock-principal-id"
-        - "d6b62dfa-87f5-49b3-bbcb-4a687c4faa96"
+        - "6096f642-63a0-4dd6-958d-715a87f33535"
         - "--insecure-azure-managed-identity-mock-tenant-id"
         - "64dc69e4-d083-49fc-9569-ebece1dd1408"
         # ARM Permissions Manager Identity flags. They should only be set in ARO-HCP environments where Microsoft's First Party Application (FPA) integration is not available.

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
@@ -8102,8 +8102,8 @@ spec:
         - --azure-operators-managed-identities-config-path=/configs/azure-operators-managed-identities-config.yaml
         - --aro-hcp-ocp-versions-config-path=/configs/aro-hcp-ocp-versions-config.yaml
         - --azure-mi-mock-service-principal-certificate-bundle-path=/secrets/keyvault/mockMiServicePrincipalCertificateBundle
-        - --azure-mi-mock-service-principal-client-id=e8723db7-9b9e-46a4-9f7d-64d75c3534f0
-        - --azure-mi-mock-service-principal-principal-id=d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+        - --azure-mi-mock-service-principal-client-id=f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a
+        - --azure-mi-mock-service-principal-principal-id=6096f642-63a0-4dd6-958d-715a87f33535
         - --azure-arm-helper-identity-certificate-bundle-path=/secrets/keyvault/armHelperIndentityCertificateBundle
         - --azure-arm-helper-identity-client-id=3331e670-0804-48e8-a086-6241671ddc93
         - --azure-arm-helper-mock-fpa-principal-id=47f69502-0065-4d9a-b19b-d403e183d2f4

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
@@ -8203,8 +8203,8 @@ spec:
         - --azure-operators-managed-identities-config-path=/configs/azure-operators-managed-identities-config.yaml
         - --aro-hcp-ocp-versions-config-path=/configs/aro-hcp-ocp-versions-config.yaml
         - --azure-mi-mock-service-principal-certificate-bundle-path=/secrets/keyvault/mockMiServicePrincipalCertificateBundle
-        - --azure-mi-mock-service-principal-client-id=e8723db7-9b9e-46a4-9f7d-64d75c3534f0
-        - --azure-mi-mock-service-principal-principal-id=d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+        - --azure-mi-mock-service-principal-client-id=f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a
+        - --azure-mi-mock-service-principal-principal-id=6096f642-63a0-4dd6-958d-715a87f33535
         - --azure-arm-helper-identity-certificate-bundle-path=/secrets/keyvault/armHelperIndentityCertificateBundle
         - --azure-arm-helper-identity-client-id=3331e670-0804-48e8-a086-6241671ddc93
         - --azure-arm-helper-mock-fpa-principal-id=47f69502-0065-4d9a-b19b-d403e183d2f4

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_distinct_arm_helper.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_distinct_arm_helper.yaml
@@ -8102,8 +8102,8 @@ spec:
         - --azure-operators-managed-identities-config-path=/configs/azure-operators-managed-identities-config.yaml
         - --aro-hcp-ocp-versions-config-path=/configs/aro-hcp-ocp-versions-config.yaml
         - --azure-mi-mock-service-principal-certificate-bundle-path=/secrets/keyvault/mockMiServicePrincipalCertificateBundle
-        - --azure-mi-mock-service-principal-client-id=e8723db7-9b9e-46a4-9f7d-64d75c3534f0
-        - --azure-mi-mock-service-principal-principal-id=d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+        - --azure-mi-mock-service-principal-client-id=f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a
+        - --azure-mi-mock-service-principal-principal-id=6096f642-63a0-4dd6-958d-715a87f33535
         - --azure-arm-helper-identity-certificate-bundle-path=/secrets/keyvault/armHelperIndentityCertificateBundle
         - --azure-arm-helper-identity-client-id=clusters-service-client-id
         - --azure-arm-helper-mock-fpa-principal-id=mock-fpa-principal-id

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_shared_arm_helper.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_shared_arm_helper.yaml
@@ -8102,8 +8102,8 @@ spec:
         - --azure-operators-managed-identities-config-path=/configs/azure-operators-managed-identities-config.yaml
         - --aro-hcp-ocp-versions-config-path=/configs/aro-hcp-ocp-versions-config.yaml
         - --azure-mi-mock-service-principal-certificate-bundle-path=/secrets/keyvault/mockMiServicePrincipalCertificateBundle
-        - --azure-mi-mock-service-principal-client-id=e8723db7-9b9e-46a4-9f7d-64d75c3534f0
-        - --azure-mi-mock-service-principal-principal-id=d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+        - --azure-mi-mock-service-principal-client-id=f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a
+        - --azure-mi-mock-service-principal-principal-id=6096f642-63a0-4dd6-958d-715a87f33535
         - --azure-arm-helper-identity-certificate-bundle-path=/secrets/keyvault/armHelperIndentityCertificateBundle
         - --azure-arm-helper-identity-client-id=shared-client-id
         - --azure-arm-helper-mock-fpa-principal-id=mock-fpa-principal-id

--- a/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
+++ b/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
@@ -8102,8 +8102,8 @@ spec:
         - --azure-operators-managed-identities-config-path=/configs/azure-operators-managed-identities-config.yaml
         - --aro-hcp-ocp-versions-config-path=/configs/aro-hcp-ocp-versions-config.yaml
         - --azure-mi-mock-service-principal-certificate-bundle-path=/secrets/keyvault/mockMiServicePrincipalCertificateBundle
-        - --azure-mi-mock-service-principal-client-id=e8723db7-9b9e-46a4-9f7d-64d75c3534f0
-        - --azure-mi-mock-service-principal-principal-id=d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+        - --azure-mi-mock-service-principal-client-id=f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a
+        - --azure-mi-mock-service-principal-principal-id=6096f642-63a0-4dd6-958d-715a87f33535
         - --azure-arm-helper-identity-certificate-bundle-path=/secrets/keyvault/armHelperIndentityCertificateBundle
         - --azure-arm-helper-identity-client-id=3331e670-0804-48e8-a086-6241671ddc93
         - --azure-arm-helper-mock-fpa-principal-id=47f69502-0065-4d9a-b19b-d403e183d2f4

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1305,8 +1305,8 @@ clouds:
         contentType: x-pkcs12
         manage: Disabled
       # Mock Managed Identities Service Princiapl
-      miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
-      miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+      miMockClientId: f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a
+      miMockPrincipalId: 6096f642-63a0-4dd6-958d-715a87f33535
       miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
       miMockCertName: msiMockCert2
       # ARM Helper

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -805,8 +805,8 @@ mgmtKeyVault:
   tagKey: aroHCPPurpose
   tagValue: mgmt
 miMockCertName: msiMockCert2
-miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
-miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+miMockClientId: f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a
+miMockPrincipalId: 6096f642-63a0-4dd6-958d-715a87f33535
 miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 mise:
   applicationName: arohcp-mise-ci00

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -805,8 +805,8 @@ mgmtKeyVault:
   tagKey: aroHCPPurpose
   tagValue: mgmt
 miMockCertName: msiMockCert2
-miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
-miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+miMockClientId: f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a
+miMockPrincipalId: 6096f642-63a0-4dd6-958d-715a87f33535
 miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 mise:
   applicationName: arohcp-mise-ci01

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -803,8 +803,8 @@ mgmtKeyVault:
   tagKey: aroHCPPurpose
   tagValue: mgmt
 miMockCertName: msiMockCert2
-miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
-miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+miMockClientId: f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a
+miMockPrincipalId: 6096f642-63a0-4dd6-958d-715a87f33535
 miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 mise:
   applicationName: arohcp-mise-cspr

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -803,8 +803,8 @@ mgmtKeyVault:
   tagKey: aroHCPPurpose
   tagValue: mgmt
 miMockCertName: msiMockCert2
-miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
-miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+miMockClientId: f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a
+miMockPrincipalId: 6096f642-63a0-4dd6-958d-715a87f33535
 miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 mise:
   applicationName: arohcp-mise-dev

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -803,8 +803,8 @@ mgmtKeyVault:
   tagKey: aroHCPPurpose
   tagValue: mgmt
 miMockCertName: msiMockCert2
-miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
-miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+miMockClientId: f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a
+miMockPrincipalId: 6096f642-63a0-4dd6-958d-715a87f33535
 miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 mise:
   applicationName: arohcp-mise-perf

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -805,8 +805,8 @@ mgmtKeyVault:
   tagKey: aroHCPPurpose
   tagValue: mgmt
 miMockCertName: msiMockCert2
-miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
-miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+miMockClientId: f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a
+miMockPrincipalId: 6096f642-63a0-4dd6-958d-715a87f33535
 miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 mise:
   applicationName: arohcp-mise-pers

--- a/docs/sops/msit-int-credential-setup.md
+++ b/docs/sops/msit-int-credential-setup.md
@@ -51,8 +51,8 @@ The MSIT INT environment is unique because the first-party, MSI mock, and ARM he
       name: intFirstPartyCert
       manage: false # we have the cert from RH for int
     # Mock Managed Identities Service Principal - from RH Tenant
-    miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
-    miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+    miMockClientId: f2e4769e-d3c2-498d-92b9-3e6d24cd2d7a
+    miMockPrincipalId: 6096f642-63a0-4dd6-958d-715a87f33535
     miMockCertName: intMsiMockCert
     # ARM Helper - from RH Tenant
     armHelperClientId: 3331e670-0804-48e8-a086-6241671ddc93


### PR DESCRIPTION
  The aro-hcp-int-msi-mock Entra app was recreated, changing its App ID
  and Principal ID. e2e-subscription-rbac-assignment-subscription.bicep
  reads miMockPrincipalId from config to grant Key Vault Crypto User on
  the E2E subscription — it never granted that role to the new principal,
  causing ValidAzureKMSConfig=False across 18 INT clusters from 2026-09-02.

  Old: miMockClientId=e8723db7  miMockPrincipalId=d6b62dfa
  New: miMockClientId=f2e4769e  miMockPrincipalId=6096f642
