### PR TITLE
[test]: Use NodePool & HostedCluster read desire during clusters & node pool status reconciliation within CS as well as persist what's done by those watching controllers to Cosmos' Resources container.

### DIFF
--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
@@ -7971,7 +7971,7 @@ spec:
             secretProviderClass: cs-keyvault
       initContainers:
       - name: clusters-service-init
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
@@ -8006,7 +8006,7 @@ spec:
         - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
       containers:
       - name: clusters-service-server
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         - name: DENYASSIGNMENTS
@@ -8256,7 +8256,7 @@ spec:
   acr:
     environment: PublicCloud
     server: 'arohcpsvcdev.azurecr.io'
-    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+    scope: 'repository:mchitimb/cs:pull'
   auth:
     workloadIdentity:
       serviceAccountRef: 'clusters-service'

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
@@ -8072,7 +8072,7 @@ spec:
             secretProviderClass: cs-keyvault
       initContainers:
       - name: clusters-service-init
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
@@ -8107,7 +8107,7 @@ spec:
         - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
       containers:
       - name: clusters-service-server
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         - name: DENYASSIGNMENTS
@@ -8357,7 +8357,7 @@ spec:
   acr:
     environment: PublicCloud
     server: 'arohcpsvcdev.azurecr.io'
-    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+    scope: 'repository:mchitimb/cs:pull'
   auth:
     workloadIdentity:
       serviceAccountRef: 'clusters-service'

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_distinct_arm_helper.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_distinct_arm_helper.yaml
@@ -7971,7 +7971,7 @@ spec:
             secretProviderClass: cs-keyvault
       initContainers:
       - name: clusters-service-init
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
@@ -8006,7 +8006,7 @@ spec:
         - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
       containers:
       - name: clusters-service-server
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         - name: DENYASSIGNMENTS
@@ -8256,7 +8256,7 @@ spec:
   acr:
     environment: PublicCloud
     server: 'arohcpsvcdev.azurecr.io'
-    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+    scope: 'repository:mchitimb/cs:pull'
   auth:
     workloadIdentity:
       serviceAccountRef: 'clusters-service'

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_shared_arm_helper.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_shared_arm_helper.yaml
@@ -7971,7 +7971,7 @@ spec:
             secretProviderClass: cs-keyvault
       initContainers:
       - name: clusters-service-init
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
@@ -8006,7 +8006,7 @@ spec:
         - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
       containers:
       - name: clusters-service-server
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         - name: DENYASSIGNMENTS
@@ -8256,7 +8256,7 @@ spec:
   acr:
     environment: PublicCloud
     server: 'arohcpsvcdev.azurecr.io'
-    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+    scope: 'repository:mchitimb/cs:pull'
   auth:
     workloadIdentity:
       serviceAccountRef: 'clusters-service'

--- a/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
+++ b/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
@@ -7971,7 +7971,7 @@ spec:
             secretProviderClass: cs-keyvault
       initContainers:
       - name: clusters-service-init
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
@@ -8006,7 +8006,7 @@ spec:
         - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
       containers:
       - name: clusters-service-server
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         - name: DENYASSIGNMENTS
@@ -8256,7 +8256,7 @@ spec:
   acr:
     environment: PublicCloud
     server: 'arohcpsvcdev.azurecr.io'
-    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+    scope: 'repository:mchitimb/cs:pull'
   auth:
     workloadIdentity:
       serviceAccountRef: 'clusters-service'

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1103,7 +1103,7 @@ defaults:
     image:
       registry: arohcpsvcdev.azurecr.io
       repository: mchitimb/cs
-      digest: sha256:28696cc83d8c806154e7b16f5d8d5deeea1bcd8eebb98cf72139fdb954149d58 # rd (2026-09-02 08:10)
+      digest: sha256:0cbd65ab5ac0c7f199a317ddb48250f86eb7d1e3dcd966d8c38b8be050c3bf63
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1103,7 +1103,7 @@ defaults:
     image:
       registry: arohcpsvcdev.azurecr.io
       repository: mchitimb/cs
-      digest: sha256:42f40e917eaa873a729ec656d99377845401642dc8a1369c54ed0c519e1622a3
+      digest: sha256:394eee85c19ce289abbbd9966008276a0573a58a47e2579e0bb41bb186b4adae
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1103,7 +1103,7 @@ defaults:
     image:
       registry: arohcpsvcdev.azurecr.io
       repository: mchitimb/cs
-      digest: sha256:394eee85c19ce289abbbd9966008276a0573a58a47e2579e0bb41bb186b4adae
+      digest: sha256:d4464057af938f1defaa363d7e347e0080128f58ed0f7ca6b27622380325284c
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1103,7 +1103,7 @@ defaults:
     image:
       registry: arohcpsvcdev.azurecr.io
       repository: mchitimb/cs
