### PR TITLE
test: prototype DEV mock-MSI ACL isolation (ARO-29287)

### DIFF
--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -95,6 +95,12 @@ ARO HCP CI is split across this repository and the OpenShift CI configuration in
 - [Lease Configuration](identity-leasing.md#lease-configuration)
 - [Where To Look](identity-leasing.md#where-to-look)
 
+### [DEV Mock-MSI ACL Isolation](mock-msi-acl-isolation.md)
+
+- How to strip (then restore) the job-leased mock MSI for one DEV e2e spec without breaking sibling clusters
+- [Helm must match the lease (false pass)](mock-msi-acl-isolation.md#helm-must-match-the-lease-false-pass)
+- [Personal-dev overlay](mock-msi-acl-isolation.md#personal-dev-overlay)
+
 ### [DEV CI Monitoring and Alert Response](dev-ci-monitoring.md)
 
 - [At A Glance](dev-ci-monitoring.md#at-a-glance)

--- a/docs/ci/identity-leasing.md
+++ b/docs/ci/identity-leasing.md
@@ -333,6 +333,8 @@ MSI_MOCK_CERT_NAME=$(yq ".miMockPool.\"${LEASED_MSI_MOCK_SP}\".certName" dev-inf
 
 Jobs only consume the Boskos key and the static `msi-mock-pool.yaml` catalog at runtime. They do not query Entra or the `dev-ci` rollout directly during provisioning.
 
+The mock SP is process-wide for the job. Stripping its subscription grants while other specs in the same OTE invocation are still creating or deleting clusters would fail those siblings. The ARM-helper pool already isolates CheckAccess per job; MSI mock uses the same job-level lease. Per-spec isolation is a dedicated `development/mock-msi-acl` suite (`Parallelism: 1`) that strips then restores only a **pooled** mock principal — never `aro-dev-msi-mock2`. The test process must receive the same lease Helm applied, and live Cluster Service / backend `miMock*` must match it, or the spec can false-pass. See [DEV Mock-MSI ACL Isolation](mock-msi-acl-isolation.md) and [Helm must match the lease](mock-msi-acl-isolation.md#helm-must-match-the-lease-false-pass).
+
 ## ARM Helper Service Principal Pool
 
 The DEV ARM helper pool prevents concurrent E2E backends from sharing the

--- a/docs/ci/mock-msi-acl-isolation.md
+++ b/docs/ci/mock-msi-acl-isolation.md
@@ -1,0 +1,243 @@
+# DEV Mock-MSI ACL Isolation (ARO-29287)
+
+Spike design for a non-vacuous DEV e2e signal that cluster delete still works
+when the identity used for cluster operations has **no ACL**. This is not
+about replicating the MSI RP, and it is not about product resource-cleanup
+work (ARO-21580 is already tested in STG).
+
+Status: prototype for review. Chosen mechanism is implemented behind a
+dedicated suite that is **not** wired into the default DEV parallel job.
+
+## Current topology
+
+```
+                    ┌─────────────────────────────────────────┐
+                    │  e2e job (OTE, parallelism ~24)         │
+                    │                                         │
+  Boskos lease ────►│  one MSI mock SP for the whole job      │
+  (LEASED_MSI_MOCK_SP)│  hardcodedIdentityManagedIdentities…   │
+                    │  returns that SP for every operator UAMI│
+                    │                                         │
+                    │  spec A  spec B  spec C  …   (parallel) │
+                    └─────────────────────────────────────────┘
+                                      │
+                                      ▼
+                    subscription-scoped grants on that SP:
+                      • custom role `dev-msi-mock-<sub>`
+                      • built-in Key Vault Crypto User
+```
+
+- **Shared personal-dev identity:** `aro-dev-msi-mock2`
+  (`miMockPrincipalId` `d6b62dfa-87f5-49b3-bbcb-4a687c4faa96` in
+  `config/config.yaml`). Never strip this principal.
+- **Job-leased pool:** Azure display name `aro-dev-msi-mock-pool-<i>`, Boskos
+  / catalog key `aro-hcp-msi-mock-cs-sp-dev-<i>` in
+  `dev-infrastructure/openshift-ci/msi-mock-pool.yaml`, leased per e2e **job**
+  (same shape as the ARM-helper CheckAccess pool). See the
+  [naming bridge](identity-leasing.md#naming-bridge).
+- **Identity-container pool:** per-**spec** leasing of UAMI resource groups.
+  Orthogonal. The mock SP still authenticates as every operator regardless of
+  which UAMI resource IDs the cluster declared.
+- **Product deny assignments:** `ClusterDenyAssignment` is **disabled** in
+  DEV/INT (`clustersService.denyAssignments: disabled`) because there is no
+  real FPA. E2E can list deny assignments (cleanup probes) but cannot create
+  them. Product deny assignments also *except* operator principals — and in
+  DEV the mock SP *is* those operators — so enabling the product controller
+  would not strip mock ACL.
+
+Deleting customer UAMIs in DEV (`cluster_delete_missing_identities` today) is
+vacuous: CAPZ/Hypershift still get mock-SP credentials that keep
+subscription `dev-msi-mock`.
+
+## Isolation options considered
+
+| Mechanism | Parallel-safe? | Restorable? | Notes |
+|---|---|---|---|
+| Strip the job's subscription `dev-msi-mock` grant | **No**, unless no sibling spec is running | Yes, if we recreate the same assignment GUID | Ginkgo `Serial` does **not** serialize across OTE worker processes. Default DEV suite is `Parallelism: 24`. |
+| RG-scoped deny targeting the mock SP | Yes | Yes (delete deny; RG delete removes it) | Ideal spatially, but e2e identities cannot write deny assignments; FPA-backed controller is off in DEV. |
+| ABAC condition on the subscription grant excluding this spec's RGs | Maybe | Fragile | Mutates the shared grant in place; abort mid-update can leave a poisoned condition. Not prototyped. |
+| Per-spec mock SP in the backend | Yes | N/A | Process-wide hardcoded client. Would be "replicate MSI RP". Out of scope. |
+| Dedicated suite, `Parallelism: 1`, strip the **leased pool** SP | Yes (no siblings in that invocation) | Yes | Reuses the ARM-helper pattern at **suite** grain. Chosen. |
+
+## Chosen mechanism
+
+1. Leave `test/e2e/cluster_delete_missing_identities.go` unchanged. It is
+   already `StageAndProdOnly`, so DEV/INT suites never select it.
+2. Add a **new** DEV spec in `test/e2e/cluster_delete_missing_identities_dev_mock_msi.go`,
+   selected **only** by suite `development/mock-msi-acl` (`Parallelism: 1`).
+   It is excluded from every existing parallel suite.
+3. After the cluster is verified healthy, **delete** the leased mock SP's
+   subscription-scoped `dev-msi-mock` and Key Vault Crypto User assignments,
+   then delete the dedicated UAMIs (so CS still sees missing identities),
+   then delete the cluster.
+4. `DeferCleanup` always recreates the stripped assignments using the original
+   assignment GUIDs (the Bicep names are `guid(subscription().id, principalId, roleDefinitionId)`).
+5. **Do not delete the mock app registration.** Entra ghosts / directory quota.
+6. **Refuse** to strip `aro-dev-msi-mock2`. Only pool principals from
+   `msi-mock-pool.yaml` (or an explicit `ARO_HCP_MSI_MOCK_PRINCIPAL_ID` that
+   matches a pool entry) are eligible.
+
+This is the CheckAccess identity-leasing pattern applied to MSI mock: isolation
+is "this invocation owns the leased SP exclusively", not "mutate a grant while
+24 other specs are using it".
+
+## Lease vs dedicated UAMIs
+
+The DEV spec still uses `useMsiPool=false` / `MIContainers(0)` so it can delete
+UAMIs without corrupting the identity-container pool (ARO-29288). Permission
+strip is what makes the DEV signal non-vacuous; UAMI delete is extra CS
+coverage, not a substitute.
+
+If ARO-29288 concludes CS does not need identity deletion in DEV, switch this
+spec to `MIContainers(1)` and stop calling `DeleteUserAssignedIdentities`.
+Keep the mock-SP strip.
+
+## Restore and abort
+
+| Event | What restores the leased SP |
+|---|---|
+| Spec succeeds or fails after strip | `DeferCleanup` → `RestoreMockMSIPermissions` (same assignment GUIDs) |
+| Process killed, `DeferCleanup` does not run | Next privileged `mock-identity-rbac.bicep` apply recreates the deterministic GUIDs. Until then, the next job that leases this pool member will see operators without ACL (fail closed, noisy). |
+| Personal-dev / shared `aro-dev-msi-mock2` | Strip is refused. No restore problem. |
+
+Do **not** rely on the hourly leftover sweeper: it deletes *orphaned*
+assignments, it does not re-create missing ones.
+
+Required env for the DEV spec (ARO-29290 must export these from the provision
+step into the test step; today `LEASED_MSI_MOCK_SP` is consumed at provision
+time and is not guaranteed in the test process):
+
+- `LEASED_MSI_MOCK_SP` — Boskos catalog key (`aro-hcp-msi-mock-cs-sp-dev-<i>`),
+  looked up in `msi-mock-pool.yaml`. This is **not** the Azure display name
+  `aro-dev-msi-mock-pool-<i>`.
+- `ARO_HCP_MSI_MOCK_PRINCIPAL_ID` — optional explicit principal. Prefer this
+  when provision already exported it (ARO-29290). If both env vars are set,
+  they must resolve to the **same** principal or the spec errors.
+
+Optional: `ARO_HCP_MSI_MOCK_POOL_CATALOG` overrides the catalog path.
+
+Exporting those variables is **necessary but not sufficient**. The spec
+strips whichever principal the env resolves to. It cannot see Helm. If
+Cluster Service / backend are still impersonating a different mock SP
+(typically `aro-dev-msi-mock2`), strip is a no-op for the identity that
+actually runs cluster ops and delete can still succeed — a vacuous pass.
+ARO-29290 must export the **same** values Helm applied and prove live Helm
+matches the lease (see [Helm must match the lease](#helm-must-match-the-lease-false-pass)).
+
+## What this prototype does not do
+
+- Wire `development/mock-msi-acl` into `openshift/release` (ARO-29289).
+- Change the hardcoded MI dataplane client.
+- Enable product deny assignments in DEV.
+- Delete Entra applications.
+
+## Helm must match the lease (false pass)
+
+The spec's first `By` only resolves env (`LEASED_MSI_MOCK_SP` /
+`ARO_HCP_MSI_MOCK_PRINCIPAL_ID`). It does **not** read Cluster Service or
+backend. Personal-dev soak showed env can say pool member N while live Helm
+is still `aro-dev-msi-mock2`.
+
+| Live impersonation | Env / strip target | Create | Strip | Delete | Signal |
+|---|---|---|---|---|---|
+| Leased pool SP (Helm `miMock*` = lease) | Same pool SP | Succeeds | Removes the operators' ACL | Succeeds without ACL | **Real** |
+| `aro-dev-msi-mock2` (default pers Helm) | Pool member N | Succeeds (mock2 still has ACL) | Removes unused pool grants | Succeeds via mock2 ACL | **Vacuous** |
+| Pool client ID + `msiMockCert2` (or the reverse) | Anything | Fails `AADSTS700027`; Maestro posts no ManifestWork | Never reached | n/a | Env broken, not a spec bug |
+
+`kubectl get deploy -o yaml` is not enough: a failed or cached Helm upgrade can
+leave the **desired** spec on new `miMock*` values while Ready pods are still
+the previous ReplicaSet. Confirm **running pod** args and the **mounted** mock
+cert on every replica.
+
+List role assignments with ARM `$filter=assignedTo('{principalId}')`. The Go
+SDK's `principalId eq '{id}'` form returns `400 UnsupportedQuery`.
+
+## How to run the prototype
+
+The RP under test must already be provisioned with the **job-leased pooled**
+MSI mock SP (Helm `miMock*` on **both** Cluster Service and backend), not
+personal-dev `aro-dev-msi-mock2`. Pass the same Boskos catalog key that
+provision consumed.
+
+`LEASED_MSI_MOCK_SP` is the Boskos / static-catalog key
+(`aro-hcp-msi-mock-cs-sp-dev-<i>`), not the Azure app display name
+(`aro-dev-msi-mock-pool-<i>`). See the
+[naming bridge](identity-leasing.md#naming-bridge).
+
+If `ARO_HCP_MSI_MOCK_PRINCIPAL_ID` is also set, it must match that lease's
+`principalId` in `msi-mock-pool.yaml`.
+
+```bash
+export AROHCP_ENV=development
+export CUSTOMER_SUBSCRIPTION=<name>
+export LOCATION=<region>
+# Boskos key for the SP this RP was provisioned with — never aro-dev-msi-mock2
+export LEASED_MSI_MOCK_SP=aro-hcp-msi-mock-cs-sp-dev-0
+# Optional; if set, must match the lease (example is pool member 0)
+# export ARO_HCP_MSI_MOCK_PRINCIPAL_ID=db27175c-5bd0-48b4-929a-41de9a53ffbf
+make -C test
+./test/aro-hcp-tests run-suite "development/mock-msi-acl"
+```
+
+`run-suite development/mock-msi-acl` is the CI-shaped invocation (`Parallelism`
+is the literal `1`). `make e2e-local/run-test TEST_NAME="Customer should be
+able to delete an HCP cluster after stripping DEV mock-MSI permissions"`
+exercises the same spec through the personal-dev port-forward. This spec
+does not create a node pool; do not use the 4.21 complete-cluster-create
+entry as a substitute.
+
+### Personal-dev overlay
+
+Default pers Helm is `aro-dev-msi-mock2` (`miMockCertName: msiMockCert2`).
+The spec refuses to strip that principal, so you must point **Cluster Service
+and backend** at a pooled member first, run the spec, then put pers back on
+mock2. `DeferCleanup` restores RBAC, not Helm `miMock*`.
+
+Pick a high-index Boskos key so you are less likely to collide with a live CI
+job. Look up `clientId` / `principalId` / `certName` in
+`dev-infrastructure/openshift-ci/msi-mock-pool.yaml`. Overlay those three
+fields at `.clouds.dev.environments.pers.defaults` (same shape CI uses). Pin
+service image digests that match the charts you are deploying — a newer
+backend chart with `--backup-schedule-cadence` against an older image
+crashloops the new ReplicaSet while old pods keep serving.
+
+```bash
+export DEPLOY_ENV=pers
+export OVERRIDE_CONFIG_FILE=/path/to/pers-combined-override.yaml
+# PERSIST=true does not bypass .step-cache. A cached Helm digest can skip
+# the upgrade while _artifacts/config.yaml already shows the overlay.
+# Cluster Service and backend are separate releases / sentinels.
+PERSIST=true make pipeline/ClusterService \
+  OVERRIDE_CONFIG_FILE="${OVERRIDE_CONFIG_FILE}" \
+  STEP_CACHE_DIR=/tmp/cs-step-cache-force-helm
+PERSIST=true make pipeline/RP.Backend \
+  OVERRIDE_CONFIG_FILE="${OVERRIDE_CONFIG_FILE}" \
+  STEP_CACHE_DIR=/tmp/backend-step-cache-force-helm
+```
+
+After Helm reports success, confirm the **live** impersonation before
+running the spec:
+
+1. SecretProviderClass `objectName` is the pool `certName` (not
+   `msiMockCert2`) in **both** `clusters-service` and `aro-hcp`.
+2. Running CS and backend pods have the pool `clientId` / `principalId`.
+   Desired deploy spec can lie if an old ReplicaSet is still Ready.
+3. Mounted mock cert fingerprint on **every** CS replica matches the Key
+   Vault certificate named in the catalog (`az keyvault certificate show
+   --vault-name aro-hcp-dev-svc-kv --name <certName>`), not mock2
+   (`CN=msimock.hcp.osadev.cloud`). CSI binds at pod start: Helm can update
+   the SecretProviderClass in place, then the first new replica can still
+   mount the previous `objectName`. Recycle any replica whose cert does not
+   match.
+4. Backend is not crashlooping on an unknown flag.
+
+When finished, redeploy Cluster Service and backend **without** the pool
+`miMock*` overlay (fresh `STEP_CACHE_DIR` again) so pers is back on
+`aro-dev-msi-mock2`.
+
+## Tickets
+
+- Spike: [ARO-29287](https://issues.redhat.com/browse/ARO-29287)
+- CS delete vs strip: [ARO-29288](https://issues.redhat.com/browse/ARO-29288)
+- Productionize strip/restore + env export: [ARO-29290](https://issues.redhat.com/browse/ARO-29290)
+- Ungate in default DEV e2e: [ARO-29289](https://issues.redhat.com/browse/ARO-29289)

--- a/nonlocal-e2e-specs.txt
+++ b/nonlocal-e2e-specs.txt
@@ -10,6 +10,7 @@
   "creates and deletes a GPU nodepool in a single cluster",
   "should allow pods with images from allowed registries and have a valid allowlist",
   "should be able to create an HCP cluster then delete it by deleting the customer resource group",
+  "should be able to delete an HCP cluster after stripping DEV mock-MSI permissions",
   "should be able to delete an HCP cluster whose managed identities were deleted first",
   "should be able to forward control plane logs to a storage account and Event Hub via shoebox diagnostic settings",
   "should confirm the HCP cluster is deleted (not found)",

--- a/test/cmd/aro-hcp-tests/main.go
+++ b/test/cmd/aro-hcp-tests/main.go
@@ -511,7 +511,7 @@ func setupCli() *cobra.Command {
 
 	// The tests that a suite is composed of can be filtered by CEL expressions. By
 	// default, the qualifiers only apply to tests from this extension.
-	integrationQuery := fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.DevelopmentOnly[0], labels.StageAndProdOnly[0], labels.HypershiftPresubmit[0])
+	integrationQuery := fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.DevelopmentOnly[0], labels.StageAndProdOnly[0], labels.HypershiftPresubmit[0], labels.MockMSIACL[0])
 	integrationTestTimeout := 150 * time.Minute
 	ext.AddSuite(e.Suite{
 		Name: "integration/parallel",
@@ -537,7 +537,7 @@ func setupCli() *cobra.Command {
 		ResourcePools: miPools,
 	})
 
-	stageQuery := fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.IntegrationOnly[0], labels.DevelopmentOnly[0], labels.HypershiftPresubmit[0])
+	stageQuery := fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.IntegrationOnly[0], labels.DevelopmentOnly[0], labels.HypershiftPresubmit[0], labels.MockMSIACL[0])
 	stageTestTimeout := 150 * time.Minute
 	ext.AddSuite(e.Suite{
 		Name: "stage/parallel",
@@ -562,7 +562,7 @@ func setupCli() *cobra.Command {
 		ResourcePools: miPools,
 	})
 
-	prodQuery := fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.IntegrationOnly[0], labels.DevelopmentOnly[0], labels.HypershiftPresubmit[0])
+	prodQuery := fmt.Sprintf(`labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.RequireNothing[0], labels.IntegrationOnly[0], labels.DevelopmentOnly[0], labels.HypershiftPresubmit[0], labels.MockMSIACL[0])
 	prodTestTimeout := 150 * time.Minute
 	ext.AddSuite(e.Suite{
 		Name: "prod/parallel",
@@ -593,7 +593,7 @@ func setupCli() *cobra.Command {
 			// Subset of E2E tests to be executed as a final step during ARO
 			// HCP Continous Deployment GitHub Action Workflow.
 			// TODO: revisit labels to tweak which tests to select here
-			fmt.Sprintf(`labels.exists(l, l=="%s" ) && labels.exists(l, l=="%s")`, labels.AroRpApiCompatible[0], labels.Positive[0]),
+			fmt.Sprintf(`labels.exists(l, l=="%s" ) && labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, labels.AroRpApiCompatible[0], labels.Positive[0], labels.MockMSIACL[0]),
 		},
 		// Override at runtime via ARO_HCP_SUITE_PARALLELISM.
 		Parallelism:   parallelism(20),
@@ -603,9 +603,9 @@ func setupCli() *cobra.Command {
 	rpApiCompatBaseQualifier := fmt.Sprintf(`labels.exists(l, l=="%s")`, labels.AroRpApiCompatible[0])
 
 	if framework.IsDevelopmentEnvironment() {
-		rpApiCompatBaseQualifier = fmt.Sprintf(`%s || labels.exists(l, l=="%s")`, rpApiCompatBaseQualifier, labels.DevelopmentOnly[0])
+		rpApiCompatBaseQualifier = fmt.Sprintf(`(%s || labels.exists(l, l=="%s")) && !labels.exists(l, l=="%s")`, rpApiCompatBaseQualifier, labels.DevelopmentOnly[0], labels.MockMSIACL[0])
 	} else {
-		rpApiCompatBaseQualifier = fmt.Sprintf(`%s && !labels.exists(l, l=="%s")`, rpApiCompatBaseQualifier, labels.DevelopmentOnly[0])
+		rpApiCompatBaseQualifier = fmt.Sprintf(`%s && !labels.exists(l, l=="%s") && !labels.exists(l, l=="%s")`, rpApiCompatBaseQualifier, labels.DevelopmentOnly[0], labels.MockMSIACL[0])
 	}
 
 	rpApiCompatTestTimeout := 150 * time.Minute
@@ -636,6 +636,20 @@ func setupCli() *cobra.Command {
 		Parallelism:   parallelism(24),
 		TestTimeout:   &hypershiftPresubmitTimeout,
 		ResourcePools: miPools,
+	})
+
+	// development/mock-msi-acl owns the job-leased MSI mock SP exclusively so it
+	// can strip (then restore) subscription RBAC without racing sibling specs.
+	// Parallelism is the literal 1: ARO_HCP_SUITE_PARALLELISM must not raise it.
+	// Not wired into default DEV parallel CI; see docs/ci/mock-msi-acl-isolation.md.
+	mockMSIACLTimeout := 150 * time.Minute
+	ext.AddSuite(e.Suite{
+		Name: "development/mock-msi-acl",
+		Qualifiers: []string{
+			fmt.Sprintf(`labels.exists(l, l=="%s")`, labels.MockMSIACL[0]),
+		},
+		Parallelism: 1,
+		TestTimeout: &mockMSIACLTimeout,
 	})
 
 	// upgrade/in-place runs UpgradeInPlace specs in parallel. Each spec provisions

--- a/test/cmd/aro-hcp-tests/main_test.go
+++ b/test/cmd/aro-hcp-tests/main_test.go
@@ -297,6 +297,7 @@ func TestMainListSuitesForEachSuite(t *testing.T) {
 		{suite: "rp-api-compat-all/parallel", suffix: "rp-api-compat-all-parallel"},
 		{suite: "rp-api-compat-all/parallel", suffix: "rp-api-compat-all-parallel-development", setDevelopmentEnv: true},
 		{suite: "hypershift-presubmit/parallel", suffix: "hypershift-presubmit-parallel"},
+		{suite: "development/mock-msi-acl", suffix: "development-mock-msi-acl"},
 		{suite: "upgrade/in-place", suffix: "upgrade-in-place"},
 	}
 

--- a/test/e2e/cluster_delete_missing_identities_dev_mock_msi.go
+++ b/test/e2e/cluster_delete_missing_identities_dev_mock_msi.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+	"github.com/Azure/ARO-HCP/test/util/verifiers"
+)
+
+// DEV prototype for ARO-29287. The STG/PROD spec in
+// cluster_delete_missing_identities.go stays StageAndProdOnly: deleting
+// customer UAMIs is the real signal there, and it is vacuous in DEV because
+// every operator authenticates as the job-leased mock SP.
+//
+// This spec is selected only by suite development/mock-msi-acl (Parallelism 1)
+// so it can strip that mock SP without racing sibling specs. See
+// docs/ci/mock-msi-acl-isolation.md.
+var _ = Describe("Customer", func() {
+	It("should be able to delete an HCP cluster after stripping DEV mock-MSI permissions",
+		labels.RequireNothing,
+		labels.High,
+		labels.Positive,
+		labels.MockMSIACL,
+		labels.MIContainers(0),
+		func(ctx context.Context) {
+			const customerClusterName = "missing-mi-hcp-cluster"
+			tc := framework.NewTestContext()
+
+			By("resolving the leased mock-MSI principal from env (must match the RP Helm miMockPrincipalId this process was provisioned with)")
+			_, err := framework.ResolveLeasedMockMSIPrincipalID()
+			Expect(err).NotTo(HaveOccurred(), "failed to resolve leased mock-MSI principal; set %s to the Boskos key this RP was provisioned with, or %s to that key's principalId", framework.LeasedMSIMockSPEnvvar, framework.MSIMockPrincipalIDEnvvar)
+
+			By("creating the customer resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "delete-mi-rg", tc.Location())
+			Expect(err).NotTo(HaveOccurred(), "failed to create customer resource group")
+
+			clusterParams := framework.NewDefaultClusterParams20240610()
+			clusterParams.ClusterName = customerClusterName
+			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+			clusterParams.ManagedResourceGroupName = managedResourceGroupName
+
+			By("deploying customer infrastructure (NSG, VNet, subnet, KeyVault)")
+			customerInfraResult, err := tc.CreateBicepTemplateAndWait(ctx,
+				framework.WithTemplateFromFS(TestArtifactsFS, "test-artifacts/generated-test-artifacts/modules/customer-infra.json"),
+				framework.WithDeploymentName("customer-infra-"+customerClusterName),
+				framework.WithScope(framework.BicepDeploymentScopeResourceGroup),
+				framework.WithClusterResourceGroup(*resourceGroup.Name),
+				framework.WithParameters(map[string]interface{}{
+					"clusterName": customerClusterName,
+				}),
+				framework.WithTimeout(45*time.Minute),
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to deploy customer infrastructure")
+			clusterParams, err = framework.PopulateClusterParamsFromCustomerInfraDeployment20240610(clusterParams, customerInfraResult)
+			Expect(err).NotTo(HaveOccurred(), "failed to populate cluster params from customer infra deployment")
+
+			// Dedicated identities (useMsiPool=false) so UAMI delete cannot corrupt
+			// the shared identity-container pool. ARO-29288 may later drop the UAMI
+			// delete; mock-SP strip is what makes the DEV signal non-vacuous.
+			By("deploying dedicated managed identities in the customer resource group")
+			identities := framework.NewDefaultIdentitiesWithSuffix(customerClusterName)
+			managedIdentitiesResult, err := tc.CreateBicepTemplateAndWait(ctx,
+				framework.WithTemplateFromFS(TestArtifactsFS, "test-artifacts/generated-test-artifacts/modules/managed-identities.json"),
+				framework.WithDeploymentName(fmt.Sprintf("mi-%s-%s", customerClusterName, rand.String(6))),
+				framework.WithScope(framework.BicepDeploymentScopeSubscription),
+				framework.WithLocation(tc.Location()),
+				framework.WithParameters(map[string]interface{}{
+					"useMsiPool":               false,
+					"clusterResourceGroupName": *resourceGroup.Name,
+					"msiResourceGroupName":     *resourceGroup.Name,
+					"identities":               identities,
+					"rbacScope":                framework.RBACScopeResourceGroup,
+					"nsgName":                  clusterParams.NsgName,
+					"vnetName":                 clusterParams.VnetName,
+					"subnetName":               clusterParams.SubnetName,
+					"keyVaultName":             clusterParams.KeyVaultName,
+					"clusterName":              customerClusterName,
+				}),
+				framework.WithTimeout(45*time.Minute),
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to deploy dedicated managed identities")
+			clusterParams, err = framework.PopulateClusterParamsFromManagedIdentitiesDeployment20240610(clusterParams, managedIdentitiesResult)
+			Expect(err).NotTo(HaveOccurred(), "failed to populate cluster params from managed identities deployment")
+
+			By("creating the HCP cluster")
+			err = tc.CreateHCPClusterFromParam20240610(
+				ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				framework.ClusterCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q", customerClusterName)
+
+			hcpClient := tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()
+
+			By("ensuring the cluster is viable before stripping mock-MSI permissions")
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
+				ctx,
+				hcpClient,
+				*resourceGroup.Name,
+				customerClusterName,
+				framework.GetAdminRESTConfigTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for cluster %q", customerClusterName)
+			err = verifiers.VerifyHCPCluster(ctx, adminRESTConfig)
+			Expect(err).NotTo(HaveOccurred(), "failed to verify HCP cluster %q is viable", customerClusterName)
+
+			By("listing subscription permissions on the leased DEV mock MSI")
+			snapshots, err := tc.ListLeasedMockMSIPermissions(ctx)
+			Expect(err).NotTo(HaveOccurred(), "failed to list leased mock-MSI permissions")
+			Expect(len(snapshots)).To(BeNumerically(">=", 2), "expected at least the custom dev-msi-mock role and Key Vault Crypto User assignments")
+			DeferCleanup(func(ctx context.Context) {
+				Expect(tc.RestoreMockMSIPermissions(ctx, snapshots)).NotTo(HaveOccurred(), "failed to restore leased mock-MSI permissions")
+			})
+
+			By("stripping subscription permissions on the leased DEV mock MSI")
+			err = tc.DeleteMockMSIRoleAssignments(ctx, snapshots)
+			Expect(err).NotTo(HaveOccurred(), "failed to strip leased mock-MSI permissions")
+
+			By("deleting all of the cluster's managed identities behind the scenes")
+			err = tc.DeleteUserAssignedIdentities(ctx, *resourceGroup.Name, identities.ToSlice())
+			Expect(err).NotTo(HaveOccurred(), "failed to delete managed identities for cluster %q", customerClusterName)
+
+			By("deleting the HCP cluster")
+			err = framework.DeleteHCPCluster20240610(
+				ctx,
+				hcpClient,
+				*resourceGroup.Name,
+				customerClusterName,
+				framework.HCPClusterDeletionTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to delete HCP cluster %q after stripping mock-MSI permissions", customerClusterName)
+
+			By("verifying the cluster resource is deleted (Not Found)")
+			_, err = hcpClient.Get(ctx, *resourceGroup.Name, customerClusterName, nil)
+			Expect(err).To(HaveOccurred(), "expected an error when getting deleted cluster %q", customerClusterName)
+			var respErr *azcore.ResponseError
+			Expect(errors.As(err, &respErr)).To(BeTrue(), "expected azcore.ResponseError when getting deleted cluster %q, got %v", customerClusterName, err)
+			Expect(respErr.StatusCode).To(Equal(http.StatusNotFound), "expected HTTP 404 when getting deleted cluster %q", customerClusterName)
+
+			By("verifying the managed resource group is deleted (404)")
+			rgClient := tc.GetARMResourcesClientFactoryOrDie(ctx).NewResourceGroupsClient()
+			lastObserved := ""
+			logObservedDelta := func(observed string) {
+				if observed == lastObserved {
+					return
+				}
+				lastObserved = observed
+				GinkgoLogr.Info("waiting for managed resource group deletion",
+					"resourceGroup", managedResourceGroupName, "expected", "HTTP 404", "observed", observed)
+			}
+			Eventually(func() error {
+				_, err := rgClient.Get(ctx, managedResourceGroupName, nil)
+				if err == nil {
+					logObservedDelta("resource group still exists")
+					return fmt.Errorf("managed resource group %q still exists", managedResourceGroupName)
+				}
+				var respErr *azcore.ResponseError
+				if errors.As(err, &respErr) {
+					if respErr.StatusCode == http.StatusNotFound {
+						return nil
+					}
+					logObservedDelta(fmt.Sprintf("HTTP %d (%s)", respErr.StatusCode, respErr.ErrorCode))
+				} else {
+					logObservedDelta(fmt.Sprintf("non-HTTP error: %v", err))
+				}
+				return fmt.Errorf("unexpected error getting managed resource group %q: %w", managedResourceGroupName, err)
+			}, 15*time.Minute, 30*time.Second).Should(Succeed(), "expected managed resource group %q to be deleted", managedResourceGroupName)
+		})
+})

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_development_mock_msi_acldevelopment_mock_msi_acl.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_development_mock_msi_acldevelopment_mock_msi_acl.txt
@@ -1,0 +1,1 @@
+Customer should be able to delete an HCP cluster after stripping DEV mock-MSI permissions

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -83,13 +83,11 @@ Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
 Image Registry Policy should deny pods with images from disallowed registries
 Image Registry Policy should allow pods with images from allowed registries and have a valid allowlist
-Customer should be able to rotate KMS key for a cluster with version >= 4.22
 Engineering should be able to retrieve kusto logs for a cluster and services
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
 Customer should respect cluster-wide node limits with nodepool autoscaling
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
-Customer should be able to update nodepool replicas and autoscaling
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.21.z to 4.21.zLatest
 Customer should upgrade and update a nodepool from 4.20.z to 4.20.zLatest

--- a/test/util/framework/mock_msi_permissions.go
+++ b/test/util/framework/mock_msi_permissions.go
@@ -1,0 +1,570 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	armauthorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"
+)
+
+const (
+	// LeasedMSIMockSPEnvvar is the Boskos key for the job's MSI mock SP
+	// (for example aro-hcp-msi-mock-cs-sp-dev-0). Provisioning already consumes
+	// this to override backend/CS Helm values; the DEV missing-identity spec
+	// needs the same value (or ARO_HCP_MSI_MOCK_PRINCIPAL_ID) in the test process.
+	LeasedMSIMockSPEnvvar = "LEASED_MSI_MOCK_SP"
+
+	// MSIMockPrincipalIDEnvvar is an explicit principal-id override. It must
+	// still resolve to a pooled mock SP; the shared personal-dev identity is
+	// rejected. If LEASED_MSI_MOCK_SP is also set, both must resolve to the
+	// same principal (ARO-29290 provision export).
+	MSIMockPrincipalIDEnvvar = "ARO_HCP_MSI_MOCK_PRINCIPAL_ID"
+
+	// MSIMockPoolCatalogEnvvar overrides the path to msi-mock-pool.yaml.
+	MSIMockPoolCatalogEnvvar = "ARO_HCP_MSI_MOCK_POOL_CATALOG"
+
+	// keyVaultCryptoUserRoleDefinitionGUID is the built-in Key Vault Crypto
+	// User role granted to every MSI mock principal
+	// (dev-infrastructure/templates/e2e-subscription-rbac-assignment-subscription.bicep).
+	keyVaultCryptoUserRoleDefinitionGUID = "12338af0-0e69-4776-bea7-57ae8d297424"
+
+	// sharedMockMSIPrincipalID is aro-dev-msi-mock2 (config.yaml miMockPrincipalId).
+	// Stripping it would take down personal-dev and any job that did not lease a
+	// pool member. The strip helper refuses this principal.
+	sharedMockMSIPrincipalID = "d6b62dfa-87f5-49b3-bbcb-4a687c4faa96"
+
+	msiMockRoleNamePrefix     = "dev-msi-mock"
+	msiMockPoolCatalogRelPath = "dev-infrastructure/openshift-ci/msi-mock-pool.yaml"
+)
+
+var (
+	// ErrSharedMockMSIPrincipal is returned when the resolved principal is the
+	// shared personal-dev / default CI mock SP.
+	ErrSharedMockMSIPrincipal = errors.New("refusing to strip permissions on the shared personal-dev MSI mock principal aro-dev-msi-mock2")
+
+	// ErrMockMSIPrincipalUnresolved is returned when neither a lease name nor an
+	// explicit principal id is available to the test process.
+	ErrMockMSIPrincipalUnresolved = errors.New("could not resolve a leased MSI mock principal; set " + LeasedMSIMockSPEnvvar + " or " + MSIMockPrincipalIDEnvvar)
+
+	// ErrMockMSIPrincipalNotPooled is returned when the resolved principal is not
+	// in msi-mock-pool.yaml.
+	ErrMockMSIPrincipalNotPooled = errors.New("resolved MSI mock principal is not a pooled mock SP; refusing to strip")
+
+	// ErrMockMSIPrincipalMismatch is returned when both a Boskos lease and an
+	// explicit principal id are set and they do not resolve to the same SP.
+	ErrMockMSIPrincipalMismatch = errors.New(LeasedMSIMockSPEnvvar + " and " + MSIMockPrincipalIDEnvvar + " resolve to different principals")
+)
+
+// MockMSIRoleAssignmentSnapshot is one subscription-scoped role assignment that
+// was deleted so it can be recreated with the same assignment GUID. Keeping the
+// GUID matches Bicep's guid(subscription().id, principalId, roleDefinitionId)
+// so a later mock-identity-rbac apply is a no-op once restore succeeds.
+type MockMSIRoleAssignmentSnapshot struct {
+	AssignmentID     string
+	Name             string
+	Scope            string
+	PrincipalID      string
+	RoleDefinitionID string
+	PrincipalType    armauthorization.PrincipalType
+}
+
+type msiMockPoolCatalogFile struct {
+	MIMockPool map[string]msiMockPoolEntry `json:"miMockPool"`
+}
+
+type msiMockPoolEntry struct {
+	ClientID    string `json:"clientId"`
+	PrincipalID string `json:"principalId"`
+	CertName    string `json:"certName"`
+}
+
+// ResolveLeasedMockMSIPrincipalID returns the object id of the MSI mock SP this
+// job's backend is impersonating. When LEASED_MSI_MOCK_SP is set, that lease is
+// the source of truth. An explicit ARO_HCP_MSI_MOCK_PRINCIPAL_ID must match the
+// lease when both are set. It never returns the shared aro-dev-msi-mock2
+// principal.
+func ResolveLeasedMockMSIPrincipalID() (string, error) {
+	catalog, err := loadMSIMockPoolCatalog()
+	if err != nil {
+		return "", err
+	}
+	return resolveLeasedMockMSIPrincipalID(os.Getenv(MSIMockPrincipalIDEnvvar), os.Getenv(LeasedMSIMockSPEnvvar), catalog)
+}
+
+func resolveLeasedMockMSIPrincipalID(explicitPrincipalID, leasedSP string, catalog msiMockPoolCatalogFile) (string, error) {
+	pooled := pooledPrincipalIDs(catalog)
+	explicitPrincipalID = strings.TrimSpace(explicitPrincipalID)
+	leasedSP = strings.TrimSpace(leasedSP)
+
+	var leasedPrincipal string
+	if leasedSP != "" {
+		entry, ok := catalog.MIMockPool[leasedSP]
+		if !ok || strings.TrimSpace(entry.PrincipalID) == "" {
+			return "", fmt.Errorf("%w: lease %q not in MSI mock pool catalog", ErrMockMSIPrincipalUnresolved, leasedSP)
+		}
+		leasedPrincipal = strings.TrimSpace(entry.PrincipalID)
+		if strings.EqualFold(leasedPrincipal, sharedMockMSIPrincipalID) {
+			return "", ErrSharedMockMSIPrincipal
+		}
+	}
+
+	if explicitPrincipalID != "" {
+		if strings.EqualFold(explicitPrincipalID, sharedMockMSIPrincipalID) {
+			return "", ErrSharedMockMSIPrincipal
+		}
+		if !pooled[strings.ToLower(explicitPrincipalID)] {
+			return "", fmt.Errorf("%w: %s", ErrMockMSIPrincipalNotPooled, explicitPrincipalID)
+		}
+		if leasedPrincipal != "" && !strings.EqualFold(explicitPrincipalID, leasedPrincipal) {
+			return "", fmt.Errorf("%w: %s=%s resolved to %s, %s=%s", ErrMockMSIPrincipalMismatch, LeasedMSIMockSPEnvvar, leasedSP, leasedPrincipal, MSIMockPrincipalIDEnvvar, explicitPrincipalID)
+		}
+		return explicitPrincipalID, nil
+	}
+
+	if leasedPrincipal != "" {
+		return leasedPrincipal, nil
+	}
+	return "", ErrMockMSIPrincipalUnresolved
+}
+
+func pooledPrincipalIDs(catalog msiMockPoolCatalogFile) map[string]bool {
+	out := make(map[string]bool, len(catalog.MIMockPool))
+	for _, entry := range catalog.MIMockPool {
+		if entry.PrincipalID == "" {
+			continue
+		}
+		out[strings.ToLower(entry.PrincipalID)] = true
+	}
+	return out
+}
+
+func loadMSIMockPoolCatalog() (msiMockPoolCatalogFile, error) {
+	path, err := msiMockPoolCatalogPath()
+	if err != nil {
+		return msiMockPoolCatalogFile{}, err
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return msiMockPoolCatalogFile{}, fmt.Errorf("failed to read MSI mock pool catalog %s: %w", path, err)
+	}
+	var catalog msiMockPoolCatalogFile
+	if err := yaml.Unmarshal(raw, &catalog); err != nil {
+		return msiMockPoolCatalogFile{}, fmt.Errorf("failed to parse MSI mock pool catalog %s: %w", path, err)
+	}
+	return catalog, nil
+}
+
+func msiMockPoolCatalogPath() (string, error) {
+	if explicit := strings.TrimSpace(os.Getenv(MSIMockPoolCatalogEnvvar)); explicit != "" {
+		return explicit, nil
+	}
+	if root, err := repoRoot(); err == nil {
+		candidate := filepath.Join(root, msiMockPoolCatalogRelPath)
+		if _, statErr := os.Stat(candidate); statErr == nil {
+			return candidate, nil
+		}
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve MSI mock pool catalog: %w", err)
+	}
+	dir := cwd
+	for {
+		candidate := filepath.Join(dir, msiMockPoolCatalogRelPath)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("failed to find %s from %s; set %s", msiMockPoolCatalogRelPath, cwd, MSIMockPoolCatalogEnvvar)
+		}
+		dir = parent
+	}
+}
+
+// isStrippableMockMSIRole reports whether a subscription-scoped assignment is
+// one of the two grants that make the mock SP a stand-in for every operator.
+func isStrippableMockMSIRole(roleDefinitionID, roleDefinitionName string) bool {
+	if strings.Contains(strings.ToLower(roleDefinitionID), keyVaultCryptoUserRoleDefinitionGUID) {
+		return true
+	}
+	return strings.HasPrefix(strings.ToLower(roleDefinitionName), msiMockRoleNamePrefix)
+}
+
+func roleAssignmentNameFromID(assignmentID string) string {
+	assignmentID = strings.TrimSuffix(assignmentID, "/")
+	i := strings.LastIndex(assignmentID, "/")
+	if i < 0 || i+1 >= len(assignmentID) {
+		return ""
+	}
+	return assignmentID[i+1:]
+}
+
+const (
+	roleAssignmentExistsErrorCode = "RoleAssignmentExists"
+	mockMSIRestoreCreateAttempts  = 5
+	mockMSIRestoreRetryDelay      = 2 * time.Second
+)
+
+type restoreCreateResult int
+
+const (
+	restoreCreateOK restoreCreateResult = iota
+	restoreCreateRetryTombstone
+	restoreCreateFailed
+)
+
+func isRoleAssignmentExistsError(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.ErrorCode == roleAssignmentExistsErrorCode
+}
+
+func isRoleAssignmentNotFoundError(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
+}
+
+// interpretRestoreCreate classifies a Role Assignments Create error.
+// Only ARM ErrorCode RoleAssignmentExists is success; a generic HTTP 409
+// (including ErrorCode Conflict) is a tombstone that must be GET-verified
+// and retried, not swallowed.
+func interpretRestoreCreate(err error) restoreCreateResult {
+	if err == nil || isRoleAssignmentExistsError(err) {
+		return restoreCreateOK
+	}
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) && respErr.StatusCode == http.StatusConflict {
+		return restoreCreateRetryTombstone
+	}
+	return restoreCreateFailed
+}
+
+func restoreOneAssignmentWithWait(ctx context.Context, snapshot MockMSIRoleAssignmentSnapshot, create, get func() error, wait func(time.Duration)) error {
+	var lastErr error
+	for attempt := 1; attempt <= mockMSIRestoreCreateAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		lastErr = create()
+		switch interpretRestoreCreate(lastErr) {
+		case restoreCreateOK:
+			return nil
+		case restoreCreateFailed:
+			return fmt.Errorf("failed to restore mock-MSI role assignment %s: %w", snapshot.AssignmentID, lastErr)
+		case restoreCreateRetryTombstone:
+			getErr := get()
+			if getErr == nil {
+				return nil
+			}
+			if !isRoleAssignmentNotFoundError(getErr) {
+				return fmt.Errorf("failed to restore mock-MSI role assignment %s: create conflicted (%w) and GET failed: %v", snapshot.AssignmentID, lastErr, getErr)
+			}
+			if attempt == mockMSIRestoreCreateAttempts {
+				return fmt.Errorf("failed to restore mock-MSI role assignment %s: still missing after %d creates (%w)", snapshot.AssignmentID, mockMSIRestoreCreateAttempts, lastErr)
+			}
+			wait(mockMSIRestoreRetryDelay)
+		}
+	}
+	return fmt.Errorf("failed to restore mock-MSI role assignment %s: %w", snapshot.AssignmentID, lastErr)
+}
+
+func errIfNoStrippableMockMSIAssignments(snapshots []MockMSIRoleAssignmentSnapshot, principalID, subscriptionScope string) error {
+	if len(snapshots) == 0 {
+		return fmt.Errorf("no strippable mock-MSI role assignments found for principal %s at %s; strip would be a no-op", principalID, subscriptionScope)
+	}
+	return nil
+}
+
+func snapshotIfStrippableMockMSIAssignment(
+	ra *armauthorization.RoleAssignment,
+	subscriptionScope string,
+	expectedPrincipalID string,
+	roleNamesByID map[string]string,
+) (MockMSIRoleAssignmentSnapshot, bool, error) {
+	if ra == nil || ra.ID == nil || ra.Properties == nil || ra.Properties.RoleDefinitionID == nil || ra.Properties.Scope == nil {
+		return MockMSIRoleAssignmentSnapshot{}, false, nil
+	}
+	if !strings.EqualFold(*ra.Properties.Scope, subscriptionScope) {
+		return MockMSIRoleAssignmentSnapshot{}, false, nil
+	}
+	principalID := expectedPrincipalID
+	if ra.Properties.PrincipalID != nil && *ra.Properties.PrincipalID != "" {
+		if !strings.EqualFold(*ra.Properties.PrincipalID, expectedPrincipalID) {
+			return MockMSIRoleAssignmentSnapshot{}, false, nil
+		}
+		principalID = *ra.Properties.PrincipalID
+	}
+	roleName := roleNamesByID[strings.ToLower(*ra.Properties.RoleDefinitionID)]
+	if !isStrippableMockMSIRole(*ra.Properties.RoleDefinitionID, roleName) {
+		return MockMSIRoleAssignmentSnapshot{}, false, nil
+	}
+	name := roleAssignmentNameFromID(*ra.ID)
+	if name == "" {
+		return MockMSIRoleAssignmentSnapshot{}, false, fmt.Errorf("mock-MSI role assignment %s has no assignment name", *ra.ID)
+	}
+	principalType := armauthorization.PrincipalTypeServicePrincipal
+	if ra.Properties.PrincipalType != nil {
+		principalType = *ra.Properties.PrincipalType
+	}
+	return MockMSIRoleAssignmentSnapshot{
+		AssignmentID:     *ra.ID,
+		Name:             name,
+		Scope:            *ra.Properties.Scope,
+		PrincipalID:      principalID,
+		RoleDefinitionID: *ra.Properties.RoleDefinitionID,
+		PrincipalType:    principalType,
+	}, true, nil
+}
+
+func (tc *perItOrDescribeTestContext) mockMSIRoleAssignmentClients(ctx context.Context) (*armauthorization.RoleAssignmentsClient, *armauthorization.RoleDefinitionsClient, string, error) {
+	creds, err := tc.perBinaryInvocationTestContext.getAzureCredentials()
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("failed to get Azure credentials: %w", err)
+	}
+	subscriptionID, err := tc.getSubscriptionIDUnlocked(ctx)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("failed to get subscription ID: %w", err)
+	}
+	roleAssignmentsClient, err := armauthorization.NewRoleAssignmentsClient(subscriptionID, creds, nil)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("failed to create role assignments client: %w", err)
+	}
+	roleDefsClient, err := armauthorization.NewRoleDefinitionsClient(creds, nil)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("failed to create role definitions client: %w", err)
+	}
+	return roleAssignmentsClient, roleDefsClient, subscriptionID, nil
+}
+
+// ListLeasedMockMSIPermissions lists the subscription-scoped mock-MSI grants
+// that StripLeasedMockMSIPermissions would delete. Callers should register
+// RestoreMockMSIPermissions (DeferCleanup) after a successful list and before
+// any DeleteByID.
+func (tc *perItOrDescribeTestContext) ListLeasedMockMSIPermissions(ctx context.Context) ([]MockMSIRoleAssignmentSnapshot, error) {
+	startTime := time.Now()
+	defer func() {
+		tc.RecordTestStep("List leased mock-MSI permissions", startTime, time.Now())
+	}()
+
+	principalID, err := ResolveLeasedMockMSIPrincipalID()
+	if err != nil {
+		return nil, err
+	}
+
+	roleAssignmentsClient, roleDefsClient, subscriptionID, err := tc.mockMSIRoleAssignmentClients(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	subscriptionScope := fmt.Sprintf("/subscriptions/%s", subscriptionID)
+	roleNamesByID, err := customRoleNamesByID(ctx, roleDefsClient, subscriptionScope)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshots, err := listStrippableMockMSIAssignments(ctx, roleAssignmentsClient, subscriptionScope, principalID, roleNamesByID)
+	if err != nil {
+		return nil, err
+	}
+	if err := errIfNoStrippableMockMSIAssignments(snapshots, principalID, subscriptionScope); err != nil {
+		return nil, err
+	}
+	return snapshots, nil
+}
+
+// DeleteMockMSIRoleAssignments deletes previously listed mock-MSI grants.
+func (tc *perItOrDescribeTestContext) DeleteMockMSIRoleAssignments(ctx context.Context, snapshots []MockMSIRoleAssignmentSnapshot) error {
+	startTime := time.Now()
+	defer func() {
+		tc.RecordTestStep(fmt.Sprintf("Delete %d leased mock-MSI role assignments", len(snapshots)), startTime, time.Now())
+	}()
+
+	roleAssignmentsClient, _, _, err := tc.mockMSIRoleAssignmentClients(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, snapshot := range snapshots {
+		ginkgo.GinkgoLogr.Info("stripping leased mock-MSI role assignment",
+			"assignmentID", snapshot.AssignmentID,
+			"principalID", snapshot.PrincipalID,
+			"roleDefinitionID", snapshot.RoleDefinitionID)
+		_, err := roleAssignmentsClient.DeleteByID(ctx, snapshot.AssignmentID, nil)
+		if err != nil {
+			if isRoleAssignmentNotFoundError(err) {
+				continue
+			}
+			return fmt.Errorf("failed to delete mock-MSI role assignment %s: %w", snapshot.AssignmentID, err)
+		}
+	}
+	return nil
+}
+
+// StripLeasedMockMSIPermissions deletes the subscription-scoped mock-MSI grants
+// for this job's leased pool SP so cluster operations fail ACL checks the way
+// they do in STG/PROD after customer UAMIs are gone. On a partial delete it
+// restores already-removed assignments before returning. Callers that need to
+// keep the grants stripped across later steps should List, register
+// DeferCleanup restore, then Delete.
+func (tc *perItOrDescribeTestContext) StripLeasedMockMSIPermissions(ctx context.Context) ([]MockMSIRoleAssignmentSnapshot, error) {
+	startTime := time.Now()
+	defer func() {
+		tc.RecordTestStep("Strip leased mock-MSI permissions", startTime, time.Now())
+	}()
+
+	snapshots, err := tc.ListLeasedMockMSIPermissions(ctx)
+	if err != nil {
+		return snapshots, err
+	}
+	if err := tc.DeleteMockMSIRoleAssignments(ctx, snapshots); err != nil {
+		restoreErr := tc.RestoreMockMSIPermissions(ctx, snapshots)
+		return snapshots, errors.Join(err, restoreErr)
+	}
+	return snapshots, nil
+}
+
+func customRoleNamesByID(ctx context.Context, roleDefsClient *armauthorization.RoleDefinitionsClient, scope string) (map[string]string, error) {
+	names := make(map[string]string)
+	filter := "type eq 'CustomRole'"
+	pager := roleDefsClient.NewListPager(scope, &armauthorization.RoleDefinitionsClientListOptions{
+		Filter: &filter,
+	})
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list custom role definitions: %w", err)
+		}
+		for _, roleDef := range page.Value {
+			if roleDef == nil || roleDef.ID == nil || roleDef.Properties == nil || roleDef.Properties.RoleName == nil {
+				continue
+			}
+			names[strings.ToLower(*roleDef.ID)] = *roleDef.Properties.RoleName
+		}
+	}
+	return names, nil
+}
+
+// mockMSIRoleAssignmentListFilter is the ARM $filter for listing this
+// principal's assignments. Do not use `principalId eq '{id}'`: the
+// authorization RP returns 400 UnsupportedQuery ("The filter 'principalId' is
+// not supported") for that form when sent by the Go SDK. assignedTo() is the
+// filter identities_helper uses. snapshotIfStrippableMockMSIAssignment still
+// drops assignments whose Properties.PrincipalID does not match.
+func mockMSIRoleAssignmentListFilter(principalID string) string {
+	return fmt.Sprintf("assignedTo('%s')", principalID)
+}
+
+func listStrippableMockMSIAssignments(
+	ctx context.Context,
+	roleAssignmentsClient *armauthorization.RoleAssignmentsClient,
+	subscriptionScope string,
+	principalID string,
+	roleNamesByID map[string]string,
+) ([]MockMSIRoleAssignmentSnapshot, error) {
+	filter := mockMSIRoleAssignmentListFilter(principalID)
+	pager := roleAssignmentsClient.NewListForScopePager(subscriptionScope, &armauthorization.RoleAssignmentsClientListForScopeOptions{
+		Filter: &filter,
+	})
+
+	var snapshots []MockMSIRoleAssignmentSnapshot
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list role assignments for mock-MSI principal %s: %w", principalID, err)
+		}
+		for _, ra := range page.Value {
+			snapshot, ok, err := snapshotIfStrippableMockMSIAssignment(ra, subscriptionScope, principalID, roleNamesByID)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				snapshots = append(snapshots, snapshot)
+			}
+		}
+	}
+	return snapshots, nil
+}
+
+// RestoreMockMSIPermissions recreates previously stripped mock-MSI role
+// assignments. ARM ErrorCode RoleAssignmentExists is treated as success so
+// restore is idempotent if DeferCleanup races a privileged rbac re-apply.
+// A generic HTTP 409 is GET-verified and retried: Create is retried when GET
+// returns 404 (tombstone), not swallowed as success.
+func (tc *perItOrDescribeTestContext) RestoreMockMSIPermissions(ctx context.Context, snapshots []MockMSIRoleAssignmentSnapshot) error {
+	startTime := time.Now()
+	defer func() {
+		tc.RecordTestStep(fmt.Sprintf("Restore %d leased mock-MSI role assignments", len(snapshots)), startTime, time.Now())
+	}()
+
+	if len(snapshots) == 0 {
+		return nil
+	}
+
+	roleAssignmentsClient, _, _, err := tc.mockMSIRoleAssignmentClients(ctx)
+	if err != nil {
+		return err
+	}
+
+	wait := func(d time.Duration) {
+		timer := time.NewTimer(d)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+		case <-timer.C:
+		}
+	}
+
+	var errs []error
+	for _, snapshot := range snapshots {
+		ginkgo.GinkgoLogr.Info("restoring leased mock-MSI role assignment",
+			"assignmentID", snapshot.AssignmentID,
+			"principalID", snapshot.PrincipalID)
+		params := armauthorization.RoleAssignmentCreateParameters{
+			Properties: &armauthorization.RoleAssignmentProperties{
+				PrincipalID:      &snapshot.PrincipalID,
+				RoleDefinitionID: &snapshot.RoleDefinitionID,
+				PrincipalType:    &snapshot.PrincipalType,
+			},
+		}
+		create := func() error {
+			_, err := roleAssignmentsClient.Create(ctx, snapshot.Scope, snapshot.Name, params, nil)
+			return err
+		}
+		get := func() error {
+			_, err := roleAssignmentsClient.GetByID(ctx, snapshot.AssignmentID, nil)
+			return err
+		}
+		if err := restoreOneAssignmentWithWait(ctx, snapshot, create, get, wait); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}

--- a/test/util/framework/mock_msi_permissions_test.go
+++ b/test/util/framework/mock_msi_permissions_test.go
@@ -1,0 +1,445 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	armauthorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"
+)
+
+func TestResolveLeasedMockMSIPrincipalID(t *testing.T) {
+	t.Parallel()
+
+	const (
+		jobALease     = "aro-hcp-msi-mock-cs-sp-dev-0"
+		jobAPrincipal = "db27175c-5bd0-48b4-929a-41de9a53ffbf"
+		jobBLease     = "aro-hcp-msi-mock-cs-sp-dev-1"
+		jobBPrincipal = "cd39c606-1f6a-4062-a5b9-497cd04c39fc"
+	)
+
+	catalog := msiMockPoolCatalogFile{
+		MIMockPool: map[string]msiMockPoolEntry{
+			jobALease: {PrincipalID: jobAPrincipal},
+			jobBLease: {PrincipalID: jobBPrincipal},
+		},
+	}
+
+	tests := []struct {
+		name                string
+		explicitPrincipalID string
+		leasedSP            string
+		wantPrincipal       string
+		wantErr             error
+	}{
+		{
+			name:          "lease name maps to pool principal",
+			leasedSP:      jobALease,
+			wantPrincipal: jobAPrincipal,
+		},
+		{
+			name:                "explicit pooled principal without a lease is accepted",
+			explicitPrincipalID: jobAPrincipal,
+			wantPrincipal:       jobAPrincipal,
+		},
+		{
+			name:                "explicit principal matching the lease is accepted",
+			explicitPrincipalID: jobAPrincipal,
+			leasedSP:            jobALease,
+			wantPrincipal:       jobAPrincipal,
+		},
+		{
+			name:                "job A lease plus stale job B explicit principal is refused",
+			explicitPrincipalID: jobBPrincipal,
+			leasedSP:            jobALease,
+			wantErr:             ErrMockMSIPrincipalMismatch,
+		},
+		{
+			name:    "missing lease and principal",
+			wantErr: ErrMockMSIPrincipalUnresolved,
+		},
+		{
+			name:     "unknown lease name",
+			leasedSP: "not-a-pool-member",
+			wantErr:  ErrMockMSIPrincipalUnresolved,
+		},
+		{
+			name:                "unknown lease is refused even when an explicit pooled principal is set",
+			explicitPrincipalID: jobBPrincipal,
+			leasedSP:            "not-a-pool-member",
+			wantErr:             ErrMockMSIPrincipalUnresolved,
+		},
+		{
+			name:                "shared personal-dev principal is refused",
+			explicitPrincipalID: sharedMockMSIPrincipalID,
+			wantErr:             ErrSharedMockMSIPrincipal,
+		},
+		{
+			name:                "non-pool principal is refused",
+			explicitPrincipalID: "22222222-2222-2222-2222-222222222222",
+			wantErr:             ErrMockMSIPrincipalNotPooled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveLeasedMockMSIPrincipalID(tt.explicitPrincipalID, tt.leasedSP, catalog)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantPrincipal {
+				t.Fatalf("principal = %q, want %q", got, tt.wantPrincipal)
+			}
+		})
+	}
+}
+
+func TestIsStrippableMockMSIRole(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		roleDefinitionID string
+		roleName         string
+		want             bool
+	}{
+		{
+			name:             "key vault crypto user by guid",
+			roleDefinitionID: "/subscriptions/sub/providers/Microsoft.Authorization/roleDefinitions/12338af0-0e69-4776-bea7-57ae8d297424",
+			want:             true,
+		},
+		{
+			name:             "suffixed custom mock role",
+			roleDefinitionID: "/subscriptions/sub/providers/Microsoft.Authorization/roleDefinitions/abcd",
+			roleName:         "dev-msi-mock-00000000-0000-0000-0000-000000000000",
+			want:             true,
+		},
+		{
+			name:             "contributor is left alone",
+			roleDefinitionID: "/subscriptions/sub/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+			roleName:         "Contributor",
+			want:             false,
+		},
+		{
+			name:             "e2e custom role prefix is left alone",
+			roleDefinitionID: "/subscriptions/sub/providers/Microsoft.Authorization/roleDefinitions/ffff",
+			roleName:         E2ECustomRolePrefix + "cluster-api-azure",
+			want:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isStrippableMockMSIRole(tt.roleDefinitionID, tt.roleName); got != tt.want {
+				t.Fatalf("isStrippableMockMSIRole() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMockMSIRoleAssignmentListFilter(t *testing.T) {
+	t.Parallel()
+
+	const principalID = "12eafc4e-f869-4b62-8198-816b7d6d0876"
+	got := mockMSIRoleAssignmentListFilter(principalID)
+	want := "assignedTo('12eafc4e-f869-4b62-8198-816b7d6d0876')"
+	if got != want {
+		t.Fatalf("filter = %q, want %q", got, want)
+	}
+	// ARM 400 UnsupportedQuery: "The filter 'principalId' is not supported"
+	// when the Go SDK sends principalId eq '{id}'.
+	if strings.Contains(got, "principalId") {
+		t.Fatalf("filter %q must not use principalId eq; ARM returns UnsupportedQuery", got)
+	}
+}
+
+func TestRoleAssignmentNameFromID(t *testing.T) {
+	t.Parallel()
+
+	got := roleAssignmentNameFromID("/subscriptions/sub/providers/Microsoft.Authorization/roleAssignments/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	if got != "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" {
+		t.Fatalf("name = %q", got)
+	}
+	if roleAssignmentNameFromID("") != "" {
+		t.Fatal("expected empty name for empty id")
+	}
+}
+
+func TestInterpretRestoreCreateDoesNotTreatGeneric409AsSuccess(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want restoreCreateResult
+	}{
+		{
+			name: "nil create error is success",
+			want: restoreCreateOK,
+		},
+		{
+			name: "RoleAssignmentExists is success",
+			err:  &azcore.ResponseError{StatusCode: http.StatusConflict, ErrorCode: roleAssignmentExistsErrorCode},
+			want: restoreCreateOK,
+		},
+		{
+			name: "HTTP 409 Conflict is a tombstone, not success",
+			err:  &azcore.ResponseError{StatusCode: http.StatusConflict, ErrorCode: "Conflict"},
+			want: restoreCreateRetryTombstone,
+		},
+		{
+			name: "HTTP 409 with empty ErrorCode is a tombstone, not success",
+			err:  &azcore.ResponseError{StatusCode: http.StatusConflict},
+			want: restoreCreateRetryTombstone,
+		},
+		{
+			name: "HTTP 500 is a hard failure",
+			err:  &azcore.ResponseError{StatusCode: http.StatusInternalServerError, ErrorCode: "InternalServerError"},
+			want: restoreCreateFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := interpretRestoreCreate(tt.err); got != tt.want {
+				t.Fatalf("interpretRestoreCreate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRestoreOneAssignmentDoesNotTreatGeneric409AsSuccess(t *testing.T) {
+	t.Parallel()
+
+	snapshot := MockMSIRoleAssignmentSnapshot{AssignmentID: "/subscriptions/sub/providers/Microsoft.Authorization/roleAssignments/aaaa"}
+	createErr := &azcore.ResponseError{StatusCode: http.StatusConflict, ErrorCode: "Conflict"}
+	getErr := &azcore.ResponseError{StatusCode: http.StatusNotFound, ErrorCode: "RoleAssignmentNotFound"}
+
+	err := restoreOneAssignmentWithWait(context.Background(), snapshot,
+		func() error { return createErr },
+		func() error { return getErr },
+		func(time.Duration) {},
+	)
+	if err == nil {
+		t.Fatal("generic HTTP 409 Conflict with GET 404 must not be treated as restore success")
+	}
+}
+
+func TestRestoreOneAssignmentRoleAssignmentExistsIsSuccess(t *testing.T) {
+	t.Parallel()
+
+	snapshot := MockMSIRoleAssignmentSnapshot{AssignmentID: "/subscriptions/sub/providers/Microsoft.Authorization/roleAssignments/aaaa"}
+	gets := 0
+	err := restoreOneAssignmentWithWait(context.Background(), snapshot,
+		func() error {
+			return &azcore.ResponseError{StatusCode: http.StatusConflict, ErrorCode: roleAssignmentExistsErrorCode}
+		},
+		func() error {
+			gets++
+			t.Fatal("GET must not run when Create returns RoleAssignmentExists")
+			return nil
+		},
+		func(time.Duration) {},
+	)
+	if err != nil {
+		t.Fatalf("RoleAssignmentExists must be restore success, got %v", err)
+	}
+	if gets != 0 {
+		t.Fatalf("GET ran %d times", gets)
+	}
+}
+
+func TestRestoreOneAssignmentRetriesWhenGETIs404ThenCreateSucceeds(t *testing.T) {
+	t.Parallel()
+
+	snapshot := MockMSIRoleAssignmentSnapshot{AssignmentID: "/subscriptions/sub/providers/Microsoft.Authorization/roleAssignments/aaaa"}
+	creates := 0
+	err := restoreOneAssignmentWithWait(context.Background(), snapshot,
+		func() error {
+			creates++
+			if creates == 1 {
+				return &azcore.ResponseError{StatusCode: http.StatusConflict, ErrorCode: "Conflict"}
+			}
+			return nil
+		},
+		func() error {
+			return &azcore.ResponseError{StatusCode: http.StatusNotFound, ErrorCode: "RoleAssignmentNotFound"}
+		},
+		func(time.Duration) {},
+	)
+	if err != nil {
+		t.Fatalf("tombstone 409 then successful Create must restore, got %v", err)
+	}
+	if creates != 2 {
+		t.Fatalf("creates = %d, want 2", creates)
+	}
+}
+
+func TestErrIfNoStrippableMockMSIAssignments(t *testing.T) {
+	t.Parallel()
+
+	if err := errIfNoStrippableMockMSIAssignments(nil, "principal", "/subscriptions/sub"); err == nil {
+		t.Fatal("empty snapshot list must fail closed")
+	}
+	snapshots := []MockMSIRoleAssignmentSnapshot{{AssignmentID: "id"}}
+	if err := errIfNoStrippableMockMSIAssignments(snapshots, "principal", "/subscriptions/sub"); err != nil {
+		t.Fatalf("non-empty list must succeed, got %v", err)
+	}
+}
+
+func TestSnapshotIfStrippableMockMSIAssignment(t *testing.T) {
+	t.Parallel()
+
+	const (
+		subscriptionScope = "/subscriptions/sub"
+		principalID       = "db27175c-5bd0-48b4-929a-41de9a53ffbf"
+		otherPrincipal    = "cd39c606-1f6a-4062-a5b9-497cd04c39fc"
+		kvRoleID          = "/subscriptions/sub/providers/Microsoft.Authorization/roleDefinitions/12338af0-0e69-4776-bea7-57ae8d297424"
+		customRoleID      = "/subscriptions/sub/providers/Microsoft.Authorization/roleDefinitions/abcd"
+		contributorRoleID = "/subscriptions/sub/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+		assignmentID      = "/subscriptions/sub/providers/Microsoft.Authorization/roleAssignments/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	)
+	roleNamesByID := map[string]string{
+		strings.ToLower(customRoleID):      "dev-msi-mock-00000000-0000-0000-0000-000000000000",
+		strings.ToLower(contributorRoleID): "Contributor",
+	}
+
+	tests := []struct {
+		name    string
+		ra      *armauthorization.RoleAssignment
+		wantOK  bool
+		wantErr bool
+		wantPID string
+	}{
+		{
+			name: "key vault crypto user at subscription scope",
+			ra: &armauthorization.RoleAssignment{
+				ID: to.Ptr(assignmentID),
+				Properties: &armauthorization.RoleAssignmentProperties{
+					Scope:            to.Ptr(subscriptionScope),
+					PrincipalID:      to.Ptr(principalID),
+					RoleDefinitionID: to.Ptr(kvRoleID),
+				},
+			},
+			wantOK:  true,
+			wantPID: principalID,
+		},
+		{
+			name: "custom mock role at subscription scope",
+			ra: &armauthorization.RoleAssignment{
+				ID: to.Ptr(assignmentID),
+				Properties: &armauthorization.RoleAssignmentProperties{
+					Scope:            to.Ptr(subscriptionScope),
+					PrincipalID:      to.Ptr(principalID),
+					RoleDefinitionID: to.Ptr(customRoleID),
+				},
+			},
+			wantOK:  true,
+			wantPID: principalID,
+		},
+		{
+			name: "contributor is skipped",
+			ra: &armauthorization.RoleAssignment{
+				ID: to.Ptr(assignmentID),
+				Properties: &armauthorization.RoleAssignmentProperties{
+					Scope:            to.Ptr(subscriptionScope),
+					PrincipalID:      to.Ptr(principalID),
+					RoleDefinitionID: to.Ptr(contributorRoleID),
+				},
+			},
+		},
+		{
+			name: "resource-group scope is skipped",
+			ra: &armauthorization.RoleAssignment{
+				ID: to.Ptr(assignmentID),
+				Properties: &armauthorization.RoleAssignmentProperties{
+					Scope:            to.Ptr(subscriptionScope + "/resourceGroups/rg"),
+					PrincipalID:      to.Ptr(principalID),
+					RoleDefinitionID: to.Ptr(kvRoleID),
+				},
+			},
+		},
+		{
+			name: "different principal is skipped",
+			ra: &armauthorization.RoleAssignment{
+				ID: to.Ptr(assignmentID),
+				Properties: &armauthorization.RoleAssignmentProperties{
+					Scope:            to.Ptr(subscriptionScope),
+					PrincipalID:      to.Ptr(otherPrincipal),
+					RoleDefinitionID: to.Ptr(kvRoleID),
+				},
+			},
+		},
+		{
+			name: "missing assignment name is an error",
+			ra: &armauthorization.RoleAssignment{
+				ID: to.Ptr("not-an-id"),
+				Properties: &armauthorization.RoleAssignmentProperties{
+					Scope:            to.Ptr(subscriptionScope),
+					PrincipalID:      to.Ptr(principalID),
+					RoleDefinitionID: to.Ptr(kvRoleID),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "nil assignment is skipped",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok, err := snapshotIfStrippableMockMSIAssignment(tt.ra, subscriptionScope, principalID, roleNamesByID)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if got.PrincipalID != tt.wantPID {
+				t.Fatalf("principalID = %q, want %q", got.PrincipalID, tt.wantPID)
+			}
+			if got.AssignmentID != assignmentID {
+				t.Fatalf("assignmentID = %q", got.AssignmentID)
+			}
+		})
+	}
+}

--- a/test/util/labels/labels.go
+++ b/test/util/labels/labels.go
@@ -52,6 +52,11 @@ var (
 	// behavior. Selected by the hypershift-presubmit/parallel suite so that
 	// HyperShift presubmit PRs can run a targeted subset of ARO-HCP e2e tests.
 	HypershiftPresubmit = ginkgo.Label("Hypershift-Presubmit")
+	// MockMSIACL marks the DEV prototype that strips leased mock-MSI
+	// permissions. It is selected only by the development/mock-msi-acl suite
+	// (Parallelism 1) so it cannot run beside sibling specs that still need
+	// the job's mock SP. See docs/ci/mock-msi-acl-isolation.md (ARO-29287).
+	MockMSIACL = ginkgo.Label("Mock-MSI-ACL")
 )
 
 var (


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-29287

Related: [ARO-29290](https://issues.redhat.com/browse/ARO-29290), [ARO-29288](https://issues.redhat.com/browse/ARO-29288), [ARO-29289](https://issues.redhat.com/browse/ARO-29289)

### What

Adds a DEV-only e2e spec and dedicated suite `development/mock-msi-acl` (`Parallelism` is the literal `1`) that strips, then restores, the **job-leased** mock-MSI subscription grants so cluster delete can be shown to work when the identity used for cluster ops has no ACL.

- New spec: `test/e2e/cluster_delete_missing_identities_dev_mock_msi.go` (`Mock-MSI-ACL`, `MIContainers:0`, dedicated UAMIs).
- Helpers: resolve lease from `LEASED_MSI_MOCK_SP` / `ARO_HCP_MSI_MOCK_PRINCIPAL_ID`, list with `assignedTo('{id}')`, strip, restore the same assignment GUIDs. Refuses `aro-dev-msi-mock2`.
- Excluded from every existing parallel suite. `test/e2e/cluster_delete_missing_identities.go` stays `StageAndProdOnly`.
- Docs: `docs/ci/mock-msi-acl-isolation.md` (false-pass if Helm drifted, personal-dev overlay).

Does **not** wire `openshift/release` ([ARO-29289](https://redhat.atlassian.net/browse/ARO-29289)) or change the hardcoded MI dataplane client.

### Why

In DEV every operator authenticates as one mock SP. Deleting customer UAMIs does not remove that SP's subscription `dev-msi-mock` / Key Vault Crypto User grants, so the STG/PROD missing-identity delete spec is vacuous if run in DEV. The high-value [ARO-29096](https://redhat.atlassian.net/browse/ARO-29096) signal is that delete still works when that impersonated identity has **no ACL**.

Ginkgo `Serial` does not serialize across OTE workers, and the default DEV suite is `Parallelism: 24`, so stripping the job's mock SP in-place would fail sibling specs. Isolation is "this invocation owns the leased pool SP exclusively", not "mutate a shared grant while 24 specs are using it". Shared personal-dev `aro-dev-msi-mock2` must never be stripped.

### Testing

- Unit tests: `test/util/framework/mock_msi_permissions_test.go` — lease resolve (mock2 refuse, pool lookup, env mismatch), `assignedTo` list filter, strip/restore (`RoleAssignmentExists` is success on restore).
- Integration tests: none. This is e2e + suite wiring; no RP/Cosmos artifact change.
- E2E: personal-dev soak on pool member 19 (`aro-hcp-msi-mock-cs-sp-dev-19`). Create + viability, strip both subscription assignments, delete customer UAMIs, cluster delete to ARM 404 and managed RG 404, `DeferCleanup` restored both GUIDs. `SUCCESS! -- 1 Passed | 0 Failed`.

  Failure modes seen while bringing pers up (spec/helpers did fail closed as intended): ARM `400 UnsupportedQuery` on `principalId eq` (filter is `assignedTo`); `AADSTS700027` when Helm `clientId` and mounted cert disagree; spec refuses to strip mock2. A 4.21 complete-create sanity created a viable cluster first; that spec later failed on a local `:8443` port-forward drop during node pool wait — this PR spec does not create a node pool.

  Not in the default DEV parallel job. `LEASED_MSI_MOCK_SP` is still provision-only until [ARO-29290](https://redhat.atlassian.net/browse/ARO-29290).

### Special notes for your reviewer

- `Parallelism: 1` must stay a literal. `ARO_HCP_SUITE_PARALLELISM` must not raise it.
- Env export is not enough: if CS/backend Helm still impersonate `aro-dev-msi-mock2` while the test strips a pool member, delete can false-pass. See the false-pass section in the isolation doc; [ARO-29290](https://redhat.atlassian.net/browse/ARO-29290) should smoke **running** pods, not only rendered config.
- Restore is RBAC only. Personal-dev Helm `miMock*` must be put back on mock2 after overlay testing.
- Suggested reviewers: @bvesel @stevekuznetsov

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [x] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [x] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.

Made with [Cursor](https://cursor.com)