### PR TITLE
fix(e2e test): make >= version selection compatible with nightly runs

### DIFF
--- a/test/e2e/cluster_create_private_kas.go
+++ b/test/e2e/cluster_create_private_kas.go
@@ -75,10 +75,6 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for private KAS cluster")
 
-			By("deploying test VM in customer VNet")
-			vmName, _, err := tc.DeployTestVM(ctx, TestArtifactsFS, *resourceGroup.Name, customerClusterName, clusterParams.VnetName, clusterParams.SubnetName)
-			Expect(err).NotTo(HaveOccurred(), "failed to deploy test VM for private KAS verification")
-
 			By("creating the HCP cluster with private KAS")
 			err = tc.CreateHCPClusterFromParam20251223(ctx,
 				GinkgoLogr,
@@ -88,6 +84,10 @@ var _ = Describe("Customer", func() {
 				framework.ClusterCreationTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %q with private KAS", customerClusterName)
+
+			By("deploying test VM in customer VNet")
+			vmName, _, err := tc.DeployTestVM(ctx, TestArtifactsFS, *resourceGroup.Name, customerClusterName, clusterParams.VnetName, clusterParams.SubnetName)
+			Expect(err).NotTo(HaveOccurred(), "failed to deploy test VM for private KAS verification")
 
 			By("verifying cluster API visibility is Private via ARM GET")
 			hcpClient := tc.Get20251223ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient()

--- a/test/e2e/cluster_create_private_kas.go
+++ b/test/e2e/cluster_create_private_kas.go
@@ -65,9 +65,13 @@ var _ = Describe("Customer", func() {
 
 			// Private KAS requires OCP >= 4.22 (CS validation rejects lower versions)
 			openshiftVersionID, err := framework.PickAtLeastOpenshiftVersionId(clusterParams.OpenshiftVersionId, "4.22")
-			// If the default is nightly which isn't >= 4.22, skip this test with an explanation
+			// If the default is nightly which isn't >= 4.22, skip this test with an explanation.
+			// Log the reason before calling Skip: Skip() stores its message internally and the
+			// Ginkgo reporter only emits file:line in verbose mode, never the message text itself.
 			if framework.IsIncompatibleNightlyVersionError(err) {
-				Skip(fmt.Sprintf("private KAS requires OCP >= 4.22, but default version %q does not satisfy it: %v", clusterParams.OpenshiftVersionId, err))
+				skipMsg := fmt.Sprintf("private KAS requires OCP >= 4.22, but default version %q does not satisfy it: %v", clusterParams.OpenshiftVersionId, err)
+				GinkgoLogr.Info(skipMsg)
+				Skip(skipMsg)
 			}
 			Expect(err).NotTo(HaveOccurred(), "failed to select OpenShift version >= 4.22 for private KAS test (default version: %q)", clusterParams.OpenshiftVersionId)
 			// Otherwise, just use the selected version

--- a/test/e2e/cluster_create_private_kas.go
+++ b/test/e2e/cluster_create_private_kas.go
@@ -62,8 +62,16 @@ var _ = Describe("Customer", func() {
 			clusterParams.ClusterName = customerClusterName
 			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.APIVisibility = "Private"
+
 			// Private KAS requires OCP >= 4.22 (CS validation rejects lower versions)
-			clusterParams.OpenshiftVersionId = "4.22"
+			openshiftVersionID, err := framework.PickAtLeastOpenshiftVersionId(clusterParams.OpenshiftVersionId, "4.22")
+			// If the default is nightly which isn't >= 4.22, skip this test with an explanation
+			if framework.IsIncompatibleNightlyVersionError(err) {
+				Skip(fmt.Sprintf("private KAS requires OCP >= 4.22, but default version %q does not satisfy it: %v", clusterParams.OpenshiftVersionId, err))
+			}
+			Expect(err).NotTo(HaveOccurred(), "failed to select OpenShift version >= 4.22 for private KAS test (default version: %q)", clusterParams.OpenshiftVersionId)
+			// Otherwise, just use the selected version
+			clusterParams.OpenshiftVersionId = openshiftVersionID
 
 			By("creating customer resources (infrastructure and managed identities)")
 			clusterParams, err = tc.CreateClusterCustomerResources20251223(ctx,

--- a/test/e2e/kms_key_rotation.go
+++ b/test/e2e/kms_key_rotation.go
@@ -55,7 +55,9 @@ var _ = Describe("Customer", func() {
 				if time.Now().After(framework.V20260630PreviewDeploymentDeadline) {
 					Fail(fmt.Sprintf("API version 2026-06-30-preview should be fully available by %s", framework.V20260630PreviewDeploymentDeadline.Format(time.RFC3339)))
 				}
-				Skip("API version 2026-06-30-preview is not fully available in this environment")
+				skipMsg := "API version 2026-06-30-preview is not fully available in this environment"
+				GinkgoLogr.Info(skipMsg)
+				Skip(skipMsg)
 			}
 
 			if tc.UsePooledIdentities() {
@@ -72,7 +74,9 @@ var _ = Describe("Customer", func() {
 			clusterParams.ClusterName = clusterName
 			openshiftVersionID, err := framework.PickAtLeastOpenshiftVersionId(clusterParams.OpenshiftVersionId, "4.22")
 			if framework.IsIncompatibleNightlyVersionError(err) {
-				Skip(fmt.Sprintf("this test needs OCP >= 4.22, but default version %q does not satisfy it: %v", clusterParams.OpenshiftVersionId, err))
+				skipMsg := fmt.Sprintf("this test needs OCP >= 4.22, but default version %q does not satisfy it: %v", clusterParams.OpenshiftVersionId, err)
+				GinkgoLogr.Info(skipMsg)
+				Skip(skipMsg)
 			}
 			Expect(err).NotTo(HaveOccurred(), "failed to select OpenShift version >= 4.22 (default version: %q)", clusterParams.OpenshiftVersionId)
 			clusterParams.OpenshiftVersionId = openshiftVersionID
@@ -103,7 +107,9 @@ var _ = Describe("Customer", func() {
 			)
 			if isAPINotDeployedError(err) {
 				if time.Now().Before(framework.V20260630PreviewDeploymentDeadline) {
-					Skip(fmt.Sprintf("v20260630preview API not yet deployed; skipping until %s", framework.V20260630PreviewDeploymentDeadline.Format(time.RFC3339)))
+					skipMsg := fmt.Sprintf("v20260630preview API not yet deployed; skipping until %s", framework.V20260630PreviewDeploymentDeadline.Format(time.RFC3339))
+					GinkgoLogr.Info(skipMsg)
+					Skip(skipMsg)
 				}
 				Fail(fmt.Sprintf("v20260630preview API still not deployed as of %s deadline", framework.V20260630PreviewDeploymentDeadline.Format(time.RFC3339)))
 			}

--- a/test/e2e/kms_key_rotation.go
+++ b/test/e2e/kms_key_rotation.go
@@ -67,10 +67,15 @@ var _ = Describe("Customer", func() {
 			resourceGroup, err := tc.NewResourceGroup(ctx, "kms-key-rotate", tc.Location())
 			Expect(err).NotTo(HaveOccurred(), "failed to create resource group for KMS key rotation test")
 
-			By("creating cluster parameters with version 4.22")
+			By("creating cluster parameters with version 4.22 or higher")
 			clusterParams := framework.NewDefaultClusterParams20260630()
 			clusterParams.ClusterName = clusterName
-			clusterParams.OpenshiftVersionId = "4.22"
+			openshiftVersionID, err := framework.PickAtLeastOpenshiftVersionId(clusterParams.OpenshiftVersionId, "4.22")
+			if framework.IsIncompatibleNightlyVersionError(err) {
+				Skip(fmt.Sprintf("this test needs OCP >= 4.22, but default version %q does not satisfy it: %v", clusterParams.OpenshiftVersionId, err))
+			}
+			Expect(err).NotTo(HaveOccurred(), "failed to select OpenShift version >= 4.22 (default version: %q)", clusterParams.OpenshiftVersionId)
+			clusterParams.OpenshiftVersionId = openshiftVersionID
 
 			managedResourceGroupName := framework.SuffixName(*resourceGroup.Name, "-managed", 64)
 			clusterParams.ManagedResourceGroupName = managedResourceGroupName
@@ -87,7 +92,7 @@ var _ = Describe("Customer", func() {
 			)
 			Expect(err).NotTo(HaveOccurred(), "failed to create customer resources for KMS key rotation cluster")
 
-			By("creating the HCP cluster with version 4.22")
+			By("creating the HCP cluster with version 4.22 or higher")
 			err = tc.CreateHCPClusterFromParam20260630(
 				ctx,
 				GinkgoLogr,

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -189,7 +189,7 @@ func getLatestInstallVersionForNightlyChannel(ctx context.Context, version strin
 // default and given minimal version constraint arguments.
 //   - If defaultVersion already satisfies the minimalVersion, the default is
 //     returned unchanged.
-//   - If it doesn't, the mimimal version is returned instead, with one
+//   - If it doesn't, the minimal version is returned instead, with one
 //     exception: For nightly builds, an error is returned instead (since
 //     nightly versions cannot be bumped to a different minor version).
 //

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -37,6 +37,7 @@ var (
 	ErrNightlyReleaseStreamNotFound = errors.New("nightly release stream not found")
 	ErrNoAcceptedNightlyTags        = errors.New("no accepted nightly tags found")
 	ErrNoParseableNightlyTags       = errors.New("no parseable nightly tags found")
+	ErrNightlyVersionTooOld         = errors.New("nightly version is too old")
 )
 
 const (
@@ -66,6 +67,12 @@ func retryOnTransientError[T any](ctx context.Context, f func() (T, error)) (T, 
 		}
 	}
 	return zero, fmt.Errorf("after %d attempts: %w", versionFetchMaxRetries+1, lastErr)
+}
+
+// IsIncompatibleNightlyVersionError returns true if the error indicates that
+// a nightly version doesn't satisfy given constraints.
+func IsIncompatibleNightlyVersionError(err error) bool {
+	return errors.Is(err, ErrNightlyVersionTooOld)
 }
 
 // IsVersionNotFoundError returns true if the error indicates a version was not found,
@@ -176,4 +183,47 @@ func getLatestInstallVersionForNightlyChannel(ctx context.Context, version strin
 	}
 
 	return latestTagName, nil
+}
+
+// PickAtLeastOpenshiftVersionId selects latest version based on a predefined
+// default and given minimal version constraint arguments.
+//   - If defaultVersion already satisfies the minimalVersion, the default is
+//     returned unchanged.
+//   - If it doesn't, the mimimal version is returned instead, with one
+//     exception: For nightly builds, an error is returned instead (since
+//     nightly versions cannot be bumped to a different minor version).
+//
+// Nightly versions (e.g. "4.19.0-0.nightly-multi-2026-09-01-142156") are compared
+// by Major.Minor only, not by full semver, because the pre-release suffix would
+// otherwise rank them below the bare release (4.19.0) and produce false negatives.
+func PickAtLeastOpenshiftVersionId(defaultVersion, minimalVersion string) (string, error) {
+	defaultSemver, err := semver.ParseTolerant(defaultVersion)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse default version %q: %w", defaultVersion, err)
+	}
+	minimalSemver, err := semver.ParseTolerant(minimalVersion)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse minimal version %q: %w", minimalVersion, err)
+	}
+
+	if strings.Contains(defaultVersion, "nightly") {
+		// For nightly builds, ignore the pre-release suffix and compare Major.Minor.Patch
+		// directly. Bare semver ordering would rank "4.19.0-0.nightly-multi-..." below
+		// "4.19.0", producing false negatives for patch-zero minimums. Nightly builds are
+		// always patch 0 (X.Y.0-0.nightly-multi-...), so a patch-qualified minimum such
+		// as "4.22.1" correctly rejects a 4.22.0 nightly.
+		defaultAboveMin := defaultSemver.Major > minimalSemver.Major ||
+			(defaultSemver.Major == minimalSemver.Major && defaultSemver.Minor > minimalSemver.Minor) ||
+			(defaultSemver.Major == minimalSemver.Major && defaultSemver.Minor == minimalSemver.Minor && defaultSemver.Patch >= minimalSemver.Patch)
+		if defaultAboveMin {
+			return defaultVersion, nil
+		}
+		return "", fmt.Errorf("%w: nightly build %s does not satisfy minimum %s",
+			ErrNightlyVersionTooOld, defaultVersion, minimalVersion)
+	}
+
+	if defaultSemver.GTE(minimalSemver) {
+		return defaultVersion, nil
+	}
+	return minimalVersion, nil
 }

--- a/test/util/framework/version_helper_test.go
+++ b/test/util/framework/version_helper_test.go
@@ -1,0 +1,177 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPickAtLeastOpenshiftVersionId(t *testing.T) {
+	t.Parallel()
+
+	const (
+		nightly419 = "4.19.0-0.nightly-multi-2026-09-01-142156"
+		nightly421 = "4.21.0-0.nightly-multi-2026-09-03-080000"
+		nightly500 = "5.0.0-0.nightly-multi-2026-09-09-181844"
+	)
+
+	tests := []struct {
+		name           string
+		defaultVersion string
+		minimalVersion string
+		wantVersion    string
+		wantErr        bool
+		wantSkippable  bool // error should satisfy IsIncompatibleNightlyVersionError
+	}{
+		//
+		// nightly: defaultVersion satisfies the minimum
+		//
+		{
+			name:           "nightly default higher minor satisfies minimum",
+			defaultVersion: nightly421,
+			minimalVersion: "4.19",
+			wantVersion:    nightly421,
+		},
+		{
+			name:           "nightly default same minor satisfies minimum",
+			defaultVersion: nightly419,
+			minimalVersion: "4.19",
+			wantVersion:    nightly419,
+		},
+		{
+			name:           "nightly default same minor satisfies patch-zero minimum",
+			defaultVersion: nightly419,
+			minimalVersion: "4.19.0",
+			wantVersion:    nightly419,
+		},
+		{
+			name:           "nightly default patch 0 does not satisfy patch-qualified minimum",
+			defaultVersion: nightly419,
+			minimalVersion: "4.19.1",
+			wantErr:        true,
+			wantSkippable:  true,
+		},
+		{
+			name:           "nightly default higher major satisfies minimum",
+			defaultVersion: nightly500,
+			minimalVersion: "4.21",
+			wantVersion:    nightly500,
+		},
+
+		//
+		// nightly: defaultVersion does NOT satisfy the minimum → skippable error
+		//
+		{
+			name:           "nightly default lower minor does not satisfy minimum",
+			defaultVersion: nightly500,
+			minimalVersion: "5.1",
+			wantErr:        true,
+			wantSkippable:  true,
+		},
+		{
+			name:           "nightly default lower major does not satisfy minimum",
+			defaultVersion: nightly419,
+			minimalVersion: "5.0",
+			wantErr:        true,
+			wantSkippable:  true,
+		},
+
+		//
+		// non-nightly: defaultVersion satisfies the minimum
+		//
+		{
+			name:           "candidate default higher version satisfies minimum",
+			defaultVersion: "4.21.5",
+			minimalVersion: "4.19.3",
+			wantVersion:    "4.21.5",
+		},
+		{
+			name:           "candidate default equal version satisfies minimum",
+			defaultVersion: "4.19.3",
+			minimalVersion: "4.19.3",
+			wantVersion:    "4.19.3",
+		},
+		{
+			name:           "candidate default higher patch satisfies minimum",
+			defaultVersion: "4.19.5",
+			minimalVersion: "4.19.3",
+			wantVersion:    "4.19.5",
+		},
+
+		//
+		// non-nightly: defaultVersion does NOT satisfy the minimum → fallback to minimal
+		//
+		{
+			name:           "candidate default lower minor falls back to minimal",
+			defaultVersion: "4.18.5",
+			minimalVersion: "4.19.3",
+			wantVersion:    "4.19.3",
+		},
+		{
+			name:           "candidate default lower patch falls back to minimal",
+			defaultVersion: "4.19.2",
+			minimalVersion: "4.19.3",
+			wantVersion:    "4.19.3",
+		},
+
+		//
+		// bad inputs
+		//
+		{
+			name:           "unparseable defaultVersion",
+			defaultVersion: "not-a-version",
+			minimalVersion: "4.19",
+			wantErr:        true,
+			wantSkippable:  false,
+		},
+		{
+			name:           "unparseable minimalVersion",
+			defaultVersion: nightly419,
+			minimalVersion: "not-a-version",
+			wantErr:        true,
+			wantSkippable:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := PickAtLeastOpenshiftVersionId(tc.defaultVersion, tc.minimalVersion)
+
+			if tc.wantErr {
+				require.Error(t, err, "expected an error")
+				assert.Empty(t, got, "version should be empty on error")
+				if tc.wantSkippable {
+					assert.True(t, IsIncompatibleNightlyVersionError(err),
+						"error should satisfy IsIncompatibleNightlyVersionError that so test cases can Skip; got: %v", err)
+					assert.True(t, errors.Is(err, ErrNightlyVersionTooOld),
+						"nightly-too-old error should wrap ErrNightlyVersionTooOld); got: %v", err)
+				} else {
+					assert.False(t, IsIncompatibleNightlyVersionError(err),
+						"parse error should not satisfy IsIncompatibleNightlyVersionError")
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantVersion, got)
+		})
+	}
+}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-29462

This is just a quick draft how a fix could work, so that I can revisit it with more care next week.

### What

Make sure E2E tests which require a particular minimal version (eg. OCP >= 4.22) are either skipped or uses a latest version when executed in a nightly run job.

So in this PR, we:

- define new `ErrNightlyVersionTooOld` error and related `IsIncompatibleNightlyVersionError` function 
- define new funtion `PickAtLeastOpenshiftVersionId(defaultVersion, minimalVersion string) (string, error)` which returns default version if it satisfies the minimal version, otherwise a minimal is returned, with one exception: for nightly builds, `ErrNightlyVersionTooOld` is returned instead
- implement unit tests for `PickAtLeastOpenshiftVersionId`
- update E2E tests which defines particular version:
    - cluster_create_private_kas.go
    - kms_key_rotation.go
 

### Why

Current design has a bug:

- First, a test case asks for defaults via `NewDefaultClusterParams*` functions, eg. `clusterParams := framework.NewDefaultClusterParams20251223()` so that the test has this version available in `clusterParams.OpenshiftVersionId`.
- If it's a nightly run (env variable `ARO_HCP_OPENSHIFT_CHANNEL_GROUP` is `nightly`), `DefaultOpenshiftControlPlaneVersionId` function will fill in a proper nightly version id
- But if an E2E test case then redefines `clusterParams.OpenshiftVersionId` (because it needs at least 4.22 and sets it to 4.22 because of it), we have 2 problems: we don't use nightly build anymore, and we are passing only x.y version when using nightly channel. So that this can fail either because of wrong version passed, or because of missing version.

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- [X] Unit tests: unit tests created for new `PickAtLeastOpenshiftVersionId` function
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration): NA
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md):
     - [X] rerun of pre check e2e run in dev (which is mandatory)
     - [X] run of a nightly build with smaller default OCP version than the KAS test requires: [pull-ci-Azure-ARO-HCP-main-prod-e2e-parallel-ocp-nightly #2098771064220815360](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/6837/pull-ci-Azure-ARO-HCP-main-prod-e2e-parallel-ocp-nightly/2098771064220815360) (test case skipped with a clear reason when run on nightly `4.21.0-0.nightly-multi-2026-09-12-094059` while requiring at least 4.22)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [X] PR is scoped to a single task (no mixed concerns)
- [X] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [X] Summary explains the "Why" behind the change
- [X] Linked to relevant ticket/issue
- [x] Screenshots included (if dashboards or other UI changes): NA
- [X] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [X] Draft PR used for WIP (if applicable)
- [X] Commit history is clean (rebased/squashed)
- [X] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [X] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [X] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem:
  - [pull-ci-Azure-ARO-HCP-main-prod-e2e-parallel-ocp-nightly/2098541426177478656](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/6837/pull-ci-Azure-ARO-HCP-main-prod-e2e-parallel-ocp-nightly/2098541426177478656)
  - [pull-ci-Azure-ARO-HCP-main-prod-e2e-parallel-ocp-nightly #2098771064220815360](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/Azure_ARO-HCP/6837/pull-ci-Azure-ARO-HCP-main-prod-e2e-parallel-ocp-nightly/2098771064220815360) (test case skipped with a clear reason when run on nightly `4.21.0-0.nightly-multi-2026-09-12-094059` while requiring at least 4.22)

<img width="950" height="591" alt="2026-09-12_18-46" src="https://github.com/user-attachments/assets/cc627955-96fe-4bf2-9432-125a84b67822" />
