### PR TITLE
chore: update component image digests (excluding aksCommandRuntime)

### DIFF
--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: v2.16.4
-version: v2.16.4
+appVersion: v2.16.5
+version: v2.16.5
 description: A Helm chart for ACM addons
 name: policy
 dependencies:
 - name: grc
-  version: v2.16.4
+  version: v2.16.5
 - name: cluster-lifecycle
-  version: v2.16.4
+  version: v2.16.5

--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/cluster-lifecycle/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/cluster-lifecycle/Chart.yaml
@@ -1,8 +1,8 @@
 # Copyright (c) 2024 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 apiVersion: v2
-appVersion: v2.16.4
+appVersion: v2.16.5
 description: Helm chart for deploying the cluster lifecycle
 kubeVersion: ">=1.11.0-0"
 name: cluster-lifecycle
-version: v2.16.4
+version: v2.16.5

--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/grc/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/grc/Chart.yaml
@@ -1,10 +1,10 @@
 # Copyright (c) 2024 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 apiVersion: v2
-appVersion: v2.16.4
+appVersion: v2.16.5
 description: A Helm chart for multicloud grc
 keywords:
 - acm
 - grc
 name: grc
-version: v2.16.4
+version: v2.16.5

--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/values.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/values.yaml
@@ -2,7 +2,7 @@ global:
   registryOverride: "registry.redhat.io/rhacm2"
   imageOverrides:
     governance_policy_propagator: "governance-policy-propagator-rhel9@sha256:21e57c2f6b9556b45ef33934b35edb8c563385b591cb557fecd6322e1a635768"
-    governance_policy_addon_controller: "acm-governance-policy-addon-controller-rhel9@sha256:c48babbfe45a6df7dd88f08c6304f019fe60c4059d18d16f744cfae4ac8c8ea7"
+    governance_policy_addon_controller: "acm-governance-policy-addon-controller-rhel9@sha256:226041eb9c2c4424edd1fbec83c1a2041e6626d4e29907e15a1f4ce0d11ba54d"
     config_policy_controller: "config-policy-controller-rhel9@sha256:730d8bcc0bc45e93682d5a24a6825100559920216edbff161c2cc48af1f16993"
     governance_policy_framework_addon: "acm-governance-policy-framework-addon-rhel9@sha256:f5d5dde4b41e4946f306cb7539a55a673ae47a1988b865e4d2e7a5849a9dd4c5"
     klusterlet_addon_controller: "klusterlet-addon-controller-rhel9@sha256:8f63faa54bd2c261b81ccd289ed1e801decaeb85fa86d537404153f1cacc8f7d"

--- a/acm/deploy/helm/multicluster-engine-crds/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine-crds/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.11.6
+appVersion: 2.11.7
 description: A Helm chart for multicluster-engine - CRDs
 keywords:
 - mce
@@ -7,6 +7,6 @@ keywords:
 - multiclusterengine
 name: multicluster-engine-crds
 sources:
-- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18
+- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:ca617909e348bddf30ebbe49c8bbc6c7ef622192c1af6594653b0979b3498343
 type: application
-version: 2.11.6
+version: 2.11.7

--- a/acm/deploy/helm/multicluster-engine/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.11.6
+appVersion: 2.11.7
 description: A Helm chart for multicluster-engine
 keywords:
 - mce
@@ -7,6 +7,6 @@ keywords:
 - multiclusterengine
 name: multicluster-engine
 sources:
-- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18
+- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:ca617909e348bddf30ebbe49c8bbc6c7ef622192c1af6594653b0979b3498343
 type: application
-version: 2.11.6
+version: 2.11.7

