### PR TITLE
fix(acm): pin governance policy propagator image

### DIFF
--- a/acm/multicluster-engine-config.values.yaml
+++ b/acm/multicluster-engine-config.values.yaml
@@ -1,5 +1,7 @@
 global:
   registryOverride: "{{ .acr.svc.name }}.azurecr.io/acm-d-cache"
+  imageOverrides:
+    governance_policy_propagator: "governance-policy-propagator-acm-216@sha256:deb737b19932d520553c902ee5e0738ebeaad4592e8aa9649c41fec6fc00b62e"
 finalizeMceJobImage: "{{ .aksCommandRuntime.image.registry }}/{{ .aksCommandRuntime.image.repository }}@{{ .aksCommandRuntime.image.digest }}"
 localCluster:
   kubeApiUrl: https://kubernetes.default.svc

--- a/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_config.yaml
+++ b/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce_config.yaml
@@ -2199,7 +2199,7 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: governance-policy-propagator
-        image: "arohcpsvcdev.azurecr.io/acm-d-cache/governance-policy-propagator-rhel9@sha256:1234567890"
+        image: "arohcpsvcdev.azurecr.io/acm-d-cache/governance-policy-propagator-acm-216@sha256:1234567890"
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-2029

## Why

Temporarily pin the governance policy propagator workload to the requested digest while retaining bundle-derived defaults for the other ACM policy components. The image is consumed through the fixed SVC ACR cache repository introduced by #6829.

## Dependency and rollout order

This PR is blocked by #6829. PR checks deploy the Region entrypoint but do not deploy Global infrastructure, so merely adding the cache rule in a PR does not make it available to E2E.

1. Merge #6829.
2. Deploy the `Microsoft.Azure.ARO.HCP.Global` entrypoint so the cache rule reaches all SVC ACRs, including the shared development ACR used by PR checks.
3. Retry E2E on this PR.
4. Mark this PR ready after E2E passes.

Production rollout must preserve the same Global-before-Region ordering. This PR remains draft until the cache PR is merged and the Global deployment completes.

## Validation

- `make update-helm-fixtures`
- `make yamlfmt`
- `make test-helm-fixtures`
- `git diff --check`