### PR TITLE
fix: retry transient network errors fetching control plane version graph (AROSLSRE-2030)

### DIFF
--- a/backend/pkg/controllers/controlplaneversion/cincinnati.go
+++ b/backend/pkg/controllers/controlplaneversion/cincinnati.go
@@ -17,13 +17,19 @@ package controlplaneversion
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"slices"
+	"syscall"
+	"time"
 
 	"github.com/blang/semver/v4"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	configv1 "github.com/openshift/api/config/v1"
 )
@@ -54,6 +60,20 @@ type graph struct {
 }
 
 var defaultUpstreamUpdateService = "https://api.openshift.com/api/upgrades_info/graph"
+
+// cincinnatiRetryBackoff configures the retry-with-backoff behavior of
+// doWithRetry when fetching the Cincinnati update graph in production. It
+// is a package-level var (rather than a hard-coded literal inside
+// doWithRetry) purely for readability; tests exercise the retry/no-retry
+// behavior by passing their own fast backoff directly to doWithRetry
+// instead of overriding this var, to stay deterministic and avoid shared
+// mutable state.
+var cincinnatiRetryBackoff = wait.Backoff{
+	Duration: 1 * time.Second,
+	Factor:   2,
+	Steps:    5,
+	Cap:      30 * time.Second,
+}
 
 // roundTrip converts a RoundTrip function into a RoundTripper.
 type roundTrip struct {
@@ -96,15 +116,8 @@ func cincinnati(ctx context.Context, roundTripper RoundTrip, updateService *url.
 	if roundTripper != nil {
 		client.Transport = &roundTrip{roundTripper: roundTripper}
 	}
-	resp, err := client.Do(req.WithContext(ctx))
-	if err != nil {
-		return nil, updateService, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, updateService, fmt.Errorf("%s returned unexpected HTTP status %s", updateService, resp.Status)
-	}
-	body, err := io.ReadAll(resp.Body)
+
+	body, err := doWithRetry(ctx, client, req, cincinnatiRetryBackoff)
 	if err != nil {
 		return nil, updateService, err
 	}
@@ -116,6 +129,101 @@ func cincinnati(ctx context.Context, roundTripper RoundTrip, updateService *url.
 
 	releases, err := nodesToReleases(graph.Nodes)
 	return releases, updateService, err
+}
+
+// doWithRetry issues req via client, retrying transient failures (DNS lookup
+// failures, connection timeouts, and 5xx responses) with exponential
+// backoff. It returns the response body on a successful 200, or an error if
+// every attempt failed. Non-transient failures (e.g. 4xx responses) are
+// returned immediately without retrying.
+func doWithRetry(ctx context.Context, client *http.Client, req *http.Request, backoff wait.Backoff) ([]byte, error) {
+	var body []byte
+	var lastErr error
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		resp, err := client.Do(req.Clone(ctx))
+		if err != nil {
+			if ctx.Err() != nil {
+				// The context was cancelled or timed out; stop retrying and
+				// surface that immediately instead of the generic transport
+				// error.
+				return false, ctx.Err()
+			}
+			if !isTransientTransportError(err) {
+				// Misconfiguration-style errors (bad URL, unsupported
+				// protocol scheme, TLS cert errors, etc.) will not clear up
+				// on retry; fail fast instead of masking them.
+				return false, err
+			}
+			// Treat known-transient transport errors (DNS lookup failures,
+			// dial timeouts, connection resets, etc.) as retryable,
+			// remembering the error in case every attempt fails.
+			lastErr = err
+			return false, nil
+		}
+		defer func() {
+			// Drain the body before closing so the underlying connection
+			// can be reused by later retry attempts.
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}()
+
+		if resp.StatusCode >= http.StatusInternalServerError {
+			// Server-side errors are typically transient; retry.
+			lastErr = fmt.Errorf("%s returned unexpected HTTP status %d", req.URL, resp.StatusCode)
+			return false, nil
+		}
+		if resp.StatusCode != http.StatusOK {
+			return false, fmt.Errorf("%s returned unexpected HTTP status %d", req.URL, resp.StatusCode)
+		}
+
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			lastErr = err
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			// The caller's context was cancelled or timed out; surface that
+			// directly rather than a generic retries-exhausted error.
+			return nil, err
+		}
+		if wait.Interrupted(err) {
+			if lastErr != nil {
+				return nil, fmt.Errorf("%s did not respond successfully after retries: %w", req.URL, lastErr)
+			}
+			return nil, fmt.Errorf("%s did not respond successfully after retries", req.URL)
+		}
+		return nil, err
+	}
+	return body, nil
+}
+
+// isTransientTransportError reports whether err, returned from
+// client.Do, is likely to clear up on its own (DNS resolution failures,
+// dial timeouts, connection resets) as opposed to a persistent
+// misconfiguration (unsupported URL scheme, TLS certificate errors,
+// malformed requests) that will fail identically on every retry.
+func isTransientTransportError(err error) bool {
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		// Permanent lookup failures (e.g. NXDOMAIN / "no such host") will
+		// not clear up on retry; only timeouts and other temporary
+		// resolver failures are worth retrying.
+		return dnsErr.IsTimeout || dnsErr.IsTemporary
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ETIMEDOUT) {
+		return true
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	return false
 }
 
 // nodesToReleases converts a slice of update-service nodes to a slice

