### PR TITLE
fix(ci): stop CodeQL Go autobuild from running full test suite (AROSLSRE-2031)

### DIFF
--- a/.github/workflows/codeql-analysis-retry.yml
+++ b/.github/workflows/codeql-analysis-retry.yml
@@ -6,13 +6,16 @@ on:
     - completed
 jobs:
   retry-on-failure:
-    # Only retry once: run_attempt is 1 on the first try, so this only fires
-    # after the first failure and never again after the automatic re-run.
+    # run_attempt is 1 on the original run, 2 after the first retry, and so
+    # on, so this fires again only while there are retries left to spend.
+    # Total attempts = 1 original run + CODEQL_MAX_RETRIES retries. Set a
+    # repository/org Actions variable named CODEQL_MAX_RETRIES to change how
+    # many times it retries; defaults to 1 if unset.
     # Covers cancelled/timed_out as well as failure, since a runner
     # preemption or our own job timeout-minutes can surface as either.
     if: >-
       contains(fromJSON('["failure", "cancelled", "timed_out"]'), github.event.workflow_run.conclusion) &&
-      github.event.workflow_run.run_attempt < 2
+      github.event.workflow_run.run_attempt <= fromJSON(vars.CODEQL_MAX_RETRIES || '1')
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/codeql-analysis-retry.yml
+++ b/.github/workflows/codeql-analysis-retry.yml
@@ -14,8 +14,7 @@ jobs:
     # Covers cancelled/timed_out as well as failure, since a runner
     # preemption or our own job timeout-minutes can surface as either.
     if: >-
-      contains(fromJSON('["failure", "cancelled", "timed_out"]'), github.event.workflow_run.conclusion) &&
-      github.event.workflow_run.run_attempt <= fromJSON(vars.CODEQL_MAX_RETRIES || '1')
+      contains(fromJSON('["failure", "cancelled", "timed_out"]'), github.event.workflow_run.conclusion) && github.event.workflow_run.run_attempt <= fromJSON(vars.CODEQL_MAX_RETRIES || '1')
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/codeql-analysis-retry.yml
+++ b/.github/workflows/codeql-analysis-retry.yml
@@ -1,0 +1,22 @@
+name: "CodeQL Analysis Retry"
+on:
+  workflow_run:
+    workflows: ["CodeQL Analysis"]
+    types:
+    - completed
+jobs:
+  retry-on-failure:
+    # Only retry once: run_attempt is 1 on the first try, so this only fires
+    # after the first failure and never again after the automatic re-run.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 2
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+    - name: Re-run failed jobs
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+      run: gh run rerun ${{ github.event.workflow_run.id }} --failed

--- a/.github/workflows/codeql-analysis-retry.yml
+++ b/.github/workflows/codeql-analysis-retry.yml
@@ -8,8 +8,10 @@ jobs:
   retry-on-failure:
     # Only retry once: run_attempt is 1 on the first try, so this only fires
     # after the first failure and never again after the automatic re-run.
+    # Covers cancelled/timed_out as well as failure, since a runner
+    # preemption or our own job timeout-minutes can surface as either.
     if: >-
-      github.event.workflow_run.conclusion == 'failure' &&
+      contains(fromJSON('["failure", "cancelled", "timed_out"]'), github.event.workflow_run.conclusion) &&
       github.event.workflow_run.run_attempt < 2
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,9 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    # Bound the job so a stuck/reclaimed runner fails fast and predictably
+    # instead of running until GitHub-side infra kills it.
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read
@@ -39,11 +42,23 @@ jobs:
       uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       with:
         languages: ${{ matrix.language }}
+        # Go doesn't support build-mode: none on this CodeQL version, so build
+        # it manually instead of relying on Autobuild. Autobuild detects our
+        # root Makefile and runs it as a build heuristic, which triggers
+        # `make test` (the full repo test suite). That always fails on this
+        # runner because `promtool` isn't installed, and it adds several
+        # minutes of wasted, always-failing work to every run before falling
+        # back to a build - the main contributor to the job running long
+        # enough to hit runner preemption. Building manually below skips the
+        # Makefile entirely. Unit test coverage is unaffected: the required
+        # ci/prow/test-unit presubmit already runs the same `make test-unit`
+        # target in a properly provisioned CI image.
+        build-mode: ${{ matrix.language == 'go' && 'manual' || 'none' }}
         # Use default CodeQL query packs
         # For custom queries, add: queries: security-and-quality
-    # Autobuild attempts to build any compiled languages (Go, C/C++, C#, Java, etc.)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+    - name: Build (go)
+      if: matrix.language == 'go'
+      run: go list -f '{{.Dir}}/...' -m | xargs go build
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
       with:


### PR DESCRIPTION
Jira: [AROSLSRE-2031](https://redhat.atlassian.net/browse/AROSLSRE-2031)

### What

Stops CodeQL's Go `Autobuild` from invoking the root `Makefile` (which runs `make test`, the whole repo's Go test suite) by switching Go analysis to `build-mode: manual` with an explicit `go build` step, and Python analysis to `build-mode: none`. Also adds an explicit job `timeout-minutes`, and a companion workflow, `codeql-analysis-retry.yml`, that automatically retries the run once on failure.

### Why

The `Analyze (go)` job has failed intermittently across unrelated PRs with `The runner has received a shutdown signal`. In every failure, the job dies deep in CodeQL's Autobuild step while extracting large Go files, after first running `make test` as a build heuristic. That test run always fails on this runner because `tooling/prometheus-rules` tests need the `promtool` binary, which isn't installed here, and it adds several minutes of wasted, always-failing work to every run before falling back to a build. Building manually with `go list -f '{{.Dir}}/...' -m | xargs go build` skips the Makefile detour entirely. No test coverage is lost: the required `ci/prow/test-unit` presubmit already runs the identical `make test-unit` target in a properly provisioned CI image.

`build-mode: none` isn't usable for Go on this CodeQL version (`github/codeql-action` v4.36.0 rejects it with "Go does not support the none build mode"), which is why Go needs the explicit manual build step while Python, which doesn't compile, can stay on `build-mode: none`.

The retry workflow has to live in its own file: GitHub rejects a `workflow_run` trigger that references its own workflow's name from within that same file ("self-reference not allowed"), so `codeql-analysis-retry.yml` watches `CodeQL Analysis` via `workflow_run` and calls `gh run rerun --failed`, capped to one retry via `run_attempt < 2`.

### Testing

Validated both workflow files with `actionlint` and a YAML parser. Verified locally that `go list -f '{{.Dir}}/...' -m | xargs go build` builds all workspace modules from the repo root (`go build ./...` doesn't work here due to Go workspace mode). Confirmed live on this PR: `Analyze (go)` and `Analyze (python)` both pass with the new build steps.

### Special notes for your reviewer

The retry workflow only fires on completed runs of `CodeQL Analysis` and only re-runs failed jobs once, so a genuine analysis failure (not a runner preemption) still surfaces as a normal PR check failure after the single retry.

### PR Checklist
- [x] Tested changes locally
- [ ] Added/updated relevant documentation
- [ ] Added/updated relevant tests