--- a/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-operator.deployment.yaml
+++ b/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-operator.deployment.yaml
@@ -56,43 +56,43 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: OPERAND_IMAGE_ADDON_MANAGER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/addon-manager-rhel9@sha256:dde21beb44c32882e09766d59a13d07d8442844463fca4c9655d7b4d447587b1'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/addon-manager-rhel9@sha256:4919a70599f967e396290ebc00a1a35dddebfa7a3b9107c259be0fbafd7d493f'
         - name: OPERAND_IMAGE_AZURE_SERVICE_OPERATOR_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/azure-service-operator-rhel9@sha256:0b8c0d6554ab0537ec274923a124d46b4d3d97b5f5d015519565a9ea2a222aab'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/azure-service-operator-rhel9@sha256:e65c9c211ba061fc772e368c315d2390cfc245ab403325beed2ec15c91a4cf24'
         - name: OPERAND_IMAGE_BACKPLANE_MUST_GATHER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/must-gather-rhel9@sha256:189fe907052598270b45323bb286cd4675b9c19cfd411dae4f2952c7249ec77d'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/must-gather-rhel9@sha256:8ed2459dc27a9248be4c4c3a316abb5194d8b5d26856928130afed5cdef77902'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AGENT
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-agent-rhel9@sha256:7eb1a6562cdfe51e649bc993aecc86892c94ea8af084592fc4c556123ef254b8'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AWS_RHEL9
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-aws-rhel9@sha256:cedc5d27bd611cb2357419416464ff20824168348aee627d86e168143dd8fdf5'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AZURE_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-azure-rhel9@sha256:ef696bb15a0d8ca0f528032eeec7e5a09b3bd30bb38559284a88ee6e67feb171'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-azure-rhel9@sha256:3cfcaccd65dd904e3b4ac93f4056a8208850fffddcdfa8d6c53c762a1019ee35'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_KUBEVIRT
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-kubevirt-rhel9@sha256:aa076770d211915d7a6b12118e4aa63fa01a27842bbc1734ab8b7ce8f263b837'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_OPENSHIFT_ASSISTED_BOOTSTRAP
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/capoa-bootstrap-rhel9@sha256:10a28cd23ab4e0fd72d8e337c7e904b1bb499da59c35b1b9f9bc2b5a8328cba0'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_OPENSHIFT_ASSISTED_CONTROL_PLANE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/capoa-control-plane-rhel9@sha256:270c985fb8b9adbdd0f7fad109c11f4f1b868634603cf09674b2ac65694720fd'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/capoa-control-plane-rhel9@sha256:e76e5a4cac6b9ee396bb5419598e7bc4fe443e2df8df2c1811f119ae7480a56e'
         - name: OPERAND_IMAGE_MCE_CAPI_WEBHOOK_CONFIG_RHEL9
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/mce-capi-webhook-config-rhel9@sha256:4a0d1acfbd56cf2f7f3c30d2ce7ce3d7f040f7c4744a0b292787d5f5f43dd5aa'
         - name: OPERAND_IMAGE_CLUSTERCLAIMS_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/clusterclaims-controller-rhel9@sha256:652be33ec98de64ea578aef9b9b08a4c594c44419ccf3925dd4864d35b1d03b3'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/clusterclaims-controller-rhel9@sha256:e51c1cd26215b6e7aec5f3b5c47633400e9a0ad1da6ceaa20d7b64053750f467'
         - name: OPERAND_IMAGE_CLUSTER_CURATOR_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-curator-controller-rhel9@sha256:0073473d233a571a9d0b4dd23c3c94731d3c4213e9caba84171b009669689307'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-curator-controller-rhel9@sha256:759dbffea7531c0bddddea97d3e51ba3de222bcabadd00fcffd8ecb3c9256e4c'
         - name: OPERAND_IMAGE_CLUSTER_IMAGE_SET_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-image-set-controller-rhel9@sha256:27fd5de3c58b3f17c69445f3d6bf48862a366aa294cb6b8744b970c1c0afc51d'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-image-set-controller-rhel9@sha256:56e4361440bab6066509b871bce1e9941b10bde55b789ed83448fa80b7f1f478'
         - name: OPERAND_IMAGE_CLUSTERLIFECYCLE_STATE_METRICS
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/clusterlifecycle-state-metrics-rhel9@sha256:b1f00cdca8ac6a04c6609a13a09d5c32a22cbb5758832629d73bdb40c8069bcb'
         - name: OPERAND_IMAGE_CLUSTER_PROXY
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-proxy-rhel9@sha256:9fa3ade43abc8dc164e3cedf91ac881e440d9d810d6ecbcdfabea1ceec153f0f'
         - name: OPERAND_IMAGE_CONSOLE_MCE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/console-mce-rhel9@sha256:49c8398c6d3e68a001a028fca6b10303c78c917aa913299650e7ad79c871a710'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/console-mce-rhel9@sha256:8339fe72636f4307b071a6c88fca11448a7e897556ec1c5f08ba526dc4ab045d'
         - name: OPERAND_IMAGE_DISCOVERY_OPERATOR
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/discovery-rhel9@sha256:dfb3deb181dceb12f427f7bafe950305c4e58263dcc538f76fa25eef5dcb7816'
         - name: OPERAND_IMAGE_OPENSHIFT_HIVE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hive-rhel9@sha256:5b534749630cabf09dfbb14287ed4b9fdaa8295cc95371adf611f9f1fa3a8abb'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hive-rhel9@sha256:4bacf1269df6d0e7c292944f1040f5a5e9016a2a462182b8c9d92763c3e2552f'
         - name: OPERAND_IMAGE_HYPERSHIFT_ADDON_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-addon-rhel9-operator@sha256:d8fcc7c22bcb8db2606fcebaf05f4c1a684ae899d982b055314abb900af73020'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-addon-rhel9-operator@sha256:0e7c4e8d7a4e9eb5e7b310425c1806bed43769c4180fa8b1785aae302f178a52'
         - name: OPERAND_IMAGE_HYPERSHIFT_CLI
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-cli-rhel9@sha256:dbe4cbe742025c856aae31c5eb5ac841cd9fabca6edebc7171f938ba2783da7e'
         - name: OPERAND_IMAGE_HYPERSHIFT_OPERATOR
@@ -106,17 +106,17 @@ spec:
         - name: OPERAND_IMAGE_MANAGED_SERVICEACCOUNT
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/managed-serviceaccount-rhel9@sha256:206deca0716a54e239d0ab0d91c8e9a9f21fdf1dc1b1546a6c933a12dcafbea6'
         - name: OPERAND_IMAGE_MULTICLOUD_MANAGER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/multicloud-manager-rhel9@sha256:e82bddd0888636a414970c461833f61ce31b02892e9541470c59f6d20cf93ebf'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/multicloud-manager-rhel9@sha256:10061c3e5900ae9068cd148e9bc04d2dea08697ce974acebe4c8a45568916012'
         - name: OPERAND_IMAGE_PROVIDER_CREDENTIAL_CONTROLLER
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/provider-credential-controller-rhel9@sha256:9d4aa6b492727c2aaa2c7d0e047d41d279a88f2aaeacaec3658471c67278d46f'
         - name: OPERAND_IMAGE_PLACEMENT
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/placement-rhel9@sha256:6686007f4656bb4049ca70397c290d12fb9d33551b59004a8c73155b217fbd92'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/placement-rhel9@sha256:5e2a4ba2eeff6a9ca864d5dcd322b42d9156851741f97d0d008a167fc194f3b8'
         - name: OPERAND_IMAGE_REGISTRATION
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-rhel9@sha256:a9f27fb8e1b0a4466ceab011a35abde76ee3f213f1c43863cdecc1a1669fead1'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-rhel9@sha256:82348c4fc33619b8ec621718bf97d473a62dfb0bc9cd236170a6c30779f9cd95'
         - name: OPERAND_IMAGE_REGISTRATION_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-operator-rhel9@sha256:ff918172773de7995a355e768d13d5f64daeaee022644a93e26af69b07cee9bb'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-operator-rhel9@sha256:47257894132346453ba99cc945ff1959ecf02eb3702faa9ba36a83a7086a276c'
         - name: OPERAND_IMAGE_WORK
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/work-rhel9@sha256:49e6dbc3782264f94fa0d0b802213f3d678aa9b2367d23aa07e38558378850d6'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/work-rhel9@sha256:564501ff40f0f6cebd6fb36de856ed83b3ccce1a95b4802123533de8c53f734c'
         - name: OPERAND_IMAGE_ASSISTED_IMAGE_SERVICE
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-image-service-rhel9@sha256:56cd39d85b9814dffee4a595e93b2c145c622491608c93c5f85537346c4a1e89'
         - name: OPERAND_IMAGE_ASSISTED_INSTALLER