--- a/backend/pkg/controllers/controlplaneversion/cincinnati.go
+++ b/backend/pkg/controllers/controlplaneversion/cincinnati.go
@@ -213,15 +213,19 @@ func isTransientTransportError(err error) bool {
 		// resolver failures are worth retrying.
 		return dnsErr.IsTimeout || dnsErr.IsTemporary
 	}
-	var netErr net.Error
-	if errors.As(err, &netErr) {
-		return netErr.Timeout()
-	}
 	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ETIMEDOUT) {
 		return true
 	}
 	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		return true
+	}
+	// net.Error (e.g. *net.OpError) wraps connection resets/refusals too,
+	// but its Timeout() only reports timeouts; the syscall checks above
+	// must run first so those cases are retried rather than short-circuited
+	// here as non-timeout, non-retryable errors.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
 	}
 	return false
 }

--- a/backend/pkg/controllers/controlplaneversion/cincinnati_retry_test.go
+++ b/backend/pkg/controllers/controlplaneversion/cincinnati_retry_test.go
@@ -1,0 +1,211 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplaneversion
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// fastTestBackoff keeps the retry test deterministic and fast: three steps
+// with 1ms delays, well within any test timeout.
+var fastTestBackoff = wait.Backoff{
+	Duration: time.Millisecond,
+	Factor:   1,
+	Steps:    3,
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+// transientDNSErr simulates the DNS lookup failure that motivated this
+// retry logic (dial tcp: lookup api.openshift.com: i/o timeout).
+var transientDNSErr = &net.DNSError{Err: "i/o timeout", Name: "api.openshift.com", IsTimeout: true}
+
+func TestDoWithRetry(t *testing.T) {
+	t.Run("retries a transient transport error and succeeds once it clears", func(t *testing.T) {
+		attempts := 0
+		client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts < 2 {
+				return nil, transientDNSErr
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok"))}, nil
+		})}
+
+		req, err := http.NewRequest("GET", "https://api.openshift.com/api/upgrades_info/graph", nil)
+		if err != nil {
+			t.Fatalf("failed to build request: %v", err)
+		}
+
+		body, err := doWithRetry(context.Background(), client, req, fastTestBackoff)
+		if err != nil {
+			t.Fatalf("expected success after retry, got error: %v", err)
+		}
+		if string(body) != "ok" {
+			t.Errorf("expected body %q, got %q", "ok", body)
+		}
+		if attempts != 2 {
+			t.Errorf("expected 2 attempts, got %d", attempts)
+		}
+	})
+
+	t.Run("retries a 5xx response", func(t *testing.T) {
+		attempts := 0
+		client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts < 2 {
+				return &http.Response{StatusCode: http.StatusServiceUnavailable, Body: io.NopCloser(strings.NewReader(""))}, nil
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok"))}, nil
+		})}
+
+		req, err := http.NewRequest("GET", "https://api.openshift.com/api/upgrades_info/graph", nil)
+		if err != nil {
+			t.Fatalf("failed to build request: %v", err)
+		}
+
+		_, err = doWithRetry(context.Background(), client, req, fastTestBackoff)
+		if err != nil {
+			t.Fatalf("expected success after retry, got error: %v", err)
+		}
+		if attempts != 2 {
+			t.Errorf("expected 2 attempts, got %d", attempts)
+		}
+	})
+
+	t.Run("does not retry a 4xx response", func(t *testing.T) {
+		attempts := 0
+		client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			return &http.Response{StatusCode: http.StatusNotFound, Status: "404 Not Found", Body: io.NopCloser(strings.NewReader(""))}, nil
+		})}
+
+		req, err := http.NewRequest("GET", "https://api.openshift.com/api/upgrades_info/graph", nil)
+		if err != nil {
+			t.Fatalf("failed to build request: %v", err)
+		}
+
+		_, err = doWithRetry(context.Background(), client, req, fastTestBackoff)
+		if err == nil {
+			t.Fatal("expected an error for a 4xx response")
+		}
+		if attempts != 1 {
+			t.Errorf("expected exactly 1 attempt (no retry) for a 4xx response, got %d", attempts)
+		}
+	})
+
+	t.Run("does not retry a non-transient transport error", func(t *testing.T) {
+		attempts := 0
+		nonTransient := errors.New(`unsupported protocol scheme ""`)
+		client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			return nil, nonTransient
+		})}
+
+		req, err := http.NewRequest("GET", "https://api.openshift.com/api/upgrades_info/graph", nil)
+		if err != nil {
+			t.Fatalf("failed to build request: %v", err)
+		}
+
+		_, err = doWithRetry(context.Background(), client, req, fastTestBackoff)
+		if !errors.Is(err, nonTransient) {
+			t.Errorf("expected the non-transient error to be returned as-is, got %v", err)
+		}
+		if attempts != 1 {
+			t.Errorf("expected exactly 1 attempt (no retry) for a non-transient error, got %d", attempts)
+		}
+	})
+
+	t.Run("does not retry a permanent DNS lookup failure", func(t *testing.T) {
+		attempts := 0
+		nxdomain := &net.DNSError{Err: "no such host", Name: "api.openshift.com", IsNotFound: true}
+		client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			return nil, nxdomain
+		})}
+
+		req, err := http.NewRequest("GET", "https://api.openshift.com/api/upgrades_info/graph", nil)
+		if err != nil {
+			t.Fatalf("failed to build request: %v", err)
+		}
+
+		_, err = doWithRetry(context.Background(), client, req, fastTestBackoff)
+		if !errors.Is(err, nxdomain) {
+			t.Errorf("expected the NXDOMAIN error to be returned as-is, got %v", err)
+		}
+		if attempts != 1 {
+			t.Errorf("expected exactly 1 attempt (no retry) for a permanent DNS failure, got %d", attempts)
+		}
+	})
+
+	t.Run("gives up after exhausting the backoff and preserves the last transport error", func(t *testing.T) {
+		attempts := 0
+		client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			return nil, transientDNSErr
+		})}
+
+		req, err := http.NewRequest("GET", "https://api.openshift.com/api/upgrades_info/graph", nil)
+		if err != nil {
+			t.Fatalf("failed to build request: %v", err)
+		}
+
+		_, err = doWithRetry(context.Background(), client, req, fastTestBackoff)
+		if err == nil {
+			t.Fatal("expected an error once the backoff is exhausted")
+		}
+		if !errors.Is(err, transientDNSErr) {
+			t.Errorf("expected the returned error to wrap the last transport error, got %v", err)
+		}
+		if attempts != fastTestBackoff.Steps {
+			t.Errorf("expected %d attempts, got %d", fastTestBackoff.Steps, attempts)
+		}
+	})
+
+	t.Run("stops immediately on context cancellation instead of retrying", func(t *testing.T) {
+		attempts := 0
+		ctx, cancel := context.WithCancel(context.Background())
+		client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			cancel()
+			return nil, req.Context().Err()
+		})}
+
+		req, err := http.NewRequest("GET", "https://api.openshift.com/api/upgrades_info/graph", nil)
+		if err != nil {
+			t.Fatalf("failed to build request: %v", err)
+		}
+
+		_, err = doWithRetry(ctx, client, req, fastTestBackoff)
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("expected a context.Canceled error, got %v", err)
+		}
+		if attempts != 1 {
+			t.Errorf("expected exactly 1 attempt (no retry) after context cancellation, got %d", attempts)
+		}
+	})
+}

