### PR TITLE
chore: ignore .tmp to have a dir AI can write temp results to, withou…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ must-gather-*
 /hcpctl
 timing-metadata-*
 /.claude/
+.tmp
 
 # Allow Secret resource fixtures in the kube-applier read-desire testdata.
 # The `secrets` rule above otherwise excludes the manifestclient directory


### PR DESCRIPTION
…t needed write access outside the current dir

https://redhat.atlassian.net/browse/ARO-29440

<!-- Link to Jira issue -->

### What

ignore .tmp

### Why

to have a dir AI can write temp results to, without needed write access outside the current dir

### Testing

-

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Commit history is clean (rebased/squashed)
- [ ] All comment threads resolved before merge
