### PR TITLE
feat: add HCP pod churn ratio panel to gather-observability

### DIFF
--- a/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
@@ -517,13 +517,15 @@ panels:
           )
         )
         / on (cluster, namespace, workload)
-        max by (cluster, namespace, workload) (
-          label_replace(
-            max_over_time(
-              kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"ocm-.*"}[1m]
-            ),
-            "workload", "$1", "deployment", "(.*)"
-          )
+        (
+          max by (cluster, namespace, workload) (
+            label_replace(
+              max_over_time(
+                kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"ocm-.*"}[1m]
+              ),
+              "workload", "$1", "deployment", "(.*)"
+            )
+          ) > 0
         )
       )
     unit: ratio

--- a/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
@@ -495,33 +495,35 @@ panels:
     workspace: svc
     step: "60s"
   - title: "HCP Control Plane Pod Churn Ratio"
-    description: "Distinct pods observed per Deployment, divided by desired replica count. ~1 = healthy; higher means pods were repeatedly replaced, not just scaled up. Covers HostedControlPlane pods, which normally churn heavily in their first few minutes of life."
+    description: "Highest pod churn ratio seen anywhere on each management cluster: distinct pods observed per Deployment, divided by desired replica count, maxed across every HostedControlPlane Deployment on that cluster. ~1 = healthy; higher means at least one Deployment somewhere on the cluster had pods repeatedly replaced, not just scaled up. Copy the query below and drop the outer max-by-cluster to drill into which HCP instance and component is churning."
     query: |
-      count by (cluster, namespace, workload) (
-        count_over_time(
-          label_replace(
+      max by (cluster) (
+        count by (cluster, namespace, workload) (
+          count_over_time(
             label_replace(
-              max without (prometheus_replica) (
-                kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet", namespace=~"ocm-.*"}
-              ),
-              "replicaset", "$1", "owner_name", "(.*)"
-            )
-            * on (replicaset, namespace) group_left(owner_name) topk by (replicaset, namespace) (
-              1, max without (prometheus_replica) (
-                kube_replicaset_owner{job="kube-state-metrics", owner_kind="Deployment", namespace=~"ocm-.*"}
+              label_replace(
+                max without (prometheus_replica) (
+                  kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet", namespace=~"ocm-.*"}
+                ),
+                "replicaset", "$1", "owner_name", "(.*)"
               )
-            ),
-            "workload", "$1", "owner_name", "(.*)"
-          )[1m:30s]
+              * on (replicaset, namespace) group_left(owner_name) topk by (replicaset, namespace) (
+                1, max without (prometheus_replica) (
+                  kube_replicaset_owner{job="kube-state-metrics", owner_kind="Deployment", namespace=~"ocm-.*"}
+                )
+              ),
+              "workload", "$1", "owner_name", "(.*)"
+            )[1m:30s]
+          )
         )
-      )
-      / on (cluster, namespace, workload)
-      max by (cluster, namespace, workload) (
-        label_replace(
-          max_over_time(
-            kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"ocm-.*"}[1m]
-          ),
-          "workload", "$1", "deployment", "(.*)"
+        / on (cluster, namespace, workload)
+        max by (cluster, namespace, workload) (
+          label_replace(
+            max_over_time(
+              kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"ocm-.*"}[1m]
+            ),
+            "workload", "$1", "deployment", "(.*)"
+          )
         )
       )
     unit: ratio

--- a/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
@@ -494,3 +494,24 @@ panels:
     unit: percent
     workspace: svc
     step: "60s"
+  - title: "HCP Control Plane Pod Churn Ratio"
+    description: "Distinct pods created per Deployment, divided by desired replica count. ~1 = healthy; higher means pods were repeatedly replaced, not just scaled up. Covers HostedControlPlane pods, which normally churn heavily in their first few minutes of life."
+    query: |
+      count by (cluster, namespace, workload) (
+        count_over_time(
+          namespace_workload_pod:kube_pod_owner:relabel{workload_type="deployment", namespace=~"ocm-.*"}[1m]
+        )
+      )
+      / on (cluster, namespace, workload)
+      max by (cluster, namespace, workload) (
+        label_replace(
+          max_over_time(
+            kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"ocm-.*"}[1m]
+          ),
+          "workload", "$1", "deployment", "(.*)"
+        )
+      )
+    unit: ratio
+    workspace: hcp
+    step: "1m"
+    minPeakThreshold: 2

--- a/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
@@ -495,11 +495,24 @@ panels:
     workspace: svc
     step: "60s"
   - title: "HCP Control Plane Pod Churn Ratio"
