### PR TITLE
Feat : ARO-29371 | Improve CA Certificate Validation in RP for ExternalAuth

### DIFF
--- a/backend/pkg/controllers/externalauth/status/externalauth_degraded_aggregator.go
+++ b/backend/pkg/controllers/externalauth/status/externalauth_degraded_aggregator.go
@@ -39,6 +39,11 @@ const (
 	// CACertificateExpiryConditionType is the user-facing condition type set when the issuer
 	// CA certificate has expired. Written to Status.UserFacingConditions only while expired;
 	CACertificateExpiryConditionType = "CACertificateExpiry"
+
+	// CACertificateNotYetValidConditionType is the user-facing condition type set when the
+	// issuer CA certificate has a NotBefore in the future. A future NotBefore is accepted at
+	// admission time but surfaced here so operators are aware.
+	CACertificateNotYetValidConditionType = "CACertificateNotYetValid"
 )
 
 // externalAuthDegradedAggregator rolls per-controller Degraded conditions
@@ -123,10 +128,17 @@ func (c *externalAuthDegradedAggregator) SyncOnce(ctx context.Context, key contr
 	apimeta.SetStatusCondition(&replacement.Status.Conditions, aggregated)
 
 	// CACertificateExpiry is user-facing only when the CA has expired.
-	if caCond := caCertExpiryCondition(existing.Properties.Issuer.CA, c.clock.Now()); caCond != nil {
-		apimeta.SetStatusCondition(&replacement.Status.UserFacingConditions, *caCond)
+	// CACertificateNotYetValid is user-facing only when the CA has a start date in the future.
+	expiryCond, notYetValidCond := caCertValidityConditions(existing.Properties.Issuer.CA, c.clock.Now())
+	if expiryCond != nil {
+		apimeta.SetStatusCondition(&replacement.Status.UserFacingConditions, *expiryCond)
 	} else {
 		apimeta.RemoveStatusCondition(&replacement.Status.UserFacingConditions, CACertificateExpiryConditionType)
+	}
+	if notYetValidCond != nil {
+		apimeta.SetStatusCondition(&replacement.Status.UserFacingConditions, *notYetValidCond)
+	} else {
+		apimeta.RemoveStatusCondition(&replacement.Status.UserFacingConditions, CACertificateNotYetValidConditionType)
 	}
 
 	conditionsChanged := !equality.Semantic.DeepEqual(existing.Status.Conditions, replacement.Status.Conditions)
@@ -149,18 +161,23 @@ func (c *externalAuthDegradedAggregator) SyncOnce(ctx context.Context, key contr
 	return nil
 }
 
-// caCertExpiryCondition inspects all CERTIFICATE PEM blocks in ca and returns a
-// CACertificateExpiry condition only when the CA has expired. Healthy, missing, or
-// unparseable CAs return nil so the condition is omitted from user-facing status.
-// When a bundle contains multiple certs the cert with the earliest NotAfter
-// drives the condition.
-func caCertExpiryCondition(ca string, now time.Time) *metav1.Condition {
+// caCertValidityConditions inspects all CERTIFICATE PEM blocks in ca and returns
+// two conditions: expiryCond (CACertificateExpiry) and notYetValidCond (CACertificateNotYetValid).
+// Each is nil when not applicable. Both are derived from a single pass over the PEM bundle:
+//   - expiryCond is set when any cert has expired; the cert with the earliest NotAfter drives
+//     the condition message.
+//   - notYetValidCond is set when any cert has a start date in the future;
+//
+// Missing, empty, or entirely unparseable input causes both to return nil.
+func caCertValidityConditions(ca string, now time.Time) (expiryCond, notYetValidCond *metav1.Condition) {
 	if ca == "" {
-		return nil
+		return nil, nil
 	}
 
-	// Walk every PEM block; only CERTIFICATE blocks are relevant.
-	var earliest *x509.Certificate
+	// Single pass: track earliest-expiring cert and start date is in the future cert.
+	var earliestExpired *x509.Certificate     // drives CACertificateExpiry
+	var earliestNotYetValid *x509.Certificate // drives CACertificateNotYetValid
+
 	rest := []byte(ca)
 	for {
 		var block *pem.Block
@@ -175,25 +192,39 @@ func caCertExpiryCondition(ca string, now time.Time) *metav1.Condition {
 		if err != nil {
 			continue
 		}
-		if earliest == nil || cert.NotAfter.Before(earliest.NotAfter) {
-			earliest = cert
+		// Expiry: keep the cert with the earliest NotAfter.
+		if now.After(cert.NotAfter) {
+			if earliestExpired == nil || cert.NotAfter.Before(earliestExpired.NotAfter) {
+				earliestExpired = cert
+			}
+		}
+		// Not-yet-valid: keep the cert with the NotBefore that is start date still in the future.
+		if now.Before(cert.NotBefore) {
+			if earliestNotYetValid == nil || cert.NotBefore.After(earliestNotYetValid.NotBefore) {
+				earliestNotYetValid = cert
+			}
 		}
 	}
 
-	if earliest == nil {
-		return nil
+	if earliestExpired != nil {
+		notAfter := earliestExpired.NotAfter.UTC().Format(time.RFC3339)
+		expiryCond = &metav1.Condition{
+			Type:    CACertificateExpiryConditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  "Expired",
+			Message: fmt.Sprintf("issuer CA certificate (CN=%s) expired at %s", earliestExpired.Subject.CommonName, notAfter),
+		}
 	}
 
-	// If the CA is not expired, return nil.
-	if !now.After(earliest.NotAfter) {
-		return nil
+	if earliestNotYetValid != nil {
+		notBefore := earliestNotYetValid.NotBefore.UTC().Format(time.RFC3339)
+		notYetValidCond = &metav1.Condition{
+			Type:    CACertificateNotYetValidConditionType,
+			Status:  metav1.ConditionTrue,
+			Reason:  "NotYetValid",
+			Message: fmt.Sprintf("issuer CA certificate (CN=%s) is not yet valid (NotBefore %s)", earliestNotYetValid.Subject.CommonName, notBefore),
+		}
 	}
 
-	notAfter := earliest.NotAfter.UTC().Format(time.RFC3339)
-	return &metav1.Condition{
-		Type:    CACertificateExpiryConditionType,
-		Status:  metav1.ConditionTrue,
-		Reason:  "Expired",
-		Message: fmt.Sprintf("issuer CA certificate (CN=%s) expired at %s", earliest.Subject.CommonName, notAfter),
-	}
+	return expiryCond, notYetValidCond
 }

--- a/backend/pkg/controllers/externalauth/status/externalauth_degraded_aggregator.go
+++ b/backend/pkg/controllers/externalauth/status/externalauth_degraded_aggregator.go
@@ -16,6 +16,8 @@ package status
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"time"
 
@@ -31,6 +33,12 @@ import (
 	"github.com/Azure/ARO-HCP/internal/database/informers/coreinformers"
 	"github.com/Azure/ARO-HCP/internal/database/listers/corelisters"
 	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	// CACertificateExpiryConditionType is the user-facing condition type set when the issuer
+	// CA certificate has expired. Written to Status.UserFacingConditions only while expired;
+	CACertificateExpiryConditionType = "CACertificateExpiry"
 )
 
 // externalAuthDegradedAggregator rolls per-controller Degraded conditions
@@ -113,7 +121,17 @@ func (c *externalAuthDegradedAggregator) SyncOnce(ctx context.Context, key contr
 
 	replacement := existing.DeepCopy()
 	apimeta.SetStatusCondition(&replacement.Status.Conditions, aggregated)
-	if equality.Semantic.DeepEqual(existing.Status.Conditions, replacement.Status.Conditions) {
+
+	// CACertificateExpiry is user-facing only when the CA has expired.
+	if caCond := caCertExpiryCondition(existing.Properties.Issuer.CA, c.clock.Now()); caCond != nil {
+		apimeta.SetStatusCondition(&replacement.Status.UserFacingConditions, *caCond)
+	} else {
+		apimeta.RemoveStatusCondition(&replacement.Status.UserFacingConditions, CACertificateExpiryConditionType)
+	}
+
+	conditionsChanged := !equality.Semantic.DeepEqual(existing.Status.Conditions, replacement.Status.Conditions)
+	userFacingChanged := !equality.Semantic.DeepEqual(existing.Status.UserFacingConditions, replacement.Status.UserFacingConditions)
+	if !conditionsChanged && !userFacingChanged {
 		return nil
 	}
 
@@ -129,4 +147,53 @@ func (c *externalAuthDegradedAggregator) SyncOnce(ctx context.Context, key contr
 		return utils.TrackError(fmt.Errorf("failed to replace ExternalAuth: %w", err))
 	}
 	return nil
+}
+
+// caCertExpiryCondition inspects all CERTIFICATE PEM blocks in ca and returns a
+// CACertificateExpiry condition only when the CA has expired. Healthy, missing, or
+// unparseable CAs return nil so the condition is omitted from user-facing status.
+// When a bundle contains multiple certs the cert with the earliest NotAfter
+// drives the condition.
+func caCertExpiryCondition(ca string, now time.Time) *metav1.Condition {
+	if ca == "" {
+		return nil
+	}
+
+	// Walk every PEM block; only CERTIFICATE blocks are relevant.
+	var earliest *x509.Certificate
+	rest := []byte(ca)
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			continue
+		}
+		if earliest == nil || cert.NotAfter.Before(earliest.NotAfter) {
+			earliest = cert
+		}
+	}
+
+	if earliest == nil {
+		return nil
+	}
+
+	// If the CA is not expired, return nil.
+	if !now.After(earliest.NotAfter) {
+		return nil
+	}
+
+	notAfter := earliest.NotAfter.UTC().Format(time.RFC3339)
+	return &metav1.Condition{
+		Type:    CACertificateExpiryConditionType,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Expired",
+		Message: fmt.Sprintf("issuer CA certificate (CN=%s) expired at %s", earliest.Subject.CommonName, notAfter),
+	}
 }

--- a/backend/pkg/controllers/externalauth/status/externalauth_degraded_aggregator.go
+++ b/backend/pkg/controllers/externalauth/status/externalauth_degraded_aggregator.go
@@ -19,6 +19,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -36,12 +37,12 @@ import (
 )
 
 const (
-	// CACertificateExpiryConditionType is the user-facing condition type set when the issuer
+	// CACertificateExpiredConditionType is the user-facing condition type set when the
 	// CA certificate has expired. Written to Status.UserFacingConditions only while expired;
-	CACertificateExpiryConditionType = "CACertificateExpiry"
+	CACertificateExpiredConditionType = "CACertificateExpired"
 
 	// CACertificateNotYetValidConditionType is the user-facing condition type set when the
-	// issuer CA certificate has a NotBefore in the future. A future NotBefore is accepted at
+	// CA certificate has a NotBefore in the future. A future NotBefore is accepted at
 	// admission time but surfaced here so operators are aware.
 	CACertificateNotYetValidConditionType = "CACertificateNotYetValid"
 )
@@ -129,11 +130,11 @@ func (c *externalAuthDegradedAggregator) SyncOnce(ctx context.Context, key contr
 
 	// CACertificateExpiry is user-facing only when the CA has expired.
 	// CACertificateNotYetValid is user-facing only when the CA has a start date in the future.
-	expiryCond, notYetValidCond := caCertValidityConditions(existing.Properties.Issuer.CA, c.clock.Now())
+	expiryCond, notYetValidCond := c.getCaCertValidityConditions(existing.Properties.Issuer.CA)
 	if expiryCond != nil {
 		apimeta.SetStatusCondition(&replacement.Status.UserFacingConditions, *expiryCond)
 	} else {
-		apimeta.RemoveStatusCondition(&replacement.Status.UserFacingConditions, CACertificateExpiryConditionType)
+		apimeta.RemoveStatusCondition(&replacement.Status.UserFacingConditions, CACertificateExpiredConditionType)
 	}
 	if notYetValidCond != nil {
 		apimeta.SetStatusCondition(&replacement.Status.UserFacingConditions, *notYetValidCond)
@@ -162,21 +163,20 @@ func (c *externalAuthDegradedAggregator) SyncOnce(ctx context.Context, key contr
 }
 
 // caCertValidityConditions inspects all CERTIFICATE PEM blocks in ca and returns
-// two conditions: expiryCond (CACertificateExpiry) and notYetValidCond (CACertificateNotYetValid).
+// two conditions: expiryCond (CACertificateExpired) and notYetValidCond (CACertificateNotYetValid).
 // Each is nil when not applicable. Both are derived from a single pass over the PEM bundle:
-//   - expiryCond is set when any cert has expired; the cert with the earliest NotAfter drives
-//     the condition message.
+//   - expiryCond is set when any cert has expired;
 //   - notYetValidCond is set when any cert has a start date in the future;
 //
 // Missing, empty, or entirely unparseable input causes both to return nil.
-func caCertValidityConditions(ca string, now time.Time) (expiryCond, notYetValidCond *metav1.Condition) {
+func (c *externalAuthDegradedAggregator) getCaCertValidityConditions(ca string) (expiryCond, notYetValidCond *metav1.Condition) {
 	if ca == "" {
 		return nil, nil
 	}
 
-	// Single pass: track earliest-expiring cert and start date is in the future cert.
-	var earliestExpired *x509.Certificate     // drives CACertificateExpiry
-	var earliestNotYetValid *x509.Certificate // drives CACertificateNotYetValid
+	var expired []*x509.Certificate
+	var notYetValid []*x509.Certificate
+	now := c.clock.Now()
 
 	rest := []byte(ca)
 	for {
@@ -192,39 +192,47 @@ func caCertValidityConditions(ca string, now time.Time) (expiryCond, notYetValid
 		if err != nil {
 			continue
 		}
-		// Expiry: keep the cert with the earliest NotAfter.
 		if now.After(cert.NotAfter) {
-			if earliestExpired == nil || cert.NotAfter.Before(earliestExpired.NotAfter) {
-				earliestExpired = cert
-			}
+			expired = append(expired, cert)
 		}
-		// Not-yet-valid: keep the cert with the NotBefore that is start date still in the future.
 		if now.Before(cert.NotBefore) {
-			if earliestNotYetValid == nil || cert.NotBefore.After(earliestNotYetValid.NotBefore) {
-				earliestNotYetValid = cert
-			}
+			notYetValid = append(notYetValid, cert)
 		}
 	}
 
-	if earliestExpired != nil {
-		notAfter := earliestExpired.NotAfter.UTC().Format(time.RFC3339)
+	if len(expired) > 0 {
 		expiryCond = &metav1.Condition{
-			Type:    CACertificateExpiryConditionType,
+			Type:    CACertificateExpiredConditionType,
 			Status:  metav1.ConditionTrue,
 			Reason:  "Expired",
-			Message: fmt.Sprintf("issuer CA certificate (CN=%s) expired at %s", earliestExpired.Subject.CommonName, notAfter),
+			Message: formatCACertExpiredMessage(expired),
 		}
 	}
 
-	if earliestNotYetValid != nil {
-		notBefore := earliestNotYetValid.NotBefore.UTC().Format(time.RFC3339)
+	if len(notYetValid) > 0 {
 		notYetValidCond = &metav1.Condition{
 			Type:    CACertificateNotYetValidConditionType,
 			Status:  metav1.ConditionTrue,
 			Reason:  "NotYetValid",
-			Message: fmt.Sprintf("issuer CA certificate (CN=%s) is not yet valid (NotBefore %s)", earliestNotYetValid.Subject.CommonName, notBefore),
+			Message: formatCACertNotYetValidMessage(notYetValid),
 		}
 	}
 
 	return expiryCond, notYetValidCond
+}
+
+func formatCACertExpiredMessage(certs []*x509.Certificate) string {
+	parts := make([]string, len(certs))
+	for i, cert := range certs {
+		parts[i] = fmt.Sprintf("CN=%s (NotAfter %s)", cert.Subject.CommonName, cert.NotAfter.UTC().Format(time.RFC3339))
+	}
+	return fmt.Sprintf("%d CA certificate(s) in the issuer bundle have expired: %s", len(certs), strings.Join(parts, "; "))
+}
+
+func formatCACertNotYetValidMessage(certs []*x509.Certificate) string {
+	parts := make([]string, len(certs))
+	for i, cert := range certs {
+		parts[i] = fmt.Sprintf("CN=%s (NotBefore %s)", cert.Subject.CommonName, cert.NotBefore.UTC().Format(time.RFC3339))
+	}
+	return fmt.Sprintf("%d CA certificate(s) in the issuer bundle are not yet valid: %s", len(certs), strings.Join(parts, "; "))
 }

--- a/backend/pkg/controllers/externalauth/status/externalauth_degraded_aggregator_test.go
+++ b/backend/pkg/controllers/externalauth/status/externalauth_degraded_aggregator_test.go
@@ -269,113 +269,164 @@ func TestExternalAuthDegradedAggregator_SyncOnce(t *testing.T) {
 	}
 }
 
-// TestCACertExpiryCondition exercises the caCertExpiryCondition helper in isolation.
-func TestCACertExpiryCondition(t *testing.T) {
-	now := statusutils.FixedNow // 2026-06-04T12:00:00Z
+// TestCACertValidityConditions exercises the caCertValidityConditions helper in isolation,
+// covering both the expiry and not-yet-valid cases.
+func TestCACertValidityConditions(t *testing.T) {
+	now := statusutils.FixedNow
 
 	validCA := mustMakeCAPEM(t, "valid-ca", now.Add(-time.Hour), now.Add(90*24*time.Hour))
 	expiredCA := mustMakeCAPEM(t, "expired-ca", now.Add(-48*time.Hour), now.Add(-time.Hour))
+	futureCA := mustMakeCAPEM(t, "future-ca", now.Add(24*time.Hour), now.Add(90*24*time.Hour))
 
 	tests := []struct {
-		name          string
-		ca            string
-		expectNil     bool
-		expectStatus  metav1.ConditionStatus
-		expectReason  string
-		expectMessage string
+		name                 string
+		ca                   string
+		expectExpiryNil      bool
+		expectExpiryReason   string
+		expectExpiryMessage  string
+		expectNotYetValidNil bool
+		expectNYVReason      string
+		expectNYVMessage     string
 	}{
 		{
-			name:      "empty CA — condition not applicable",
-			ca:        "",
-			expectNil: true,
+			name:                 "empty CA — both conditions nil",
+			ca:                   "",
+			expectExpiryNil:      true,
+			expectNotYetValidNil: true,
 		},
 		{
-			name:      "valid CA — no user-facing condition",
-			ca:        validCA,
-			expectNil: true,
+			name:                 "currently valid CA — both conditions nil",
+			ca:                   validCA,
+			expectExpiryNil:      true,
+			expectNotYetValidNil: true,
 		},
 		{
-			name:      "CA valid at exactly NotAfter — no user-facing condition",
-			ca:        mustMakeCAPEM(t, "boundary-ca", now.Add(-time.Hour), now),
-			expectNil: true,
+			name:                 "CA valid starting exactly now — both nil",
+			ca:                   mustMakeCAPEM(t, "boundary-start", now, now.Add(time.Hour)),
+			expectExpiryNil:      true,
+			expectNotYetValidNil: true,
 		},
 		{
-			name:          "expired CA — condition True/Expired",
-			ca:            expiredCA,
-			expectStatus:  metav1.ConditionTrue,
-			expectReason:  "Expired",
-			expectMessage: `expired at`,
+			name:                 "CA valid until exactly now — both nil",
+			ca:                   mustMakeCAPEM(t, "boundary-end", now.Add(-time.Hour), now),
+			expectExpiryNil:      true,
+			expectNotYetValidNil: true,
 		},
 		{
-			// Bundle: expired cert drives the condition.
-			name:          "CA bundle: one valid, one expired — Expired wins",
-			ca:            validCA + expiredCA,
-			expectStatus:  metav1.ConditionTrue,
-			expectReason:  "Expired",
-			expectMessage: `expired at`,
+			name:                 "expired CA — expiry set, notYetValid nil",
+			ca:                   expiredCA,
+			expectExpiryNil:      false,
+			expectExpiryReason:   "Expired",
+			expectExpiryMessage:  "expired at",
+			expectNotYetValidNil: true,
 		},
 		{
-			name:      "unparseable PEM — no condition set",
-			ca:        "NOT A PEM",
-			expectNil: true,
+			name:                 "future CA — expiry nil, notYetValid set",
+			ca:                   futureCA,
+			expectExpiryNil:      true,
+			expectNotYetValidNil: false,
+			expectNYVReason:      "NotYetValid",
+			expectNYVMessage:     "is not yet valid",
+		},
+		{
+			name:                 "bundle: one valid, one expired — expiry set",
+			ca:                   validCA + expiredCA,
+			expectExpiryNil:      false,
+			expectExpiryReason:   "Expired",
+			expectExpiryMessage:  "expired at",
+			expectNotYetValidNil: true,
+		},
+		{
+			name:                 "bundle: one valid, one future — notYetValid set",
+			ca:                   validCA + futureCA,
+			expectExpiryNil:      true,
+			expectNotYetValidNil: false,
+			expectNYVReason:      "NotYetValid",
+			expectNYVMessage:     "is not yet valid",
+		},
+		{
+			name:                 "bundle: expired and future — both set",
+			ca:                   expiredCA + futureCA,
+			expectExpiryNil:      false,
+			expectExpiryReason:   "Expired",
+			expectExpiryMessage:  "expired at",
+			expectNotYetValidNil: false,
+			expectNYVReason:      "NotYetValid",
+			expectNYVMessage:     "is not yet valid",
+		},
+		{
+			name:                 "unparseable PEM — both nil",
+			ca:                   "NOT A PEM",
+			expectExpiryNil:      true,
+			expectNotYetValidNil: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			cond := caCertExpiryCondition(tc.ca, now)
-			if tc.expectNil {
-				assert.Nil(t, cond, "expected no condition")
-				return
+			expiry, notYetValid := caCertValidityConditions(tc.ca, now)
+
+			if tc.expectExpiryNil {
+				assert.Nil(t, expiry, "expected no expiry condition")
+			} else {
+				require.NotNil(t, expiry, "expected expiry condition")
+				assert.Equal(t, CACertificateExpiryConditionType, expiry.Type)
+				assert.Equal(t, metav1.ConditionTrue, expiry.Status)
+				assert.Equal(t, tc.expectExpiryReason, expiry.Reason)
+				assert.Contains(t, expiry.Message, tc.expectExpiryMessage)
 			}
-			require.NotNil(t, cond, "expected a condition")
-			assert.Equal(t, CACertificateExpiryConditionType, cond.Type, "Type")
-			assert.Equal(t, tc.expectStatus, cond.Status, "Status")
-			assert.Equal(t, tc.expectReason, cond.Reason, "Reason")
-			assert.Contains(t, cond.Message, tc.expectMessage, "Message")
+
+			if tc.expectNotYetValidNil {
+				assert.Nil(t, notYetValid, "expected no notYetValid condition")
+			} else {
+				require.NotNil(t, notYetValid, "expected notYetValid condition")
+				assert.Equal(t, CACertificateNotYetValidConditionType, notYetValid.Type)
+				assert.Equal(t, metav1.ConditionTrue, notYetValid.Status)
+				assert.Equal(t, tc.expectNYVReason, notYetValid.Reason)
+				assert.Contains(t, notYetValid.Message, tc.expectNYVMessage)
+			}
 		})
 	}
 }
 
-// TestExternalAuthDegradedAggregator_SyncOnce_CACertExpiry verifies that
-// SyncOnce writes the CACertificateExpiry condition onto the ExternalAuth
-// when a CA is configured.
-func TestExternalAuthDegradedAggregator_SyncOnce_CACertExpiry(t *testing.T) {
+// TestExternalAuthDegradedAggregator_SyncOnce_CACertConditions verifies that SyncOnce
+// correctly sets/clears CACertificateExpiry and CACertificateNotYetValid conditions.
+func TestExternalAuthDegradedAggregator_SyncOnce_CACertConditions(t *testing.T) {
 	now := statusutils.FixedNow
 
 	validCA := mustMakeCAPEM(t, "valid-ca", now.Add(-time.Hour), now.Add(90*24*time.Hour))
 	expiredCA := mustMakeCAPEM(t, "expired-ca", now.Add(-48*time.Hour), now.Add(-time.Hour))
+	futureCA := mustMakeCAPEM(t, "future-ca", now.Add(24*time.Hour), now.Add(90*24*time.Hour))
 
 	tests := []struct {
-		name             string
-		ca               string
-		wantExpiryStatus metav1.ConditionStatus
-		wantExpiryReason string
-		wantConditionSet bool
+		name            string
+		ca              string
+		wantExpiry      bool
+		wantNotYetValid bool
 	}{
 		{
-			name:             "no CA — CACertificateExpiry condition not written",
-			ca:               "",
-			wantConditionSet: false,
+			name: "no CA — neither condition written",
+			ca:   "",
 		},
 		{
-			name:             "valid CA — CACertificateExpiry condition omitted",
-			ca:               validCA,
-			wantConditionSet: false,
+			name: "valid CA — neither condition written",
+			ca:   validCA,
 		},
 		{
-			name:             "expired CA — CACertificateExpiry condition True/Expired",
-			ca:               expiredCA,
-			wantConditionSet: true,
-			wantExpiryStatus: metav1.ConditionTrue,
-			wantExpiryReason: "Expired",
+			name:       "expired CA — expiry condition set",
+			ca:         expiredCA,
+			wantExpiry: true,
+		},
+		{
+			name:            "future CA — notYetValid condition set",
+			ca:              futureCA,
+			wantNotYetValid: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-
 			parentClusterID := metadataapi.Must(azcorearm.ParseResourceID(
 				"/subscriptions/" + statusutils.TestSubscriptionID +
 					"/resourceGroups/" + statusutils.TestResourceGroupName +
@@ -418,14 +469,23 @@ func TestExternalAuthDegradedAggregator_SyncOnce_CACertExpiry(t *testing.T) {
 			updated, err := mockDB.HCPClusters(statusutils.TestSubscriptionID, statusutils.TestResourceGroupName).ExternalAuth(statusutils.TestClusterName).Get(ctx, statusutils.TestExternalAuthName)
 			require.NoError(t, err)
 
-			cond := apimeta.FindStatusCondition(updated.Status.UserFacingConditions, CACertificateExpiryConditionType)
-			if !tc.wantConditionSet {
-				assert.Nil(t, cond, "expected no CACertificateExpiry user-facing condition when CA is empty")
-				return
+			expiryCond := apimeta.FindStatusCondition(updated.Status.UserFacingConditions, CACertificateExpiryConditionType)
+			if tc.wantExpiry {
+				require.NotNil(t, expiryCond, "expected CACertificateExpiry condition")
+				assert.Equal(t, metav1.ConditionTrue, expiryCond.Status)
+				assert.Equal(t, "Expired", expiryCond.Reason)
+			} else {
+				assert.Nil(t, expiryCond, "expected no CACertificateExpiry condition")
 			}
-			require.NotNil(t, cond, "expected CACertificateExpiry user-facing condition to be set")
-			assert.Equal(t, tc.wantExpiryStatus, cond.Status, "Status")
-			assert.Equal(t, tc.wantExpiryReason, cond.Reason, "Reason")
+
+			nyvCond := apimeta.FindStatusCondition(updated.Status.UserFacingConditions, CACertificateNotYetValidConditionType)
+			if tc.wantNotYetValid {
+				require.NotNil(t, nyvCond, "expected CACertificateNotYetValid condition")
+				assert.Equal(t, metav1.ConditionTrue, nyvCond.Status)
+				assert.Equal(t, "NotYetValid", nyvCond.Reason)
+			} else {
+				assert.Nil(t, nyvCond, "expected no CACertificateNotYetValid condition")
+			}
 		})
 	}
 }

--- a/backend/pkg/controllers/externalauth/status/externalauth_degraded_aggregator_test.go
+++ b/backend/pkg/controllers/externalauth/status/externalauth_degraded_aggregator_test.go
@@ -16,6 +16,13 @@ package status
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"regexp"
 	"strings"
 	"testing"
@@ -37,6 +44,26 @@ import (
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/corecosmosstoragetesting"
 	"github.com/Azure/ARO-HCP/internal/database/listertesting/corelistertesting"
 )
+
+// mustMakeCAPEM generates a self-signed CA certificate valid from notBefore to
+// notAfter and returns it as a PEM-encoded string. The certificate's Subject CN
+// is set to cn. Fails the test on any generation error (test helper).
+func mustMakeCAPEM(t *testing.T, cn string, notBefore, notAfter time.Time) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err, "generate test CA key")
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err, "create test CA certificate")
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
 
 // newTestExternalAuthForAggregator builds a minimal
 // HCPOpenShiftClusterExternalAuth suitable for the aggregator tests.
@@ -240,4 +267,225 @@ func TestExternalAuthDegradedAggregator_SyncOnce(t *testing.T) {
 			assert.Equal(t, tc.expectMessage, cond.Message, "message")
 		})
 	}
+}
+
+// TestCACertExpiryCondition exercises the caCertExpiryCondition helper in isolation.
+func TestCACertExpiryCondition(t *testing.T) {
+	now := statusutils.FixedNow // 2026-06-04T12:00:00Z
+
+	validCA := mustMakeCAPEM(t, "valid-ca", now.Add(-time.Hour), now.Add(90*24*time.Hour))
+	expiredCA := mustMakeCAPEM(t, "expired-ca", now.Add(-48*time.Hour), now.Add(-time.Hour))
+
+	tests := []struct {
+		name          string
+		ca            string
+		expectNil     bool
+		expectStatus  metav1.ConditionStatus
+		expectReason  string
+		expectMessage string
+	}{
+		{
+			name:      "empty CA — condition not applicable",
+			ca:        "",
+			expectNil: true,
+		},
+		{
+			name:      "valid CA — no user-facing condition",
+			ca:        validCA,
+			expectNil: true,
+		},
+		{
+			name:      "CA valid at exactly NotAfter — no user-facing condition",
+			ca:        mustMakeCAPEM(t, "boundary-ca", now.Add(-time.Hour), now),
+			expectNil: true,
+		},
+		{
+			name:          "expired CA — condition True/Expired",
+			ca:            expiredCA,
+			expectStatus:  metav1.ConditionTrue,
+			expectReason:  "Expired",
+			expectMessage: `expired at`,
+		},
+		{
+			// Bundle: expired cert drives the condition.
+			name:          "CA bundle: one valid, one expired — Expired wins",
+			ca:            validCA + expiredCA,
+			expectStatus:  metav1.ConditionTrue,
+			expectReason:  "Expired",
+			expectMessage: `expired at`,
+		},
+		{
+			name:      "unparseable PEM — no condition set",
+			ca:        "NOT A PEM",
+			expectNil: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cond := caCertExpiryCondition(tc.ca, now)
+			if tc.expectNil {
+				assert.Nil(t, cond, "expected no condition")
+				return
+			}
+			require.NotNil(t, cond, "expected a condition")
+			assert.Equal(t, CACertificateExpiryConditionType, cond.Type, "Type")
+			assert.Equal(t, tc.expectStatus, cond.Status, "Status")
+			assert.Equal(t, tc.expectReason, cond.Reason, "Reason")
+			assert.Contains(t, cond.Message, tc.expectMessage, "Message")
+		})
+	}
+}
+
+// TestExternalAuthDegradedAggregator_SyncOnce_CACertExpiry verifies that
+// SyncOnce writes the CACertificateExpiry condition onto the ExternalAuth
+// when a CA is configured.
+func TestExternalAuthDegradedAggregator_SyncOnce_CACertExpiry(t *testing.T) {
+	now := statusutils.FixedNow
+
+	validCA := mustMakeCAPEM(t, "valid-ca", now.Add(-time.Hour), now.Add(90*24*time.Hour))
+	expiredCA := mustMakeCAPEM(t, "expired-ca", now.Add(-48*time.Hour), now.Add(-time.Hour))
+
+	tests := []struct {
+		name             string
+		ca               string
+		wantExpiryStatus metav1.ConditionStatus
+		wantExpiryReason string
+		wantConditionSet bool
+	}{
+		{
+			name:             "no CA — CACertificateExpiry condition not written",
+			ca:               "",
+			wantConditionSet: false,
+		},
+		{
+			name:             "valid CA — CACertificateExpiry condition omitted",
+			ca:               validCA,
+			wantConditionSet: false,
+		},
+		{
+			name:             "expired CA — CACertificateExpiry condition True/Expired",
+			ca:               expiredCA,
+			wantConditionSet: true,
+			wantExpiryStatus: metav1.ConditionTrue,
+			wantExpiryReason: "Expired",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			parentClusterID := metadataapi.Must(azcorearm.ParseResourceID(
+				"/subscriptions/" + statusutils.TestSubscriptionID +
+					"/resourceGroups/" + statusutils.TestResourceGroupName +
+					"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + statusutils.TestClusterName,
+			))
+			existing := newTestExternalAuthForAggregator(func(ea *coreapi.HCPOpenShiftClusterExternalAuth) {
+				ea.Properties.Issuer.CA = tc.ca
+			})
+			parentCluster := &coreapi.HCPOpenShiftCluster{
+				CosmosMetadata: coreapi.CosmosMetadata{
+					ResourceID:   parentClusterID,
+					PartitionKey: strings.ToLower(parentClusterID.SubscriptionID),
+				},
+				TrackedResource: coreapi.TrackedResource{
+					Resource: coreapi.Resource{ID: parentClusterID, Name: statusutils.TestClusterName, Type: parentClusterID.ResourceType.String()},
+				},
+			}
+
+			mockDB, err := corecosmosstoragetesting.NewMockResourcesDBClientWithResources(ctx, []any{parentCluster, existing})
+			require.NoError(t, err)
+
+			clock := clocktesting.NewFakePassiveClock(now)
+			syncer := &externalAuthDegradedAggregator{
+				externalAuthLister: &corelistertesting.DBExternalAuthLister{ResourcesDBClient: mockDB},
+				controllerLister:   &corelistertesting.DBControllerLister{ResourcesDBClient: mockDB},
+				resourcesDBClient:  mockDB,
+				inertia:            externalAuthDegradedAggregatorInertia(),
+				clock:              clock,
+				firstObservedBad:   statusutils.NewFirstObservedBadCache(clock),
+			}
+
+			err = syncer.SyncOnce(ctx, controllerutils.HCPExternalAuthKey{
+				SubscriptionID:      statusutils.TestSubscriptionID,
+				ResourceGroupName:   statusutils.TestResourceGroupName,
+				HCPClusterName:      statusutils.TestClusterName,
+				HCPExternalAuthName: statusutils.TestExternalAuthName,
+			})
+			require.NoError(t, err)
+
+			updated, err := mockDB.HCPClusters(statusutils.TestSubscriptionID, statusutils.TestResourceGroupName).ExternalAuth(statusutils.TestClusterName).Get(ctx, statusutils.TestExternalAuthName)
+			require.NoError(t, err)
+
+			cond := apimeta.FindStatusCondition(updated.Status.UserFacingConditions, CACertificateExpiryConditionType)
+			if !tc.wantConditionSet {
+				assert.Nil(t, cond, "expected no CACertificateExpiry user-facing condition when CA is empty")
+				return
+			}
+			require.NotNil(t, cond, "expected CACertificateExpiry user-facing condition to be set")
+			assert.Equal(t, tc.wantExpiryStatus, cond.Status, "Status")
+			assert.Equal(t, tc.wantExpiryReason, cond.Reason, "Reason")
+		})
+	}
+}
+
+// TestExternalAuthDegradedAggregator_SyncOnce_CACertExpiry_clearsStaleCondition verifies that
+// SyncOnce removes the CACertificateExpiry condition from the ExternalAuth when a CA is
+// configured and the condition is stale.
+func TestExternalAuthDegradedAggregator_SyncOnce_CACertExpiry_clearsStaleCondition(t *testing.T) {
+	now := statusutils.FixedNow
+	validCA := mustMakeCAPEM(t, "valid-ca", now.Add(-time.Hour), now.Add(90*24*time.Hour))
+
+	ctx := context.Background()
+	parentClusterID := metadataapi.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + statusutils.TestSubscriptionID +
+			"/resourceGroups/" + statusutils.TestResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + statusutils.TestClusterName,
+	))
+	existing := newTestExternalAuthForAggregator(func(ea *coreapi.HCPOpenShiftClusterExternalAuth) {
+		ea.Properties.Issuer.CA = validCA
+		ea.Status.UserFacingConditions = []metav1.Condition{
+			{
+				Type:    CACertificateExpiryConditionType,
+				Status:  metav1.ConditionFalse,
+				Reason:  "Valid",
+				Message: "stale healthy condition should be removed",
+			},
+		}
+	})
+	parentCluster := &coreapi.HCPOpenShiftCluster{
+		CosmosMetadata: coreapi.CosmosMetadata{
+			ResourceID:   parentClusterID,
+			PartitionKey: strings.ToLower(parentClusterID.SubscriptionID),
+		},
+		TrackedResource: coreapi.TrackedResource{
+			Resource: coreapi.Resource{ID: parentClusterID, Name: statusutils.TestClusterName, Type: parentClusterID.ResourceType.String()},
+		},
+	}
+
+	mockDB, err := corecosmosstoragetesting.NewMockResourcesDBClientWithResources(ctx, []any{parentCluster, existing})
+	require.NoError(t, err)
+
+	syncer := &externalAuthDegradedAggregator{
+		externalAuthLister: &corelistertesting.DBExternalAuthLister{ResourcesDBClient: mockDB},
+		controllerLister:   &corelistertesting.DBControllerLister{ResourcesDBClient: mockDB},
+		resourcesDBClient:  mockDB,
+		inertia:            externalAuthDegradedAggregatorInertia(),
+		clock:              clocktesting.NewFakePassiveClock(now),
+		firstObservedBad:   statusutils.NewFirstObservedBadCache(clocktesting.NewFakePassiveClock(now)),
+	}
+
+	err = syncer.SyncOnce(ctx, controllerutils.HCPExternalAuthKey{
+		SubscriptionID:      statusutils.TestSubscriptionID,
+		ResourceGroupName:   statusutils.TestResourceGroupName,
+		HCPClusterName:      statusutils.TestClusterName,
+		HCPExternalAuthName: statusutils.TestExternalAuthName,
+	})
+	require.NoError(t, err)
+
+	updated, err := mockDB.HCPClusters(statusutils.TestSubscriptionID, statusutils.TestResourceGroupName).ExternalAuth(statusutils.TestClusterName).Get(ctx, statusutils.TestExternalAuthName)
+	require.NoError(t, err)
+	assert.Nil(t, apimeta.FindStatusCondition(updated.Status.UserFacingConditions, CACertificateExpiryConditionType),
+		"healthy CA should remove CACertificateExpiry from user-facing conditions")
 }

--- a/backend/pkg/controllers/externalauth/status/externalauth_degraded_aggregator_test.go
+++ b/backend/pkg/controllers/externalauth/status/externalauth_degraded_aggregator_test.go
@@ -317,7 +317,7 @@ func TestCACertValidityConditions(t *testing.T) {
 			ca:                   expiredCA,
 			expectExpiryNil:      false,
 			expectExpiryReason:   "Expired",
-			expectExpiryMessage:  "expired at",
+			expectExpiryMessage:  "have expired",
 			expectNotYetValidNil: true,
 		},
 		{
@@ -326,14 +326,14 @@ func TestCACertValidityConditions(t *testing.T) {
 			expectExpiryNil:      true,
 			expectNotYetValidNil: false,
 			expectNYVReason:      "NotYetValid",
-			expectNYVMessage:     "is not yet valid",
+			expectNYVMessage:     "are not yet valid",
 		},
 		{
 			name:                 "bundle: one valid, one expired — expiry set",
 			ca:                   validCA + expiredCA,
 			expectExpiryNil:      false,
 			expectExpiryReason:   "Expired",
-			expectExpiryMessage:  "expired at",
+			expectExpiryMessage:  "have expired",
 			expectNotYetValidNil: true,
 		},
 		{
@@ -342,17 +342,17 @@ func TestCACertValidityConditions(t *testing.T) {
 			expectExpiryNil:      true,
 			expectNotYetValidNil: false,
 			expectNYVReason:      "NotYetValid",
-			expectNYVMessage:     "is not yet valid",
+			expectNYVMessage:     "are not yet valid",
 		},
 		{
 			name:                 "bundle: expired and future — both set",
 			ca:                   expiredCA + futureCA,
 			expectExpiryNil:      false,
 			expectExpiryReason:   "Expired",
-			expectExpiryMessage:  "expired at",
+			expectExpiryMessage:  "have expired",
 			expectNotYetValidNil: false,
 			expectNYVReason:      "NotYetValid",
-			expectNYVMessage:     "is not yet valid",
+			expectNYVMessage:     "are not yet valid",
 		},
 		{
 			name:                 "unparseable PEM — both nil",
@@ -362,15 +362,19 @@ func TestCACertValidityConditions(t *testing.T) {
 		},
 	}
 
+	agg := &externalAuthDegradedAggregator{
+		clock: clocktesting.NewFakePassiveClock(now),
+	}
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			expiry, notYetValid := caCertValidityConditions(tc.ca, now)
+			expiry, notYetValid := agg.getCaCertValidityConditions(tc.ca)
 
 			if tc.expectExpiryNil {
 				assert.Nil(t, expiry, "expected no expiry condition")
 			} else {
 				require.NotNil(t, expiry, "expected expiry condition")
-				assert.Equal(t, CACertificateExpiryConditionType, expiry.Type)
+				assert.Equal(t, CACertificateExpiredConditionType, expiry.Type)
 				assert.Equal(t, metav1.ConditionTrue, expiry.Status)
 				assert.Equal(t, tc.expectExpiryReason, expiry.Reason)
 				assert.Contains(t, expiry.Message, tc.expectExpiryMessage)
@@ -469,7 +473,7 @@ func TestExternalAuthDegradedAggregator_SyncOnce_CACertConditions(t *testing.T) 
 			updated, err := mockDB.HCPClusters(statusutils.TestSubscriptionID, statusutils.TestResourceGroupName).ExternalAuth(statusutils.TestClusterName).Get(ctx, statusutils.TestExternalAuthName)
 			require.NoError(t, err)
 
-			expiryCond := apimeta.FindStatusCondition(updated.Status.UserFacingConditions, CACertificateExpiryConditionType)
+			expiryCond := apimeta.FindStatusCondition(updated.Status.UserFacingConditions, CACertificateExpiredConditionType)
 			if tc.wantExpiry {
 				require.NotNil(t, expiryCond, "expected CACertificateExpiry condition")
 				assert.Equal(t, metav1.ConditionTrue, expiryCond.Status)
@@ -507,7 +511,7 @@ func TestExternalAuthDegradedAggregator_SyncOnce_CACertExpiry_clearsStaleConditi
 		ea.Properties.Issuer.CA = validCA
 		ea.Status.UserFacingConditions = []metav1.Condition{
 			{
-				Type:    CACertificateExpiryConditionType,
+				Type:    CACertificateExpiredConditionType,
 				Status:  metav1.ConditionFalse,
 				Reason:  "Valid",
 				Message: "stale healthy condition should be removed",
@@ -546,6 +550,6 @@ func TestExternalAuthDegradedAggregator_SyncOnce_CACertExpiry_clearsStaleConditi
 
 	updated, err := mockDB.HCPClusters(statusutils.TestSubscriptionID, statusutils.TestResourceGroupName).ExternalAuth(statusutils.TestClusterName).Get(ctx, statusutils.TestExternalAuthName)
 	require.NoError(t, err)
-	assert.Nil(t, apimeta.FindStatusCondition(updated.Status.UserFacingConditions, CACertificateExpiryConditionType),
+	assert.Nil(t, apimeta.FindStatusCondition(updated.Status.UserFacingConditions, CACertificateExpiredConditionType),
 		"healthy CA should remove CACertificateExpiry from user-facing conditions")
 }

--- a/docs/cosmos-data-flow.md
+++ b/docs/cosmos-data-flow.md
@@ -1119,6 +1119,17 @@ Records the observed placement (`Status.ManagementClusterResourceID`) from the C
 | **Write** | **`HCPOpenShiftClusterNodePool`** | <ul><li>**`Status.Conditions[Degraded]`** = aggregated union</li></ul> |
 | **Write** | **`HCPOpenShiftClusterExternalAuth`** | <ul><li>**`Status.Conditions[Degraded]`** = aggregated union</li></ul> |
 
+#### ExternalAuthDegradedAggregator — CA Certificate Validity
+
+**File:** [externalauth_degraded_aggregator.go](../backend/pkg/controllers/externalauth/status/externalauth_degraded_aggregator.go)
+**Trigger:** ExternalAuth informer, 1-minute resync
+**Writes user-facing conditions** (visible to end-users via the ARM API) whenever the CA certificate bundle in an `ExternalAuth` resource is expired or not yet valid. These complement the `Status.Conditions[Degraded]` entry above.
+
+| | Object | Fields |
+|---|--------|--------|
+| Read | `HCPOpenShiftClusterExternalAuth` | <ul><li>`Properties.Issuer.CA` (PEM bundle — inspected for expired / not-yet-valid X.509 certificates)</li><li>`Status.UserFacingConditions` (skip write when unchanged)</li></ul> |
+| **Write** | **`HCPOpenShiftClusterExternalAuth`** | <ul><li>**`Status.UserFacingConditions[CACertificateExpired]`** = True when ≥1 cert in the bundle has `NotAfter < now`; message lists every expired cert as `CN=… (NotAfter …)`; condition removed when all certs are valid</li><li>**`Status.UserFacingConditions[CACertificateNotYetValid]`** = True when ≥1 cert has `NotBefore > now`; message lists every not-yet-valid cert as `CN=… (NotBefore …)`; condition removed when all certs are valid</li></ul> |
+
 #### ClusterRequirementsValidAggregator
 
 **File:** [cluster_requirements_valid_aggregator.go](../backend/pkg/controllers/statuscontrollers/cluster_requirements_valid_aggregator.go)
@@ -1512,6 +1523,14 @@ Single writer today (`RequirementsValid` only).
 | [NodePoolRequirementsValidAggregator](#nodepoolrequirementsvalidaggregator) | Aggregated `RequirementsValid` condition from `ServiceProviderNodePool.Status.Validations` |
 
 Single writer today (`RequirementsValid` only).
+
+### `HCPOpenShiftClusterExternalAuth.Status.UserFacingConditions`
+
+| Actor | When |
+|-------|------|
+| [ExternalAuthDegradedAggregator — CA Certificate Validity](#externalauthdegradedaggregator--ca-certificate-validity) | Sets `CACertificateExpired` when ≥1 cert in `Properties.Issuer.CA` is expired; sets `CACertificateNotYetValid` when ≥1 cert has a future `NotBefore`; clears both when all certs are valid |
+
+Single writer. Both conditions are written (or cleared) on every reconcile of the ExternalAuth resource.
 
 ### `HCPOpenShiftClusterNodePool.Properties.ProvisioningState`
 

--- a/internal/api/coreapi/types_externalauth.go
+++ b/internal/api/coreapi/types_externalauth.go
@@ -58,6 +58,7 @@ type HCPOpenShiftClusterExternalAuthStatus struct {
 	// Addition of new conditions here should be done only when strictly necessary, sparingly and only done
 	// when there is a clear benefit to doing so. We expect the number of conditions at this
 	// level to be kept to a minimum.
+	// Written by: ExternalAuthDegradedAggregator
 	// +optional
 	// +patchMergeKey=type
 	// +patchStrategy=merge

--- a/internal/validation/validate_externalauth_comprehensive_test.go
+++ b/internal/validation/validate_externalauth_comprehensive_test.go
@@ -265,7 +265,7 @@ func TestValidateExternalAuth(t *testing.T) {
 			},
 		},
 		{
-			name: "not-yet-valid CA certificate is rejected",
+			name: "not-yet-valid CA certificate is accepted at admission",
 			newObj: func() *coreapi.HCPOpenShiftClusterExternalAuth {
 				obj := createMinimalExternalAuth()
 				obj.Properties.Issuer.URL = "https://valid.example.com"
@@ -274,9 +274,6 @@ func TestValidateExternalAuth(t *testing.T) {
 				return obj
 			}(),
 			op: operation.Operation{Type: operation.Create},
-			expectErrors: []utils.ExpectedError{
-				{FieldPath: "properties.issuer.ca", Message: "is not yet valid"},
-			},
 		},
 		{
 			name: "too many clients",
@@ -1350,11 +1347,8 @@ func TestValidateCACertificatePEM(t *testing.T) {
 			},
 		},
 		{
-			name:  "not-yet-valid CA rejected",
+			name:  "not-yet-valid CA accepted at admission",
 			value: ptr.To(notYetValidCA),
-			expectErrors: []utils.ExpectedError{
-				{FieldPath: "properties.issuer.ca", Message: "certificate 1 (CN=test-ca) is not yet valid"},
-			},
 		},
 		{
 			name:  "trailing non-PEM data rejected",

--- a/internal/validation/validate_externalauth_comprehensive_test.go
+++ b/internal/validation/validate_externalauth_comprehensive_test.go
@@ -233,7 +233,7 @@ func TestValidateExternalAuth(t *testing.T) {
 			}(),
 			op: operation.Operation{Type: operation.Create},
 			expectErrors: []utils.ExpectedError{
-				{FieldPath: "properties.issuer.ca", Message: "not a valid PEM"},
+				{FieldPath: "properties.issuer.ca", Message: "must be CERTIFICATE"},
 			},
 		},
 		{
@@ -1318,7 +1318,7 @@ func TestValidateCACertificatePEM(t *testing.T) {
 			name:  "private key rejected",
 			value: ptr.To(privateKey),
 			expectErrors: []utils.ExpectedError{
-				{FieldPath: "properties.issuer.ca", Message: "not a valid PEM"},
+				{FieldPath: "properties.issuer.ca", Message: "must be CERTIFICATE"},
 			},
 		},
 		{
@@ -1329,10 +1329,10 @@ func TestValidateCACertificatePEM(t *testing.T) {
 			},
 		},
 		{
-			name:  "empty certificate block is not a valid PEM",
+			name:  "empty certificate block is not a valid X.509 certificate",
 			value: ptr.To("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"),
 			expectErrors: []utils.ExpectedError{
-				{FieldPath: "properties.issuer.ca", Message: "not a valid PEM"},
+				{FieldPath: "properties.issuer.ca", Message: "is not a valid X.509 certificate"},
 			},
 		},
 		{

--- a/internal/validation/validate_externalauth_comprehensive_test.go
+++ b/internal/validation/validate_externalauth_comprehensive_test.go
@@ -16,12 +16,22 @@ package validation
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/operation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 
 	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 
@@ -210,6 +220,62 @@ func TestValidateExternalAuth(t *testing.T) {
 			op: operation.Operation{Type: operation.Create},
 			expectErrors: []utils.ExpectedError{
 				{FieldPath: "properties.issuer.ca", Message: "not a valid PEM"},
+			},
+		},
+		{
+			name: "CA PEM with private key is rejected",
+			newObj: func() *coreapi.HCPOpenShiftClusterExternalAuth {
+				obj := createMinimalExternalAuth()
+				obj.Properties.Issuer.URL = "https://valid.example.com"
+				obj.Properties.Issuer.Audiences = []string{"audience1"}
+				obj.Properties.Issuer.CA = mustGenerateTestPrivateKeyPEM(t)
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.issuer.ca", Message: "not a valid PEM"},
+			},
+		},
+		{
+			name: "non-CA certificate is rejected",
+			newObj: func() *coreapi.HCPOpenShiftClusterExternalAuth {
+				obj := createMinimalExternalAuth()
+				obj.Properties.Issuer.URL = "https://valid.example.com"
+				obj.Properties.Issuer.Audiences = []string{"audience1"}
+				obj.Properties.Issuer.CA = mustGenerateTestCertPEM(t, time.Now().Add(-time.Hour), time.Now().Add(24*time.Hour), false)
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.issuer.ca", Message: "must be a CA certificate"},
+			},
+		},
+		{
+			name: "expired CA certificate is rejected",
+			newObj: func() *coreapi.HCPOpenShiftClusterExternalAuth {
+				obj := createMinimalExternalAuth()
+				obj.Properties.Issuer.URL = "https://valid.example.com"
+				obj.Properties.Issuer.Audiences = []string{"audience1"}
+				obj.Properties.Issuer.CA = mustGenerateTestCertPEM(t, time.Now().Add(-48*time.Hour), time.Now().Add(-time.Hour), true)
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.issuer.ca", Message: "has expired"},
+			},
+		},
+		{
+			name: "not-yet-valid CA certificate is rejected",
+			newObj: func() *coreapi.HCPOpenShiftClusterExternalAuth {
+				obj := createMinimalExternalAuth()
+				obj.Properties.Issuer.URL = "https://valid.example.com"
+				obj.Properties.Issuer.Audiences = []string{"audience1"}
+				obj.Properties.Issuer.CA = mustGenerateTestCertPEM(t, time.Now().Add(time.Hour), time.Now().Add(24*time.Hour), true)
+				return obj
+			}(),
+			op: operation.Operation{Type: operation.Create},
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.issuer.ca", Message: "is not yet valid"},
 			},
 		},
 		{
@@ -1206,18 +1272,257 @@ func createValidExternalAuth() *coreapi.HCPOpenShiftClusterExternalAuth {
 }
 
 func validCertPEM() string {
-	return `-----BEGIN CERTIFICATE-----
-MIICMzCCAZygAwIBAgIJALiPnVsvq8dsMA0GCSqGSIb3DQEBBQUAMFMxCzAJBgNV
-BAYTAlVTMQwwCgYDVQQIEwNmb28xDDAKBgNVBAcTA2ZvbzEMMAoGA1UEChMDZm9v
-MQwwCgYDVQQLEwNmb28xDDAKBgNVBAMTA2ZvbzAeFw0xMzAzMTkxNTQwMTlaFw0x
-ODAzMTgxNTQwMTlaMFMxCzAJBgNVBAYTAlVTMQwwCgYDVQQIEwNmb28xDDAKBgNV
-BAcTA2ZvbzEMMAoGA1UEChMDZm9vMQwwCgYDVQQLEwNmb28xDDAKBgNVBAMTA2Zv
-bzCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAzdGfxi9CNbMf1UUcvDQh7MYB
-OveIHyc0E0KIbhjK5FkCBU4CiZrbfHagaW7ZEcN0tt3EvpbOMxxc/ZQU2WN/s/wP
-xph0pSfsfFsTKM4RhTWD2v4fgk+xZiKd1p0+L4hTtpwnEw0uXRVd0ki6muwV5y/P
-+5FHUeldq+pgTcgzuK8CAwEAAaMPMA0wCwYDVR0PBAQDAgLkMA0GCSqGSIb3DQEB
-BQUAA4GBAJiDAAtY0mQQeuxWdzLRzXmjvdSuL9GoyT3BF/jSnpxz5/58dba8pWen
-v3pj4P3w5DoOso0rzkZy2jEsEitlVM2mLSbQpMM+MUVQCQoiG6W9xuCFuxSrwPIS
-pAqEAuV4DNoxQKKWmhVv+J0ptMWD25Pnpxeq5sXzghfJnslJlQND
------END CERTIFICATE-----`
+	return mustValidCAPEM()
+}
+
+func TestValidateCACertificatePEM(t *testing.T) {
+	fldPath := field.NewPath("properties", "issuer", "ca")
+	now := time.Now()
+
+	validCA := mustGenerateTestCertPEM(t, now.Add(-time.Hour), now.Add(24*time.Hour), true)
+	secondValidCA := mustGenerateTestCertPEM(t, now.Add(-time.Hour), now.Add(24*time.Hour), true)
+	nonCA := mustGenerateTestCertPEM(t, now.Add(-time.Hour), now.Add(24*time.Hour), false)
+	expiredCA := mustGenerateTestCertPEM(t, now.Add(-48*time.Hour), now.Add(-time.Hour), true)
+	notYetValidCA := mustGenerateTestCertPEM(t, now.Add(time.Hour), now.Add(24*time.Hour), true)
+	privateKey := mustGenerateTestPrivateKeyPEM(t)
+
+	tests := []struct {
+		name         string
+		value        *string
+		expectErrors []utils.ExpectedError
+	}{
+		{
+			name:  "nil is accepted",
+			value: nil,
+		},
+		{
+			name:  "empty is accepted",
+			value: ptr.To(""),
+		},
+		{
+			name:  "valid CA certificate",
+			value: ptr.To(validCA),
+		},
+		{
+			name:  "valid CA bundle",
+			value: ptr.To(validCA + secondValidCA),
+		},
+		{
+			name:  "not a PEM is rejected by ValidatePEM",
+			value: ptr.To("NOT A PEM DOC"),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.issuer.ca", Message: "not a valid PEM"},
+			},
+		},
+		{
+			name:  "private key rejected",
+			value: ptr.To(privateKey),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.issuer.ca", Message: "not a valid PEM"},
+			},
+		},
+		{
+			name:  "mixed certificate and private key rejected",
+			value: ptr.To(validCA + privateKey),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.issuer.ca", Message: `PEM block 2 has type "EC PRIVATE KEY"; must be CERTIFICATE`},
+			},
+		},
+		{
+			name:  "empty certificate block is not a valid PEM",
+			value: ptr.To("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.issuer.ca", Message: "not a valid PEM"},
+			},
+		},
+		{
+			name:  "non-CA certificate rejected",
+			value: ptr.To(nonCA),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.issuer.ca", Message: "certificate 1 (CN=test-cert) must be a CA certificate"},
+			},
+		},
+		{
+			name:  "expired CA rejected",
+			value: ptr.To(expiredCA),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.issuer.ca", Message: "certificate 1 (CN=test-ca) has expired"},
+			},
+		},
+		{
+			name:  "not-yet-valid CA rejected",
+			value: ptr.To(notYetValidCA),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.issuer.ca", Message: "certificate 1 (CN=test-ca) is not yet valid"},
+			},
+		},
+		{
+			name:  "trailing non-PEM data rejected",
+			value: ptr.To(validCA + "not-pem-data\n"),
+			expectErrors: []utils.ExpectedError{
+				{FieldPath: "properties.issuer.ca", Message: "contains trailing non-PEM data"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidatePEM(context.Background(), operation.Operation{}, fldPath, tt.value, nil)
+			utils.VerifyErrorsMatch(t, tt.expectErrors, errs)
+		})
+	}
+
+	t.Run("ValidatePEM uses current time", func(t *testing.T) {
+		errs := ValidatePEM(context.Background(), operation.Operation{}, fldPath, ptr.To(validCA), nil)
+		if len(errs) != 0 {
+			t.Fatalf("expected valid current CA to pass, got %v", errs)
+		}
+	})
+}
+
+func TestValidateCACertificatePEM_diagnostics(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	fldPath := field.NewPath("ca")
+	nonCA := mustGenerateTestCertPEM(t, now.Add(-time.Hour), now.Add(24*time.Hour), false)
+	privateKey := mustGenerateTestPrivateKeyPEM(t)
+	validCA := mustGenerateTestCertPEM(t, now.Add(-time.Hour), now.Add(24*time.Hour), true)
+
+	t.Run("non-CA uses block index and subject", func(t *testing.T) {
+		errs := validateCACertificatePEM(fldPath, ptr.To(nonCA), now)
+		if len(errs) != 1 {
+			t.Fatalf("expected 1 error, got %v", errs)
+		}
+		if got := fmt.Sprint(errs[0].BadValue); got != "block 1: CN=test-cert" {
+			t.Errorf("BadValue = %q, want %q", got, "block 1: CN=test-cert")
+		}
+		if !strings.Contains(errs[0].Detail, "certificate 1 (CN=test-cert) must be a CA certificate") {
+			t.Errorf("Detail = %q", errs[0].Detail)
+		}
+	})
+
+	t.Run("non-CERTIFICATE block uses block index", func(t *testing.T) {
+		errs := validateCACertificatePEM(fldPath, ptr.To(validCA+privateKey), now)
+		if len(errs) != 1 {
+			t.Fatalf("expected 1 error, got %v", errs)
+		}
+		if got := fmt.Sprint(errs[0].BadValue); got != "block 2" {
+			t.Errorf("BadValue = %q, want %q", got, "block 2")
+		}
+		if !strings.Contains(errs[0].Detail, `PEM block 2 has type "EC PRIVATE KEY"`) {
+			t.Errorf("Detail = %q", errs[0].Detail)
+		}
+	})
+
+	t.Run("trailing garbage is a single dedicated error", func(t *testing.T) {
+		errs := validateCACertificatePEM(fldPath, ptr.To(validCA+"not-pem-data\n"), now)
+		if len(errs) != 1 {
+			t.Fatalf("expected 1 error, got %v", errs)
+		}
+		if got := fmt.Sprint(errs[0].BadValue); got != "" {
+			t.Errorf("BadValue = %q, want empty", got)
+		}
+		if errs[0].Detail != "contains trailing non-PEM data" {
+			t.Errorf("Detail = %q", errs[0].Detail)
+		}
+	})
+
+	t.Run("trailing whitespace after PEM is accepted", func(t *testing.T) {
+		if errs := validateCACertificatePEM(fldPath, ptr.To(validCA+"\n  \n"), now); len(errs) != 0 {
+			t.Fatalf("expected trailing whitespace to pass, got %v", errs)
+		}
+	})
+}
+
+func mustGenerateTestCertPEM(t *testing.T, notBefore, notAfter time.Time, isCA bool) string {
+	t.Helper()
+	pemBytes, err := generateTestCertPEM(notBefore, notAfter, isCA)
+	if err != nil {
+		t.Fatalf("failed to generate test certificate: %v", err)
+	}
+	return pemBytes
+}
+
+func mustGenerateTestPrivateKeyPEM(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate test private key: %v", err)
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("failed to marshal test private key: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}))
+}
+
+func generateTestCertPEM(notBefore, notAfter time.Time, isCA bool) (string, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", err
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-cert"},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		IsCA:                  isCA,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+	}
+	if isCA {
+		template.Subject.CommonName = "test-ca"
+		template.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return "", err
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})), nil
+}
+
+func mustValidCAPEM() string {
+	validCAPEMOnce.Do(func() {
+		pemBytes, err := generateTestCertPEM(time.Now().Add(-time.Hour), time.Now().Add(24*time.Hour), true)
+		if err != nil {
+			panic(err)
+		}
+		validCAPEMForTests = pemBytes
+	})
+	return validCAPEMForTests
+}
+
+var (
+	validCAPEMOnce     sync.Once
+	validCAPEMForTests string
+)
+
+func TestValidateCACertificatePEM_boundaryTimes(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	fldPath := field.NewPath("ca")
+
+	atNotBefore := mustGenerateTestCertPEM(t, now, now.Add(time.Hour), true)
+	atNotAfter := mustGenerateTestCertPEM(t, now.Add(-time.Hour), now, true)
+
+	if errs := validateCACertificatePEM(fldPath, &atNotBefore, now); len(errs) != 0 {
+		t.Fatalf("certificate valid starting exactly now should pass, got %v", errs)
+	}
+	if errs := validateCACertificatePEM(fldPath, &atNotAfter, now); len(errs) != 0 {
+		t.Fatalf("certificate valid until exactly now should pass, got %v", errs)
+	}
+}
+
+func TestValidateCACertificatePEM_doesNotEchoPrivateKey(t *testing.T) {
+	fldPath := field.NewPath("ca")
+	privateKey := mustGenerateTestPrivateKeyPEM(t)
+	errs := validateCACertificatePEM(fldPath, &privateKey, time.Now())
+	if len(errs) == 0 {
+		t.Fatal("expected errors for a private key PEM")
+	}
+	for _, err := range errs {
+		if strings.Contains(err.Error(), "BEGIN") || strings.Contains(err.Error(), privateKey) {
+			t.Fatalf("error leaked PEM contents: %v", err)
+		}
+	}
 }

--- a/internal/validation/validators.go
+++ b/internal/validation/validators.go
@@ -15,14 +15,17 @@
 package validation
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net"
 	"net/url"
 	"regexp"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/google/uuid"
@@ -846,6 +849,10 @@ func ValidatePEM(ctx context.Context, op operation.Operation, fldPath *field.Pat
 		return field.ErrorList{field.Invalid(fldPath, *value, "not a valid PEM")}
 	}
 
+	errs := validateCACertificatePEM(fldPath, value, time.Now())
+	if len(errs) > 0 {
+		return errs
+	}
 	return nil
 }
 
@@ -1046,4 +1053,107 @@ func ValidateNodePoolVersionChange(desiredVersion semver.Version, activeVersions
 	}
 
 	return nil
+}
+
+// pemBlockDiagnostic is the field.Error BadValue for a PEM block. It always
+// includes the 1-based block index and, when known, the certificate subject.
+func pemBlockDiagnostic(blockIndex int, subject string) string {
+	if subject == "" {
+		return fmt.Sprintf("block %d", blockIndex)
+	}
+	return fmt.Sprintf("block %d: %s", blockIndex, subject)
+}
+
+// pemBlockDetail prefixes a CA PEM error with the block index and, when known,
+// the certificate subject so every message has the same identity.
+func pemBlockDetail(blockIndex int, subject, detail string) string {
+	if subject == "" {
+		return fmt.Sprintf("certificate %d %s", blockIndex, detail)
+	}
+	return fmt.Sprintf("certificate %d (%s) %s", blockIndex, subject, detail)
+}
+
+// validateCACertificatePEM checks that a PEM-encoded certificate is a valid CA certificate.
+//   - only CERTIFICATE blocks are allowed (private keys and other types are rejected)
+//   - each certificate must parse as X.509, have the CA basic constraint, and
+//     satisfy NotBefore ≤ now ≤ NotAfter
+//   - trailing non-PEM data after the last block is rejected
+func validateCACertificatePEM(fldPath *field.Path, value *string, now time.Time) field.ErrorList {
+	if value == nil || len(*value) == 0 {
+		return nil
+	}
+
+	rest := []byte(*value)
+	errs := field.ErrorList{}
+	foundBlock := false
+	blockIndex := 0
+
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		foundBlock = true
+		blockIndex++
+		diagnostic := pemBlockDiagnostic(blockIndex, "")
+
+		if block.Type != "CERTIFICATE" {
+			errs = append(errs, field.Invalid(
+				fldPath,
+				diagnostic,
+				fmt.Sprintf("PEM block %d has type %q; must be CERTIFICATE", blockIndex, block.Type),
+			))
+			continue
+		}
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			errs = append(errs, field.Invalid(
+				fldPath,
+				diagnostic,
+				pemBlockDetail(blockIndex, "", fmt.Sprintf("is not a valid X.509 certificate: %s", err)),
+			))
+			continue
+		}
+
+		subject := cert.Subject.String()
+		diagnostic = pemBlockDiagnostic(blockIndex, subject)
+
+		if !cert.IsCA {
+			errs = append(errs, field.Invalid(
+				fldPath,
+				diagnostic,
+				pemBlockDetail(blockIndex, subject, "must be a CA certificate"),
+			))
+		}
+
+		if now.Before(cert.NotBefore) {
+			notBefore := cert.NotBefore.UTC().Format(time.RFC3339)
+			errs = append(errs, field.Invalid(
+				fldPath,
+				diagnostic,
+				pemBlockDetail(blockIndex, subject, fmt.Sprintf("is not yet valid (NotBefore %s)", notBefore)),
+			))
+		}
+		if now.After(cert.NotAfter) {
+			notAfter := cert.NotAfter.UTC().Format(time.RFC3339)
+			errs = append(errs, field.Invalid(
+				fldPath,
+				diagnostic,
+				pemBlockDetail(blockIndex, subject, fmt.Sprintf("has expired (NotAfter %s)", notAfter)),
+			))
+		}
+	}
+
+	// No PEM blocks: ValidatePEM reports "not a valid PEM".
+	if !foundBlock {
+		return nil
+	}
+
+	if len(bytes.TrimSpace(rest)) > 0 {
+		errs = append(errs, field.Invalid(fldPath, "", "contains trailing non-PEM data"))
+	}
+
+	return errs
 }

--- a/internal/validation/validators.go
+++ b/internal/validation/validators.go
@@ -837,7 +837,6 @@ func newOr[T any](validateFns ...validate.ValidateFunc[T]) validate.ValidateFunc
 	}
 }
 
-// TODO this is compatible with what existed before, but still allows much invalid content
 func ValidatePEM(ctx context.Context, op operation.Operation, fldPath *field.Path, value, _ *string) field.ErrorList {
 	if value == nil {
 		return nil
@@ -845,15 +844,7 @@ func ValidatePEM(ctx context.Context, op operation.Operation, fldPath *field.Pat
 	if len(*value) == 0 {
 		return nil
 	}
-	if !x509.NewCertPool().AppendCertsFromPEM([]byte(*value)) {
-		return field.ErrorList{field.Invalid(fldPath, *value, "not a valid PEM")}
-	}
-
-	errs := validateCACertificatePEM(fldPath, value, time.Now())
-	if len(errs) > 0 {
-		return errs
-	}
-	return nil
+	return validateCACertificatePEM(fldPath, value, time.Now())
 }
 
 // EachMapKey validates each element of newMap with the specified validation function.
@@ -1146,9 +1137,8 @@ func validateCACertificatePEM(fldPath *field.Path, value *string, now time.Time)
 		}
 	}
 
-	// No PEM blocks: ValidatePEM reports "not a valid PEM".
 	if !foundBlock {
-		return nil
+		return field.ErrorList{field.Invalid(fldPath, "", "not a valid PEM")}
 	}
 
 	if len(bytes.TrimSpace(rest)) > 0 {

--- a/internal/validation/validators.go
+++ b/internal/validation/validators.go
@@ -1067,7 +1067,7 @@ func pemBlockDetail(blockIndex int, subject, detail string) string {
 // validateCACertificatePEM checks that a PEM-encoded certificate is a valid CA certificate.
 //   - only CERTIFICATE blocks are allowed (private keys and other types are rejected)
 //   - each certificate must parse as X.509, have the CA basic constraint, and
-//     satisfy NotBefore ≤ now ≤ NotAfter
+//     satisfy certificate is not expired
 //   - trailing non-PEM data after the last block is rejected
 func validateCACertificatePEM(fldPath *field.Path, value *string, now time.Time) field.ErrorList {
 	if value == nil || len(*value) == 0 {
@@ -1119,14 +1119,6 @@ func validateCACertificatePEM(fldPath *field.Path, value *string, now time.Time)
 			))
 		}
 
-		if now.Before(cert.NotBefore) {
-			notBefore := cert.NotBefore.UTC().Format(time.RFC3339)
-			errs = append(errs, field.Invalid(
-				fldPath,
-				diagnostic,
-				pemBlockDetail(blockIndex, subject, fmt.Sprintf("is not yet valid (NotBefore %s)", notBefore)),
-			))
-		}
 		if now.After(cert.NotAfter) {
 			notAfter := cert.NotAfter.UTC().Format(time.RFC3339)
 			errs = append(errs, field.Invalid(

--- a/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-format/04-httpCreate-externalauth/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/ExternalAuth/invalid-format/04-httpCreate-externalauth/expected-error.txt
@@ -5,7 +5,7 @@
       }
       {
         "code": "InvalidRequestContent",
-        "message": "Invalid value: \"invalid\": not a valid PEM",
+        "message": "Invalid value: \"\": not a valid PEM",
         "target": "properties.issuer.ca"
       }
       {


### PR DESCRIPTION
<!-- Link to Jira issue -->
[Improve CA Certificate Validation in RP for ExternalAuth](https://redhat.atlassian.net/browse/ARO-29371)

### What

<!-- Briefly describe what this PR does -->
RP External Auth now rejects issuer CAs that are 

- not PEM certificates, 
- are not CA:TRUE, 
- are expired 
-  include private keys or other PEM types
-  have trailing non-PEM data. 

If ca cert expires after creation or not yet valid, then it shows error in user facing condition

### Why

<!-- Briefly explain why this change is needed -->
ValidatePEM previously accepted any parseable cert bundle, so a leaf, expired, or key-mixed CA could be stored and later break OIDC discovery against a private IdP. Stricter checks fail those requests at admission with a clear properties.issuer.ca error 

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- Manual tests
 1. Not a pem certificate. Some blabber in ca feild.
<img width="1671" height="191" alt="image" src="https://github.com/user-attachments/assets/0e2549f3-8287-4602-a7ad-68482882c2db" />

2. Passed private key instead of ca cert
<img width="1683" height="214" alt="image" src="https://github.com/user-attachments/assets/5372b709-5ae1-48af-b1f8-93d4e629d54b" />


3. Passed csr
<img width="1917" height="271" alt="image" src="https://github.com/user-attachments/assets/1d98d438-71ca-471b-a78e-31b3b2bd0836" />

4. Empty certificate block
<img width="1916" height="224" alt="image" src="https://github.com/user-attachments/assets/06012c69-751d-41cc-ab85-ff0e18e987a8" />

5. Valid ca + private key
<img width="1915" height="204" alt="image" src="https://github.com/user-attachments/assets/f1db5710-b4ef-45de-b1bd-73aec395097b" />

6. Trailing junk after valid certificate
<img width="1918" height="204" alt="image" src="https://github.com/user-attachments/assets/077cd828-19af-4e23-b9c1-c4a3386fc26a" />

7. Invalid CA cert 
* A true CA certificate must explicitly state that it is allowed to sign other certificates. Looking at the decoded extension data inside your certificate text:
* Basic Constraints: CA:FALSE
<img width="1916" height="205" alt="image" src="https://github.com/user-attachments/assets/f548a5fb-7f84-4ab7-a88e-3039eb7debd5" />

8. Root CA is valid | leaf CA is invalid
<img width="1918" height="210" alt="image" src="https://github.com/user-attachments/assets/4a972d03-7bdf-4c0c-87e3-7b6321b1d40f" />

9. Expired CA
<img width="1919" height="207" alt="image" src="https://github.com/user-attachments/assets/306f1936-2a77-4bf8-9b6f-092c36fb2e6e" />

10. CA cert not valid yet - It gives user facing condition / No error while put/patch 
<img width="1913" height="935" alt="image" src="https://github.com/user-attachments/assets/ace36128-0f6c-4283-ac3d-61781e26944e" />

<img width="1913" height="754" alt="image" src="https://github.com/user-attachments/assets/95b68994-131f-4b0c-9e8d-ba507e88ee71" />



11. If Ca cert expired after creating external auth -
<img width="1907" height="877" alt="image" src="https://github.com/user-attachments/assets/e253de86-490b-485e-a5ef-9af0bdce2273" />



Positive Scenarios - 
1. Valid CA cert
<img width="1900" height="956" alt="image" src="https://github.com/user-attachments/assets/cee25505-181a-4e99-9a44-4eedc06b530d" />

2. Valid CA bundle
<img width="1912" height="1014" alt="image" src="https://github.com/user-attachments/assets/6e72dfdc-3dc3-4771-85cb-b1f8fa3709a7" />


### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if dashboards or other UI changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
