### PR TITLE
fix(backend): wait for managed resource group before deny-assignment writes (AROSLSRE-2012)

### DIFF
--- a/backend/pkg/azure/azuremockclient/mock_clients.go
+++ b/backend/pkg/azure/azuremockclient/mock_clients.go
@@ -87,12 +87,43 @@ func (m *GenericResourcesClientFunc) BeginDeleteByID(ctx context.Context, resour
 	return nil, fmt.Errorf("GenericResourcesClientFunc: set DeleteErr to control this path; PollUntilDone cannot be called on a nil poller")
 }
 
+// ResourceGroupsClientFunc adapts a function to the ResourceGroupsClient.Get interface.
+// Tests set GetFunc to control the response per call; unset GetFunc reports the resource
+// group as existing (an empty successful response), which is the common case for tests that
+// don't care about resource-group existence.
+type ResourceGroupsClientFunc struct {
+	GetFunc func(ctx context.Context, resourceGroupName string, options *armresources.ResourceGroupsClientGetOptions) (armresources.ResourceGroupsClientGetResponse, error)
+}
+
+var _ azureclient.ResourceGroupsClient = (*ResourceGroupsClientFunc)(nil)
+
+func (m *ResourceGroupsClientFunc) Get(ctx context.Context, resourceGroupName string, options *armresources.ResourceGroupsClientGetOptions) (armresources.ResourceGroupsClientGetResponse, error) {
+	if m.GetFunc != nil {
+		return m.GetFunc(ctx, resourceGroupName, options)
+	}
+	return armresources.ResourceGroupsClientGetResponse{}, nil
+}
+
+func (m *ResourceGroupsClientFunc) CreateOrUpdate(ctx context.Context, resourceGroupName string, parameters armresources.ResourceGroup, options *armresources.ResourceGroupsClientCreateOrUpdateOptions) (armresources.ResourceGroupsClientCreateOrUpdateResponse, error) {
+	return armresources.ResourceGroupsClientCreateOrUpdateResponse{}, fmt.Errorf("CreateOrUpdate not implemented")
+}
+
+func (m *ResourceGroupsClientFunc) BeginDelete(ctx context.Context, resourceGroupName string, options *armresources.ResourceGroupsClientBeginDeleteOptions) (*azruntime.Poller[armresources.ResourceGroupsClientDeleteResponse], error) {
+	return nil, fmt.Errorf("BeginDelete not implemented")
+}
+
+func (m *ResourceGroupsClientFunc) NewListPager(options *armresources.ResourceGroupsClientListOptions) *azruntime.Pager[armresources.ResourceGroupsClientListResponse] {
+	return nil
+}
+
 // FirstPartyApplicationClientBuilderFunc builds mock Azure clients.
 type FirstPartyApplicationClientBuilderFunc struct {
 	GenericResourcesClientVal azureclient.GenericResourcesClient
 	GenericResourcesClientErr error
 	DenyAssignmentsClientVal  azureclient.DenyAssignmentsClient
 	DenyAssignmentsClientErr  error
+	ResourceGroupsClientVal   azureclient.ResourceGroupsClient
+	ResourceGroupsClientErr   error
 }
 
 var _ azureclient.FirstPartyApplicationClientBuilder = (*FirstPartyApplicationClientBuilderFunc)(nil)
