### PR TITLE
fix: protect *unlocked helpers with contextLock

### DIFF
--- a/test/util/framework/identities_helper.go
+++ b/test/util/framework/identities_helper.go
@@ -363,7 +363,7 @@ func (tc *perItOrDescribeTestContext) DeleteUserAssignedIdentities(ctx context.C
 	if err != nil {
 		return fmt.Errorf("failed to get Azure credentials: %w", err)
 	}
-	subscriptionID, err := tc.getSubscriptionIDUnlocked(ctx)
+	subscriptionID, err := tc.SubscriptionID(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get subscription ID: %w", err)
 	}
@@ -422,7 +422,7 @@ func (tc *perItOrDescribeTestContext) releaseLeasedIdentities(ctx context.Contex
 
 	if !tc.UsePooledIdentities() {
 		// For non-pooled mode, still clean up role assignments and custom role definitions
-		subscriptionID, err := tc.getSubscriptionIDUnlocked(ctx)
+		subscriptionID, err := tc.SubscriptionID(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to get subscription ID: %w", err)
 		}
@@ -452,7 +452,7 @@ func (tc *perItOrDescribeTestContext) releaseLeasedIdentities(ctx context.Contex
 	if err != nil {
 		return err
 	}
-	subscriptionID, err := tc.getSubscriptionIDUnlocked(ctx)
+	subscriptionID, err := tc.SubscriptionID(ctx)
 	if err != nil {
 		return err
 	}
@@ -628,7 +628,7 @@ func (tc *perItOrDescribeTestContext) cleanupCustomE2ETestRolesAssignmentsForIde
 		return fmt.Errorf("failed to get Azure credentials: %w", err)
 	}
 
-	subscriptionID, err := tc.getSubscriptionIDUnlocked(ctx)
+	subscriptionID, err := tc.SubscriptionID(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get subscription ID: %w", err)
 	}
@@ -733,7 +733,7 @@ func (tc *perItOrDescribeTestContext) cleanupCustomE2ETestRolesAssignmentsForIde
 func (tc *perItOrDescribeTestContext) cleanupLeasedIdentityContainerRoleAssignments(ctx context.Context,
 	client *armauthorization.RoleAssignmentsClient, resourceGroup string) error {
 
-	subscriptionID, err := tc.getSubscriptionIDUnlocked(ctx)
+	subscriptionID, err := tc.SubscriptionID(ctx)
 	if err != nil {
 		return err
 	}
@@ -1273,7 +1273,7 @@ func (tc *perItOrDescribeTestContext) EnsureIdentityRoleAssignments(
 		return fmt.Errorf("failed to get Azure credentials: %w", err)
 	}
 
-	subscriptionID, err := tc.getSubscriptionIDUnlocked(ctx)
+	subscriptionID, err := tc.SubscriptionID(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get subscription ID: %w", err)
 	}

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -704,7 +704,7 @@ func (tc *perItOrDescribeTestContext) cleanupResourceGroupNoRP(ctx context.Conte
 	startTime := time.Now()
 	defer func() {
 		finishTime := time.Now()
-		tc.recordTestStepUnlocked(fmt.Sprintf("Clean up resource group %s (no RP)", resourceGroupName), startTime, finishTime)
+		tc.RecordTestStep(fmt.Sprintf("Clean up resource group %s (no RP)", resourceGroupName), startTime, finishTime)
 	}()
 
 	managedResourceGroups, err := tc.findManagedResourceGroups(ctx, resourceGroupName)
@@ -1220,7 +1220,12 @@ func (tc *perItOrDescribeTestContext) getGraphClientUnlocked(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	return graphutil.NewClient(ctx, creds)
+	client, err := graphutil.NewClient(ctx, creds)
+	if err != nil {
+		return nil, err
+	}
+	tc.graphClient = client
+	return tc.graphClient, nil
 }
 
 func (tc *perItOrDescribeTestContext) Location() string {

--- a/test/util/framework/per_test_framework_test.go
+++ b/test/util/framework/per_test_framework_test.go
@@ -15,14 +15,24 @@
 package framework
 
 import (
+	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
+
+	graphutil "github.com/Azure/ARO-HCP/internal/graph/util"
+	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 )
 
 func TestIsResourceGroupNotFoundError(t *testing.T) {
@@ -208,5 +218,265 @@ func TestIsIgnorableResourceGroupCleanupError(t *testing.T) {
 			got := isIgnorableResourceGroupCleanupError(tt.err)
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+func TestGetARMSubscriptionsClientFactoryReturnsCachedFactory(t *testing.T) {
+	t.Parallel()
+
+	sentinel := &armsubscriptions.ClientFactory{}
+	tc := &perItOrDescribeTestContext{
+		armSubscriptionsClientFactory: sentinel,
+	}
+
+	got, err := tc.GetARMSubscriptionsClientFactory()
+	assert.NoError(t, err)
+	assert.Same(t, sentinel, got)
+}
+
+func TestGetARMSubscriptionsClientFactoryUnlockedReturnsCachedFactory(t *testing.T) {
+	t.Parallel()
+
+	sentinel := &armsubscriptions.ClientFactory{}
+	tc := &perItOrDescribeTestContext{
+		armSubscriptionsClientFactory: sentinel,
+	}
+
+	got, err := tc.getARMSubscriptionsClientFactoryUnlocked()
+	assert.NoError(t, err)
+	assert.Same(t, sentinel, got)
+}
+
+func TestGetARMSubscriptionsClientFactoryIgnoresSiblingFactories(t *testing.T) {
+	t.Parallel()
+
+	tc := newTestContextWithStubCredential()
+	tc.clientFactory20240610 = &hcpsdk20240610preview.ClientFactory{}
+	tc.armResourcesClientFactory = &armresources.ClientFactory{}
+
+	got, err := tc.GetARMSubscriptionsClientFactory()
+	assert.NoError(t, err, "sibling factories must not short-circuit subscriptions factory construction")
+	assert.NotNil(t, got, "must not return (nil, nil) when armSubscriptionsClientFactory is unset")
+	assert.Same(t, got, tc.armSubscriptionsClientFactory, "constructed factory must be cached")
+
+	cached, err := tc.GetARMSubscriptionsClientFactory()
+	assert.NoError(t, err)
+	assert.Same(t, got, cached)
+}
+
+func TestGetARMSubscriptionsClientFactoryUnlockedIgnoresSiblingFactories(t *testing.T) {
+	t.Parallel()
+
+	tc := newTestContextWithStubCredential()
+	tc.clientFactory20240610 = &hcpsdk20240610preview.ClientFactory{}
+	tc.armResourcesClientFactory = &armresources.ClientFactory{}
+
+	got, err := tc.getARMSubscriptionsClientFactoryUnlocked()
+	assert.NoError(t, err, "sibling factories must not short-circuit unlocked subscriptions factory construction")
+	assert.NotNil(t, got, "must not return (nil, nil) when armSubscriptionsClientFactory is unset")
+	assert.Same(t, got, tc.armSubscriptionsClientFactory)
+
+	cached, err := tc.getARMSubscriptionsClientFactoryUnlocked()
+	assert.NoError(t, err)
+	assert.Same(t, got, cached)
+}
+
+func TestGetARMSubscriptionsClientFactoryCacheHitConcurrent(t *testing.T) {
+	t.Parallel()
+
+	tc := newTestContextWithStubCredential()
+	sentinel, err := tc.GetARMSubscriptionsClientFactory()
+	assert.NoError(t, err)
+	assert.NotNil(t, sentinel)
+
+	for i := 0; i < 8; i++ {
+		t.Run(fmt.Sprintf("reader-%d", i), func(t *testing.T) {
+			t.Parallel()
+			got, err := tc.GetARMSubscriptionsClientFactory()
+			assert.NoError(t, err)
+			assert.Same(t, sentinel, got)
+		})
+	}
+}
+
+// Per-test subscriptionID is never assigned in production (the live cache is
+// perBinaryInvocationTestContext.subscriptionID). These tests seed the unused
+// field on purpose: they catch the Lock()/RUnlock() mismatch from PR #6312,
+// which is a runtime fatal if that field is ever written. Persisting a
+// per-test copy in getSubscriptionIDUnlocked is a separate follow-up.
+func TestSubscriptionIDCacheHit(t *testing.T) {
+	t.Parallel()
+
+	tc := &perItOrDescribeTestContext{
+		subscriptionID: "sub-123",
+	}
+
+	got, err := tc.SubscriptionID(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, "sub-123", got)
+}
+
+func TestSubscriptionIDCacheHitConcurrent(t *testing.T) {
+	t.Parallel()
+
+	tc := &perItOrDescribeTestContext{
+		subscriptionID: "sub-123",
+	}
+
+	for i := 0; i < 8; i++ {
+		t.Run(fmt.Sprintf("reader-%d", i), func(t *testing.T) {
+			t.Parallel()
+			got, err := tc.SubscriptionID(context.Background())
+			assert.NoError(t, err)
+			assert.Equal(t, "sub-123", got)
+		})
+	}
+}
+
+func TestGetGraphClientReturnsCachedClient(t *testing.T) {
+	t.Parallel()
+
+	sentinel := &graphutil.Client{}
+	tc := &perItOrDescribeTestContext{
+		graphClient: sentinel,
+	}
+
+	got, err := tc.GetGraphClient(context.Background())
+	assert.NoError(t, err)
+	assert.Same(t, sentinel, got)
+}
+
+func TestGetGraphClientUnlockedReturnsCachedClient(t *testing.T) {
+	t.Parallel()
+
+	sentinel := &graphutil.Client{}
+	tc := &perItOrDescribeTestContext{
+		graphClient: sentinel,
+	}
+
+	got, err := tc.getGraphClientUnlocked(context.Background())
+	assert.NoError(t, err)
+	assert.Same(t, sentinel, got)
+}
+
+func TestGetGraphClientPersistsOnCreate(t *testing.T) {
+	t.Parallel()
+
+	tc := newTestContextWithStubCredential()
+	tc.perBinaryInvocationTestContext.azureCredentials = stubTokenCredential{
+		token: unsignedJWT(`{"oid":"00000000-0000-0000-0000-000000000001","idtyp":"app"}`),
+	}
+
+	got, err := tc.GetGraphClient(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Same(t, got, tc.graphClient, "successful NewClient must be stored on the test context")
+
+	cached, err := tc.GetGraphClient(context.Background())
+	assert.NoError(t, err)
+	assert.Same(t, got, cached)
+}
+
+func TestGetGraphClientUnlockedPersistsOnCreate(t *testing.T) {
+	t.Parallel()
+
+	tc := newTestContextWithStubCredential()
+	tc.perBinaryInvocationTestContext.azureCredentials = stubTokenCredential{
+		token: unsignedJWT(`{"oid":"00000000-0000-0000-0000-000000000001","idtyp":"app"}`),
+	}
+
+	got, err := tc.getGraphClientUnlocked(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Same(t, got, tc.graphClient)
+
+	cached, err := tc.getGraphClientUnlocked(context.Background())
+	assert.NoError(t, err)
+	assert.Same(t, got, cached)
+}
+
+func TestGetGraphClientDoesNotCacheFailedCreate(t *testing.T) {
+	t.Parallel()
+
+	tc := newTestContextWithStubCredential()
+	tc.perBinaryInvocationTestContext.azureCredentials = stubTokenCredential{
+		err: errors.New("no token"),
+	}
+
+	got, err := tc.GetGraphClient(context.Background())
+	assert.Error(t, err)
+	assert.Nil(t, got)
+	assert.Nil(t, tc.graphClient, "failed NewClient must not cache a client")
+}
+
+func TestRecordTestStep(t *testing.T) {
+	t.Parallel()
+
+	tc := &perItOrDescribeTestContext{}
+	start := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	finish := start.Add(time.Second)
+
+	tc.RecordTestStep("Clean up resource group rg (no RP)", start, finish)
+	tc.RecordTestStep("second step", start.Add(2*time.Second), finish.Add(2*time.Second))
+
+	assert.Len(t, tc.timingMetadata.Steps, 2)
+	assert.Equal(t, "Clean up resource group rg (no RP)", tc.timingMetadata.Steps[0].Name)
+	assert.Equal(t, start.Format(time.RFC3339), tc.timingMetadata.Steps[0].StartedAt)
+	assert.Equal(t, finish.Format(time.RFC3339), tc.timingMetadata.Steps[0].FinishedAt)
+	assert.Equal(t, "second step", tc.timingMetadata.Steps[1].Name)
+}
+
+func TestRecordTestStepConcurrent(t *testing.T) {
+	t.Parallel()
+
+	tc := &perItOrDescribeTestContext{}
+	start := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	finish := start.Add(time.Second)
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			tc.RecordTestStep(fmt.Sprintf("step-%d", i), start, finish)
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Len(t, tc.timingMetadata.Steps, goroutines)
+	names := make(map[string]struct{}, goroutines)
+	for _, step := range tc.timingMetadata.Steps {
+		names[step.Name] = struct{}{}
+	}
+	assert.Len(t, names, goroutines)
+}
+
+type stubTokenCredential struct {
+	token string
+	err   error
+}
+
+func (s stubTokenCredential) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	if s.err != nil {
+		return azcore.AccessToken{}, s.err
+	}
+	return azcore.AccessToken{
+		Token:     s.token,
+		ExpiresOn: time.Now().Add(time.Hour),
+	}, nil
+}
+
+func unsignedJWT(claimsJSON string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(claimsJSON))
+	return header + "." + payload + "."
+}
+
+func newTestContextWithStubCredential() *perItOrDescribeTestContext {
+	return &perItOrDescribeTestContext{
+		perBinaryInvocationTestContext: &perBinaryInvocationTestContext{
+			azureCredentials: stubTokenCredential{token: "unused"},
+		},
 	}
 }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-29346

### What

Follow-up to Address some locking issues found during review of https://github.com/Azure/ARO-HCP/pull/6312
Graph client caches are not written
*Unlocked helpers are called with holding contextLock

### Why

For now this fixes some possible latent races with the way current cleanup code works. If we add more parallelism to cleanup operations in the future we will probably surface cache or timing data corruption without these locking fixes. 

### Testing

Pre-merge e2e should be sufficient to catch regressions. This is more to head off future failures or timing data corruption. 

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)


### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