@@ -128,18 +128,18 @@ spec:
         - name: OPERAND_IMAGE_ASSISTED_SERVICE_9
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-service-9-rhel9@sha256:cc6e93b403f94d87f7e4e2c159fd0633c5b107071f52415c7fa7baa8777fd910'
         - name: OPERAND_IMAGE_OSE_CLUSTER_API_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/ose-cluster-api-rhel9@sha256:ba4da29ef8097031f3b24ca92d892674217773d75e73d5ff3e00590127246811'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/ose-cluster-api-rhel9@sha256:da702340f05c0cefd0eb0896e3dfb6896cdc26abaebffd13e7711900a4843cf4'
         - name: OPERAND_IMAGE_OSE_BAREMETAL_CLUSTER_API_CONTROLLERS_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/ose-baremetal-cluster-api-controllers-rhel9@sha256:471b7a0cdf8933317bec4c98265ac908f93ad656a531baffb30a5bbec391f156'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/ose-baremetal-cluster-api-controllers-rhel9@sha256:824a9d3c4bee40bd894e7fa4f40e56c021e232cc73ca1c59151323e6c6139fe2'
         - name: OPERAND_IMAGE_POSTGRESQL_13
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/postgresql-13@sha256:97b64c18a32944b86fd1a118aa0d1aa04ff1fad8068c3c20f6e94af24712ff36'
         - name: OPERATOR_VERSION
-          value: 2.11.6
+          value: 2.11.7
         - name: OPERATOR_PACKAGE
           value: multicluster-engine
         - name: OPERAND_IMAGE_BACKPLANE_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:62b7e08e6cef9554878ff6def3b250f106846d6a0347388fb03802ad5155a030'
-        image: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:62b7e08e6cef9554878ff6def3b250f106846d6a0347388fb03802ad5155a030'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:6d4f83990a3e26fb20097e26cadd5ffabeab2b39b2f6669f2794bc341b21b2a5'
+        image: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:6d4f83990a3e26fb20097e26cadd5ffabeab2b39b2f6669f2794bc341b21b2a5'
         livenessProbe:
           httpGet:
             path: /healthz

--- a/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce.yaml
+++ b/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce.yaml
@@ -3571,7 +3571,7 @@ spec:
         - name: OPERAND_IMAGE_POSTGRESQL_13
           value: 'arohcpsvcdev.azurecr.io/acm-d-cache/postgresql-13@sha256:1234567890'
         - name: OPERATOR_VERSION
-          value: 2.11.6
+          value: 2.11.7
         - name: OPERATOR_PACKAGE
           value: multicluster-engine
         - name: OPERAND_IMAGE_BACKPLANE_OPERATOR

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -193,14 +193,14 @@ defaults:
       image:
         registry: mcr.microsoft.com
         repository: geneva/distroless/mdsd
-        digest: sha256:2a250598df9900192e145f5bea8175325f3b14aa69c5150be0c2bd803fdcdec9 # 1.43.0-20260828-1 (2026-08-28 04:45)
+        digest: sha256:13c33d4e6952e6ddd69d9dd7bb941dc5e8f9fb3d589f016aaca01a9f1067f409 # 1.43.0-20260904-2 (2026-09-04 21:37)
   # Kube Events
   kubeEvents:
     enabled: true
     image:
       registry: kubernetesshared.azurecr.io
       repository: shared/kube-events
-      digest: sha256:326a165eb7b65ae43b85c9538d3572c57aa56a1862febd90f293783824c62d5f # 20260830.1 (2026-08-30 03:25)
+      digest: sha256:76b03f4c04291c80a7269474b055cee5f188746c68b444b20c03ea180d0c1348 # 20260906.1 (2026-09-06 03:25)
     k8s:
       namespace: monitoring
       serviceAccountName: ke-serviceaccount
@@ -279,7 +279,7 @@ defaults:
     providerImage:
       registry: mcr.microsoft.com
       repository: oss/v2/azure/secrets-store/provider-azure
-      digest: sha256:407ff33bb445d44db9924eeffa2b61d4adf475e5805bdcda10d33e7f68578217 # v1.8.2 (2026-08-24 20:22)
+      digest: sha256:f21fca34342808670e8696dffd25efd5ef4347327b30371950b9e08fee2f11f8 # v1.8.2 (2026-09-05 01:44)
     k8s:
       namespace: secret-sync-controller
       serviceAccountName: secrets-store-sync-controller-manager
@@ -396,7 +396,7 @@ defaults:
     image:
       registry: quay.io
       repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
-      digest: sha256:cabce18d0674442c8fb4d931e4d44306b74fbaca5e6c9c23f92c8aa790daf53d # 7334c42fbd88f69fbcf9fbfbdaf7e13d82e16880 (2026-08-31 03:07)
+      digest: sha256:cb8bf5c16f961dc9d673a44867a681bdd2d7844a8d12564ad7ff42d8bc22db3b # 6e6cb83772382fca668279ea55316cf74f128c6c (2026-09-05 06:07)
     namespace: hypershift
     additionalInstallArg: '--enable-cpo-overrides --disable-capi-migration'
     # By default we set it to empty as this tag is only required for msft environments. We override
@@ -524,15 +524,15 @@ defaults:
     server:
       registry: registry.stage.redhat.io
       repository: oadp/oadp-velero-rhel9
-      digest: sha256:857c25afa2fced585ba68ae40248278c6d244f65d72b35b635b8789417d0b9a5 # 1.6.2 (2026-08-28 13:01)
+      digest: sha256:d712b510c9224d194e3da94bbc87d6ff66f44f2d513dd51c2b10b7d2681eb0d1 # 1.6.2 (2026-09-04 17:56)
     azurePlugin:
       registry: registry.stage.redhat.io
       repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