-      digest: sha256:0cbd65ab5ac0c7f199a317ddb48250f86eb7d1e3dcd966d8c38b8be050c3bf63
+      digest: sha256:42f40e917eaa873a729ec656d99377845401642dc8a1369c54ed0c519e1622a3
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1101,9 +1101,9 @@ defaults:
   # Cluster Service
   clustersService:
     image:
-      registry: quay.io
-      repository: app-sre/aro-hcp-clusters-service
-      digest: sha256:4bc659373dbf9b5eba2df7da2ceccec2952fa6d712a406a2a2a13e887228c912 # 5fc479961bb4bdcad6a58b5075879613a913d583 (2026-08-30 13:46)
+      registry: arohcpsvcdev.azurecr.io
+      repository: mchitimb/cs
+      digest: sha256:28696cc83d8c806154e7b16f5d8d5deeea1bcd8eebb98cf72139fdb954149d58 # rd (2026-09-02 08:10)
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci00
   image:
-    digest: sha256:42f40e917eaa873a729ec656d99377845401642dc8a1369c54ed0c519e1622a3
+    digest: sha256:394eee85c19ce289abbbd9966008276a0573a58a47e2579e0bb41bb186b4adae
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -185,9 +185,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci00
   image:
-    digest: sha256:4bc659373dbf9b5eba2df7da2ceccec2952fa6d712a406a2a2a13e887228c912
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:28696cc83d8c806154e7b16f5d8d5deeea1bcd8eebb98cf72139fdb954149d58
+    registry: arohcpsvcdev.azurecr.io
+    repository: mchitimb/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci00
   image:
-    digest: sha256:28696cc83d8c806154e7b16f5d8d5deeea1bcd8eebb98cf72139fdb954149d58
+    digest: sha256:0cbd65ab5ac0c7f199a317ddb48250f86eb7d1e3dcd966d8c38b8be050c3bf63
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci00
   image:
-    digest: sha256:394eee85c19ce289abbbd9966008276a0573a58a47e2579e0bb41bb186b4adae
+    digest: sha256:d4464057af938f1defaa363d7e347e0080128f58ed0f7ca6b27622380325284c
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci00
   image:
-    digest: sha256:0cbd65ab5ac0c7f199a317ddb48250f86eb7d1e3dcd966d8c38b8be050c3bf63
+    digest: sha256:42f40e917eaa873a729ec656d99377845401642dc8a1369c54ed0c519e1622a3
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci01
   image:
-    digest: sha256:394eee85c19ce289abbbd9966008276a0573a58a47e2579e0bb41bb186b4adae
+    digest: sha256:d4464057af938f1defaa363d7e347e0080128f58ed0f7ca6b27622380325284c
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci01
   image:
-    digest: sha256:28696cc83d8c806154e7b16f5d8d5deeea1bcd8eebb98cf72139fdb954149d58
+    digest: sha256:0cbd65ab5ac0c7f199a317ddb48250f86eb7d1e3dcd966d8c38b8be050c3bf63
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci01
   image:
-    digest: sha256:0cbd65ab5ac0c7f199a317ddb48250f86eb7d1e3dcd966d8c38b8be050c3bf63
+    digest: sha256:42f40e917eaa873a729ec656d99377845401642dc8a1369c54ed0c519e1622a3
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci01
   image:
-    digest: sha256:42f40e917eaa873a729ec656d99377845401642dc8a1369c54ed0c519e1622a3
+    digest: sha256:394eee85c19ce289abbbd9966008276a0573a58a47e2579e0bb41bb186b4adae
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -185,9 +185,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci01
   image:
-    digest: sha256:4bc659373dbf9b5eba2df7da2ceccec2952fa6d712a406a2a2a13e887228c912
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:28696cc83d8c806154e7b16f5d8d5deeea1bcd8eebb98cf72139fdb954149d58
+    registry: arohcpsvcdev.azurecr.io
+    repository: mchitimb/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:28696cc83d8c806154e7b16f5d8d5deeea1bcd8eebb98cf72139fdb954149d58
+    digest: sha256:0cbd65ab5ac0c7f199a317ddb48250f86eb7d1e3dcd966d8c38b8be050c3bf63
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:0cbd65ab5ac0c7f199a317ddb48250f86eb7d1e3dcd966d8c38b8be050c3bf63
+    digest: sha256:42f40e917eaa873a729ec656d99377845401642dc8a1369c54ed0c519e1622a3
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:394eee85c19ce289abbbd9966008276a0573a58a47e2579e0bb41bb186b4adae
+    digest: sha256:d4464057af938f1defaa363d7e347e0080128f58ed0f7ca6b27622380325284c
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -185,9 +185,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:4bc659373dbf9b5eba2df7da2ceccec2952fa6d712a406a2a2a13e887228c912
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:28696cc83d8c806154e7b16f5d8d5deeea1bcd8eebb98cf72139fdb954149d58
+    registry: arohcpsvcdev.azurecr.io
+    repository: mchitimb/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:42f40e917eaa873a729ec656d99377845401642dc8a1369c54ed0c519e1622a3
+    digest: sha256:394eee85c19ce289abbbd9966008276a0573a58a47e2579e0bb41bb186b4adae
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:394eee85c19ce289abbbd9966008276a0573a58a47e2579e0bb41bb186b4adae
+    digest: sha256:d4464057af938f1defaa363d7e347e0080128f58ed0f7ca6b27622380325284c
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:42f40e917eaa873a729ec656d99377845401642dc8a1369c54ed0c519e1622a3
+    digest: sha256:394eee85c19ce289abbbd9966008276a0573a58a47e2579e0bb41bb186b4adae
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -185,9 +185,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:4bc659373dbf9b5eba2df7da2ceccec2952fa6d712a406a2a2a13e887228c912
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:28696cc83d8c806154e7b16f5d8d5deeea1bcd8eebb98cf72139fdb954149d58
+    registry: arohcpsvcdev.azurecr.io
+    repository: mchitimb/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:0cbd65ab5ac0c7f199a317ddb48250f86eb7d1e3dcd966d8c38b8be050c3bf63
+    digest: sha256:42f40e917eaa873a729ec656d99377845401642dc8a1369c54ed0c519e1622a3
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:28696cc83d8c806154e7b16f5d8d5deeea1bcd8eebb98cf72139fdb954149d58
+    digest: sha256:0cbd65ab5ac0c7f199a317ddb48250f86eb7d1e3dcd966d8c38b8be050c3bf63
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -185,9 +185,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:4bc659373dbf9b5eba2df7da2ceccec2952fa6d712a406a2a2a13e887228c912
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:28696cc83d8c806154e7b16f5d8d5deeea1bcd8eebb98cf72139fdb954149d58
+    registry: arohcpsvcdev.azurecr.io
+    repository: mchitimb/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:394eee85c19ce289abbbd9966008276a0573a58a47e2579e0bb41bb186b4adae
+    digest: sha256:d4464057af938f1defaa363d7e347e0080128f58ed0f7ca6b27622380325284c
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:28696cc83d8c806154e7b16f5d8d5deeea1bcd8eebb98cf72139fdb954149d58
+    digest: sha256:0cbd65ab5ac0c7f199a317ddb48250f86eb7d1e3dcd966d8c38b8be050c3bf63
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:0cbd65ab5ac0c7f199a317ddb48250f86eb7d1e3dcd966d8c38b8be050c3bf63
+    digest: sha256:42f40e917eaa873a729ec656d99377845401642dc8a1369c54ed0c519e1622a3
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:42f40e917eaa873a729ec656d99377845401642dc8a1369c54ed0c519e1622a3
+    digest: sha256:394eee85c19ce289abbbd9966008276a0573a58a47e2579e0bb41bb186b4adae
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:28696cc83d8c806154e7b16f5d8d5deeea1bcd8eebb98cf72139fdb954149d58
+    digest: sha256:0cbd65ab5ac0c7f199a317ddb48250f86eb7d1e3dcd966d8c38b8be050c3bf63
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:0cbd65ab5ac0c7f199a317ddb48250f86eb7d1e3dcd966d8c38b8be050c3bf63
+    digest: sha256:42f40e917eaa873a729ec656d99377845401642dc8a1369c54ed0c519e1622a3
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:42f40e917eaa873a729ec656d99377845401642dc8a1369c54ed0c519e1622a3
+    digest: sha256:394eee85c19ce289abbbd9966008276a0573a58a47e2579e0bb41bb186b4adae
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -185,7 +185,7 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:394eee85c19ce289abbbd9966008276a0573a58a47e2579e0bb41bb186b4adae
+    digest: sha256:d4464057af938f1defaa363d7e347e0080128f58ed0f7ca6b27622380325284c
     registry: arohcpsvcdev.azurecr.io
     repository: mchitimb/cs
   k8s:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -185,9 +185,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:4bc659373dbf9b5eba2df7da2ceccec2952fa6d712a406a2a2a13e887228c912
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:28696cc83d8c806154e7b16f5d8d5deeea1bcd8eebb98cf72139fdb954149d58
+    registry: arohcpsvcdev.azurecr.io
+    repository: mchitimb/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:


### PR DESCRIPTION
Same as https://github.com/Azure/ARO-HCP/pull/6815 and https://github.com/Azure/ARO-HCP/pull/6780 but with more changes in CS https://gitlab.cee.redhat.com/service/aro-hcp-clusters-service/-/merge_requests/446

That image changes CS to use NodePool & HostedCluster read desire during clusters & node pool status reconciliation as well as persist what's done by those watching controllers to Cosmos' Resources container.

Open a PR to run the whole e2e suite and isn't intended for merge 