### PR TITLE
feat(backend): source mock identity client/principal id from Key Vault secret (AROSLSRE-2006)

### DIFF
--- a/backend/cmd/root.go
+++ b/backend/cmd/root.go
@@ -164,7 +164,8 @@ func (f *BackendRootCmdFlags) AddFlags(cmd *cobra.Command) {
 		"The principal id of the ARO-HCP Clusters Managed Identities (MI) mock identity, which is a common Azure Service Principal identity. "+
 			"This flag should only be set in environments where Microsoft's MI Dataplane service is not available. "+
 			"When set, it must be set in combination with the '--insecure-azure-managed-identity-mock-certificate-bundle-path' and "+
-			"'--azure-mi-mock-principal-client-id' and '--insecure-azure-managed-identity-mock-tenant-id' flags. "+
+			"'--insecure-azure-managed-identity-mock-client-id' (or '--insecure-azure-managed-identity-mock-client-id-path') and "+
+			"'--insecure-azure-managed-identity-mock-tenant-id' flags. "+
 			"Mutually exclusive with '--insecure-azure-managed-identity-mock-principal-id-path'.",
 	)
 

--- a/backend/cmd/root.go
+++ b/backend/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
@@ -61,7 +62,9 @@ type BackendRootCmdFlags struct {
 	MaestroSourceEnvironmentIdentifier                                                            string
 	InsecureAzureManagedIdentityMockCertificateBundlePath                                         string
 	InsecureAzureManagedIdentityMockClientID                                                      string
+	InsecureAzureManagedIdentityMockClientIDPath                                                  string
 	InsecureAzureManagedIdentityMockServicePrincipalID                                            string
+	InsecureAzureManagedIdentityMockServicePrincipalIDPath                                        string
 	InsecureAzureManagedIdentityMockTenantID                                                      string
 	InsecureIgnoreUserAzureManagedIdentitiesThatNeedManagedIdentitiesDataplaneAvailableAndUseMock bool
 	ExitOnPanic                                                                                   bool
@@ -139,7 +142,19 @@ func (f *BackendRootCmdFlags) AddFlags(cmd *cobra.Command) {
 		"The client id of the ARO-HCP Clusters Managed Identities (MI) mock identity, which is a common Azure Service Principal identity. "+
 			"This flag should only be set in environments where Microsoft's MI Dataplane service is not available. "+
 			"When set, it must be set in combination with the '--insecure-azure-managed-identity-mock-certificate-bundle-path' and "+
-			"'--insecure-azure-managed-identity-mock-principal-id' and '--insecure-azure-managed-identity-mock-tenant-id' flags.",
+			"'--insecure-azure-managed-identity-mock-principal-id' and '--insecure-azure-managed-identity-mock-tenant-id' flags. "+
+			"Mutually exclusive with '--insecure-azure-managed-identity-mock-client-id-path'.",
+	)
+
+	cmd.Flags().StringVar(
+		&f.InsecureAzureManagedIdentityMockClientIDPath,
+		"insecure-azure-managed-identity-mock-client-id-path",
+		"",
+		"Path to a file containing the client id of the ARO-HCP Clusters Managed Identities (MI) mock identity. Use this instead of "+
+			"'--insecure-azure-managed-identity-mock-client-id' when the value is sourced from a Key Vault secret mounted via the CSI "+
+			"driver, so the mock identity's client id no longer needs to be duplicated as static configuration. The file is read once "+
+			"at startup; the file contents are trimmed of surrounding whitespace. Mutually exclusive with "+
+			"'--insecure-azure-managed-identity-mock-client-id'.",
 	)
 
 	cmd.Flags().StringVar(
@@ -149,7 +164,19 @@ func (f *BackendRootCmdFlags) AddFlags(cmd *cobra.Command) {
 		"The principal id of the ARO-HCP Clusters Managed Identities (MI) mock identity, which is a common Azure Service Principal identity. "+
 			"This flag should only be set in environments where Microsoft's MI Dataplane service is not available. "+
 			"When set, it must be set in combination with the '--insecure-azure-managed-identity-mock-certificate-bundle-path' and "+
-			"'--azure-mi-mock-principal-client-id' and '--insecure-azure-managed-identity-mock-tenant-id' flags.",
+			"'--azure-mi-mock-principal-client-id' and '--insecure-azure-managed-identity-mock-tenant-id' flags. "+
+			"Mutually exclusive with '--insecure-azure-managed-identity-mock-principal-id-path'.",
+	)
+
+	cmd.Flags().StringVar(
+		&f.InsecureAzureManagedIdentityMockServicePrincipalIDPath,
+		"insecure-azure-managed-identity-mock-principal-id-path",
+		"",
+		"Path to a file containing the principal id of the ARO-HCP Clusters Managed Identities (MI) mock identity. Use this instead of "+
+			"'--insecure-azure-managed-identity-mock-principal-id' when the value is sourced from a Key Vault secret mounted via the CSI "+
+			"driver, so the mock identity's principal id (which changes whenever the underlying Service Principal is recreated) no "+
+			"longer needs to be duplicated as static configuration. The file is read once at startup; the file contents are trimmed of "+
+			"surrounding whitespace. Mutually exclusive with '--insecure-azure-managed-identity-mock-principal-id'.",
 	)
 
 	cmd.Flags().StringVar(
@@ -245,11 +272,17 @@ func (f *BackendRootCmdFlags) validate() error {
 		if len(f.InsecureAzureManagedIdentityMockCertificateBundlePath) == 0 {
 			return utils.TrackError(fmt.Errorf("--insecure-azure-managed-identity-mock-certificate-bundle-path must be set"))
 		}
-		if len(f.InsecureAzureManagedIdentityMockClientID) == 0 {
-			return utils.TrackError(fmt.Errorf("--insecure-azure-managed-identity-mock-client-id must be set"))
+		if len(f.InsecureAzureManagedIdentityMockClientID) == 0 && len(f.InsecureAzureManagedIdentityMockClientIDPath) == 0 {
+			return utils.TrackError(fmt.Errorf("one of --insecure-azure-managed-identity-mock-client-id or --insecure-azure-managed-identity-mock-client-id-path must be set"))
 		}
-		if len(f.InsecureAzureManagedIdentityMockServicePrincipalID) == 0 {
-			return utils.TrackError(fmt.Errorf("--insecure-azure-managed-identity-mock-principal-id must be set"))
+		if len(f.InsecureAzureManagedIdentityMockClientID) != 0 && len(f.InsecureAzureManagedIdentityMockClientIDPath) != 0 {
+			return utils.TrackError(fmt.Errorf("--insecure-azure-managed-identity-mock-client-id and --insecure-azure-managed-identity-mock-client-id-path are mutually exclusive"))
+		}
+		if len(f.InsecureAzureManagedIdentityMockServicePrincipalID) == 0 && len(f.InsecureAzureManagedIdentityMockServicePrincipalIDPath) == 0 {
+			return utils.TrackError(fmt.Errorf("one of --insecure-azure-managed-identity-mock-principal-id or --insecure-azure-managed-identity-mock-principal-id-path must be set"))
+		}
+		if len(f.InsecureAzureManagedIdentityMockServicePrincipalID) != 0 && len(f.InsecureAzureManagedIdentityMockServicePrincipalIDPath) != 0 {
+			return utils.TrackError(fmt.Errorf("--insecure-azure-managed-identity-mock-principal-id and --insecure-azure-managed-identity-mock-principal-id-path are mutually exclusive"))
 		}
 		if len(f.InsecureAzureManagedIdentityMockTenantID) == 0 {
 			return utils.TrackError(fmt.Errorf("--insecure-azure-managed-identity-mock-tenant-id must be set"))
@@ -270,8 +303,14 @@ func (f *BackendRootCmdFlags) validate() error {
 		if len(f.InsecureAzureManagedIdentityMockClientID) != 0 {
 			return utils.TrackError(fmt.Errorf("--insecure-azure-managed-identity-mock-client-id must not be set"))
 		}
+		if len(f.InsecureAzureManagedIdentityMockClientIDPath) != 0 {
+			return utils.TrackError(fmt.Errorf("--insecure-azure-managed-identity-mock-client-id-path must not be set"))
+		}
 		if len(f.InsecureAzureManagedIdentityMockServicePrincipalID) != 0 {
 			return utils.TrackError(fmt.Errorf("--insecure-azure-managed-identity-mock-principal-id must not be set"))
+		}
+		if len(f.InsecureAzureManagedIdentityMockServicePrincipalIDPath) != 0 {
+			return utils.TrackError(fmt.Errorf("--insecure-azure-managed-identity-mock-principal-id-path must not be set"))
 		}
 		if len(f.InsecureAzureManagedIdentityMockTenantID) != 0 {
 			return utils.TrackError(fmt.Errorf("--insecure-azure-managed-identity-mock-tenant-id must not be set"))
@@ -302,6 +341,46 @@ func (f *BackendRootCmdFlags) validate() error {
 	}
 
 	return nil
+}
+
+// resolveInsecureManagedIdentityMockIDsFromFiles reads any of the "-path" variants of the mock identity
+// client id / principal id flags and populates the corresponding raw fields with their (whitespace-trimmed)
+// file contents. This lets the mock identity's client id / principal id be sourced from a Key Vault secret
+// mounted via the CSI driver instead of being duplicated as static configuration, so it self-heals whenever
+// the underlying Service Principal is recreated (its principal id changes) without requiring a config change.
+// Must be called after validate(), which already enforces that exactly one of the raw/path flags is set.
+func (f *BackendRootCmdFlags) resolveInsecureManagedIdentityMockIDsFromFiles() error {
+	if len(f.InsecureAzureManagedIdentityMockClientIDPath) != 0 {
+		value, err := readTrimmedFile(f.InsecureAzureManagedIdentityMockClientIDPath)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("failed to read --insecure-azure-managed-identity-mock-client-id-path: %w", err))
+		}
+		f.InsecureAzureManagedIdentityMockClientID = value
+	}
+
+	if len(f.InsecureAzureManagedIdentityMockServicePrincipalIDPath) != 0 {
+		value, err := readTrimmedFile(f.InsecureAzureManagedIdentityMockServicePrincipalIDPath)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("failed to read --insecure-azure-managed-identity-mock-principal-id-path: %w", err))
+		}
+		f.InsecureAzureManagedIdentityMockServicePrincipalID = value
+	}
+
+	return nil
+}
+
+// readTrimmedFile reads the file at path and returns its contents with leading/trailing whitespace
+// (including a trailing newline, as commonly written by Key Vault CSI driver secret mounts) removed.
+func readTrimmedFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read file %q: %w", path, err)
+	}
+	value := strings.TrimSpace(string(data))
+	if len(value) == 0 {
+		return "", fmt.Errorf("file %q is empty", path)
+	}
+	return value, nil
 }
 
 func (f *BackendRootCmdFlags) ToBackendOptions(ctx context.Context, cmd *cobra.Command) (*app.BackendOptions, error) {
@@ -565,6 +644,11 @@ func RunRootCmd(cmd *cobra.Command, flags *BackendRootCmdFlags) error {
 	err := flags.validate()
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("flags validation failed: %w", err))
+	}
+
+	err = flags.resolveInsecureManagedIdentityMockIDsFromFiles()
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to resolve mock identity ids from file: %w", err))
 	}
 
 	// Setup signal context allowing for both graceful and forceful shutdown

--- a/backend/cmd/root.go
+++ b/backend/cmd/root.go
@@ -347,8 +347,11 @@ func (f *BackendRootCmdFlags) validate() error {
 // resolveInsecureManagedIdentityMockIDsFromFiles reads any of the "-path" variants of the mock identity
 // client id / principal id flags and populates the corresponding raw fields with their (whitespace-trimmed)
 // file contents. This lets the mock identity's client id / principal id be sourced from a Key Vault secret
-// mounted via the CSI driver instead of being duplicated as static configuration, so it self-heals whenever
-// the underlying Service Principal is recreated (its principal id changes) without requiring a config change.
+// mounted via the CSI driver instead of being duplicated as static configuration, so a rotated value (e.g.
+// after the underlying Service Principal is recreated and its principal id changes) no longer requires a
+// config change to pick up. This resolution only runs once, at startup: it is called a single time before
+// the backend is constructed, so an already-running pod does not observe a later CSI secret rotation and
+// must be restarted to pick up the new value.
 // Must be called after validate(), which already enforces that exactly one of the raw/path flags is set.
 func (f *BackendRootCmdFlags) resolveInsecureManagedIdentityMockIDsFromFiles() error {
 	if len(f.InsecureAzureManagedIdentityMockClientIDPath) != 0 {

--- a/backend/cmd/root.go
+++ b/backend/cmd/root.go
@@ -118,7 +118,8 @@ func (f *BackendRootCmdFlags) AddFlags(cmd *cobra.Command) {
 			"Cluster's Control Plane Operators identities and the Cluster's Service Managed Identity. Even though when this is set there's no authentication "+
 			"as them against Azure, the backend still leverages them to perform some permissions validation checks. Additionally, when it is set, the backend will also "+
 			"use the ARM Permissions Manager identity to perform some additional permissions management and validations. When set, the --insecure-azure-managed-identity-mock-certificate-bundle-path, "+
-			"--insecure-azure-managed-identity-mock-client-id, --insecure-azure-managed-identity-mock-principal-id, --insecure-azure-managed-identity-mock-tenant-id, "+
+			"--insecure-azure-managed-identity-mock-client-id (or --insecure-azure-managed-identity-mock-client-id-path), "+
+			"--insecure-azure-managed-identity-mock-principal-id (or --insecure-azure-managed-identity-mock-principal-id-path), --insecure-azure-managed-identity-mock-tenant-id, "+
 			"--insecure-azure-arm-permissions-manager-identity-certificate-bundle-path, --insecure-azure-arm-permissions-manager-identity-client-id, "+
 			"--insecure-azure-arm-permissions-manager-identity-tenant-id flags must also be set.",
 	)
@@ -131,8 +132,9 @@ func (f *BackendRootCmdFlags) AddFlags(cmd *cobra.Command) {
 			"certificate chain, in a PEM or PKCS#12 format for authenticating clients with the msi mock identity, which is "+
 			"a common Azure Service Principal identity. This flag should only be set in environments where "+
 			"Microsoft's MI Dataplane service is not available. "+
-			"When set, it must be set in combination with the '--insecure-azure-managed-identity-mock-client-id' and "+
-			"'--insecure-azure-managed-identity-mock-principal-id' and '--insecure-azure-managed-identity-mock-tenant-id' flags.",
+			"When set, it must be set in combination with the '--insecure-azure-managed-identity-mock-client-id' (or "+
+			"'--insecure-azure-managed-identity-mock-client-id-path') and '--insecure-azure-managed-identity-mock-principal-id' "+
+			"(or '--insecure-azure-managed-identity-mock-principal-id-path') and '--insecure-azure-managed-identity-mock-tenant-id' flags.",
 	)
 
 	cmd.Flags().StringVar(
@@ -142,7 +144,8 @@ func (f *BackendRootCmdFlags) AddFlags(cmd *cobra.Command) {
 		"The client id of the ARO-HCP Clusters Managed Identities (MI) mock identity, which is a common Azure Service Principal identity. "+
 			"This flag should only be set in environments where Microsoft's MI Dataplane service is not available. "+
 			"When set, it must be set in combination with the '--insecure-azure-managed-identity-mock-certificate-bundle-path' and "+
-			"'--insecure-azure-managed-identity-mock-principal-id' and '--insecure-azure-managed-identity-mock-tenant-id' flags. "+
+			"'--insecure-azure-managed-identity-mock-principal-id' (or '--insecure-azure-managed-identity-mock-principal-id-path') and "+
+			"'--insecure-azure-managed-identity-mock-tenant-id' flags. "+
 			"Mutually exclusive with '--insecure-azure-managed-identity-mock-client-id-path'.",
 	)
 
@@ -187,7 +190,8 @@ func (f *BackendRootCmdFlags) AddFlags(cmd *cobra.Command) {
 		"The tenant id of the ARO-HCP Clusters Managed Identities (MI) mock identity, which is a common Azure Service Principal identity. "+
 			"This flag should only be set in environments where Microsoft's MI Dataplane service is not available. "+
 			"When set, it must be set in combination with the '--insecure-azure-managed-identity-mock-certificate-bundle-path', "+
-			"'--insecure-azure-managed-identity-mock-client-id' and '--insecure-azure-managed-identity-mock-principal-id' flags.",
+			"'--insecure-azure-managed-identity-mock-client-id' (or '--insecure-azure-managed-identity-mock-client-id-path') and "+
+			"'--insecure-azure-managed-identity-mock-principal-id' (or '--insecure-azure-managed-identity-mock-principal-id-path') flags.",
 	)
 
 	cmd.Flags().BoolVar(&f.ExitOnPanic, "exit-on-panic", f.ExitOnPanic,

--- a/backend/cmd/root_test.go
+++ b/backend/cmd/root_test.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	internalazure "github.com/Azure/ARO-HCP/internal/azure"
+)
+
+// validBaseFlags returns a BackendRootCmdFlags satisfying every requirement of validate()
+// that is unrelated to the mock identity / ARM Permissions Manager identity flags under test.
+func validBaseFlags() BackendRootCmdFlags {
+	return BackendRootCmdFlags{
+		AzureLocation:                           "westus3",
+		ClustersServiceURL:                      "http://localhost:8000",
+		AzureCosmosDBName:                       "db",
+		AzureCosmosDBURL:                        "http://localhost",
+		K8sNamespace:                            "ns",
+		MaestroSourceEnvironmentIdentifier:      "dev",
+		AzureClusterScopedIdentitiesRoleSetName: string(internalazure.RoleDefinitionConfigSetNameDev),
+		BackupScheduleCadence:                   "testing",
+		BackupScheduleState:                     "Disabled",
+	}
+}
+
+func withManagedMockFlags(f BackendRootCmdFlags) BackendRootCmdFlags {
+	f.InsecureIgnoreUserAzureManagedIdentitiesThatNeedManagedIdentitiesDataplaneAvailableAndUseMock = true
+	f.InsecureAzureManagedIdentityMockCertificateBundlePath = "/secrets/mi-mock-cert-bundle"
+	f.InsecureAzureManagedIdentityMockTenantID = "tenant-id"
+	f.InsecureAzureARMPermissionsManagerIdentityCertificateBundlePath = "/secrets/arm-helper-cert-bundle"
+	f.InsecureAzureARMPermissionsManagerIdentityClientID = "arm-helper-client-id"
+	f.InsecureAzureARMPermissionsManagerIdentityTenantID = "tenant-id"
+	return f
+}
+
+func TestValidateMockIdentityClientAndPrincipalID(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(f *BackendRootCmdFlags)
+		wantErr string
+	}{
+		{
+			name: "raw values only is valid",
+			mutate: func(f *BackendRootCmdFlags) {
+				f.InsecureAzureManagedIdentityMockClientID = "client-id"
+				f.InsecureAzureManagedIdentityMockServicePrincipalID = "principal-id"
+			},
+		},
+		{
+			name: "path values only is valid",
+			mutate: func(f *BackendRootCmdFlags) {
+				f.InsecureAzureManagedIdentityMockClientIDPath = "/secrets/miMockClientId"
+				f.InsecureAzureManagedIdentityMockServicePrincipalIDPath = "/secrets/miMockPrincipalId"
+			},
+		},
+		{
+			name:    "neither client id nor client id path is set",
+			mutate:  func(f *BackendRootCmdFlags) { f.InsecureAzureManagedIdentityMockServicePrincipalID = "principal-id" },
+			wantErr: "one of --insecure-azure-managed-identity-mock-client-id or --insecure-azure-managed-identity-mock-client-id-path must be set",
+		},
+		{
+			name: "both client id and client id path are set",
+			mutate: func(f *BackendRootCmdFlags) {
+				f.InsecureAzureManagedIdentityMockClientID = "client-id"
+				f.InsecureAzureManagedIdentityMockClientIDPath = "/secrets/miMockClientId"
+				f.InsecureAzureManagedIdentityMockServicePrincipalID = "principal-id"
+			},
+			wantErr: "--insecure-azure-managed-identity-mock-client-id and --insecure-azure-managed-identity-mock-client-id-path are mutually exclusive",
+		},
+		{
+			name:    "neither principal id nor principal id path is set",
+			mutate:  func(f *BackendRootCmdFlags) { f.InsecureAzureManagedIdentityMockClientID = "client-id" },
+			wantErr: "one of --insecure-azure-managed-identity-mock-principal-id or --insecure-azure-managed-identity-mock-principal-id-path must be set",
+		},
+		{
+			name: "both principal id and principal id path are set",
+			mutate: func(f *BackendRootCmdFlags) {
+				f.InsecureAzureManagedIdentityMockClientID = "client-id"
+				f.InsecureAzureManagedIdentityMockServicePrincipalID = "principal-id"
+				f.InsecureAzureManagedIdentityMockServicePrincipalIDPath = "/secrets/miMockPrincipalId"
+			},
+			wantErr: "--insecure-azure-managed-identity-mock-principal-id and --insecure-azure-managed-identity-mock-principal-id-path are mutually exclusive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := withManagedMockFlags(validBaseFlags())
+			tt.mutate(&f)
+
+			err := f.validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestValidateMockIdentityNotManagedRejectsPathFlags(t *testing.T) {
+	f := validBaseFlags()
+	f.InsecureAzureManagedIdentityMockClientIDPath = "/secrets/miMockClientId"
+
+	err := f.validate()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !contains(err.Error(), "--insecure-azure-managed-identity-mock-client-id-path must not be set") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveInsecureManagedIdentityMockIDsFromFiles(t *testing.T) {
+	dir := t.TempDir()
+	clientIDPath := filepath.Join(dir, "clientId")
+	principalIDPath := filepath.Join(dir, "principalId")
+	writeFile(t, clientIDPath, "  client-id-value\n")
+	writeFile(t, principalIDPath, "principal-id-value\n")
+
+	f := &BackendRootCmdFlags{
+		InsecureAzureManagedIdentityMockClientIDPath:           clientIDPath,
+		InsecureAzureManagedIdentityMockServicePrincipalIDPath: principalIDPath,
+	}
+
+	if err := f.resolveInsecureManagedIdentityMockIDsFromFiles(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.InsecureAzureManagedIdentityMockClientID != "client-id-value" {
+		t.Fatalf("expected trimmed client id, got %q", f.InsecureAzureManagedIdentityMockClientID)
+	}
+	if f.InsecureAzureManagedIdentityMockServicePrincipalID != "principal-id-value" {
+		t.Fatalf("expected trimmed principal id, got %q", f.InsecureAzureManagedIdentityMockServicePrincipalID)
+	}
+}
+
+func TestResolveInsecureManagedIdentityMockIDsFromFilesNoop(t *testing.T) {
+	f := &BackendRootCmdFlags{
+		InsecureAzureManagedIdentityMockClientID:           "already-set",
+		InsecureAzureManagedIdentityMockServicePrincipalID: "already-set",
+	}
+	if err := f.resolveInsecureManagedIdentityMockIDsFromFiles(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f.InsecureAzureManagedIdentityMockClientID != "already-set" {
+		t.Fatalf("expected raw value to be left untouched, got %q", f.InsecureAzureManagedIdentityMockClientID)
+	}
+}
+
+func TestResolveInsecureManagedIdentityMockIDsFromFilesMissingFile(t *testing.T) {
+	f := &BackendRootCmdFlags{
+		InsecureAzureManagedIdentityMockClientIDPath: filepath.Join(t.TempDir(), "does-not-exist"),
+	}
+	if err := f.resolveInsecureManagedIdentityMockIDsFromFiles(); err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestResolveInsecureManagedIdentityMockIDsFromFilesEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty")
+	writeFile(t, path, "   \n")
+
+	f := &BackendRootCmdFlags{
+		InsecureAzureManagedIdentityMockClientIDPath: path,
+	}
+	if err := f.resolveInsecureManagedIdentityMockIDsFromFiles(); err == nil {
+		t.Fatal("expected error for empty file, got nil")
+	}
+}
+
+func writeFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+}
+
+func contains(s, substr string) bool {
+	return strings.Contains(s, substr)
+}

--- a/backend/deploy/templates/backend.deployment.yaml
+++ b/backend/deploy/templates/backend.deployment.yaml
@@ -72,17 +72,27 @@ spec:
         - "{{ .Values.maestro.sourceEnvironmentIdentifier }}"
         - "--exit-on-panic={{ .Values.exitOnPanic }}"
         - "--log-verbosity={{ .Values.logVerbosity }}"
-       {{- if and .Values.miMock.certName .Values.miMock.clientId .Values.miMock.principalId .Values.miMock.tenantId
+       {{- if and .Values.miMock.certName (or .Values.miMock.clientId .Values.miMock.clientIdSecretName) (or .Values.miMock.principalId .Values.miMock.principalIdSecretName) .Values.miMock.tenantId
                   .Values.armPermissionsManagerIdentity.certName .Values.armPermissionsManagerIdentity.clientId .Values.armPermissionsManagerIdentity.tenantId
         }}
         # MI Mock flags. They should only be set in ARO-HCP environments where Microsoft's Managed Identities Dataplane service is not available.
         - "--insecure-ignore-user-azure-managed-identities-that-need-managed-identities-dataplane-available-and-use-mock"
         - "--insecure-azure-managed-identity-mock-certificate-bundle-path"
         - "/secrets/backend-service-key-vault/mi-mock-cert-bundle"
+{{- if .Values.miMock.clientIdSecretName }}
+        - "--insecure-azure-managed-identity-mock-client-id-path"
+        - "/secrets/backend-service-key-vault/mi-mock-client-id"
+{{- else }}
         - "--insecure-azure-managed-identity-mock-client-id"
         - "{{ .Values.miMock.clientId }}"
+{{- end }}
+{{- if .Values.miMock.principalIdSecretName }}
+        - "--insecure-azure-managed-identity-mock-principal-id-path"
+        - "/secrets/backend-service-key-vault/mi-mock-principal-id"
+{{- else }}
         - "--insecure-azure-managed-identity-mock-principal-id"
         - "{{ .Values.miMock.principalId }}"
+{{- end }}
         - "--insecure-azure-managed-identity-mock-tenant-id"
         - "{{ .Values.miMock.tenantId }}"
         # ARM Permissions Manager Identity flags. They should only be set in ARO-HCP environments where Microsoft's First Party Application (FPA) integration is not available.

--- a/backend/deploy/templates/backend.service-key-vault.secretproviderclass.yaml
+++ b/backend/deploy/templates/backend.service-key-vault.secretproviderclass.yaml
@@ -20,6 +20,18 @@ spec:
           objectType: secret
           objectAlias: mi-mock-cert-bundle
 {{- end }}
+{{- if .Values.miMock.clientIdSecretName }}
+        - |
+          objectName: '{{ .Values.miMock.clientIdSecretName }}'
+          objectType: secret
+          objectAlias: mi-mock-client-id
+{{- end }}
+{{- if .Values.miMock.principalIdSecretName }}
+        - |
+          objectName: '{{ .Values.miMock.principalIdSecretName }}'
+          objectType: secret
+          objectAlias: mi-mock-principal-id
+{{- end }}
 {{- if .Values.armPermissionsManagerIdentity.certName }}
         - |
           objectName: '{{ .Values.armPermissionsManagerIdentity.certName }}'

--- a/backend/deploy/templates/backend.service-key-vault.secretproviderclass.yaml
+++ b/backend/deploy/templates/backend.service-key-vault.secretproviderclass.yaml
@@ -19,7 +19,6 @@ spec:
           objectName: '{{ .Values.miMock.certName }}'
           objectType: secret
           objectAlias: mi-mock-cert-bundle
-{{- end }}
 {{- if .Values.miMock.clientIdSecretName }}
         - |
           objectName: '{{ .Values.miMock.clientIdSecretName }}'
@@ -31,6 +30,7 @@ spec:
           objectName: '{{ .Values.miMock.principalIdSecretName }}'
           objectType: secret
           objectAlias: mi-mock-principal-id
+{{- end }}
 {{- end }}
 {{- if .Values.armPermissionsManagerIdentity.certName }}
         - |

--- a/backend/testdata/helmtest_backend_mi_mock_ids_from_kv_secret.yaml
+++ b/backend/testdata/helmtest_backend_mi_mock_ids_from_kv_secret.yaml
@@ -1,0 +1,13 @@
+# This test case exercises the scenario where the MI Mock Identity's client id
+# and principal id are sourced from Key Vault secrets (mounted via the CSI
+# driver) instead of the static clientId/principalId values.
+values: ../values.yaml
+name: backend-mi-mock-ids-from-kv-secret
+namespace: aro-hcp
+testData:
+  miMockCertName: msiMockCert2
+  miMockClientId: ""
+  miMockPrincipalId: ""
+  miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
+  miMockClientIdSecretName: msiMockClientId
+  miMockPrincipalIdSecretName: msiMockPrincipalId

--- a/backend/testdata/helmtest_backend_mi_mock_ids_from_kv_secret.yaml
+++ b/backend/testdata/helmtest_backend_mi_mock_ids_from_kv_secret.yaml
@@ -1,13 +1,15 @@
-# This test case exercises the scenario where the MI Mock Identity's client id
-# and principal id are sourced from Key Vault secrets (mounted via the CSI
-# driver) instead of the static clientId/principalId values.
+# This test case exercises the migration scenario where both the legacy
+# static clientId/principalId values and the new secret names are set at the
+# same time (as happens mid-rollout, before the stale static values are
+# removed from config). The golden output must still only contain the
+# "-path" flags: the secret name takes precedence over the static value.
 values: ../values.yaml
 name: backend-mi-mock-ids-from-kv-secret
 namespace: aro-hcp
 testData:
   miMockCertName: msiMockCert2
-  miMockClientId: ""
-  miMockPrincipalId: ""
+  miMockClientId: stale-mi-mock-client-id
+  miMockPrincipalId: stale-mi-mock-principal-id
   miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
   miMockClientIdSecretName: msiMockClientId
   miMockPrincipalIdSecretName: msiMockPrincipalId

--- a/backend/testdata/zz_fixture_TestHelmTemplate_backend_mi_mock_ids_from_kv_secret.yaml
+++ b/backend/testdata/zz_fixture_TestHelmTemplate_backend_mi_mock_ids_from_kv_secret.yaml
@@ -1,0 +1,379 @@
+---
+# Source: backend/templates/backend.poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: aro-hcp-backend
+  namespace: aro-hcp
+spec:
+  minAvailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
+  selector:
+    matchLabels:
+      app: aro-hcp-backend
+---
+# Source: backend/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    azure.workload.identity/client-id: '__backendMsiClientId__'
+    azure.workload.identity/tenant-id: '__backendMsiTenantId__'
+  name: 'backend'
+  namespace: 'aro-hcp'
+---
+# Source: backend/templates/backend.azure-runtime-config.configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backend-azure-runtime-config
+  namespace: 'aro-hcp'
+data:
+  config.yaml: |
+    cloudEnvironment: "AzurePublicCloud"
+    managedIdentitiesDataPlaneAudienceResource: "https://dummy.org"
+    tenantID: "__tenantId__"
+    ocpImagesACR:
+      resourceID: "__ocpAcrResourceId__"
+      hostname: "__ocpAcrHostname__"
+      scopeMapName: "_repositories_pull"
+    dataPlaneIdentitiesOIDCConfiguration:
+      storageAccountBlobContainerName: "$web"
+      storageAccountBlobServiceURL: "__regionalOidcStorageAccountBlobEndpoint__"
+      oidcIssuerBaseURL: "__regionalOidcStorageAccountWebEndpoint__"
+    tlsCertificatesConfig:
+      issuer: "Self"
+      certificatesGenerationSource: AzureKeyVault
+---
+# Source: backend/templates/backend.configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backend-config
+  namespace: 'aro-hcp'
+data:
+  DB_NAME: 'arohcpdev-rp-usw3'
+  DB_URL: '__cosmosDBDocumentEndpoint__'
+  BACKEND_MI_CLIENT_ID: '__backendMsiClientId__'
+  CURRENT_VERSION: ''
+  DB_KUBE_APPLIER_CONTAINER: 'Manifests-MC-1'
+  LOCATION: 'westus3'
+---
+# Source: backend/templates/leader-election.role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: leader-election
+  namespace: 'aro-hcp'
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+  - patch
+---
+# Source: backend/templates/leader-election.rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backend-leader-election
+  namespace: 'aro-hcp'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: leader-election
+subjects:
+- kind: ServiceAccount
+  name: 'backend'
+  namespace: 'aro-hcp'
+---
+# Source: backend/templates/metrics.service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: aro-hcp-backend
+    port: metrics
+  name: aro-hcp-backend-metrics
+  namespace: 'aro-hcp'
+spec:
+  ports:
+  - port: 8081
+    protocol: TCP
+    targetPort: 8081
+    name: metrics
+  selector:
+    app: aro-hcp-backend
+---
+# Source: backend/templates/backend.deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: aro-hcp-backend
+  name: aro-hcp-backend
+  namespace: 'aro-hcp'
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: aro-hcp-backend
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: aro-hcp-backend
+        azure.workload.identity/use: "true"
+      annotations:
+        checksum/backendservicekeyvault: 'ca7ef4298bfd8b74e7e60ea397710c2b40d5f07436a1799c080025b1526f6694'
+        checksum/azureruntimeconfig: '40e0cf247edb3f1d1eb59cd97663f8ab2cf029da7a96716ee8916d38ac9fb0e5'
+    spec:
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: 'topology.kubernetes.io/zone'
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: aro-hcp-backend
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: aro-hcp-backend
+      serviceAccountName: 'backend'
+      priorityClassName: service-lifecycle-critical
+      volumes:
+      - name: backend-service-key-vault
+        csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: backend-service-key-vault
+      - name: azure-runtime-config
+        configMap:
+          name: backend-azure-runtime-config
+      containers:
+      - name: aro-hcp-backend
+        image: 'arohcpsvcdev.azurecr.io/arohcpbackend@sha256:1234567890'
+        imagePullPolicy: Always
+        args:
+        - "--clusters-service-url"
+        - "http://clusters-service.clusters-service.svc.cluster.local:8000"
+        - "--azure-runtime-config-path"
+        - "/configs/azure-runtime-config/config.yaml"
+        - "--backup-schedule-cadence"
+        - "production"
+        - "--backup-schedule-state"
+        - "Enabled"
+        - "--azure-first-party-application-certificate-bundle-path"
+        - "/secrets/backend-service-key-vault/fpa-cert-bundle"
+        - "--azure-first-party-application-client-id"
+        - "b3cb2fab-15cb-4583-ad06-f91da9bfe2d1"
+        - "--maestro-source-environment-identifier"
+        - "arohcpdev"
+        - "--exit-on-panic=true"
+        - "--log-verbosity=4"
+        # MI Mock flags. They should only be set in ARO-HCP environments where Microsoft's Managed Identities Dataplane service is not available.
+        - "--insecure-ignore-user-azure-managed-identities-that-need-managed-identities-dataplane-available-and-use-mock"
+        - "--insecure-azure-managed-identity-mock-certificate-bundle-path"
+        - "/secrets/backend-service-key-vault/mi-mock-cert-bundle"
+        - "--insecure-azure-managed-identity-mock-client-id-path"
+        - "/secrets/backend-service-key-vault/mi-mock-client-id"
+        - "--insecure-azure-managed-identity-mock-principal-id-path"
+        - "/secrets/backend-service-key-vault/mi-mock-principal-id"
+        - "--insecure-azure-managed-identity-mock-tenant-id"
+        - "64dc69e4-d083-49fc-9569-ebece1dd1408"
+        # ARM Permissions Manager Identity flags. They should only be set in ARO-HCP environments where Microsoft's First Party Application (FPA) integration is not available.
+        - "--insecure-azure-arm-permissions-manager-identity-certificate-bundle-path"
+        - "/secrets/backend-service-key-vault/arm-permissions-manager-identity-cert-bundle"
+        - "--insecure-azure-arm-permissions-manager-identity-client-id"
+        - "3331e670-0804-48e8-a086-6241671ddc93"
+        - "--insecure-azure-arm-permissions-manager-identity-tenant-id"
+        - "64dc69e4-d083-49fc-9569-ebece1dd1408"
+        - "--azure-cluster-scoped-identities-role-set-name"
+        - "dev"
+        env:
+        - name: DB_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: backend-config
+              key: DB_NAME
+        - name: DB_URL
+          valueFrom:
+            configMapKeyRef:
+              name: backend-config
+              key: DB_URL
+        - name: DB_KUBE_APPLIER_CONTAINER
+          valueFrom:
+            configMapKeyRef:
+              name: backend-config
+              key: DB_KUBE_APPLIER_CONTAINER
+        - name: LOCATION
+          valueFrom:
+            configMapKeyRef:
+              name: backend-config
+              key: LOCATION
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: ""
+        - name: OTEL_TRACES_EXPORTER
+          value: ""
+        - name: AZURE_TOKEN_CREDENTIALS
+          value: "WorkloadIdentityCredential"
+        ports:
+        - containerPort: 8081
+          protocol: TCP
+        - containerPort: 8083
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsNonRoot: true
+          runAsUser: 65532
+          runAsGroup: 65532
+          seccompProfile:
+            type: RuntimeDefault
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8083
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        volumeMounts:
+        - name: backend-service-key-vault
+          mountPath: "/secrets/backend-service-key-vault"
+        - name: azure-runtime-config
+          mountPath: /configs/azure-runtime-config
+          readOnly: true
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+---
+# Source: backend/templates/acrpullbinding.yaml
+apiVersion: acrpull.microsoft.com/v1beta2
+kind: AcrPullBinding
+metadata:
+  name: backend-pull-binding
+  namespace: 'aro-hcp'
+spec:
+  acr:
+    environment: PublicCloud
+    server: 'arohcpsvcdev.azurecr.io'
+    scope: 'repository:arohcpbackend:pull'
+  auth:
+    workloadIdentity:
+      serviceAccountRef: 'backend'
+      clientID: '__imagePullerMsiClientId__'
+      tenantID: '__imagePullerMsiTenantId__'
+  serviceAccountName: 'backend'
+---
+# Source: backend/templates/allow-metrics.authorizationpolicy.yaml
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-metrics-backend
+  namespace: 'aro-hcp'
+spec:
+  action: "ALLOW"
+  rules:
+  - to:
+    - operation:
+        paths: ["/metrics"]
+        methods: ["GET"]
+        ports: ["8081"]
+  selector:
+    matchLabels:
+      app: "aro-hcp-backend"
+---
+# Source: backend/templates/peerauthentication.yaml
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: aro-hcp-backend-metrics
+  namespace: 'aro-hcp'
+spec:
+  selector:
+    matchLabels:
+      app: aro-hcp-backend
+  portLevelMtls:
+    8081:
+      mode: PERMISSIVE
+---
+# Source: backend/templates/backend.service-key-vault.secretproviderclass.yaml
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: backend-service-key-vault
+  namespace: 'aro-hcp'
+spec:
+  parameters:
+    clientID: '__backendMsiClientId__'
+    cloudName: 'AzurePublicCloud'
+    keyvaultName: 'aro-hcp-dev-svc-kv'
+    objects: |-
+      array:
+        - |
+          objectName: 'firstPartyCert2'
+          objectType: secret
+          objectAlias: fpa-cert-bundle
+        - |
+          objectName: 'msiMockCert2'
+          objectType: secret
+          objectAlias: mi-mock-cert-bundle
+        - |
+          objectName: 'msiMockClientId'
+          objectType: secret
+          objectAlias: mi-mock-client-id
+        - |
+          objectName: 'msiMockPrincipalId'
+          objectType: secret
+          objectAlias: mi-mock-principal-id
+        - |
+          objectName: 'armHelperCert2'
+          objectType: secret
+          objectAlias: arm-permissions-manager-identity-cert-bundle
+    tenantId: '__tenantId__'
+    usePodIdentity: "false"
+  provider: azure
+---
+# Source: backend/templates/servicemonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: aro-hcp-backend
+  namespace: 'aro-hcp'
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - 'aro-hcp'
+  selector:
+    matchLabels:
+      app: aro-hcp-backend
+      port: metrics
+

--- a/backend/values.yaml
+++ b/backend/values.yaml
@@ -50,6 +50,13 @@ miMock:
   certName: "{{ .miMockCertName }}"
   clientId: "{{ .miMockClientId }}"
   principalId: "{{ .miMockPrincipalId }}"
+  # clientIdSecretName/principalIdSecretName are the names of Key Vault secrets holding the mock
+  # identity's client id / principal id. When set, these take precedence over clientId/principalId
+  # above: the values are mounted via the CSI driver and read from file at backend startup instead
+  # of being duplicated as static config. This lets the mock identity's ids stay correct even when
+  # the underlying Service Principal is recreated (its principal id changes), without a config change.
+  clientIdSecretName: "{{ .miMockClientIdSecretName }}"
+  principalIdSecretName: "{{ .miMockPrincipalIdSecretName }}"
   # The Azure Tenant ID where the MI Mock Identity is registered.
   tenantId: "{{ .miMockTenantId }}"
 # ARM Permissions Manager Identity. It is a common Azure Service Principal identity.

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1408,6 +1408,14 @@
     "miMockCertName": {
       "type": "string"
     },
+    "miMockClientIdSecretName": {
+      "type": "string",
+      "description": "Name of a Key Vault secret holding the mock identity's client id. When set, backend mounts and reads this instead of the static miMockClientId value."
+    },
+    "miMockPrincipalIdSecretName": {
+      "type": "string",
+      "description": "Name of a Key Vault secret holding the mock identity's principal id. When set, backend mounts and reads this instead of the static miMockPrincipalId value."
+    },
     "armHelperClientId": {
       "type": "string"
     },

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1183,6 +1183,11 @@ defaults:
   miMockPrincipalId: ""
   miMockTenantId: ""
   miMockCertName: ""
+  # When set, backend mounts these Key Vault secrets and reads clientId/principalId from file
+  # instead of the static miMockClientId/miMockPrincipalId above, so they stay correct even when
+  # the mock identity Service Principal is recreated. Empty by default (opt-in, backward compatible).
+  miMockClientIdSecretName: ""
+  miMockPrincipalIdSecretName: ""
   armHelperClientId: ""
   armHelperFPAPrincipalId: ""
   armHelperTenantId: ""

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -810,7 +810,9 @@ mgmtKeyVault:
   tagValue: mgmt
 miMockCertName: msiMockCert2
 miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
+miMockClientIdSecretName: ""
 miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+miMockPrincipalIdSecretName: ""
 miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 mise:
   applicationName: arohcp-mise-ci00

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -810,7 +810,9 @@ mgmtKeyVault:
   tagValue: mgmt
 miMockCertName: msiMockCert2
 miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
+miMockClientIdSecretName: ""
 miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+miMockPrincipalIdSecretName: ""
 miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 mise:
   applicationName: arohcp-mise-ci01

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -808,7 +808,9 @@ mgmtKeyVault:
   tagValue: mgmt
 miMockCertName: msiMockCert2
 miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
+miMockClientIdSecretName: ""
 miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+miMockPrincipalIdSecretName: ""
 miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 mise:
   applicationName: arohcp-mise-cspr

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -808,7 +808,9 @@ mgmtKeyVault:
   tagValue: mgmt
 miMockCertName: msiMockCert2
 miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
+miMockClientIdSecretName: ""
 miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+miMockPrincipalIdSecretName: ""
 miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 mise:
   applicationName: arohcp-mise-dev

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -808,7 +808,9 @@ mgmtKeyVault:
   tagValue: mgmt
 miMockCertName: msiMockCert2
 miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
+miMockClientIdSecretName: ""
 miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+miMockPrincipalIdSecretName: ""
 miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 mise:
   applicationName: arohcp-mise-perf

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -810,7 +810,9 @@ mgmtKeyVault:
   tagValue: mgmt
 miMockCertName: msiMockCert2
 miMockClientId: e8723db7-9b9e-46a4-9f7d-64d75c3534f0
+miMockClientIdSecretName: ""
 miMockPrincipalId: d6b62dfa-87f5-49b3-bbcb-4a687c4faa96
+miMockPrincipalIdSecretName: ""
 miMockTenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 mise:
   applicationName: arohcp-mise-pers


### PR DESCRIPTION
[AROSLSRE-2057](https://redhat.atlassian.net/browse/AROSLSRE-2057), part of [AROSLSRE-2006](https://redhat.atlassian.net/browse/AROSLSRE-2006).

### What

Adds backend support for reading the mock identity's `clientId` and `principalId` from Key Vault secrets mounted through CSI, using the same volume as the mock identity certificate.

The new `--insecure-azure-managed-identity-mock-client-id-path` and `--insecure-azure-managed-identity-mock-principal-id-path` flags read the files once at startup. Helm uses these flags when `miMockClientIdSecretName` and `miMockPrincipalIdSecretName` are configured. Both secret names default to empty, so the static-value path remains the default.

### Why

The mock identity IDs are duplicated in configuration. Recreating the service principal changes its `principalId`, leaving those copies stale.

The goal is to publish and refresh the IDs through the existing privileged identity/RBAC automation and have workloads read them from Key Vault. This keeps Graph lookups out of the backend and cluster-service deployment identities.

This PR adds the backend consumer support only. It does not yet remove the stale-config risk end to end.

### Testing

Unit tests in `backend/cmd/root_test.go` cover direct-value/file-path validation and file resolution. The Helm fixture covers the Key Vault path with both secret names configured, including precedence over static IDs.

Validation commands: `go build ./...`, `go vet ./...`, and `go test ./cmd/...` from `backend`; `make materialize` from `config`.

### Special notes for your reviewer

This PR does not publish or enable the secrets, migrate cluster-service, remove static values, or change `tenantId`. Backend needs a controlled restart after the mounted IDs change because it reads the files once at startup.

Follow-ups under [AROSLSRE-2006](https://redhat.atlassian.net/browse/AROSLSRE-2006):

- [AROSLSRE-2058](https://redhat.atlassian.net/browse/AROSLSRE-2058): publish and refresh the ID secrets in the consuming Key Vaults.
- [AROSLSRE-2059](https://redhat.atlassian.net/browse/AROSLSRE-2059): enable backend consumption and handle restarts after ID changes.
- [AROSLSRE-2060](https://redhat.atlassian.net/browse/AROSLSRE-2060): add cluster-service support and deployment wiring.
- [AROSLSRE-2061](https://redhat.atlassian.net/browse/AROSLSRE-2061): remove static values once every consumer has migrated.

Related: [AROSLSRE-1997](https://redhat.atlassian.net/browse/AROSLSRE-1997), [AROSLSRE-1999](https://redhat.atlassian.net/browse/AROSLSRE-1999).

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier), demonstrate that the test is able to detect a defect/error and fail with proper error message and logs which communicates nature of the problem.