-      digest: sha256:3cc0fe2d2f0cf66dc8b5346af8ab117046a8abe66bacd29fb3c895d4c3fef7ac # 1.6.2 (2026-08-31 05:50)
+      digest: sha256:908426eb82d213a5a50e7dc499907fbbd47d2dd80f6d5e4ed1472e0a6b9fb460 # 1.6.2 (2026-09-04 17:52)
     hypershiftPlugin:
       registry: registry.stage.redhat.io
       repository: oadp/oadp-hypershift-velero-plugin-rhel9
-      digest: sha256:57afef0f83ea72d8c98808cd894b5adfac336089ddeae9dd0559116de64ba0db # 1.6.2 (2026-08-31 05:32)
+      digest: sha256:fca00f1a9915708bededd250db55b3f954572478c1175c46eb6a350c1344f5bc # 1.6.2 (2026-09-04 17:56)
   # SVC cluster specifics
   svc:
     subscription:
@@ -578,7 +578,7 @@ defaults:
     # pipeline step had already applied.
     # istioctlVersion and targetVersion will be removed in a future cleanup.
     istio:
-      istioctlVersion: 1.30.4 # 1.30.4 (2026-08-27 15:10)
+      istioctlVersion: 1.31.0 # 1.31.0 (2026-08-31 15:47)
       tag: "prod-stable"
       targetVersion: "asm-1-29"
       versions: "asm-1-29"
@@ -646,7 +646,7 @@ defaults:
         image:
           registry: mcr.microsoft.com/oss/v2
           repository: prometheus/prometheus
-          sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3 # v3.12.0 (2026-08-24 20:42)
+          sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8 # v3.12.0 (2026-08-31 17:47)
         version: ""
         resources:
           requests:
@@ -665,7 +665,7 @@ defaults:
         image:
           registry: mcr.microsoft.com/oss/v2
           repository: kubernetes/kube-state-metrics
-          digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de # v2.20.0 (2026-08-25 00:57)
+          digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e # v2.20.0 (2026-09-04 22:52)
       admissionWebhook:
         patch:
           image:
@@ -778,7 +778,7 @@ defaults:
         image:
           registry: mcr.microsoft.com/oss/v2
           repository: prometheus/prometheus
-          sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3 # v3.12.0 (2026-08-24 20:42)
+          sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8 # v3.12.0 (2026-08-31 17:47)
         resources:
           requests:
             cpu: NONE
@@ -796,7 +796,7 @@ defaults:
         image:
           registry: mcr.microsoft.com/oss/v2
           repository: kubernetes/kube-state-metrics
-          digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de # v2.20.0 (2026-08-25 00:57)
+          digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e # v2.20.0 (2026-09-04 22:52)
       admissionWebhook:
         patch:
           image:
@@ -1086,25 +1086,25 @@ defaults:
     image:
       registry: quay.io
       repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
-      digest: sha256:7dc6bf1b8476e4737a84a5d744bc354d5949b729eeab92039a43507884dd7334 # 530edf9358e92990f92aa06b0ea3c4a08afcfb94 (2026-08-26 15:46)
+      digest: sha256:0053dfaa6931c0c60e343b3b4460c136207f4567b14df9f6a7dbd5f3a5d89ed0 # 8ab737d7f7aad40ca77dcfe36c2b8777ea6a6367 (2026-09-03 08:13)
   # ACM
   acm:
     operator:
       bundle:
         registry: quay.io
         repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
-        digest: sha256:9dfbee549e5fc354453ff6ecaa3a18f013e3c8976c63af801a58cdaba016d0ce # v2.16.4-587 (2026-08-29 13:09)
+        digest: sha256:2a939da3ff1da79c5de14109e83c37a6b9c6c14f8696afdb0fb6d0c9bc295b26 # v2.16.5-599 (2026-09-05 13:09)
     mce:
       bundle:
         registry: quay.io
         repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
-        digest: sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18 # v2.11.6-636 (2026-08-30 18:12)
+        digest: sha256:a7f8a100505c2a5255719453ce365aa43ef6fec2073054332b9a5d4ad7d359ea # v2.11.7-646 (2026-09-05 13:07)
   # Cluster Service
   clustersService:
     image:
       registry: quay.io
       repository: app-sre/aro-hcp-clusters-service
-      digest: sha256:b5c04e35493f5b6ac5bc32b401df0a6f90eff0723fb180181ea777aac0a0a737 # e80b87894dfaf74aca4f1b771da081cf6bd4f5cd (2026-09-03 17:48)
+      digest: sha256:b5c04e35493f5b6ac5bc32b401df0a6f90eff0723fb180181ea777aac0a0a737 # e80b87894dfaf74aca4f1b771da081cf6bd4f5cd (2026-09-03 17:54)
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18
+      digest: sha256:a7f8a100505c2a5255719453ce365aa43ef6fec2073054332b9a5d4ad7d359ea
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:9dfbee549e5fc354453ff6ecaa3a18f013e3c8976c63af801a58cdaba016d0ce
+      digest: sha256:2a939da3ff1da79c5de14109e83c37a6b9c6c14f8696afdb0fb6d0c9bc295b26
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -98,7 +98,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:2a250598df9900192e145f5bea8175325f3b14aa69c5150be0c2bd803fdcdec9
+      digest: sha256:13c33d4e6952e6ddd69d9dd7bb941dc5e8f9fb3d589f016aaca01a9f1067f409
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -489,7 +489,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
-    digest: sha256:cabce18d0674442c8fb4d931e4d44306b74fbaca5e6c9c23f92c8aa790daf53d
+    digest: sha256:cb8bf5c16f961dc9d673a44867a681bdd2d7844a8d12564ad7ff42d8bc22db3b
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -541,7 +541,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:326a165eb7b65ae43b85c9538d3572c57aa56a1862febd90f293783824c62d5f
+    digest: sha256:76b03f4c04291c80a7269474b055cee5f188746c68b444b20c03ea180d0c1348
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -604,7 +604,7 @@ maestro:
     name: arohcp-ci00-maestro-j7654321
     private: false
   image:
-    digest: sha256:7dc6bf1b8476e4737a84a5d744bc354d5949b729eeab92039a43507884dd7334
+    digest: sha256:0053dfaa6931c0c60e343b3b4460c136207f4567b14df9f6a7dbd5f3a5d89ed0
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -713,7 +713,7 @@ mgmt:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
+        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -733,7 +733,7 @@ mgmt:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
+        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
       replicas: 2
       resources:
         limits:
@@ -968,7 +968,7 @@ secretSyncController:
         memory: 100Mi
     serviceAccountName: secrets-store-sync-controller-manager
   providerImage:
-    digest: sha256:407ff33bb445d44db9924eeffa2b61d4adf475e5805bdcda10d33e7f68578217
+    digest: sha256:f21fca34342808670e8696dffd25efd5ef4347327b30371950b9e08fee2f11f8
     registry: mcr.microsoft.com
     repository: oss/v2/azure/secrets-store/provider-azure
 serviceKeyVault:
@@ -1062,7 +1062,7 @@ svc:
   istio:
     ingressGatewayIPAddressIPTags: ""
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
-    istioctlVersion: 1.30.4
+    istioctlVersion: 1.31.0
     tag: prod-stable
     targetVersion: asm-1-29
     versions: asm-1-29
@@ -1084,7 +1084,7 @@ svc:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
+        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -1104,7 +1104,7 @@ svc:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
+        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
       replicas: 2
       resources:
         limits:
@@ -1160,14 +1160,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:3cc0fe2d2f0cf66dc8b5346af8ab117046a8abe66bacd29fb3c895d4c3fef7ac
+    digest: sha256:908426eb82d213a5a50e7dc499907fbbd47d2dd80f6d5e4ed1472e0a6b9fb460
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:57afef0f83ea72d8c98808cd894b5adfac336089ddeae9dd0559116de64ba0db
+    digest: sha256:fca00f1a9915708bededd250db55b3f954572478c1175c46eb6a350c1344f5bc
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:857c25afa2fced585ba68ae40248278c6d244f65d72b35b635b8789417d0b9a5
+    digest: sha256:d712b510c9224d194e3da94bbc87d6ff66f44f2d513dd51c2b10b7d2681eb0d1
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18
+      digest: sha256:a7f8a100505c2a5255719453ce365aa43ef6fec2073054332b9a5d4ad7d359ea
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:9dfbee549e5fc354453ff6ecaa3a18f013e3c8976c63af801a58cdaba016d0ce
+      digest: sha256:2a939da3ff1da79c5de14109e83c37a6b9c6c14f8696afdb0fb6d0c9bc295b26
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -98,7 +98,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:2a250598df9900192e145f5bea8175325f3b14aa69c5150be0c2bd803fdcdec9
+      digest: sha256:13c33d4e6952e6ddd69d9dd7bb941dc5e8f9fb3d589f016aaca01a9f1067f409
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -489,7 +489,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
-    digest: sha256:cabce18d0674442c8fb4d931e4d44306b74fbaca5e6c9c23f92c8aa790daf53d
+    digest: sha256:cb8bf5c16f961dc9d673a44867a681bdd2d7844a8d12564ad7ff42d8bc22db3b
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -541,7 +541,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:326a165eb7b65ae43b85c9538d3572c57aa56a1862febd90f293783824c62d5f
+    digest: sha256:76b03f4c04291c80a7269474b055cee5f188746c68b444b20c03ea180d0c1348
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -604,7 +604,7 @@ maestro:
     name: arohcp-ci01-maestro-j7654321
     private: false
   image:
-    digest: sha256:7dc6bf1b8476e4737a84a5d744bc354d5949b729eeab92039a43507884dd7334
+    digest: sha256:0053dfaa6931c0c60e343b3b4460c136207f4567b14df9f6a7dbd5f3a5d89ed0
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -713,7 +713,7 @@ mgmt:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
+        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -733,7 +733,7 @@ mgmt:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
+        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
       replicas: 2
       resources:
         limits:
@@ -968,7 +968,7 @@ secretSyncController:
         memory: 100Mi
     serviceAccountName: secrets-store-sync-controller-manager
   providerImage:
-    digest: sha256:407ff33bb445d44db9924eeffa2b61d4adf475e5805bdcda10d33e7f68578217
+    digest: sha256:f21fca34342808670e8696dffd25efd5ef4347327b30371950b9e08fee2f11f8
     registry: mcr.microsoft.com
     repository: oss/v2/azure/secrets-store/provider-azure
 serviceKeyVault:
@@ -1062,7 +1062,7 @@ svc:
   istio:
     ingressGatewayIPAddressIPTags: ""
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
-    istioctlVersion: 1.30.4
+    istioctlVersion: 1.31.0
     tag: prod-stable
     targetVersion: asm-1-29
     versions: asm-1-29
@@ -1084,7 +1084,7 @@ svc:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
+        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -1104,7 +1104,7 @@ svc:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
+        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
       replicas: 2
       resources:
         limits:
@@ -1160,14 +1160,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:3cc0fe2d2f0cf66dc8b5346af8ab117046a8abe66bacd29fb3c895d4c3fef7ac
+    digest: sha256:908426eb82d213a5a50e7dc499907fbbd47d2dd80f6d5e4ed1472e0a6b9fb460
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:57afef0f83ea72d8c98808cd894b5adfac336089ddeae9dd0559116de64ba0db
+    digest: sha256:fca00f1a9915708bededd250db55b3f954572478c1175c46eb6a350c1344f5bc
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:857c25afa2fced585ba68ae40248278c6d244f65d72b35b635b8789417d0b9a5
+    digest: sha256:d712b510c9224d194e3da94bbc87d6ff66f44f2d513dd51c2b10b7d2681eb0d1
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18
+      digest: sha256:a7f8a100505c2a5255719453ce365aa43ef6fec2073054332b9a5d4ad7d359ea
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:9dfbee549e5fc354453ff6ecaa3a18f013e3c8976c63af801a58cdaba016d0ce
+      digest: sha256:2a939da3ff1da79c5de14109e83c37a6b9c6c14f8696afdb0fb6d0c9bc295b26
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -98,7 +98,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:2a250598df9900192e145f5bea8175325f3b14aa69c5150be0c2bd803fdcdec9
+      digest: sha256:13c33d4e6952e6ddd69d9dd7bb941dc5e8f9fb3d589f016aaca01a9f1067f409
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -489,7 +489,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
-    digest: sha256:cabce18d0674442c8fb4d931e4d44306b74fbaca5e6c9c23f92c8aa790daf53d
+    digest: sha256:cb8bf5c16f961dc9d673a44867a681bdd2d7844a8d12564ad7ff42d8bc22db3b
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -541,7 +541,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:326a165eb7b65ae43b85c9538d3572c57aa56a1862febd90f293783824c62d5f
+    digest: sha256:76b03f4c04291c80a7269474b055cee5f188746c68b444b20c03ea180d0c1348
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -604,7 +604,7 @@ maestro:
     name: arohcp-cspr-maestro-usw3
     private: false
   image:
-    digest: sha256:7dc6bf1b8476e4737a84a5d744bc354d5949b729eeab92039a43507884dd7334
+    digest: sha256:0053dfaa6931c0c60e343b3b4460c136207f4567b14df9f6a7dbd5f3a5d89ed0
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -711,7 +711,7 @@ mgmt:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
+        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -731,7 +731,7 @@ mgmt:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
+        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
       replicas: 2
       resources:
         limits:
@@ -966,7 +966,7 @@ secretSyncController:
         memory: 100Mi
     serviceAccountName: secrets-store-sync-controller-manager
   providerImage:
-    digest: sha256:407ff33bb445d44db9924eeffa2b61d4adf475e5805bdcda10d33e7f68578217
+    digest: sha256:f21fca34342808670e8696dffd25efd5ef4347327b30371950b9e08fee2f11f8
     registry: mcr.microsoft.com
     repository: oss/v2/azure/secrets-store/provider-azure
 serviceKeyVault:
@@ -1060,7 +1060,7 @@ svc:
   istio:
     ingressGatewayIPAddressIPTags: ""
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
-    istioctlVersion: 1.30.4
+    istioctlVersion: 1.31.0
     tag: prod-stable
     targetVersion: asm-1-29
     versions: asm-1-29
@@ -1080,7 +1080,7 @@ svc:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
+        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -1100,7 +1100,7 @@ svc:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
+        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
       replicas: 2
       resources:
         limits:
@@ -1156,14 +1156,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:3cc0fe2d2f0cf66dc8b5346af8ab117046a8abe66bacd29fb3c895d4c3fef7ac
+    digest: sha256:908426eb82d213a5a50e7dc499907fbbd47d2dd80f6d5e4ed1472e0a6b9fb460
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:57afef0f83ea72d8c98808cd894b5adfac336089ddeae9dd0559116de64ba0db
+    digest: sha256:fca00f1a9915708bededd250db55b3f954572478c1175c46eb6a350c1344f5bc
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:857c25afa2fced585ba68ae40248278c6d244f65d72b35b635b8789417d0b9a5
+    digest: sha256:d712b510c9224d194e3da94bbc87d6ff66f44f2d513dd51c2b10b7d2681eb0d1
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18
+      digest: sha256:a7f8a100505c2a5255719453ce365aa43ef6fec2073054332b9a5d4ad7d359ea
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:9dfbee549e5fc354453ff6ecaa3a18f013e3c8976c63af801a58cdaba016d0ce
+      digest: sha256:2a939da3ff1da79c5de14109e83c37a6b9c6c14f8696afdb0fb6d0c9bc295b26
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -98,7 +98,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:2a250598df9900192e145f5bea8175325f3b14aa69c5150be0c2bd803fdcdec9
+      digest: sha256:13c33d4e6952e6ddd69d9dd7bb941dc5e8f9fb3d589f016aaca01a9f1067f409
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -489,7 +489,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
-    digest: sha256:cabce18d0674442c8fb4d931e4d44306b74fbaca5e6c9c23f92c8aa790daf53d
+    digest: sha256:cb8bf5c16f961dc9d673a44867a681bdd2d7844a8d12564ad7ff42d8bc22db3b
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -541,7 +541,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:326a165eb7b65ae43b85c9538d3572c57aa56a1862febd90f293783824c62d5f
+    digest: sha256:76b03f4c04291c80a7269474b055cee5f188746c68b444b20c03ea180d0c1348
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -604,7 +604,7 @@ maestro:
     name: arohcp-dev-maestro-usw3
     private: false
   image:
-    digest: sha256:7dc6bf1b8476e4737a84a5d744bc354d5949b729eeab92039a43507884dd7334
+    digest: sha256:0053dfaa6931c0c60e343b3b4460c136207f4567b14df9f6a7dbd5f3a5d89ed0
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -711,7 +711,7 @@ mgmt:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
+        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -731,7 +731,7 @@ mgmt:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
+        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
       replicas: 2
       resources:
         limits:
@@ -966,7 +966,7 @@ secretSyncController:
         memory: 100Mi
     serviceAccountName: secrets-store-sync-controller-manager
   providerImage:
-    digest: sha256:407ff33bb445d44db9924eeffa2b61d4adf475e5805bdcda10d33e7f68578217
+    digest: sha256:f21fca34342808670e8696dffd25efd5ef4347327b30371950b9e08fee2f11f8
     registry: mcr.microsoft.com
     repository: oss/v2/azure/secrets-store/provider-azure
 serviceKeyVault:
@@ -1060,7 +1060,7 @@ svc:
   istio:
     ingressGatewayIPAddressIPTags: ""
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
-    istioctlVersion: 1.30.4
+    istioctlVersion: 1.31.0
     tag: prod-stable
     targetVersion: asm-1-29
     versions: asm-1-29
