### PR TITLE
fix: align alertEvents KQL column order with deployed Kusto schema

### DIFF
--- a/dev-infrastructure/modules/logs/kusto/tables/alertEvents.kql
+++ b/dev-infrastructure/modules/logs/kusto/tables/alertEvents.kql
@@ -25,8 +25,8 @@ with (docstring = "Staging table for metric alert events ingested from Event Hub
     resolvedDateTime: datetime,
     targetResourceId: string,
     targetResourceType: string,
-    region: string,
-    alertContext: dynamic
+    alertContext: dynamic,
+    region: string
 )
 with (docstring = "Alert events with top-level Common Alert Schema fields extracted")
 
@@ -46,8 +46,8 @@ rawAlertEventsTransform() {
         resolvedDateTime = todatetime(essentials.resolvedDateTime),
         targetResourceId = tostring(essentials.alertTargetIDs[0]),
         targetResourceType = tostring(essentials.targetResourceType),
-        region = tostring(raw.data.alertContext.labels.region),
-        alertContext = raw.data.alertContext
+        alertContext = raw.data.alertContext,
+        region = tostring(raw.data.alertContext.labels.region)
 }
 
 .alter table alertEvents policy update @'[{"IsEnabled": true, "Source": "rawAlertEvents", "Query": "rawAlertEventsTransform()", "IsTransactional": true, "PropagateIngestionProperties": false}]'


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-2028

## Summary
- The `alertEvents` table was originally created with `alertContext` as the last column. When `region` was added in [6fbf78db5](https://github.com/Azure/ARO-HCP/commit/6fbf78db5), it was placed **before** `alertContext` in the KQL source, but `.create-merge table` only appends new columns — Kusto added `region` **after** `alertContext` in the deployed schema.
- This column order mismatch causes the update policy to fail with `ScriptExecutionFailed: Query schema does not match table schema`, breaking the `global-pipeline-postsubmit` job ([failing run](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-global-pipeline-postsubmit/2095742533232496640)).
- Swaps `alertContext` and `region` in both the table definition and the transform function to match the actual deployed order (confirmed via Kusto schema query against dev).

## Test plan
- [x] Verify `make verify-kql` passes
- [ ] `global-pipeline-postsubmit` job succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)