### PR TITLE
fix(e2e test): make sure we log openshift version

### DIFF
--- a/test/util/framework/helpers_v20240610preview.go
+++ b/test/util/framework/helpers_v20240610preview.go
@@ -1076,7 +1076,7 @@ func BeginCreateHCPCluster20240610(
 	location string,
 ) (*runtime.Poller[hcpsdk20240610preview.HcpOpenShiftClustersClientCreateOrUpdateResponse], error) {
 	cluster := BuildHCPClusterFromParams20240610(clusterParams, location)
-	logger.Info("Starting HCP cluster creation", "clusterName", hcpClusterName, "resourceGroup", resourceGroupName)
+	logger.Info("Starting HCP cluster creation", "clusterName", hcpClusterName, "resourceGroup", resourceGroupName, "version", cluster.Properties.Version.ID, "channelGroup", cluster.Properties.Version.ChannelGroup)
 	poller, err := hcpClient.BeginCreateOrUpdate(ctx, resourceGroupName, hcpClusterName, cluster, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed starting cluster creation %q in resourcegroup=%q: %w", hcpClusterName, resourceGroupName, err)

--- a/test/util/framework/helpers_v20251223preview.go
+++ b/test/util/framework/helpers_v20251223preview.go
@@ -490,7 +490,7 @@ func CreateHCPClusterAndWait20251223(
 		defer cancel()
 	}
 
-	logger.Info("Starting HCP cluster creation (v20251223preview)", "clusterName", hcpClusterName, "resourceGroup", resourceGroupName)
+	logger.Info("Starting HCP cluster creation (v20251223preview)", "clusterName", hcpClusterName, "resourceGroup", resourceGroupName, "version", cluster.Properties.Version.ID, "channelGroup", cluster.Properties.Version.ChannelGroup)
 	poller, err := hcpClient.BeginCreateOrUpdate(ctx, resourceGroupName, hcpClusterName, cluster, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed starting cluster creation %q in resourcegroup=%q: %w", hcpClusterName, resourceGroupName, err)

--- a/test/util/framework/helpers_v20260630preview.go
+++ b/test/util/framework/helpers_v20260630preview.go
@@ -576,7 +576,7 @@ func CreateHCPClusterAndWait20260630(
 		defer cancel()
 	}
 
-	logger.Info("Starting HCP cluster creation (v20260630preview)", "clusterName", hcpClusterName, "resourceGroup", resourceGroupName)
+	logger.Info("Starting HCP cluster creation (v20260630preview)", "clusterName", hcpClusterName, "resourceGroup", resourceGroupName, "version", cluster.Properties.Version.ID, "channelGroup", cluster.Properties.Version.ChannelGroup)
 	poller, err := hcpClient.BeginCreateOrUpdate(ctx, resourceGroupName, hcpClusterName, cluster, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed starting cluster creation %q in resourcegroup=%q: %w", hcpClusterName, resourceGroupName, err)

--- a/test/util/framework/helpers_v20260901preview.go
+++ b/test/util/framework/helpers_v20260901preview.go
@@ -543,7 +543,7 @@ func CreateHCPClusterAndWait20260901(
 		defer cancel()
 	}
 
-	logger.Info("Starting HCP cluster creation (v20260901preview)", "clusterName", hcpClusterName, "resourceGroup", resourceGroupName)
+	logger.Info("Starting HCP cluster creation (v20260901preview)", "clusterName", hcpClusterName, "resourceGroup", resourceGroupName, "version", cluster.Properties.Version.ID, "channelGroup", cluster.Properties.Version.ChannelGroup)
 	poller, err := hcpClient.BeginCreateOrUpdate(ctx, resourceGroupName, hcpClusterName, cluster, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed starting cluster creation %q in resourcegroup=%q: %w", hcpClusterName, resourceGroupName, err)


### PR DESCRIPTION
### What

Make sure we log cluster version id as well as channel group in tc.CreateHCPCluster* functions.

### Why

Helps with debugging of E2E runs using different OCP version, such as nightly job.

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes:

- E2E rerun with inspection that the versions are logged as expected


### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [X] PR is scoped to a single task (no mixed concerns)
- [X] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [X] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue (no issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [X] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [X] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge
