### PR TITLE
fix(acr): cache governance policy propagator image

### DIFF
--- a/dev-infrastructure/templates/global-acr.bicep
+++ b/dev-infrastructure/templates/global-acr.bicep
@@ -193,6 +193,15 @@ module svcCaching '../modules/acr/cache.bicep' = {
         passwordIdentifier: 'acm-d-password'
         loginServer: 'quay.io'
       }
+      // Keep a distinct fixed target so this source can override the acm-d wildcard mapping.
+      {
+        ruleName: 'governance-policy-propagator-acm-216'
+        sourceRepo: 'quay.io/redhat-user-workloads/crt-redhat-acm-tenant/governance-policy-propagator-acm-216'
+        targetRepo: 'acm-d-cache/governance-policy-propagator-acm-216'
+        userIdentifier: 'quay-username'
+        passwordIdentifier: 'quay-password'
+        loginServer: 'quay.io'
+      }
     ]
     keyVaultName: globalKeyVaultName
   }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-2029

## Why

PR #6827 pins the governance policy propagator to an image published under the `quay.io/redhat-user-workloads/crt-redhat-acm-tenant` namespace. The existing SVC ACR wildcard maps `acm-d-cache/*` to `quay.io/acm-d/*`, so it cannot resolve that image.

Add a fixed ACR cache rule mapping the CRT repository to `acm-d-cache/governance-policy-propagator-acm-216`. The fixed target can coexist with the existing wildcard rule and is deployed to every SVC ACR through the global infrastructure template.

## Dependency and rollout order

PR checks deploy the Region entrypoint and do not deploy Global infrastructure, so #6827 cannot pass E2E until this cache rule exists in the shared development ACR.

1. Merge this PR.
2. Deploy the `Microsoft.Azure.ARO.HCP.Global` entrypoint so the cache rule reaches all SVC ACRs, including the shared development ACR used by PR checks.
3. Retry E2E on #6827.

PR #6827 remains draft until this PR is merged and the Global deployment completes. Production rollout must preserve the same Global-before-Region ordering.

## Validation

- `az bicep lint --file dev-infrastructure/templates/global-acr.bicep`
- `az bicep build --file dev-infrastructure/templates/global-acr.bicep --stdout`
- `git diff --check`