### PR TITLE
fix(test): don't fail E2E cleanup when deletedItems purge is forbidden (AROSLSRE-1982)

### DIFF
--- a/internal/graph/util/directory_objects.go
+++ b/internal/graph/util/directory_objects.go
@@ -91,14 +91,21 @@ func (c *Client) DeleteApplicationPermanently(ctx context.Context, target Applic
 			deletedItemPropagationTimeout,
 			servicePrincipalWasDeleted,
 		); err != nil {
-			purgeErr := fmt.Errorf("purge service principal %q: %w", target.ServicePrincipalObjectID, err)
-			if restoreErr := c.restoreDeletedDirectoryObject(ctx, target.ServicePrincipalObjectID); restoreErr != nil {
-				return errors.Join(
-					purgeErr,
-					fmt.Errorf("restore service principal %q after failed purge: %w", target.ServicePrincipalObjectID, restoreErr),
+			if isInsufficientPrivileges(err) {
+				logr.FromContextOrDiscard(ctx).V(1).Info(
+					"Skipping permanent deletion because this app-only credential lacks deletedItems purge permissions; leaving item soft-deleted",
+					"servicePrincipalObjectID", target.ServicePrincipalObjectID,
 				)
+			} else {
+				purgeErr := fmt.Errorf("purge service principal %q: %w", target.ServicePrincipalObjectID, err)
+				if restoreErr := c.restoreDeletedDirectoryObject(ctx, target.ServicePrincipalObjectID); restoreErr != nil {
+					return errors.Join(
+						purgeErr,
+						fmt.Errorf("restore service principal %q after failed purge: %w", target.ServicePrincipalObjectID, restoreErr),
+					)
+				}
+				return purgeErr
 			}
-			return purgeErr
 		}
 	}
 
@@ -117,6 +124,13 @@ func (c *Client) DeleteApplicationPermanently(ctx context.Context, target Applic
 		deletedItemPropagationTimeout,
 		applicationWasDeleted,
 	); err != nil {
+		if isInsufficientPrivileges(err) {
+			logr.FromContextOrDiscard(ctx).V(1).Info(
+				"Skipping permanent deletion because this app-only credential lacks deletedItems purge permissions; leaving item soft-deleted",
+				"applicationObjectID", target.ApplicationObjectID,
+			)
+			return nil
+		}
 		purgeErr := fmt.Errorf("purge application %q: %w", target.ApplicationObjectID, err)
 		if restoreErr := c.restoreDeletedDirectoryObject(ctx, target.ApplicationObjectID); restoreErr != nil {
 			return errors.Join(
@@ -226,4 +240,24 @@ func (c *Client) permanentlyDeleteDirectoryObject(
 func isODataStatus(err error, statusCode int) bool {
 	var odataErr *odataerrors.ODataError
 	return errors.As(err, &odataErr) && odataErr.ResponseStatusCode == statusCode
+}
+
+// isInsufficientPrivileges reports whether err is a Microsoft Graph 403
+// Authorization_RequestDenied response, indicating the calling credential
+// lacks the deletedItems purge permission grant rather than encountering a
+// transient failure. Some app-only credentials (e.g. per-environment E2E
+// service principals) may not have been granted this permission; permanent
+// purge is a best-effort optimization on top of the underlying soft-delete,
+// so this case must not fail the caller.
+func isInsufficientPrivileges(err error) bool {
+	var odataErr *odataerrors.ODataError
+	if !errors.As(err, &odataErr) || odataErr.ResponseStatusCode != http.StatusForbidden {
+		return false
+	}
+	odataError := odataErr.GetErrorEscaped()
+	if odataError == nil {
+		return false
+	}
+	code := odataError.GetCode()
+	return code != nil && *code == "Authorization_RequestDenied"
 }

--- a/internal/graph/util/directory_objects_test.go
+++ b/internal/graph/util/directory_objects_test.go
@@ -60,11 +60,17 @@ func newTestGraphClient(t *testing.T, server *httptest.Server) *Client {
 
 func writeGraphError(t *testing.T, writer http.ResponseWriter, statusCode int) {
 	t.Helper()
+	writeGraphErrorCode(t, writer, statusCode, "Request_ResourceNotFound")
+}
+
+func writeGraphErrorCode(t *testing.T, writer http.ResponseWriter, statusCode int, code string) {
+	t.Helper()
 	writer.Header().Set("Content-Type", "application/json")
 	writer.WriteHeader(statusCode)
 	_, err := fmt.Fprintf(
 		writer,
-		`{"error":{"code":"Request_ResourceNotFound","message":"status %d"}}`,
+		`{"error":{"code":"%s","message":"status %d"}}`,
+		code,
 		statusCode,
 	)
 	require.NoError(t, err)
@@ -233,6 +239,66 @@ func TestDeleteApplicationPermanentlyRestoresApplicationWhenPurgeFails(t *testin
 		"DELETE /applications/app-object",
 		"DELETE /directory/deletedItems/app-object",
 		"POST /directory/deletedItems/app-object/restore",
+	}, requests)
+}
+
+func TestDeleteApplicationPermanentlySkipsRestoreWhenServicePrincipalPurgeIsForbidden(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests = append(requests, request.Method+" "+request.URL.Path)
+		switch request.URL.Path {
+		case "/servicePrincipals/sp-object", "/applications/app-object", "/directory/deletedItems/app-object":
+			writer.WriteHeader(http.StatusNoContent)
+		case "/directory/deletedItems/sp-object":
+			writeGraphErrorCode(t, writer, http.StatusForbidden, "Authorization_RequestDenied")
+		default:
+			t.Errorf("unexpected request: %s %s", request.Method, request.URL.Path)
+			writer.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestGraphClient(t, server)
+	err := client.DeleteApplicationPermanently(context.Background(), ApplicationCleanupTarget{
+		ApplicationObjectID:      "app-object",
+		ServicePrincipalObjectID: "sp-object",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"DELETE /servicePrincipals/sp-object",
+		"DELETE /directory/deletedItems/sp-object",
+		"DELETE /applications/app-object",
+		"DELETE /directory/deletedItems/app-object",
+	}, requests)
+}
+
+func TestDeleteApplicationPermanentlySkipsRestoreWhenApplicationPurgeIsForbidden(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests = append(requests, request.Method+" "+request.URL.Path)
+		switch request.URL.Path {
+		case "/servicePrincipals/sp-object", "/directory/deletedItems/sp-object", "/applications/app-object":
+			writer.WriteHeader(http.StatusNoContent)
+		case "/directory/deletedItems/app-object":
+			writeGraphErrorCode(t, writer, http.StatusForbidden, "Authorization_RequestDenied")
+		default:
+			t.Errorf("unexpected request: %s %s", request.Method, request.URL.Path)
+			writer.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestGraphClient(t, server)
+	err := client.DeleteApplicationPermanently(context.Background(), ApplicationCleanupTarget{
+		ApplicationObjectID:      "app-object",
+		ServicePrincipalObjectID: "sp-object",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"DELETE /servicePrincipals/sp-object",
+		"DELETE /directory/deletedItems/sp-object",
+		"DELETE /applications/app-object",
+		"DELETE /directory/deletedItems/app-object",
 	}, requests)
 }
 


### PR DESCRIPTION
[AROSLSRE-1982](https://redhat.atlassian.net/browse/AROSLSRE-1982)

### What

Stop failing E2E tests when the Microsoft Graph deletedItems purge/restore call returns 403 Authorization_RequestDenied. When purge is forbidden, log it and leave the object soft-deleted, matching the existing behavior for delegated-user credentials, instead of returning a fatal error or attempting a restore that needs the same missing permission.

### Why

The Integration environment's E2E app-only credential doesn't have the Graph permission grant that permanent purge requires. `pull-ci-Azure-ARO-HCP-main-e2e-integration-e2e-parallel/2095925191069667328` shows three otherwise-passing specs (Authorized CIDRs Connectivity, aggregated advanced features, external auth config) failing only in teardown with:

```
purge service principal "...": HTTP 403, Authorization_RequestDenied: Insufficient privileges to complete the operation.
restore service principal "..." after failed purge: HTTP 403, Authorization_RequestDenied: Insufficient privileges to complete the operation.
```

The purge introduced in #6781 is a best-effort quota optimization on top of the underlying soft-delete; it should never fail an otherwise-passing test, and restoring the object after a forbidden purge only undoes a delete that already succeeded, for no benefit, since restore needs the same permission and fails identically.

### Testing

- `cd internal && GOTOOLCHAIN=go1.25.7 go test ./graph/util/...`
- `GOTOOLCHAIN=go1.25.7 golangci-lint run ./internal/graph/util/...`
- Added `TestDeleteApplicationPermanentlySkipsRestoreWhenServicePrincipalPurgeIsForbidden` and `TestDeleteApplicationPermanentlySkipsRestoreWhenApplicationPurgeIsForbidden` covering the new 403 handling for both the service principal and application purge paths.
