### PR TITLE
docs(ci): document self-service quota bump remediation (AROSLSRE-2019)

### DIFF
--- a/docs/ci/dev-ci-monitoring.md
+++ b/docs/ci/dev-ci-monitoring.md
@@ -63,6 +63,60 @@ knowledge should be recorded in the Jira bug during the investigation and
 promoted into a dedicated operational knowledge base once the response is
 understood and repeatable.
 
+### AzureQuotaCritical: Bumping a Quota
+
+`AzureQuotaCritical` fires when `azure_quota_usage / azure_quota_limit` exceeds
+0.95 for a given `quota_name`/`subscription_name`/`region`, from the
+`tenant-quota-collector` metrics described in [Architecture](#architecture).
+The alert annotation identifies the exact quota, subscription, and region. The
+alert's `source` label is one of `compute`, `network`, or `rbac` (see
+[`tooling/tenant-quota/pkg/subscriptionquota`](../../tooling/tenant-quota/pkg/subscriptionquota));
+use it to pick the right resource provider below. For an `rbac`-sourced alert
+(role-assignment quota), follow [CI Identity Leasing](identity-leasing.md)
+instead — role-assignment limits are not raised through `az quota`.
+
+For `compute` and `network` sources, most DEV CI subscriptions allow
+self-service quota increases through the `Microsoft.Quota` API, no Azure
+support ticket required. Install the `quota` CLI extension if it isn't already
+present, then find the current limit and raise it:
+
+```bash
+az extension add --name quota --upgrade
+
+SUBSCRIPTION_ID=<subscription_id from the alert>
+REGION=<region from the alert>
+QUOTA_NAME=<quota_name from the alert, e.g. standardEDSv5Family>
+# Use the alert's `source` label to pick the provider:
+#   compute -> Microsoft.Compute
+#   network -> Microsoft.Network
+PROVIDER=Microsoft.Compute
+
+az quota show \
+  --resource-name "$QUOTA_NAME" \
+  --scope "/subscriptions/$SUBSCRIPTION_ID/providers/$PROVIDER/locations/$REGION"
+# Read `resourceType` from the `az quota show` output above (typically
+# `dedicated` for compute quotas, `shared` for network quotas) and reuse it
+# below so the update matches this specific quota.
+RESOURCE_TYPE=<resourceType from the az quota show output>
+
+az quota update \
+  --resource-name "$QUOTA_NAME" \
+  --scope "/subscriptions/$SUBSCRIPTION_ID/providers/$PROVIDER/locations/$REGION" \
+  --limit-object value=<NEW_LIMIT> \
+  --resource-type "$RESOURCE_TYPE"
+```
+
+Target a reasonable headroom increase (for example, double the current limit)
+rather than the minimum needed to clear the alert, so a similar CI-load burst
+does not immediately re-trigger it. Re-run `az quota show` to confirm the new
+limit took effect, then record the before/after values and command used in the
+Jira bug.
+
+If `az quota update` fails or returns a pending/manual-review state, the
+subscription requires an Azure support request instead; open one from the
+Azure portal's **Help + support** blade with the subscription, region, quota
+name, and target limit from the alert.
+
 ## Exporter Health Checks
 
 Select the DEV subscription and obtain credentials for the `opstool` cluster:


### PR DESCRIPTION
[AROSLSRE-2019](https://redhat.atlassian.net/browse/AROSLSRE-2019)

### What

Adds an "AzureQuotaCritical: Bumping a Compute Quota" section to the DEV CI monitoring runbook, with the exact `az quota show`/`az quota update` commands to self-service raise a compute quota limit when the alert fires.

### Why

`AzureQuotaCritical` fired on `standardEDSv5Family` in `canadacentral` for the E2E infrastructure subscription (96% utilization). The runbook explicitly defers remediation to the Jira bug until a response is "understood and repeatable." This one now is: most DEV CI subscriptions support self-service quota increases via the `Microsoft.Quota` API, no Azure support ticket needed. Documenting the exact commands so the next on-call doesn't have to rediscover this.

### Testing

Docs-only change, no unit/integration/E2E tests apply. Verified the commands against the actual incident: ran `az quota show`/`az quota update` against subscription `0ef1ad54-9296-44cd-9600-5dc8e9a74034`, region `canadacentral`, resource `standardEDSv5Family`, raising the limit from 350 to 700, confirmed via `az quota show`.

### Special notes for your reviewer

None.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
