### PR TITLE
fix(config): bump E2E CI mgmt cluster min node count (AROSLSRE-2032)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1829,7 +1829,7 @@ clouds:
                 vmSize: Standard_D8ds_v6
               userAgentPool:
                 maxCount: 14
-                minCount: 4
+                minCount: 5
                 osDiskSizeGB: 100
                 vmSize: Standard_E16ds_v6
                 secondaryNicCount: 7
@@ -1935,7 +1935,7 @@ clouds:
                 vmSize: Standard_D8ds_v6
               userAgentPool:
                 maxCount: 14
-                minCount: 4
+                minCount: 5
                 osDiskSizeGB: 100
                 vmSize: Standard_E16ds_v6
                 secondaryNicCount: 7

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -681,7 +681,7 @@ mgmt:
       maxUnavailable: "0"
     userAgentPool:
       maxCount: 14
-      minCount: 4
+      minCount: 5
       name: userswft
       osDiskSizeGB: 100
       poolCount: 3

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -681,7 +681,7 @@ mgmt:
       maxUnavailable: "0"
     userAgentPool:
       maxCount: 14
-      minCount: 4
+      minCount: 5
       name: userswft
       osDiskSizeGB: 100
       poolCount: 3


### PR DESCRIPTION
<!-- Jira: [AROSLSRE-2032](https://redhat.atlassian.net/browse/AROSLSRE-2032) -->

### What

Bumps `mgmt.aks.userAgentPool.minCount` from 4 to 5 for the `ci00` and `ci01` dev CI environments (centralus), and re-materializes the rendered configs.

### Why

Batch E2E runs have been gated by AKS management-cluster infrastructure alerts on the shared ci01 environment, for example [pull-ci-Azure-ARO-HCP-main-e2e-parallel #2095824620140630016](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/batch/pull-ci-Azure-ARO-HCP-main-e2e-parallel/2095824620140630016), even though the E2E test suite itself passed. Running many HCP E2E tests in parallel on a small pool of nodes causes pod density issues on the short-lived management clusters. Raising the floor spreads pods across more nodes and gives us better pod distribution, reducing the impact of the alerts on CI success rate. This is a temporary mitigation while pod churn reduction and E2E test merging work lands.

### Testing

Ran `cd config && make materialize` and confirmed only the expected `userAgentPool.minCount` diff in `config/rendered/dev/ci00/centralus.yaml` and `config/rendered/dev/ci01/centralus.yaml`.

### Special notes for your reviewer

Verified against the live `ARO HCP E2E Infrastructure` subscription that the `ci01` environment's `userAgentPool` config (min 4/max 14, 3 pools via `poolCount`) matches the deployed `userswft1/2/3` node pools on a running `ci01-*-mgmt-*` cluster, confirming this is the right environment to change.

### PR Checklist

- [x] Tested changes locally
- [x] Applicable documentation updated
- [x] Sufficient testing/reproduction/regression steps provided