@@ -1080,7 +1080,7 @@ svc:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
+        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -1100,7 +1100,7 @@ svc:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
+        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
       replicas: 2
       resources:
         limits:
@@ -1156,14 +1156,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:3cc0fe2d2f0cf66dc8b5346af8ab117046a8abe66bacd29fb3c895d4c3fef7ac
+    digest: sha256:908426eb82d213a5a50e7dc499907fbbd47d2dd80f6d5e4ed1472e0a6b9fb460
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:57afef0f83ea72d8c98808cd894b5adfac336089ddeae9dd0559116de64ba0db
+    digest: sha256:fca00f1a9915708bededd250db55b3f954572478c1175c46eb6a350c1344f5bc
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:857c25afa2fced585ba68ae40248278c6d244f65d72b35b635b8789417d0b9a5
+    digest: sha256:d712b510c9224d194e3da94bbc87d6ff66f44f2d513dd51c2b10b7d2681eb0d1
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18
+      digest: sha256:a7f8a100505c2a5255719453ce365aa43ef6fec2073054332b9a5d4ad7d359ea
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:9dfbee549e5fc354453ff6ecaa3a18f013e3c8976c63af801a58cdaba016d0ce
+      digest: sha256:2a939da3ff1da79c5de14109e83c37a6b9c6c14f8696afdb0fb6d0c9bc295b26
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -98,7 +98,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:2a250598df9900192e145f5bea8175325f3b14aa69c5150be0c2bd803fdcdec9
+      digest: sha256:13c33d4e6952e6ddd69d9dd7bb941dc5e8f9fb3d589f016aaca01a9f1067f409
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -489,7 +489,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
-    digest: sha256:cabce18d0674442c8fb4d931e4d44306b74fbaca5e6c9c23f92c8aa790daf53d
+    digest: sha256:cb8bf5c16f961dc9d673a44867a681bdd2d7844a8d12564ad7ff42d8bc22db3b
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -541,7 +541,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:326a165eb7b65ae43b85c9538d3572c57aa56a1862febd90f293783824c62d5f
+    digest: sha256:76b03f4c04291c80a7269474b055cee5f188746c68b444b20c03ea180d0c1348
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -604,7 +604,7 @@ maestro:
     name: arohcp-perf-maestro-usw3ptest
     private: false
   image:
-    digest: sha256:7dc6bf1b8476e4737a84a5d744bc354d5949b729eeab92039a43507884dd7334
+    digest: sha256:0053dfaa6931c0c60e343b3b4460c136207f4567b14df9f6a7dbd5f3a5d89ed0
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -711,7 +711,7 @@ mgmt:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
+        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -731,7 +731,7 @@ mgmt:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
+        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
       replicas: 2
       resources:
         limits:
@@ -966,7 +966,7 @@ secretSyncController:
         memory: 100Mi
     serviceAccountName: secrets-store-sync-controller-manager
   providerImage:
-    digest: sha256:407ff33bb445d44db9924eeffa2b61d4adf475e5805bdcda10d33e7f68578217
+    digest: sha256:f21fca34342808670e8696dffd25efd5ef4347327b30371950b9e08fee2f11f8
     registry: mcr.microsoft.com
     repository: oss/v2/azure/secrets-store/provider-azure
 serviceKeyVault:
@@ -1060,7 +1060,7 @@ svc:
   istio:
     ingressGatewayIPAddressIPTags: ""
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
-    istioctlVersion: 1.30.4
+    istioctlVersion: 1.31.0
     tag: prod-stable
     targetVersion: asm-1-29
     versions: asm-1-29
@@ -1080,7 +1080,7 @@ svc:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
+        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -1100,7 +1100,7 @@ svc:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
+        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
       replicas: 2
       resources:
         limits:
@@ -1156,14 +1156,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:3cc0fe2d2f0cf66dc8b5346af8ab117046a8abe66bacd29fb3c895d4c3fef7ac
+    digest: sha256:908426eb82d213a5a50e7dc499907fbbd47d2dd80f6d5e4ed1472e0a6b9fb460
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:57afef0f83ea72d8c98808cd894b5adfac336089ddeae9dd0559116de64ba0db
+    digest: sha256:fca00f1a9915708bededd250db55b3f954572478c1175c46eb6a350c1344f5bc
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:857c25afa2fced585ba68ae40248278c6d244f65d72b35b635b8789417d0b9a5
+    digest: sha256:d712b510c9224d194e3da94bbc87d6ff66f44f2d513dd51c2b10b7d2681eb0d1
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18
+      digest: sha256:a7f8a100505c2a5255719453ce365aa43ef6fec2073054332b9a5d4ad7d359ea
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:9dfbee549e5fc354453ff6ecaa3a18f013e3c8976c63af801a58cdaba016d0ce
+      digest: sha256:2a939da3ff1da79c5de14109e83c37a6b9c6c14f8696afdb0fb6d0c9bc295b26
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -98,7 +98,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:2a250598df9900192e145f5bea8175325f3b14aa69c5150be0c2bd803fdcdec9
+      digest: sha256:13c33d4e6952e6ddd69d9dd7bb941dc5e8f9fb3d589f016aaca01a9f1067f409
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -489,7 +489,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
-    digest: sha256:cabce18d0674442c8fb4d931e4d44306b74fbaca5e6c9c23f92c8aa790daf53d
+    digest: sha256:cb8bf5c16f961dc9d673a44867a681bdd2d7844a8d12564ad7ff42d8bc22db3b
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -541,7 +541,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:326a165eb7b65ae43b85c9538d3572c57aa56a1862febd90f293783824c62d5f
+    digest: sha256:76b03f4c04291c80a7269474b055cee5f188746c68b444b20c03ea180d0c1348
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -604,7 +604,7 @@ maestro:
     name: arohcp-pers-maestro-usw3test
     private: false
   image:
-    digest: sha256:7dc6bf1b8476e4737a84a5d744bc354d5949b729eeab92039a43507884dd7334
+    digest: sha256:0053dfaa6931c0c60e343b3b4460c136207f4567b14df9f6a7dbd5f3a5d89ed0
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -713,7 +713,7 @@ mgmt:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
+        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -733,7 +733,7 @@ mgmt:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
+        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
       replicas: 2
       resources:
         limits:
@@ -968,7 +968,7 @@ secretSyncController:
         memory: 100Mi
     serviceAccountName: secrets-store-sync-controller-manager
   providerImage:
-    digest: sha256:407ff33bb445d44db9924eeffa2b61d4adf475e5805bdcda10d33e7f68578217
+    digest: sha256:f21fca34342808670e8696dffd25efd5ef4347327b30371950b9e08fee2f11f8
     registry: mcr.microsoft.com
     repository: oss/v2/azure/secrets-store/provider-azure
 serviceKeyVault:
@@ -1062,7 +1062,7 @@ svc:
   istio:
     ingressGatewayIPAddressIPTags: ""
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
-    istioctlVersion: 1.30.4
+    istioctlVersion: 1.31.0
     tag: prod-stable
     targetVersion: asm-1-29
     versions: asm-1-29
@@ -1084,7 +1084,7 @@ svc:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
+        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -1104,7 +1104,7 @@ svc:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
+        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
       replicas: 2
       resources:
         limits:
@@ -1160,14 +1160,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:3cc0fe2d2f0cf66dc8b5346af8ab117046a8abe66bacd29fb3c895d4c3fef7ac
+    digest: sha256:908426eb82d213a5a50e7dc499907fbbd47d2dd80f6d5e4ed1472e0a6b9fb460
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:57afef0f83ea72d8c98808cd894b5adfac336089ddeae9dd0559116de64ba0db
+    digest: sha256:fca00f1a9915708bededd250db55b3f954572478c1175c46eb6a350c1344f5bc
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:857c25afa2fced585ba68ae40248278c6d244f65d72b35b635b8789417d0b9a5
+    digest: sha256:d712b510c9224d194e3da94bbc87d6ff66f44f2d513dd51c2b10b7d2681eb0d1
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -91,7 +91,7 @@ images:
     group: platform-utils
     source:
       image: mcr.microsoft.com/aks/command/runtime
-      tagPattern: "^master\\.\\d+\\.\\d+$"
+      tag: "master.260813.1" # Pinned: master.260901.1 breaks mgmt provisioning (AROSLSRE-2021). Revert to tagPattern: AROSLSRE-2025
       multiArch: true
     targets:
     - jsonPath: defaults.aksCommandRuntime.image.digest


### PR DESCRIPTION
This PR updates ARO-HCP container image digests to the latest versions from registries, excluding aksCommandRuntime which is pinned due to a FIPS regression.

| Name | Old Digest | New Digest | Tag | Date | Status |
| --- | --- | --- | --- | --- | --- |
| **aksCommandRuntime** | **1fa09488bf40…** | **—** | **master.260813.1** | **2026-08-13 00:00** | **⚠️ pinned ([AROSLSRE-2021](https://redhat.atlassian.net/browse/AROSLSRE-2021))** |
| arobit-mdsd | 2a250598df99… | 13c33d4e6952… | 1.43.0-20260904-2 | 2026-09-04 21:37 | updated |
| kubeEvents | 326a165eb7b6… | 76b03f4c0429… | 20260906.1 | 2026-09-06 03:25 | updated |
| secretSyncProvider | 407ff33bb445… | f21fca343428… | v1.8.2 | 2026-09-05 01:44 | updated |
| hypershift | cabce18d0674… | cb8bf5c16f96… | latest | 2026-09-05 06:07 | updated |
| velero-server | 857c25afa2fc… | d712b510c922… | 1.6.2 | 2026-09-04 17:56 | updated |
| velero-azure-plugin | 3cc0fe2d2f0c… | 908426eb82d2… | 1.6.2 | 2026-09-04 17:52 | updated |
| velero-hypershift-plugin | 57afef0f83ea… | fca00f1a9915… | 1.6.2 | 2026-09-04 17:56 | updated |
| istio-istioctl | 1.30.4 | 1.31.0 | 1.31.0 | 2026-08-31 15:47 | updated |
| prometheus | 4aa428f652d2… | 3821dcf121cf… | v3.12.0 | 2026-08-31 17:47 | updated |
| kube-state-metrics | 9b99d6e6e3a5… | f054748b9710… | v2.20.0 | 2026-09-04 22:52 | updated |
| maestro | 7dc6bf1b8476… | 0053dfaa6931… | 8ab737d7f7aad40ca77dcfe36c2b8777ea6a6367 | 2026-09-03 08:13 | updated |
| acm-operator | 9dfbee549e5f… | 2a939da3ff1d… | v2.16.5-599 | 2026-09-05 13:09 | updated |
| acm-mce | c9ed6d2e2591… | a7f8a100505c… | v2.11.7-646 | 2026-09-05 13:07 | updated |

### Why aksCommandRuntime is pinned

The `aks/command/runtime` images from `master.260901.1` onward (verified through `master.260904.1`) panic on startup on FIPS-enabled AKS nodes:

```
panic: opensslcrypto: FIPS mode requested (system FIPS mode) but not available: OpenSSL 3.0.20 7 Apr 2026
```

The image was restructured from standalone binaries to Debian packages with OpenSSL 3.0.20, which lacks FIPS provider support. This breaks all mgmt cluster provisioning Jobs (unannotate-default-sc, finalize-mce, velero).

The image updater `tagPattern` has been replaced with a fixed `tag` in `tooling/image-updater/config.yaml` to prevent re-introduction. Revert tracked by [AROSLSRE-2025](https://issues.redhat.com/browse/AROSLSRE-2025).

Tracking: [AROSLSRE-2021](https://issues.redhat.com/browse/AROSLSRE-2021)

## Test plan
- [x] `cd config && make materialize` passes with all helm fixture tests green
- [x] Validated `master.260904.1` (`sha256:66e73f30cd9794aa46dc2e65997b9383d81e1661dd6c1b029b9f38148d3fa69a`) still has FIPS panic on pers dev mgmt cluster (2026-09-07)
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)