-    description: "Distinct pods created per Deployment, divided by desired replica count. ~1 = healthy; higher means pods were repeatedly replaced, not just scaled up. Covers HostedControlPlane pods, which normally churn heavily in their first few minutes of life."
+    description: "Distinct pods observed per Deployment, divided by desired replica count. ~1 = healthy; higher means pods were repeatedly replaced, not just scaled up. Covers HostedControlPlane pods, which normally churn heavily in their first few minutes of life."
     query: |
       count by (cluster, namespace, workload) (
         count_over_time(
-          namespace_workload_pod:kube_pod_owner:relabel{workload_type="deployment", namespace=~"ocm-.*"}[1m]
+          label_replace(
+            label_replace(
+              max without (prometheus_replica) (
+                kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet", namespace=~"ocm-.*"}
+              ),
+              "replicaset", "$1", "owner_name", "(.*)"
+            )
+            * on (replicaset, namespace) group_left(owner_name) topk by (replicaset, namespace) (
+              1, max without (prometheus_replica) (
+                kube_replicaset_owner{job="kube-state-metrics", owner_kind="Deployment", namespace=~"ocm-.*"}
+              )
+            ),
+            "workload", "$1", "owner_name", "(.*)"
+          )[1m:30s]
         )
       )
       / on (cluster, namespace, workload)

--- a/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
@@ -495,42 +495,80 @@ panels:
     workspace: svc
     step: "60s"
   - title: "HCP Control Plane Pod Churn Ratio (Top 10 Namespaces)"
-    description: "Top 10 HostedControlPlane namespaces by worst pod churn ratio this minute: distinct pods observed per Deployment, divided by desired replica count, maxed across every Deployment in that namespace. Only namespaces above the healthy baseline of 1 are ranked, so a quiet minute can show fewer than 10 lines (or none). Top-10 membership is recomputed every minute, so which namespaces appear can shift over time. Copy the query below and drop the outer topk/max-by-namespace to drill into which component is churning."
+    description: "Top 10 HostedControlPlane namespaces by worst pod churn ratio anywhere in this chart's whole time range: distinct pods observed per Deployment, divided by desired replica count, maxed across every Deployment in that namespace. Ranking is based on each namespace's peak over the full window (not the current minute), so membership is stable -- it only changes when a namespace posts a bigger spike than any prior top-10 member. Lines still show the real per-minute value, which can dip below other non-ranked namespaces at any given moment. Namespaces that never exceed the healthy baseline of 1 are never ranked. This ranking pass re-evaluates the full pod/Deployment join at every sub-point of a 6h lookback, so it is by far the most expensive query in this panel -- if gather-observability CI runs start timing out or slowing down noticeably, this is the first place to check."
     query: |