--- a/backend/pkg/controllers/controlplaneversion/cincinnati_retry_test.go
+++ b/backend/pkg/controllers/controlplaneversion/cincinnati_retry_test.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -137,6 +138,37 @@ func TestDoWithRetry(t *testing.T) {
 		}
 		if attempts != 1 {
 			t.Errorf("expected exactly 1 attempt (no retry) for a non-transient error, got %d", attempts)
+		}
+	})
+
+	t.Run("retries a connection reset wrapped in a net.OpError", func(t *testing.T) {
+		// *net.OpError implements net.Error, so it must not be mistaken for
+		// a plain timeout check; the underlying ECONNRESET has to still be
+		// detected and retried.
+		attempts := 0
+		econnreset := &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET}
+		client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			attempts++
+			if attempts < 2 {
+				return nil, econnreset
+			}
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok"))}, nil
+		})}
+
+		req, err := http.NewRequest("GET", "https://api.openshift.com/api/upgrades_info/graph", nil)
+		if err != nil {
+			t.Fatalf("failed to build request: %v", err)
+		}
+
+		body, err := doWithRetry(context.Background(), client, req, fastTestBackoff)
+		if err != nil {
+			t.Fatalf("expected success after retry, got error: %v", err)
+		}
+		if string(body) != "ok" {
+			t.Errorf("expected body %q, got %q", "ok", body)
+		}
+		if attempts != 2 {
+			t.Errorf("expected 2 attempts, got %d", attempts)
 		}
 	})
 


### PR DESCRIPTION
<!-- Link to Jira issue -->
[AROSLSRE-2030](https://redhat.atlassian.net/browse/AROSLSRE-2030)

### What

Retries transient failures (DNS/dial timeouts, connection resets, 5xx) with exponential backoff when fetching the control plane version graph from the Cincinnati update service, instead of failing on the first hiccup.

### Why

E2E build [2095800805629104128](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-e2e-prod-e2e-parallel/2095800805629104128) failed the `Update HCPOpenShiftCluster` test with:

```text
failed to get latest install version for candidate channel: failed getting controlPlaneVersion:
Get "https://api.openshift.com/api/upgrades_info/graph?arch=multi&channel=candidate-4.21":
dial tcp: lookup api.openshift.com on 172.30.0.10:53: read udp 10.129.222.58:38094->172.30.0.10:53: i/o timeout
```

A single DNS lookup timeout on the test pod's cluster DNS failed the whole run. `SelectControlPlaneVersion` made one unretried HTTP GET, so any transient network blip was fatal.

### Testing

- `go build ./backend/...`
- `go test ./backend/...`

A genuine 4xx response from the update service still fails immediately with no retry; existing unit tests for `SelectControlPlaneVersion` mock a single 200 response and pass unchanged.

### Special notes for your reviewer

Backoff is 1s doubling up to a 30s cap over 5 attempts, using `k8s.io/apimachinery/pkg/util/wait` (already a dependency elsewhere in the repo).

### PR Checklist
- [x] Tests pass
- [x] Documentation not required (no user-facing behavior change)
