### PR TITLE
Add Watson daemon set to HCP cluster to meet KPI

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -2784,6 +2784,48 @@
             "image"
           ]
         },
+        "watson": {
+          "type": "object",
+          "properties": {
+            "image": {
+              "$ref": "#/definitions/containerImage"
+            },
+            "securityContext": {
+              "type": "object",
+              "properties": {
+                "privileged": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "privileged"
+              ]
+            },
+            "resources": {
+              "$ref": "#/definitions/containerResources"
+            },
+            "volumes": {
+              "type": "object",
+              "properties": {
+                "crashdumpHostPath": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "crashdumpHostPath"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "image",
+            "securityContext",
+            "resources",
+            "volumes"
+          ]
+        },
         "kusto": {
           "type": "object",
           "properties": {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -184,6 +184,22 @@ defaults:
           memory: 256Mi
         limits:
           memory: 1248Mi
+    watson:
+      image:
+        registry: mcr.microsoft.com
+        repository: azure-watson/agent/azlinux3
+        digest: sha256:8e5ef3e76be33794cef7460712eb9ff0c73bce8b8e5ffc33c5c6bfe0762f5db0 # 1.24.128.0
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 250m
+          memory: 512Mi
+      volumes:
+        crashdumpHostPath: /home/docker/azure-watson
     kusto:
       enabled: false
       buffering: true

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -101,6 +101,22 @@ arobit:
       digest: sha256:0af23e7645c07968b9bd20f5c4a2966b34ccdaf8a05812b5eb5a3a26c53f24b5
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
+  watson:
+    image:
+      digest: sha256:8e5ef3e76be33794cef7460712eb9ff0c73bce8b8e5ffc33c5c6bfe0762f5db0
+      registry: mcr.microsoft.com
+      repository: azure-watson/agent/azlinux3
+    resources:
+      limits:
+        cpu: 250m
+        memory: 512Mi
+      requests:
+        cpu: 50m
+        memory: 128Mi
+    securityContext:
+      privileged: true
+    volumes:
+      crashdumpHostPath: /home/docker/azure-watson
 auditLogsEventHub:
   authRuleName: SendRule
   enabled: false

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -101,6 +101,22 @@ arobit:
       digest: sha256:0af23e7645c07968b9bd20f5c4a2966b34ccdaf8a05812b5eb5a3a26c53f24b5
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
+  watson:
+    image:
+      digest: sha256:8e5ef3e76be33794cef7460712eb9ff0c73bce8b8e5ffc33c5c6bfe0762f5db0
+      registry: mcr.microsoft.com
+      repository: azure-watson/agent/azlinux3
+    resources:
+      limits:
+        cpu: 250m
+        memory: 512Mi
+      requests:
+        cpu: 50m
+        memory: 128Mi
+    securityContext:
+      privileged: true
+    volumes:
+      crashdumpHostPath: /home/docker/azure-watson
 auditLogsEventHub:
   authRuleName: SendRule
   enabled: true

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -101,6 +101,22 @@ arobit:
       digest: sha256:0af23e7645c07968b9bd20f5c4a2966b34ccdaf8a05812b5eb5a3a26c53f24b5
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
+  watson:
+    image:
+      digest: sha256:8e5ef3e76be33794cef7460712eb9ff0c73bce8b8e5ffc33c5c6bfe0762f5db0
+      registry: mcr.microsoft.com
+      repository: azure-watson/agent/azlinux3
+    resources:
+      limits:
+        cpu: 250m
+        memory: 512Mi
+      requests:
+        cpu: 50m
+        memory: 128Mi
+    securityContext:
+      privileged: true
+    volumes:
+      crashdumpHostPath: /home/docker/azure-watson
 auditLogsEventHub:
   authRuleName: SendRule
   enabled: false

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -101,6 +101,22 @@ arobit:
       digest: sha256:0af23e7645c07968b9bd20f5c4a2966b34ccdaf8a05812b5eb5a3a26c53f24b5
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
+  watson:
+    image:
+      digest: sha256:8e5ef3e76be33794cef7460712eb9ff0c73bce8b8e5ffc33c5c6bfe0762f5db0
+      registry: mcr.microsoft.com
+      repository: azure-watson/agent/azlinux3
+    resources:
+      limits:
+        cpu: 250m
+        memory: 512Mi
+      requests:
+        cpu: 50m
+        memory: 128Mi
+    securityContext:
+      privileged: true
+    volumes:
+      crashdumpHostPath: /home/docker/azure-watson
 auditLogsEventHub:
   authRuleName: SendRule
   enabled: false

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -101,6 +101,22 @@ arobit:
       digest: sha256:0af23e7645c07968b9bd20f5c4a2966b34ccdaf8a05812b5eb5a3a26c53f24b5
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
+  watson:
+    image:
+      digest: sha256:8e5ef3e76be33794cef7460712eb9ff0c73bce8b8e5ffc33c5c6bfe0762f5db0
+      registry: mcr.microsoft.com
+      repository: azure-watson/agent/azlinux3
+    resources:
+      limits:
+        cpu: 250m
+        memory: 512Mi
+      requests:
+        cpu: 50m
+        memory: 128Mi
+    securityContext:
+      privileged: true
+    volumes:
+      crashdumpHostPath: /home/docker/azure-watson
 auditLogsEventHub:
   authRuleName: SendRule
   enabled: false

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -101,6 +101,22 @@ arobit:
       digest: sha256:0af23e7645c07968b9bd20f5c4a2966b34ccdaf8a05812b5eb5a3a26c53f24b5
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
+  watson:
+    image:
+      digest: sha256:8e5ef3e76be33794cef7460712eb9ff0c73bce8b8e5ffc33c5c6bfe0762f5db0
+      registry: mcr.microsoft.com
+      repository: azure-watson/agent/azlinux3
+    resources:
+      limits:
+        cpu: 250m
+        memory: 512Mi
+      requests:
+        cpu: 50m
+        memory: 128Mi
+    securityContext:
+      privileged: true
+    volumes:
+      crashdumpHostPath: /home/docker/azure-watson
 auditLogsEventHub:
   authRuleName: SendRule
   enabled: false

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arobit.yaml
@@ -887,6 +887,34 @@ spec:
             - name: flb-config
               mountPath: /forwarder/etc
               readOnly: true
+        - name: watson-agent
+          image: mcr.microsoft.com/azure-watson/agent/azlinux3@sha256:1234567890
+          imagePullPolicy: 'IfNotPresent'
+          env:
+            - name: INCOMING_QUEUE
+              value: "/azure-watson/cores"
+            - name: REPORT_QUEUE
+              value: "/azure-watson/queue"
+            - name: MDSD_ROLE_PREFIX
+              value: "/var/run/mdsd/asa/"
+            - name: WA_CORE_PATTERN
+              value: "/azure-watson/cores/%e.%p.%h.%t"
+            - name: AUTHENTICATION_ID
+              value: "MsiClientId#__msiClientId__"
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          volumeMounts:
+            - name: watson-crashdump
+              mountPath: /azure-watson
+            - name: mdsd-run-clusterlogs
+              mountPath: /var/run/mdsd
       terminationGracePeriodSeconds: 45
       tolerations:
       - effect: NoSchedule
@@ -920,6 +948,12 @@ spec:
           configMap:
             name: arobit-forwarder
             defaultMode: 0755
+        - name: mdsd-run-clusterlogs
+          emptyDir: {}
+        - name: watson-crashdump
+          hostPath:
+            type: DirectoryOrCreate
+            path: "/home/docker/azure-watson"
 ---
 # Source: arobit/templates/forwarder-servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arobit.yaml
@@ -721,6 +721,34 @@ spec:
             - name: flb-config
               mountPath: /forwarder/etc
               readOnly: true
+        - name: watson-agent
+          image: mcr.microsoft.com/azure-watson/agent/azlinux3@sha256:1234567890
+          imagePullPolicy: 'IfNotPresent'
+          env:
+            - name: INCOMING_QUEUE
+              value: "/azure-watson/cores"
+            - name: REPORT_QUEUE
+              value: "/azure-watson/queue"
+            - name: MDSD_ROLE_PREFIX
+              value: "/var/run/mdsd/asa/"
+            - name: WA_CORE_PATTERN
+              value: "/azure-watson/cores/%e.%p.%h.%t"
+            - name: AUTHENTICATION_ID
+              value: "MsiClientId#__msiClientId__"
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          volumeMounts:
+            - name: watson-crashdump
+              mountPath: /azure-watson
+            - name: mdsd-run-clusterlogs
+              mountPath: /var/run/mdsd
       terminationGracePeriodSeconds: 45
       tolerations:
       - effect: NoSchedule
@@ -754,6 +782,14 @@ spec:
           configMap:
             name: arobit-forwarder
             defaultMode: 0755
+        - name: mdsd-run-clusterlogs
+          hostPath:
+            path: /var/run/mdsd
+            type: Directory
+        - name: watson-crashdump
+          hostPath:
+            type: DirectoryOrCreate
+            path: "/home/docker/azure-watson"
 ---
 # Source: arobit/templates/forwarder-servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1

--- a/observability/arobit/deploy/templates/forwarder-daemonset.yaml
+++ b/observability/arobit/deploy/templates/forwarder-daemonset.yaml
@@ -102,7 +102,34 @@ spec:
             - name: flb-config
               mountPath: /forwarder/etc
               readOnly: true
-        {{- if and .Values.forwarder.mdsd.enabled (eq .Values.forwarder.clusterType "mgmt") }}
+{{- if and .Values.forwarder.mdsd.enabled (eq .Values.forwarder.clusterType "mgmt") }}
+            - name: shoebox-mappings
+              mountPath: /shoebox-config
+              readOnly: true
+{{- end }}
+        - name: watson-agent
+          image: {{ .Values.watson.image.registry }}/{{ .Values.watson.image.repository }}@{{ .Values.watson.image.digest }}
+          imagePullPolicy: '{{ .Values.watson.image.pullPolicy }}'
+          env:
+            - name: INCOMING_QUEUE
+              value: {{ .Values.watson.env.INCOMING_QUEUE | quote }}
+            - name: REPORT_QUEUE
+              value: {{ .Values.watson.env.REPORT_QUEUE | quote }}
+            - name: MDSD_ROLE_PREFIX
+              value: {{ .Values.watson.env.MDSD_ROLE_PREFIX | quote }}
+            - name: WA_CORE_PATTERN
+              value: {{ .Values.watson.env.WA_CORE_PATTERN | quote }}
+            - name: AUTHENTICATION_ID
+              value: {{ .Values.watson.env.AUTHENTICATION_ID | quote }}
+          securityContext:
+            privileged: {{ .Values.watson.securityContext.privileged }}
+          resources: {{- toYaml .Values.watson.resources | nindent 12 }}
+          volumeMounts:
+            - name: watson-crashdump
+              mountPath: /azure-watson
+            - name: mdsd-run-clusterlogs
+              mountPath: /var/run/mdsd
+{{- if and .Values.forwarder.mdsd.enabled (eq .Values.forwarder.clusterType "mgmt") }}
         - name: mdsd-clusterlogs
           image: {{ .Values.forwarder.mdsd.image.registry }}/{{ .Values.forwarder.mdsd.image.repository }}@{{ .Values.forwarder.mdsd.image.digest }}
           imagePullPolicy: '{{ .Values.forwarder.mdsd.image.pullPolicy }}'
@@ -327,9 +354,23 @@ spec:
           configMap:
             name: arobit-forwarder
             defaultMode: 0755
-        {{- if and .Values.forwarder.mdsd.enabled (eq .Values.forwarder.clusterType "mgmt") }}
         - name: mdsd-run-clusterlogs
+          {{- if eq .Values.forwarder.clusterType "svc" }}
+          hostPath:
+            path: /var/run/mdsd
+            type: Directory
+          {{- else }}
           emptyDir: {}
+          {{- end }}
+        - name: watson-crashdump
+          hostPath:
+            type: DirectoryOrCreate
+            path: {{ .Values.watson.volumes.crashdumpHostPath | quote }}
+        {{- if and .Values.forwarder.mdsd.enabled (eq .Values.forwarder.clusterType "mgmt") }}
+        - name: shoebox-mappings
+          configMap:
+            name: namespace-resourceid-mapping
+            optional: true
         - name: geneva-certs-clusterlogs
           csi:
             driver: secrets-store.csi.k8s.io

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_buffering_disabled_svc.yaml
@@ -620,6 +620,34 @@ spec:
             - name: flb-config
               mountPath: /forwarder/etc
               readOnly: true
+        - name: watson-agent
+          image: mcr.microsoft.com/azure-watson/agent/azlinux3@sha256:1234567890
+          imagePullPolicy: 'IfNotPresent'
+          env:
+            - name: INCOMING_QUEUE
+              value: "/azure-watson/cores"
+            - name: REPORT_QUEUE
+              value: "/azure-watson/queue"
+            - name: MDSD_ROLE_PREFIX
+              value: "/var/run/mdsd/asa/"
+            - name: WA_CORE_PATTERN
+              value: "/azure-watson/cores/%e.%p.%h.%t"
+            - name: AUTHENTICATION_ID
+              value: "MsiClientId#__msiClientId__"
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          volumeMounts:
+            - name: watson-crashdump
+              mountPath: /azure-watson
+            - name: mdsd-run-clusterlogs
+              mountPath: /var/run/mdsd
       terminationGracePeriodSeconds: 45
       tolerations:
       - effect: NoSchedule
@@ -653,6 +681,14 @@ spec:
           configMap:
             name: arobit-forwarder
             defaultMode: 0755
+        - name: mdsd-run-clusterlogs
+          hostPath:
+            path: /var/run/mdsd
+            type: Directory
+        - name: watson-crashdump
+          hostPath:
+            type: DirectoryOrCreate
+            path: "/home/docker/azure-watson"
 ---
 # Source: arobit/templates/forwarder-servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_disabled_svc.yaml
@@ -720,6 +720,34 @@ spec:
             - name: flb-config
               mountPath: /forwarder/etc
               readOnly: true
+        - name: watson-agent
+          image: mcr.microsoft.com/azure-watson/agent/azlinux3@sha256:1234567890
+          imagePullPolicy: 'IfNotPresent'
+          env:
+            - name: INCOMING_QUEUE
+              value: "/azure-watson/cores"
+            - name: REPORT_QUEUE
+              value: "/azure-watson/queue"
+            - name: MDSD_ROLE_PREFIX
+              value: "/var/run/mdsd/asa/"
+            - name: WA_CORE_PATTERN
+              value: "/azure-watson/cores/%e.%p.%h.%t"
+            - name: AUTHENTICATION_ID
+              value: "MsiClientId#__msiClientId__"
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          volumeMounts:
+            - name: watson-crashdump
+              mountPath: /azure-watson
+            - name: mdsd-run-clusterlogs
+              mountPath: /var/run/mdsd
       terminationGracePeriodSeconds: 45
       tolerations:
       - effect: NoSchedule
@@ -753,6 +781,14 @@ spec:
           configMap:
             name: arobit-forwarder
             defaultMode: 0755
+        - name: mdsd-run-clusterlogs
+          hostPath:
+            path: /var/run/mdsd
+            type: Directory
+        - name: watson-crashdump
+          hostPath:
+            type: DirectoryOrCreate
+            path: "/home/docker/azure-watson"
 ---
 # Source: arobit/templates/forwarder-servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_kusto_unlimited_memory_svc.yaml
@@ -719,6 +719,34 @@ spec:
             - name: flb-config
               mountPath: /forwarder/etc
               readOnly: true
+        - name: watson-agent
+          image: mcr.microsoft.com/azure-watson/agent/azlinux3@sha256:1234567890
+          imagePullPolicy: 'IfNotPresent'
+          env:
+            - name: INCOMING_QUEUE
+              value: "/azure-watson/cores"
+            - name: REPORT_QUEUE
+              value: "/azure-watson/queue"
+            - name: MDSD_ROLE_PREFIX
+              value: "/var/run/mdsd/asa/"
+            - name: WA_CORE_PATTERN
+              value: "/azure-watson/cores/%e.%p.%h.%t"
+            - name: AUTHENTICATION_ID
+              value: "MsiClientId#__msiClientId__"
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          volumeMounts:
+            - name: watson-crashdump
+              mountPath: /azure-watson
+            - name: mdsd-run-clusterlogs
+              mountPath: /var/run/mdsd
       terminationGracePeriodSeconds: 45
       tolerations:
       - effect: NoSchedule
@@ -752,6 +780,14 @@ spec:
           configMap:
             name: arobit-forwarder
             defaultMode: 0755
+        - name: mdsd-run-clusterlogs
+          hostPath:
+            path: /var/run/mdsd
+            type: Directory
+        - name: watson-crashdump
+          hostPath:
+            type: DirectoryOrCreate
+            path: "/home/docker/azure-watson"
 ---
 # Source: arobit/templates/forwarder-servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_mgmt.yaml
@@ -1056,6 +1056,37 @@ spec:
             - name: flb-config
               mountPath: /forwarder/etc
               readOnly: true
+            - name: shoebox-mappings
+              mountPath: /shoebox-config
+              readOnly: true
+        - name: watson-agent
+          image: mcr.microsoft.com/azure-watson/agent/azlinux3@sha256:1234567890
+          imagePullPolicy: 'IfNotPresent'
+          env:
+            - name: INCOMING_QUEUE
+              value: "/azure-watson/cores"
+            - name: REPORT_QUEUE
+              value: "/azure-watson/queue"
+            - name: MDSD_ROLE_PREFIX
+              value: "/var/run/mdsd/asa/"
+            - name: WA_CORE_PATTERN
+              value: "/azure-watson/cores/%e.%p.%h.%t"
+            - name: AUTHENTICATION_ID
+              value: "MsiClientId#__msiClientId__"
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          volumeMounts:
+            - name: watson-crashdump
+              mountPath: /azure-watson
+            - name: mdsd-run-clusterlogs
+              mountPath: /var/run/mdsd
         - name: mdsd-clusterlogs
           image: mcr.microsoft.com/geneva/distroless/mdsd@sha256:1234567890
           imagePullPolicy: 'IfNotPresent'
@@ -1281,6 +1312,14 @@ spec:
             defaultMode: 0755
         - name: mdsd-run-clusterlogs
           emptyDir: {}
+        - name: watson-crashdump
+          hostPath:
+            type: DirectoryOrCreate
+            path: "/home/docker/azure-watson"
+        - name: shoebox-mappings
+          configMap:
+            name: namespace-resourceid-mapping
+            optional: true
         - name: geneva-certs-clusterlogs
           csi:
             driver: secrets-store.csi.k8s.io

--- a/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
+++ b/observability/arobit/testdata/zz_fixture_TestHelmTemplate_helmtest_mdsd_and_kusto_enabled_svc.yaml
@@ -721,6 +721,34 @@ spec:
             - name: flb-config
               mountPath: /forwarder/etc
               readOnly: true
+        - name: watson-agent
+          image: mcr.microsoft.com/azure-watson/agent/azlinux3@sha256:1234567890
+          imagePullPolicy: 'IfNotPresent'
+          env:
+            - name: INCOMING_QUEUE
+              value: "/azure-watson/cores"
+            - name: REPORT_QUEUE
+              value: "/azure-watson/queue"
+            - name: MDSD_ROLE_PREFIX
+              value: "/var/run/mdsd/asa/"
+            - name: WA_CORE_PATTERN
+              value: "/azure-watson/cores/%e.%p.%h.%t"
+            - name: AUTHENTICATION_ID
+              value: "MsiClientId#__msiClientId__"
+          securityContext:
+            privileged: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 512Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          volumeMounts:
+            - name: watson-crashdump
+              mountPath: /azure-watson
+            - name: mdsd-run-clusterlogs
+              mountPath: /var/run/mdsd
       terminationGracePeriodSeconds: 45
       tolerations:
       - effect: NoSchedule
@@ -754,6 +782,14 @@ spec:
           configMap:
             name: arobit-forwarder
             defaultMode: 0755
+        - name: mdsd-run-clusterlogs
+          hostPath:
+            path: /var/run/mdsd
+            type: Directory
+        - name: watson-crashdump
+          hostPath:
+            type: DirectoryOrCreate
+            path: "/home/docker/azure-watson"
 ---
 # Source: arobit/templates/forwarder-servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1

--- a/observability/arobit/values-mgmt.yaml
+++ b/observability/arobit/values-mgmt.yaml
@@ -91,3 +91,26 @@ forwarder:
   tenantId: "__tenantId__"
   secretProvider:
     keyVault: "{{ .mgmtKeyVault.name }}"
+watson:
+  image:
+    registry: "{{ .arobit.watson.image.registry }}"
+    repository: "{{ .arobit.watson.image.repository }}"
+    digest: "{{ .arobit.watson.image.digest }}"
+    pullPolicy: IfNotPresent
+  securityContext:
+    privileged: {{ .arobit.watson.securityContext.privileged }}
+  resources:
+    requests:
+      cpu: "{{ .arobit.watson.resources.requests.cpu }}"
+      memory: "{{ .arobit.watson.resources.requests.memory }}"
+    limits:
+      cpu: "{{ .arobit.watson.resources.limits.cpu }}"
+      memory: "{{ .arobit.watson.resources.limits.memory }}"
+  env:
+    INCOMING_QUEUE: "/azure-watson/cores"
+    REPORT_QUEUE: "/azure-watson/queue"
+    MDSD_ROLE_PREFIX: "/var/run/mdsd/asa/"
+    WA_CORE_PATTERN: "/azure-watson/cores/%e.%p.%h.%t"
+    AUTHENTICATION_ID: "MsiClientId#__msiClientId__"
+  volumes:
+    crashdumpHostPath: "{{ .arobit.watson.volumes.crashdumpHostPath }}"

--- a/observability/arobit/values-svc.yaml
+++ b/observability/arobit/values-svc.yaml
@@ -91,3 +91,26 @@ forwarder:
   tenantId: "__tenantId__"
   secretProvider:
     keyVault: "{{ .serviceKeyVault.name }}"
+watson:
+  image:
+    registry: "{{ .arobit.watson.image.registry }}"
+    repository: "{{ .arobit.watson.image.repository }}"
+    digest: "{{ .arobit.watson.image.digest }}"
+    pullPolicy: IfNotPresent
+  securityContext:
+    privileged: {{ .arobit.watson.securityContext.privileged }}
+  resources:
+    requests:
+      cpu: "{{ .arobit.watson.resources.requests.cpu }}"
+      memory: "{{ .arobit.watson.resources.requests.memory }}"
+    limits:
+      cpu: "{{ .arobit.watson.resources.limits.cpu }}"
+      memory: "{{ .arobit.watson.resources.limits.memory }}"
+  env:
+    INCOMING_QUEUE: "/azure-watson/cores"
+    REPORT_QUEUE: "/azure-watson/queue"
+    MDSD_ROLE_PREFIX: "/var/run/mdsd/asa/"
+    WA_CORE_PATTERN: "/azure-watson/cores/%e.%p.%h.%t"
+    AUTHENTICATION_ID: "MsiClientId#__msiClientId__"
+  volumes:
+    crashdumpHostPath: "{{ .arobit.watson.volumes.crashdumpHostPath }}"


### PR DESCRIPTION
<!-- Link to Jira issue -->
https://redhat.atlassian.net/jira/software/c/projects/ARO/boards/3274?assignee=64066bea4d5e4b44e233a4c8&selectedIssue=[ARO-29045](https://redhat.atlassian.net/browse/ARO-29045)
### What
The Azure Watson container accesses coredumps from the service container once the generated coredumps is saved to a directory (also called incoming queue) on the host node. Azure Watson container relies on host node mounts to persist the dump files on the host node if the container stops unexpectedly and also to store larger dump files. 
<!-- Briefly describe what this PR does -->

### Why
We need to add watson daemon set to every cluster required by aks to meet KPI.
<!-- Briefly explain why this change is needed -->

### Testing
MGMT:
```
jonachang@DESKTOP-09U5LAV:~/microsoft/sdp-pipelines$ kubectl -n arobit get pods -l app.kubernetes.io/name=arobit-forwarder   -o custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[*].ready,CONTAINERS:.spec.containers[*].name --no-headers
arobit-forwarder-22ksm   true,true,true,true    fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-2q5tv   true,true,true,false   fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-5xhxf   true,true,true,false   fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-7hthq   true,true,true,true    fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-8fth8   true,true,true,true    fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-bz2kb   true,true,true,false   fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-csjzc   true,true,true,true    fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-dn96k   true,true,true,true    fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-h7tcj   true,true,true,false   fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-lpsqq   true,true,true,true    fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-mfnch   true,true,true,false   fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-nhz96   true,true,true,false   fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-pkmfg   true,true,true,true    fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-rgdxh   true,true,true,false   fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-sb2tm   true,true,true,false   fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-skfft   true,true,true,false   fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-td5t9   true,true,true,true    fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-whxpz   true,true,true,false   fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-x6bms   true,true,true,false   fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-xf86r   true,true,true,true    fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-zs2hj   true,true,true,true    fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
arobit-forwarder-zvz7v   true,true,true,false   fluentbit,watson-agent,mdsd-clusterlogs,mdsd-cert-watchdog
```

SVC:
```
jonachang@DESKTOP-09U5LAV:~/microsoft/sdp-pipelines$ kubectl -n arobit get pods -l app.kubernetes.io/name=arobit-forwarder \
  -o custom-columns=NAME:.metadata.name,READY:.status.containerStatuses[*].ready,CONTAINERS:.spec.containers[*].name --no-headers
arobit-forwarder-2p452   true,true   fluentbit,watson-agent
arobit-forwarder-6qpkw   true,true   fluentbit,watson-agent
arobit-forwarder-7fl9h   true,true   fluentbit,watson-agent
arobit-forwarder-8kpq4   true,true   fluentbit,watson-agent
arobit-forwarder-g2vxk   true,true   fluentbit,watson-agent
arobit-forwarder-gxvjt   true,true   fluentbit,watson-agent
arobit-forwarder-jcphh   true,true   fluentbit,watson-agent
arobit-forwarder-lcbtr   true,true   fluentbit,watson-agent
arobit-forwarder-p2n7z   true,true   fluentbit,watson-agent
arobit-forwarder-vgkrj   true,true   fluentbit,watson-agent
```
```
jonachang@DESKTOP-09U5LAV:~/microsoft/sdp-pipelines$ kubectl -n arobit get ds arobit-forwarder -o jsonpath='{.spec.template.spec.containers[*].name}'; echo
fluentbit watson-agent
```
Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if dashboards or other UI changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