@@ -102,7 +133,12 @@ func (m *FirstPartyApplicationClientBuilderFunc) BuilderType() azureclient.First
 }
 
 func (m *FirstPartyApplicationClientBuilderFunc) ResourceGroupsClient(tenantID string, subscriptionID string) (azureclient.ResourceGroupsClient, error) {
-	return nil, fmt.Errorf("not implemented")
+	if m.ResourceGroupsClientVal == nil && m.ResourceGroupsClientErr == nil {
+		// Default to "the resource group exists" so tests that don't care about
+		// resource-group existence aren't forced to wire this up explicitly.
+		return &ResourceGroupsClientFunc{}, nil
+	}
+	return m.ResourceGroupsClientVal, m.ResourceGroupsClientErr
 }
 
 func (m *FirstPartyApplicationClientBuilderFunc) ResourceProvidersClient(tenantID string, subscriptionID string) (azureclient.ResourceProvidersClient, error) {

--- a/backend/pkg/controllers/cluster/denyassignments/deny_assignment_controller.go
+++ b/backend/pkg/controllers/cluster/denyassignments/deny_assignment_controller.go
@@ -182,6 +182,26 @@ func (c *clusterDenyAssignmentSyncer) syncDenyAssignmentUpsert(ctx context.Conte
 		return utils.TrackError(fmt.Errorf("failed to build managed resource group resource ID: %w", err))
 	}
 
+	// Deny assignments are scoped to the managed resource group, which Cluster Service creates
+	// asynchronously and independently of the identity-resolution status this sync is gated on
+	// (see syncDenyAssignmentNeedsWork). Confirm the resource group actually exists before issuing
+	// any deny-assignment writes against it; otherwise every write fails with ResourceGroupNotFound
+	// and keeps failing on every one-minute reconcile until the overall cluster-create deadline
+	// expires. Wait for a later pass instead, mirroring the same check in
+	// managed_resource_group_controller.go.
+	resourceGroupsClient, err := c.azureFPAClientBuilder.ResourceGroupsClient(tenantID, key.SubscriptionID)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to create resource groups client: %w", err))
+	}
+	if _, err := resourceGroupsClient.Get(ctx, cluster.CustomerProperties.Platform.ManagedResourceGroup, nil); err != nil {
+		if azureclient.IsResourceGroupNotFoundErr(err) {
+			logger.Info("managed resource group does not exist yet, waiting for a later pass",
+				"managedResourceGroup", cluster.CustomerProperties.Platform.ManagedResourceGroup)
+			return nil
+		}
+		return utils.TrackError(fmt.Errorf("failed to get managed resource group %q: %w", cluster.CustomerProperties.Platform.ManagedResourceGroup, err))
+	}
+
 	requiredDenyAssignmentReferences, err := allDenyAssignmentReferences(cluster)
 	if err != nil {
 		return utils.TrackError(err)


### PR DESCRIPTION
## What

The `ClusterDenyAssignment` controller (added in #6680) writes deny assignments scoped to the cluster's managed resource group without first confirming that resource group exists in Azure. This causes repeated `ResourceGroupNotFound` failures against ARM until the cluster-create deadline expires. See [AROSLSRE-2012](https://redhat.atlassian.net/browse/AROSLSRE-2012) and the evidence linked from [#6804](https://github.com/Azure/ARO-HCP/pull/6804#issuecomment-5527582776).

## Why

The deny-assignment controller can run before the managed resource group exists because it gates on `ClusterServiceIDForCluster`, which resolves via `PendingClusterServiceID`, set before the real CS cluster object (and its managed resource group) exists.

There is also a separate, deeper circular dependency: `createPreconditionDenyAssignmentsCreated` in `cluster_cluster_service_create_controller.go` blocks CS cluster object creation until deny assignments succeed, but Cluster Service only provisions the managed resource group after the CS cluster object exists, so deny assignments can never succeed on their own. That loop is not fixed by this PR, deads2k is pulling out that initialization logic separately to break it.

## Fix

Before issuing deny-assignment writes, check whether the managed resource group exists, mirroring the same check already used in `managed_resource_group_controller.go`. On `ResourceGroupNotFound`, log and wait for a later reconcile instead of hard-failing and retrying to failure.

This is a stopgap: it stops the ARM hammering, it does not break the circular dependency described above.

## Testing

- `go build ./pkg/azure/... ./pkg/controllers/cluster/denyassignments/...`
- `go test ./pkg/controllers/cluster/denyassignments/... ./pkg/azure/azuremockclient/... ./pkg/controllers/cluster/azureresources/...` all pass
- Added a `ResourceGroupsClientFunc` test fake (mirroring the existing `GenericResourcesClientFunc`/`DenyAssignmentsClientFunc` fakes), defaulting to "resource group exists" so existing tests didn't need changes

Refs: [AROSLSRE-2012](https://redhat.atlassian.net/browse/AROSLSRE-2012), #6680, #6804