-      topk(10,
-        (
-          max by (cluster, namespace) (
-            count by (cluster, namespace, workload) (
-              count_over_time(
+      (
+        max by (cluster, namespace) (
+          count by (cluster, namespace, workload) (
+            count_over_time(
+              label_replace(
                 label_replace(
-                  label_replace(
-                    max without (prometheus_replica) (
-                      kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet", namespace=~"ocm-.*"}
-                    ),
-                    "replicaset", "$1", "owner_name", "(.*)"
-                  )
-                  * on (replicaset, namespace) group_left(owner_name) topk by (replicaset, namespace) (
-                    1, max without (prometheus_replica) (
-                      kube_replicaset_owner{job="kube-state-metrics", owner_kind="Deployment", namespace=~"ocm-.*"}
-                    )
+                  max without (prometheus_replica) (
+                    kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet", namespace=~"ocm-.*"}
                   ),
-                  "workload", "$1", "owner_name", "(.*)"
-                )[1m:30s]
-              )
-            )
-            / on (cluster, namespace, workload)
-            (
-              max by (cluster, namespace, workload) (
-                label_replace(
-                  max_over_time(
-                    kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"ocm-.*"}[1m]
-                  ),
-                  "workload", "$1", "deployment", "(.*)"
+                  "replicaset", "$1", "owner_name", "(.*)"
                 )
-              ) > 0
+                * on (replicaset, namespace) group_left(owner_name) topk by (replicaset, namespace) (
+                  1, max without (prometheus_replica) (
+                    kube_replicaset_owner{job="kube-state-metrics", owner_kind="Deployment", namespace=~"ocm-.*"}
+                  )
+                ),
+                "workload", "$1", "owner_name", "(.*)"
+              )[1m:30s]
             )
           )
-        ) > 1
+          / on (cluster, namespace, workload)
+          (
+            max by (cluster, namespace, workload) (
+              label_replace(
+                max_over_time(
+                  kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"ocm-.*"}[1m]
+                ),
+                "workload", "$1", "deployment", "(.*)"
+              )
+            ) > 0
+          )
+        )
+      )
+      and on (cluster, namespace)
+      topk(10,
+        max_over_time(
+          (
+            (
+              max by (cluster, namespace) (
+                count by (cluster, namespace, workload) (
+                  count_over_time(
+                    label_replace(
+                      label_replace(
+                        max without (prometheus_replica) (
+                          kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet", namespace=~"ocm-.*"}
+                        ),
+                        "replicaset", "$1", "owner_name", "(.*)"
+                      )
+                      * on (replicaset, namespace) group_left(owner_name) topk by (replicaset, namespace) (
+                        1, max without (prometheus_replica) (
+                          kube_replicaset_owner{job="kube-state-metrics", owner_kind="Deployment", namespace=~"ocm-.*"}
+                        )
+                      ),
+                      "workload", "$1", "owner_name", "(.*)"
+                    )[1m:30s]
+                  )
+                )
+                / on (cluster, namespace, workload)
+                (
+                  max by (cluster, namespace, workload) (
+                    label_replace(
+                      max_over_time(
+                        kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"ocm-.*"}[1m]
+                      ),
+                      "workload", "$1", "deployment", "(.*)"
+                    )
+                  ) > 0
+                )
+              )
+            ) > 1
+          )[6h:1m]
+        )
       )
     unit: ratio
     workspace: hcp

--- a/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
+++ b/test/cmd/aro-hcp-tests/gather-observability/queries.yaml
@@ -494,41 +494,44 @@ panels:
     unit: percent
     workspace: svc
     step: "60s"
-  - title: "HCP Control Plane Pod Churn Ratio"
-    description: "Highest pod churn ratio seen anywhere on each management cluster: distinct pods observed per Deployment, divided by desired replica count, maxed across every HostedControlPlane Deployment on that cluster. ~1 = healthy; higher means at least one Deployment somewhere on the cluster had pods repeatedly replaced, not just scaled up. Copy the query below and drop the outer max-by-cluster to drill into which HCP instance and component is churning."
+  - title: "HCP Control Plane Pod Churn Ratio (Top 10 Namespaces)"
+    description: "Top 10 HostedControlPlane namespaces by worst pod churn ratio this minute: distinct pods observed per Deployment, divided by desired replica count, maxed across every Deployment in that namespace. Only namespaces above the healthy baseline of 1 are ranked, so a quiet minute can show fewer than 10 lines (or none). Top-10 membership is recomputed every minute, so which namespaces appear can shift over time. Copy the query below and drop the outer topk/max-by-namespace to drill into which component is churning."
     query: |
-      max by (cluster) (
-        count by (cluster, namespace, workload) (
-          count_over_time(
-            label_replace(
-              label_replace(
-                max without (prometheus_replica) (
-                  kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet", namespace=~"ocm-.*"}
-                ),
-                "replicaset", "$1", "owner_name", "(.*)"
-              )
-              * on (replicaset, namespace) group_left(owner_name) topk by (replicaset, namespace) (
-                1, max without (prometheus_replica) (
-                  kube_replicaset_owner{job="kube-state-metrics", owner_kind="Deployment", namespace=~"ocm-.*"}
-                )
-              ),
-              "workload", "$1", "owner_name", "(.*)"
-            )[1m:30s]
-          )
-        )
-        / on (cluster, namespace, workload)
+      topk(10,
         (
-          max by (cluster, namespace, workload) (
-            label_replace(
-              max_over_time(
-                kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"ocm-.*"}[1m]
-              ),
-              "workload", "$1", "deployment", "(.*)"
+          max by (cluster, namespace) (
+            count by (cluster, namespace, workload) (
+              count_over_time(
+                label_replace(
+                  label_replace(
+                    max without (prometheus_replica) (
+                      kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet", namespace=~"ocm-.*"}
+                    ),
+                    "replicaset", "$1", "owner_name", "(.*)"
+                  )
+                  * on (replicaset, namespace) group_left(owner_name) topk by (replicaset, namespace) (
+                    1, max without (prometheus_replica) (
+                      kube_replicaset_owner{job="kube-state-metrics", owner_kind="Deployment", namespace=~"ocm-.*"}
+                    )
+                  ),
+                  "workload", "$1", "owner_name", "(.*)"
+                )[1m:30s]
+              )
             )
-          ) > 0
-        )
+            / on (cluster, namespace, workload)
+            (
+              max by (cluster, namespace, workload) (
+                label_replace(
+                  max_over_time(
+                    kube_deployment_spec_replicas{job="kube-state-metrics", namespace=~"ocm-.*"}[1m]
+                  ),
+                  "workload", "$1", "deployment", "(.*)"
+                )
+              ) > 0
+            )
+          )
+        ) > 1
       )
     unit: ratio
     workspace: hcp
     step: "1m"
-    minPeakThreshold: 2


### PR DESCRIPTION
## Summary
- Adds a "HCP Control Plane Pod Churn Ratio" query to the existing "MC AKS Metrics" panel in `test/cmd/aro-hcp-tests/gather-observability/queries.yaml`.
- Reports distinct pods created per Deployment (HostedControlPlane namespaces only) divided by desired replica count, in 1-minute tumbling windows. ~1 = healthy; higher means pods were repeatedly replaced rather than just scaled up.
- Useful for spotting node instability / crash-loop-driven pod replacement during a HCP's short (~30 min) lifetime, which tends to concentrate in the first few minutes after creation.
- Reuses the existing `namespace_workload_pod:kube_pod_owner:relabel` recording rule (kube-prometheus-mixin, already deployed to management clusters) for the pod→Deployment join instead of re-deriving it.

## Test plan
- [x] `go test ./gather-observability/... -run TestLoadQueriesConfigEmbedded` passes
- [x] `make -C config materialize` passes with no diff issues
- [ ] Visually confirm the new chart renders correctly in a real `gather-observability` run (Spyglass artifact) once available on a PR/CI job