### PR TITLE
feat(hcpctl): export whole management-cluster history to k8shark .kshrk archives

### DIFF
--- a/mgmt-agent/pkg/controller/resourcewatcher.go
+++ b/mgmt-agent/pkg/controller/resourcewatcher.go
@@ -94,6 +94,16 @@ func (w *ResourceWatcher) Run(ctx context.Context) error {
 		return err
 	}
 	gvrs = append(gvrs, watchedBuiltinGVRs...)
+
+	// CustomResourceDefinitions are watched (and logged, like every other GVR
+	// above) so a snapshot can resolve a CRD's exact plural/singular/shortNames
+	// instead of guessing them from the Kind alone.
+	crdGVR := schema.GroupVersionResource{
+		Group:    "apiextensions.k8s.io",
+		Version:  "v1",
+		Resource: "customresourcedefinitions",
+	}
+	gvrs = append(gvrs, crdGVR)
 	logger.Info("Discovered resources to watch", "count", len(gvrs))
 
 	knownGVRs := sets.New[schema.GroupVersionResource](gvrs...)
@@ -103,11 +113,6 @@ func (w *ResourceWatcher) Run(ctx context.Context) error {
 	// Watch CRDs so we can detect when new API resources matching our group
 	// suffixes are registered in the cluster. When that happens, we exit the
 	// process so the pod restarts and picks up the new GVRs.
-	crdGVR := schema.GroupVersionResource{
-		Group:    "apiextensions.k8s.io",
-		Version:  "v1",
-		Resource: "customresourcedefinitions",
-	}
 	handleCRD := func(obj interface{}) {
 		newGVRs := newMatchingGVRsFromCRD(obj, knownGVRs)
 		if newGVRs.Len() > 0 {

--- a/tooling/hcpctl/cmd/oc-adm-inspect/cmd.go
+++ b/tooling/hcpctl/cmd/oc-adm-inspect/cmd.go
@@ -87,6 +87,27 @@ func (o *CompletedOptions) Inspect(ctx context.Context) error {
 
 	inspector := ocadminspect.NewInspector(o.kustoClient, o.factory, o.baseOptions, o.ClusterName, o.writer)
 
+	if o.Out != "" {
+		logger.Info("inspecting whole cluster",
+			"cluster", o.ClusterName,
+			"windowStart", o.TimestampMin.Format(time.RFC3339),
+			"windowEnd", o.TimestampMax.Format(time.RFC3339),
+			"output", o.Out,
+		)
+		if err := inspector.InspectCluster(ctx, o.TimestampMin.Add(-pollBaselineLookback)); err != nil {
+			return err
+		}
+		kshrkWriter, ok := o.writer.(*ocadminspect.KshrkWriter)
+		if !ok {
+			return fmt.Errorf("internal error: --out set but writer is not a KshrkWriter")
+		}
+		if err := kshrkWriter.Finish(); err != nil {
+			return fmt.Errorf("failed to seal kshrk archive: %w", err)
+		}
+		logger.Info("wrote kshrk archive", "path", o.Out)
+		return nil
+	}
+
 	namespaces, err := inspector.ExpandWithPairedNamespaces(ctx, o.Namespaces)
 	if err != nil {
 		return fmt.Errorf("failed to pair hosted-cluster/control-plane namespaces: %w", err)

--- a/tooling/hcpctl/cmd/oc-adm-inspect/options.go
+++ b/tooling/hcpctl/cmd/oc-adm-inspect/options.go
@@ -34,6 +34,14 @@ import (
 // is safe to use as an on-disk path segment.
 var namespacePattern = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$`)
 
+// pollBaselineLookback bounds how far back the whole-cluster poll-baseline
+// query searches for each object's last known state before the export
+// window starts. Not user-tunable by design: an object whose last real
+// change predates it is missing from the baseline regardless of how wide
+// this is (see Inspector.InspectCluster) — this is simply "as far back as
+// practical" rather than a value worth exposing as a flag.
+const pollBaselineLookback = 90 * 24 * time.Hour
+
 // RawOptions is the unvalidated CLI configuration for oc-adm-inspect.
 type RawOptions struct {
 	Kusto             string
@@ -46,8 +54,12 @@ type RawOptions struct {
 	ManagementCluster string
 	ServiceCluster    string
 	OutputPath        string
-	QueryTimeout      time.Duration
-	Limit             int
+	// Out, when set, exports the whole cluster (not a namespace) as a
+	// .kshrk archive at this path instead of writing a filesystem tree —
+	// mutually exclusive with namespace args/flags.
+	Out          string
+	QueryTimeout time.Duration
+	Limit        int
 }
 
 // DefaultOptions returns RawOptions with sensible defaults. The time-window
@@ -75,6 +87,7 @@ func BindOptions(opts *RawOptions, cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&opts.ManagementCluster, "management-cluster", opts.ManagementCluster, "management cluster to inspect (the telemetry 'cluster' name)")
 	cmd.Flags().StringVar(&opts.ServiceCluster, "service-cluster", opts.ServiceCluster, "service cluster to inspect (the telemetry 'cluster' name)")
 	cmd.Flags().StringVar(&opts.OutputPath, "output-path", opts.OutputPath, "path to write the gathered data")
+	cmd.Flags().StringVar(&opts.Out, "out", opts.Out, "export the whole cluster as a .kshrk archive (github.com/phenixblue/k8shark) at this path, instead of one namespace as a filesystem tree; mutually exclusive with namespace args/flags")
 	cmd.Flags().DurationVar(&opts.QueryTimeout, "query-timeout", opts.QueryTimeout, "timeout for query execution")
 	cmd.Flags().IntVar(&opts.Limit, "limit", opts.Limit, "limit the number of rows per query (-1 for no limit)")
 
@@ -121,12 +134,18 @@ func (o *RawOptions) Validate(ctx context.Context, args []string) (*ValidatedOpt
 	}
 
 	namespaces := normalizeNamespaces(append(append([]string{}, o.Namespaces...), args...))
-	if len(namespaces) == 0 {
-		return nil, fmt.Errorf("at least one namespace is required (use --namespace or a positional ns/<name> argument)")
-	}
-	for _, namespace := range namespaces {
-		if !namespacePattern.MatchString(namespace) {
-			return nil, fmt.Errorf("invalid namespace %q: must be a valid Kubernetes namespace name (RFC 1123 label; this also rejects path separators and traversal)", namespace)
+	if o.Out != "" {
+		if len(namespaces) > 0 {
+			return nil, fmt.Errorf("--out exports the whole cluster; it cannot be combined with --namespace or a positional ns/<name> argument")
+		}
+	} else {
+		if len(namespaces) == 0 {
+			return nil, fmt.Errorf("at least one namespace is required (use --namespace or a positional ns/<name> argument), or use --out to export the whole cluster")
+		}
+		for _, namespace := range namespaces {
+			if !namespacePattern.MatchString(namespace) {
+				return nil, fmt.Errorf("invalid namespace %q: must be a valid Kubernetes namespace name (RFC 1123 label; this also rejects path separators and traversal)", namespace)
+			}
 		}
 	}
 
@@ -171,12 +190,22 @@ func (o *ValidatedOptions) Complete(ctx context.Context) (*CompletedOptions, err
 	baseOptions.TimestampMax = o.TimestampMax
 	baseOptions.Limit = o.Limit
 
+	var writer ocadminspect.Writer
+	if o.Out != "" {
+		writer, err = ocadminspect.NewKshrkWriter(o.Out, o.ClusterName, o.TimestampMin, o.TimestampMax)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create kshrk writer: %w", err)
+		}
+	} else {
+		writer = ocadminspect.NewFilesystemWriter(o.OutputPath)
+	}
+
 	return &CompletedOptions{
 		ValidatedOptions: o,
 		kustoClient:      kustoClient,
 		factory:          factory,
 		baseOptions:      baseOptions,
-		writer:           ocadminspect.NewFilesystemWriter(o.OutputPath),
+		writer:           writer,
 	}, nil
 }
 

--- a/tooling/hcpctl/cmd/oc-adm-inspect/options_test.go
+++ b/tooling/hcpctl/cmd/oc-adm-inspect/options_test.go
@@ -97,6 +97,36 @@ func TestValidate(t *testing.T) {
 		}
 	})
 
+	t.Run("out rejects namespace flags", func(t *testing.T) {
+		o := base()
+		o.Out = "capture.kshrk"
+		o.Namespaces = []string{"kube-system"}
+		if _, err := o.Validate(ctx, nil); err == nil {
+			t.Errorf("expected error when --out is combined with --namespace")
+		}
+	})
+
+	t.Run("out rejects positional namespace args", func(t *testing.T) {
+		o := base()
+		o.Out = "capture.kshrk"
+		if _, err := o.Validate(ctx, []string{"ns/ocm-stg-abc"}); err == nil {
+			t.Errorf("expected error when --out is combined with a positional ns/<name> argument")
+		}
+	})
+
+	t.Run("out alone needs no namespace", func(t *testing.T) {
+		o := base()
+		o.Out = "capture.kshrk"
+		o.ManagementCluster = "aro-hcp-mgmt-1"
+		v, err := o.Validate(ctx, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(v.Namespaces) != 0 {
+			t.Errorf("Namespaces = %v, want empty", v.Namespaces)
+		}
+	})
+
 	t.Run("positional args are treated as namespaces", func(t *testing.T) {
 		o := base()
 		v, err := o.Validate(ctx, []string{"ns/ocm-stg-abc"})

--- a/tooling/hcpctl/go.mod
+++ b/tooling/hcpctl/go.mod
@@ -18,7 +18,9 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
+	github.com/klauspost/compress v1.18.3
 	github.com/openshift-eng/openshift-tests-extension v0.0.0-20260812190735-a8b44e9f9fed
 	github.com/openshift/hypershift/api v0.0.0-20260708113917-8b5103a5875b
 	github.com/spf13/cobra v1.10.2
@@ -104,7 +106,6 @@ require (
 	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/pprof v0.0.0-20260507013755-92041b743c96 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect

--- a/tooling/hcpctl/go.sum
+++ b/tooling/hcpctl/go.sum
@@ -227,6 +227,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
+github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=
+github.com/klauspost/compress v1.18.3/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/tooling/hcpctl/pkg/kshrk/format.go
+++ b/tooling/hcpctl/pkg/kshrk/format.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package kshrk writes .kshrk archives: the portable capture format read by
+// k8shark (https://github.com/phenixblue/k8shark), a Wireshark-style offline
+// Kubernetes cluster replay tool. The format (ZIP container, Zstd-compressed
+// JSON entries) is documented for third-party writers in k8shark's
+// docs/archive-format.md; k8shark's own implementation lives entirely under
+// internal/ and cannot be imported, so this package implements the documented
+// schema independently. It only writes archives — reading one back is k8shark's
+// job (via `kshrk open`/`kshrk ui`).
+package kshrk
+
+import "time"
+
+// CurrentFormatVersion is the .kshrk archive schema version this package
+// writes, matching k8shark's documented format_version 2 (index/watch-index
+// wrapped under a top-level "entries" key).
+const CurrentFormatVersion = 2
+
+// CaptureMetadata is written as metadata.json inside the archive.
+type CaptureMetadata struct {
+	FormatVersion     int       `json:"format_version,omitempty"`
+	CaptureID         string    `json:"capture_id"`
+	CapturedAt        time.Time `json:"captured_at"`
+	CapturedUntil     time.Time `json:"captured_until"`
+	KubernetesVersion string    `json:"kubernetes_version"`
+	ServerAddress     string    `json:"server_address"`
+	RecordCount       int       `json:"record_count"`
+}
+
+// IndexEntry maps an API path to the ordered poll records captured for it.
+// Seqs, Times, and Counts are parallel arrays ordered by capture time
+// ascending; Counts is omitted when the caller never supplied an item count
+// for that path (non-list-shaped responses).
+type IndexEntry struct {
+	APIPath string      `json:"api_path"`
+	Seqs    []int       `json:"seqs"`
+	Times   []time.Time `json:"times"`
+	Counts  []int       `json:"counts,omitempty"`
+}
+
+// index is the on-disk shape of index.json.zst: format version 2 wraps the
+// path->entry map under "entries" so sibling fields can be added later
+// without another format-version bump.
+type index struct {
+	Entries map[string]*IndexEntry `json:"entries"`
+}
+
+// WatchIndexEntry maps an API path to the ordered watch events captured for
+// it. Seqs, Times, and EventTypes are parallel arrays ordered by capture time
+// ascending; each event_type is ADDED, MODIFIED, or DELETED.
+type WatchIndexEntry struct {
+	APIPath    string      `json:"api_path"`
+	Seqs       []int       `json:"seqs"`
+	Times      []time.Time `json:"times"`
+	EventTypes []string    `json:"event_types"`
+}
+
+// watchIndex is the on-disk shape of watch-index.json.zst, wrapped under
+// "entries" for the same reason as index.
+type watchIndex struct {
+	Entries map[string]*WatchIndexEntry `json:"entries"`
+}
+
+// Record holds one archived API response: a full List body for a poll record,
+// or a single object body for a watch record (EventType set).
+type Record struct {
+	ID           string    `json:"id"`
+	CapturedAt   time.Time `json:"captured_at"`
+	APIPath      string    `json:"api_path"`
+	EventType    string    `json:"event_type,omitempty"`
+	HTTPMethod   string    `json:"http_method"`
+	ResponseCode int       `json:"response_code"`
+	ResponseBody any       `json:"response_body"`
+}

--- a/tooling/hcpctl/pkg/kshrk/writer.go
+++ b/tooling/hcpctl/pkg/kshrk/writer.go
@@ -1,0 +1,253 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kshrk
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/klauspost/compress/zstd"
+)
+
+// archiveRoot is the top-level directory name inside the ZIP container,
+// matching k8shark's documented layout.
+const archiveRoot = "k8shark-capture"
+
+// epochModTime is a fixed, valid ZIP entry timestamp so archives are
+// deterministic byte-for-byte given identical input, mirroring k8shark's own
+// writer.
+var epochModTime = time.Date(1980, 1, 1, 12, 0, 0, 0, time.UTC)
+
+// validEventTypes are the only event_type values a watch record may carry.
+var validEventTypes = map[string]bool{"ADDED": true, "MODIFIED": true, "DELETED": true}
+
+// ArchiveWriter builds a .kshrk archive by accepting poll and watch records
+// and writing metadata.json, index.json.zst, watch-index.json.zst, and
+// records/<pathDir>/<seq>.json.zst on Finish. Not safe for concurrent use.
+type ArchiveWriter struct {
+	f  *os.File
+	zw *zip.Writer
+
+	// pathSeq assigns the shared, per-apiPath sequence number every record
+	// (poll or watch) under that path is numbered from, matching k8shark's
+	// own writer — index.json and watch-index.json reference disjoint seqs
+	// out of the same per-path sequence, not independent counters.
+	pathSeq map[string]int
+
+	index       index
+	watchIndex  watchIndex
+	recordCount int
+
+	closed bool
+}
+
+// NewArchiveWriter creates a new .kshrk archive at outputPath.
+func NewArchiveWriter(outputPath string) (*ArchiveWriter, error) {
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return nil, fmt.Errorf("creating archive %q: %w", outputPath, err)
+	}
+	return &ArchiveWriter{
+		f:          f,
+		zw:         zip.NewWriter(f),
+		pathSeq:    make(map[string]int),
+		index:      index{Entries: make(map[string]*IndexEntry)},
+		watchIndex: watchIndex{Entries: make(map[string]*WatchIndexEntry)},
+	}, nil
+}
+
+// WritePollRecord writes a full poll response (a List body) under apiPath and
+// registers it in index.json. itemCount is the number of top-level items in
+// body, recorded as index.json's optional Counts field.
+func (a *ArchiveWriter) WritePollRecord(apiPath string, capturedAt time.Time, body any, itemCount int) error {
+	seq, err := a.writeRecord(apiPath, "", capturedAt, body)
+	if err != nil {
+		return err
+	}
+	entry, ok := a.index.Entries[apiPath]
+	if !ok {
+		entry = &IndexEntry{APIPath: apiPath}
+		a.index.Entries[apiPath] = entry
+	}
+	entry.Seqs = append(entry.Seqs, seq)
+	entry.Times = append(entry.Times, capturedAt)
+	entry.Counts = append(entry.Counts, itemCount)
+	return nil
+}
+
+// WriteWatchRecord writes a single-object watch event (eventType: ADDED,
+// MODIFIED, or DELETED) under apiPath and registers it in watch-index.json.
+func (a *ArchiveWriter) WriteWatchRecord(apiPath, eventType string, capturedAt time.Time, body any) error {
+	if !validEventTypes[eventType] {
+		return fmt.Errorf("invalid watch event type %q for %s: must be ADDED, MODIFIED, or DELETED", eventType, apiPath)
+	}
+	seq, err := a.writeRecord(apiPath, eventType, capturedAt, body)
+	if err != nil {
+		return err
+	}
+	entry, ok := a.watchIndex.Entries[apiPath]
+	if !ok {
+		entry = &WatchIndexEntry{APIPath: apiPath}
+		a.watchIndex.Entries[apiPath] = entry
+	}
+	entry.Seqs = append(entry.Seqs, seq)
+	entry.Times = append(entry.Times, capturedAt)
+	entry.EventTypes = append(entry.EventTypes, eventType)
+	return nil
+}
+
+// RecordCount returns the number of records written so far.
+func (a *ArchiveWriter) RecordCount() int {
+	return a.recordCount
+}
+
+// writeRecord marshals rec, zstd-compresses it, and writes it to
+// records/<pathDir>/<seq>.json.zst, returning the assigned seq.
+func (a *ArchiveWriter) writeRecord(apiPath, eventType string, capturedAt time.Time, body any) (int, error) {
+	rec := Record{
+		ID:           uuid.NewString(),
+		CapturedAt:   capturedAt,
+		APIPath:      apiPath,
+		EventType:    eventType,
+		HTTPMethod:   "GET",
+		ResponseCode: 200,
+		ResponseBody: body,
+	}
+	recBytes, err := json.Marshal(rec)
+	if err != nil {
+		return 0, fmt.Errorf("marshaling record for %s: %w", apiPath, err)
+	}
+	compressed, err := zstdCompress(recBytes)
+	if err != nil {
+		return 0, fmt.Errorf("compressing record for %s: %w", apiPath, err)
+	}
+
+	seq := a.pathSeq[apiPath]
+	a.pathSeq[apiPath] = seq + 1
+
+	entryName := fmt.Sprintf("%s/records/%s/%d.json.zst", archiveRoot, pathDir(apiPath), seq)
+	if err := a.writeZipEntry(entryName, compressed); err != nil {
+		return 0, err
+	}
+	a.recordCount++
+	return seq, nil
+}
+
+// pathDir returns the filesystem-safe directory name for an API path: the
+// first 16 hex chars of SHA-256(apiPath), matching k8shark's documented
+// derivation.
+func pathDir(apiPath string) string {
+	sum := sha256.Sum256([]byte(apiPath))
+	return fmt.Sprintf("%x", sum[:8])
+}
+
+func (a *ArchiveWriter) writeZipEntry(name string, data []byte) error {
+	hdr := &zip.FileHeader{
+		Name:     name,
+		Method:   zip.Store, // payloads are already zstd-compressed (or tiny, for metadata.json)
+		Modified: epochModTime,
+	}
+	w, err := a.zw.CreateHeader(hdr)
+	if err != nil {
+		return fmt.Errorf("creating zip entry %s: %w", name, err)
+	}
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("writing zip entry %s: %w", name, err)
+	}
+	return nil
+}
+
+func zstdCompress(data []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	enc, err := zstd.NewWriter(&buf)
+	if err != nil {
+		return nil, fmt.Errorf("creating zstd encoder: %w", err)
+	}
+	if _, err := enc.Write(data); err != nil {
+		_ = enc.Close()
+		return nil, fmt.Errorf("zstd-compressing data: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("closing zstd encoder: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// Finish writes metadata.json (uncompressed), index.json.zst, and (when any
+// watch records were written) watch-index.json.zst, then closes the archive.
+// meta's FormatVersion and RecordCount are set automatically.
+func (a *ArchiveWriter) Finish(meta CaptureMetadata) error {
+	meta.FormatVersion = CurrentFormatVersion
+	meta.RecordCount = a.recordCount
+
+	metaBytes, err := json.Marshal(meta)
+	if err != nil {
+		return fmt.Errorf("marshaling metadata.json: %w", err)
+	}
+	if err := a.writeZipEntry(archiveRoot+"/metadata.json", metaBytes); err != nil {
+		return err
+	}
+
+	if err := a.writeCompressedJSON(archiveRoot+"/index.json.zst", a.index); err != nil {
+		return fmt.Errorf("writing index.json.zst: %w", err)
+	}
+
+	if len(a.watchIndex.Entries) > 0 {
+		if err := a.writeCompressedJSON(archiveRoot+"/watch-index.json.zst", a.watchIndex); err != nil {
+			return fmt.Errorf("writing watch-index.json.zst: %w", err)
+		}
+	}
+
+	a.closed = true
+	if err := a.zw.Close(); err != nil {
+		return fmt.Errorf("closing zip writer: %w", err)
+	}
+	if err := a.f.Close(); err != nil {
+		return fmt.Errorf("closing archive file: %w", err)
+	}
+	return nil
+}
+
+func (a *ArchiveWriter) writeCompressedJSON(name string, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("marshaling: %w", err)
+	}
+	compressed, err := zstdCompress(data)
+	if err != nil {
+		return err
+	}
+	return a.writeZipEntry(name, compressed)
+}
+
+// Abort discards a partially-written archive: it closes the underlying file
+// handles without writing metadata/index entries and removes the output file.
+// Call this on an error path in place of Finish.
+func (a *ArchiveWriter) Abort() error {
+	if a.closed {
+		return nil
+	}
+	a.closed = true
+	name := a.f.Name()
+	_ = a.zw.Close()
+	_ = a.f.Close()
+	return os.Remove(name)
+}

--- a/tooling/hcpctl/pkg/kshrk/writer_test.go
+++ b/tooling/hcpctl/pkg/kshrk/writer_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kshrk
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"io"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// readZipEntry reads and, unless raw is true, zstd-decompresses a single
+// entry from a plain (unencrypted) .kshrk archive — exercising the archive
+// exactly as a third-party reader following docs/archive-format.md would,
+// without importing anything from k8shark itself.
+func readZipEntry(t *testing.T, archivePath, name string, raw bool) []byte {
+	t.Helper()
+	zr, err := zip.OpenReader(archivePath)
+	if err != nil {
+		t.Fatalf("opening archive: %v", err)
+	}
+	defer zr.Close()
+
+	for _, f := range zr.File {
+		if f.Name != name {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("opening entry %s: %v", name, err)
+		}
+		defer rc.Close()
+		data, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("reading entry %s: %v", name, err)
+		}
+		if raw {
+			return data
+		}
+		dec, err := zstd.NewReader(nil)
+		if err != nil {
+			t.Fatalf("creating zstd decoder: %v", err)
+		}
+		defer dec.Close()
+		decompressed, err := dec.DecodeAll(data, nil)
+		if err != nil {
+			t.Fatalf("decompressing entry %s: %v", name, err)
+		}
+		return decompressed
+	}
+	t.Fatalf("entry %s not found in archive", name)
+	return nil
+}
+
+func TestArchiveWriter_RoundTrip(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "capture.kshrk")
+	aw, err := NewArchiveWriter(archivePath)
+	if err != nil {
+		t.Fatalf("NewArchiveWriter: %v", err)
+	}
+
+	t0 := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(30 * time.Second)
+
+	pollBody := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "NodeList",
+		"items": []any{
+			map[string]any{"metadata": map[string]any{"name": "node-1"}},
+		},
+	}
+	if err := aw.WritePollRecord("/api/v1/nodes", t0, pollBody, 1); err != nil {
+		t.Fatalf("WritePollRecord: %v", err)
+	}
+
+	watchBody := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Node",
+		"metadata":   map[string]any{"name": "node-2"},
+	}
+	if err := aw.WriteWatchRecord("/api/v1/nodes", "ADDED", t1, watchBody); err != nil {
+		t.Fatalf("WriteWatchRecord: %v", err)
+	}
+
+	if got, want := aw.RecordCount(), 2; got != want {
+		t.Errorf("RecordCount() = %d, want %d", got, want)
+	}
+
+	meta := CaptureMetadata{
+		CaptureID:         "test-capture-id",
+		CapturedAt:        t0,
+		CapturedUntil:     t1,
+		KubernetesVersion: "v1.30.2",
+		ServerAddress:     "kusto-reconstructed://mgmt-1",
+	}
+	if err := aw.Finish(meta); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// metadata.json is stored uncompressed.
+	var gotMeta CaptureMetadata
+	if err := json.Unmarshal(readZipEntry(t, archivePath, "k8shark-capture/metadata.json", true), &gotMeta); err != nil {
+		t.Fatalf("unmarshaling metadata.json: %v", err)
+	}
+	if gotMeta.FormatVersion != CurrentFormatVersion {
+		t.Errorf("FormatVersion = %d, want %d", gotMeta.FormatVersion, CurrentFormatVersion)
+	}
+	if gotMeta.RecordCount != 2 {
+		t.Errorf("RecordCount = %d, want 2", gotMeta.RecordCount)
+	}
+	if gotMeta.CaptureID != "test-capture-id" {
+		t.Errorf("CaptureID = %q, want %q", gotMeta.CaptureID, "test-capture-id")
+	}
+
+	// index.json.zst wraps the map under "entries" (format version 2).
+	var gotIndex index
+	if err := json.Unmarshal(readZipEntry(t, archivePath, "k8shark-capture/index.json.zst", false), &gotIndex); err != nil {
+		t.Fatalf("unmarshaling index.json.zst: %v", err)
+	}
+	pollEntry, ok := gotIndex.Entries["/api/v1/nodes"]
+	if !ok {
+		t.Fatalf("index.json.zst missing entry for /api/v1/nodes")
+	}
+	if len(pollEntry.Seqs) != 1 || pollEntry.Seqs[0] != 0 {
+		t.Errorf("poll entry Seqs = %v, want [0]", pollEntry.Seqs)
+	}
+	if len(pollEntry.Counts) != 1 || pollEntry.Counts[0] != 1 {
+		t.Errorf("poll entry Counts = %v, want [1]", pollEntry.Counts)
+	}
+
+	// watch-index.json.zst is present (we wrote a watch record) and wrapped
+	// the same way, referencing the seq *after* the poll record's (shared
+	// per-apiPath sequence space).
+	var gotWatchIndex watchIndex
+	if err := json.Unmarshal(readZipEntry(t, archivePath, "k8shark-capture/watch-index.json.zst", false), &gotWatchIndex); err != nil {
+		t.Fatalf("unmarshaling watch-index.json.zst: %v", err)
+	}
+	watchEntry, ok := gotWatchIndex.Entries["/api/v1/nodes"]
+	if !ok {
+		t.Fatalf("watch-index.json.zst missing entry for /api/v1/nodes")
+	}
+	if len(watchEntry.Seqs) != 1 || watchEntry.Seqs[0] != 1 {
+		t.Errorf("watch entry Seqs = %v, want [1]", watchEntry.Seqs)
+	}
+	if len(watchEntry.EventTypes) != 1 || watchEntry.EventTypes[0] != "ADDED" {
+		t.Errorf("watch entry EventTypes = %v, want [ADDED]", watchEntry.EventTypes)
+	}
+
+	// The actual record files live under records/<pathDir>/<seq>.json.zst,
+	// pathDir derived from SHA-256(apiPath) — same directory for both the
+	// poll record (seq 0) and the watch record (seq 1), since they share an
+	// api_path.
+	dir := pathDir("/api/v1/nodes")
+	if len(dir) != 16 {
+		t.Fatalf("pathDir length = %d, want 16", len(dir))
+	}
+
+	var pollRec Record
+	if err := json.Unmarshal(readZipEntry(t, archivePath, "k8shark-capture/records/"+dir+"/0.json.zst", false), &pollRec); err != nil {
+		t.Fatalf("unmarshaling poll record: %v", err)
+	}
+	if pollRec.EventType != "" {
+		t.Errorf("poll record EventType = %q, want empty", pollRec.EventType)
+	}
+	if pollRec.APIPath != "/api/v1/nodes" || pollRec.ResponseCode != 200 || pollRec.HTTPMethod != "GET" {
+		t.Errorf("poll record envelope wrong: %+v", pollRec)
+	}
+
+	var watchRec Record
+	if err := json.Unmarshal(readZipEntry(t, archivePath, "k8shark-capture/records/"+dir+"/1.json.zst", false), &watchRec); err != nil {
+		t.Fatalf("unmarshaling watch record: %v", err)
+	}
+	if watchRec.EventType != "ADDED" {
+		t.Errorf("watch record EventType = %q, want ADDED", watchRec.EventType)
+	}
+}
+
+func TestArchiveWriter_NoWatchRecords_OmitsWatchIndex(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "capture.kshrk")
+	aw, err := NewArchiveWriter(archivePath)
+	if err != nil {
+		t.Fatalf("NewArchiveWriter: %v", err)
+	}
+	if err := aw.WritePollRecord("/api/v1/nodes", time.Now(), map[string]any{"items": []any{}}, 0); err != nil {
+		t.Fatalf("WritePollRecord: %v", err)
+	}
+	if err := aw.Finish(CaptureMetadata{CaptureID: "c1"}); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	zr, err := zip.OpenReader(archivePath)
+	if err != nil {
+		t.Fatalf("opening archive: %v", err)
+	}
+	defer zr.Close()
+	for _, f := range zr.File {
+		if f.Name == "k8shark-capture/watch-index.json.zst" {
+			t.Fatalf("watch-index.json.zst should be omitted when no watch records were written")
+		}
+	}
+}
+
+func TestArchiveWriter_WriteWatchRecord_RejectsInvalidEventType(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "capture.kshrk")
+	aw, err := NewArchiveWriter(archivePath)
+	if err != nil {
+		t.Fatalf("NewArchiveWriter: %v", err)
+	}
+	defer func() { _ = aw.Abort() }()
+
+	err = aw.WriteWatchRecord("/api/v1/nodes", "UPDATED", time.Now(), map[string]any{})
+	if err == nil {
+		t.Fatal("expected error for invalid event type, got nil")
+	}
+}

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/events.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/events.kql.gotmpl
@@ -1,15 +1,17 @@
 {{- /*
-Kubernetes API events for a namespace on the management/service cluster, up to
-the requested timestamp. Mirrors the events oc adm inspect writes under
-namespaces/<ns>/core/events.yaml.
+Kubernetes API events on the management/service cluster (or, when Namespace is
+set, for that one namespace), up to the requested timestamp. Mirrors the events
+oc adm inspect writes under namespaces/<ns>/core/events.yaml.
 */ -}}
 {{- if .NoTruncation}}set notruncation;
 {{end -}}
 kubernetesEvents
 | where timestamp between ({{ .TimestampMin }} .. {{ .TimestampMax }})
 | where cluster == '{{.ClusterName}}'
+{{- if .Namespace}}
 | where eventNamespace == '{{.Namespace}}'
-| project timestamp, firstSeen, lastSeen, count, kubeEventType, reason, objectKind, objectApiVersion, objectName, sourceComponent, message
+{{- end}}
+| project timestamp, firstSeen, lastSeen, count, kubeEventType, reason, objectKind, objectApiVersion, objectName, eventNamespace, sourceComponent, message
 | order by timestamp {{.OrderBy}}
 {{- if gt .Limit 0}}
 | limit {{.Limit}}

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/resource_history.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/resource_history.kql.gotmpl
@@ -1,0 +1,21 @@
+{{- /*
+Every resource-snapshot row on the cluster (or, when Namespace is set, in that
+one namespace) within the requested window, unsummarized: one row per captured
+Add/Update/Delete event, ordered by timestamp ascending. Unlike
+resource_snapshots.kql.gotmpl this does not collapse to "state as of
+TimestampMax" and does not drop deleted objects — it is the raw change history
+a watch-index (ADDED/MODIFIED/DELETED) is built from.
+*/ -}}
+{{- if .NoTruncation}}set notruncation;
+{{end -}}
+kubernetesResourceSnapshots
+| where timestamp between ({{ .TimestampMin }} .. {{ .TimestampMax }})
+| where cluster == '{{.ClusterName}}'
+{{- if .Namespace}}
+| where namespace == '{{.Namespace}}' or (objectKind == 'Namespace' and name == '{{.Namespace}}')
+{{- end}}
+| project timestamp, event, apiVersion, objectKind, namespace, name, uid, object
+| order by timestamp asc
+{{- if gt .Limit 0}}
+| limit {{.Limit}}
+{{- end}}

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/resource_snapshots.kql.gotmpl
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/oc-adm-inspect/resource_snapshots.kql.gotmpl
@@ -1,7 +1,8 @@
 {{- /*
-Reconstructs the state of every resource in a namespace as of the requested
-timestamp (TimestampMax) from the management cluster's resource snapshots. For
-each object (identified by apiVersion/kind/namespace/name/uid) it keeps the most
+Reconstructs the state of every resource on the cluster (or, when Namespace is
+set, of every resource in that one namespace) as of the requested timestamp
+(TimestampMax) from the management cluster's resource snapshots. For each
+object (identified by apiVersion/kind/namespace/name/uid) it keeps the most
 recent snapshot at or before the timestamp, then drops objects that were actually
 deleted by then: either the latest event was a Delete, or the object carried a
 deletionTimestamp whose graceful-deletion deadline (deletionTimestamp +
@@ -13,7 +14,9 @@ grace period has not yet expired are kept, because they still existed.
 kubernetesResourceSnapshots
 | where timestamp between ({{ .TimestampMin }} .. {{ .TimestampMax }})
 | where cluster == '{{.ClusterName}}'
+{{- if .Namespace}}
 | where namespace == '{{.Namespace}}' or (objectKind == 'Namespace' and name == '{{.Namespace}}')
+{{- end}}
 | summarize arg_max(timestamp, event, object) by apiVersion, objectKind, namespace, name, uid
 | where event != 'Delete'
 | extend deletionTimestamp = todatetime(object.metadata.deletionTimestamp)

--- a/tooling/hcpctl/pkg/kusto/templates/builtin/queries.yaml
+++ b/tooling/hcpctl/pkg/kusto/templates/builtin/queries.yaml
@@ -6,6 +6,10 @@
   queryType: oc-adm-inspect-resource
   database: ServiceLogs
   templatePath: templates/builtin/oc-adm-inspect/resource_snapshots.kql.gotmpl
+- name: ocAdmInspectResourceHistory
+  queryType: oc-adm-inspect-resource
+  database: ServiceLogs
+  templatePath: templates/builtin/oc-adm-inspect/resource_history.kql.gotmpl
 - name: ocAdmInspectEvents
   queryType: oc-adm-inspect-events
   database: ServiceLogs

--- a/tooling/hcpctl/pkg/ocadminspect/inspect.go
+++ b/tooling/hcpctl/pkg/ocadminspect/inspect.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"golang.org/x/sync/errgroup"
@@ -36,10 +37,11 @@ import (
 
 // Builtin query definition names (registered in pkg/kusto/templates/builtin/queries.yaml).
 const (
-	resourcesQueryName      = "ocAdmInspectResources"
-	eventsQueryName         = "ocAdmInspectEvents"
-	activeClustersQueryName = "ocAdmInspectActiveClusters"
-	namespacesQueryName     = "ocAdmInspectNamespaces"
+	resourcesQueryName       = "ocAdmInspectResources"
+	resourceHistoryQueryName = "ocAdmInspectResourceHistory"
+	eventsQueryName          = "ocAdmInspectEvents"
+	activeClustersQueryName  = "ocAdmInspectActiveClusters"
+	namespacesQueryName      = "ocAdmInspectNamespaces"
 )
 
 // containerLogSourceQueries are the container-log queries run per namespace, one
@@ -79,13 +81,34 @@ type LogLine struct {
 	Log any
 }
 
-// Writer persists what the inspector gathers for a namespace. Implementations
-// choose the on-disk layout.
+// ResourceEvent is one raw Add/Update/Delete row from the resource-snapshot
+// changelog (the ocAdmInspectResourceHistory query), unsummarized. Unlike
+// Resource — a single object reconstructed as of one point in time — it
+// carries the event type and timestamp needed to build a watch-index.
+type ResourceEvent struct {
+	Timestamp time.Time
+	// Event is Kusto's kubernetesResourceSnapshots.event value: "Add",
+	// "Update", or "Delete".
+	Event    string
+	Resource Resource
+}
+
+// Writer persists what the inspector gathers for a namespace, or for the
+// whole cluster. Implementations choose the on-disk layout.
 type Writer interface {
-	// WriteResources writes all resources gathered for a namespace.
+	// WriteResources writes all resources gathered for a namespace, or (for a
+	// whole-cluster inspection) every resource gathered for the whole cluster
+	// at once, with namespace passed as "".
 	WriteResources(ctx context.Context, namespace string, resources []Resource) error
+	// WriteResourceHistory writes the raw Add/Update/Delete changelog for a
+	// whole-cluster inspection. Implementations that have no use for
+	// per-event history (e.g. FilesystemWriter) may no-op. Callers must
+	// invoke WriteResources before this, on writers that build cross-call
+	// state (e.g. CRD-derived resource names) from it.
+	WriteResourceHistory(ctx context.Context, events []ResourceEvent) error
 	// WriteEvents writes the namespace's Kubernetes events (each event is a
-	// column->value map from the events query).
+	// column->value map from the events query), or every event gathered for
+	// the whole cluster at once, with namespace passed as "".
 	WriteEvents(ctx context.Context, namespace string, events []map[string]any) error
 	// WriteContainerLog writes the log lines for a single pod container.
 	WriteContainerLog(ctx context.Context, namespace, pod, container string, lines []LogLine) error
@@ -143,11 +166,87 @@ func (i *Inspector) InspectNamespaces(ctx context.Context, namespaces []string) 
 	return joinErrors(errs)
 }
 
-func (i *Inspector) inspectResources(ctx context.Context, namespace string) error {
-	rows, err := i.runNamespaceQuery(ctx, resourcesQueryName, namespace)
+// InspectCluster gathers and writes the poll-baseline state, history, and
+// events for the entire cluster across [baseOptions.TimestampMin,
+// baseOptions.TimestampMax] — rather than one namespace at one point in time.
+// lookbackFloor bounds how far back the poll-baseline query searches for each
+// object's last known state before TimestampMin: an object whose last real
+// change predates it (or predates table retention entirely) is missing from
+// the baseline. In practice this only matters for long-lived, untouched
+// Pods — everything else gets a synthetic Update row at least every 10h from
+// mgmt-agent's informer resync (see resourcewatcher.go), so a lookback wider
+// than that makes them reliably present regardless of real server-side
+// activity. No amount of lookback fully eliminates the possibility; widen it
+// as far as practical and accept the gap.
+//
+// Unlike InspectNamespaces, this runs exactly three Kusto queries total — no
+// namespace loop, no DiscoverNamespaces call. Every underlying query's
+// namespace filter is left unset, so each one already spans every namespace
+// and every cluster-scoped resource in one pass; grouping the results back
+// into per-namespace/per-cluster-scope collections happens in the Writer
+// (see KshrkWriter), not here.
+func (i *Inspector) InspectCluster(ctx context.Context, lookbackFloor time.Time) error {
+	logger := logr.FromContextOrDiscard(ctx)
+	windowStart := i.baseOptions.TimestampMin
+	windowEnd := i.baseOptions.TimestampMax
+
+	logger.Info("inspecting whole cluster",
+		"cluster", i.clusterName,
+		"windowStart", windowStart.Format(time.RFC3339),
+		"windowEnd", windowEnd.Format(time.RFC3339),
+		"lookbackFloor", lookbackFloor.Format(time.RFC3339),
+	)
+
+	baselineRows, err := i.runClusterQuery(ctx, resourcesQueryName, lookbackFloor, windowStart)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to query poll-baseline resource snapshots: %w", err)
 	}
+	if err := i.writer.WriteResources(ctx, "", rowsToResources(baselineRows)); err != nil {
+		return fmt.Errorf("failed to write poll-baseline resources: %w", err)
+	}
+
+	historyRows, err := i.runClusterQuery(ctx, resourceHistoryQueryName, windowStart, windowEnd)
+	if err != nil {
+		return fmt.Errorf("failed to query resource history: %w", err)
+	}
+	if err := i.writer.WriteResourceHistory(ctx, rowsToResourceEvents(historyRows)); err != nil {
+		return fmt.Errorf("failed to write resource history: %w", err)
+	}
+
+	eventRows, err := i.runClusterQuery(ctx, eventsQueryName, windowStart, windowEnd)
+	if err != nil {
+		return fmt.Errorf("failed to query events: %w", err)
+	}
+	if err := i.writer.WriteEvents(ctx, "", eventRows); err != nil {
+		return fmt.Errorf("failed to write events: %w", err)
+	}
+
+	return nil
+}
+
+// runClusterQuery runs a builtin query definition across the whole cluster —
+// namespace left unset, so cluster-scoped resources and every namespace are
+// returned in one pass — over [timestampMin, timestampMax], overriding the
+// Inspector's base window for that one query.
+func (i *Inspector) runClusterQuery(ctx context.Context, defName string, timestampMin, timestampMax time.Time) ([]map[string]any, error) {
+	def, err := i.factory.GetBuiltinQueryDefinition(defName)
+	if err != nil {
+		return nil, err
+	}
+	data := kusto.NewTemplateDataFromOptions(i.baseOptions,
+		kusto.WithClusterName(i.clusterName),
+		kusto.WithTimestampMin(timestampMin),
+		kusto.WithTimestampMax(timestampMax),
+	)
+	queries, err := i.factory.Build(*def, data)
+	if err != nil {
+		return nil, err
+	}
+	return runQuery(ctx, i.exec, queries[0])
+}
+
+// rowsToResources converts ocAdmInspectResources rows into Resources.
+func rowsToResources(rows []map[string]any) []Resource {
 	resources := make([]Resource, 0, len(rows))
 	for _, row := range rows {
 		object, _ := row["object"].(map[string]any)
@@ -159,7 +258,37 @@ func (i *Inspector) inspectResources(ctx context.Context, namespace string) erro
 			Object:     object,
 		})
 	}
-	return i.writer.WriteResources(ctx, namespace, resources)
+	return resources
+}
+
+// rowsToResourceEvents converts ocAdmInspectResourceHistory rows into
+// ResourceEvents.
+func rowsToResourceEvents(rows []map[string]any) []ResourceEvent {
+	events := make([]ResourceEvent, 0, len(rows))
+	for _, row := range rows {
+		object, _ := row["object"].(map[string]any)
+		timestamp, _ := time.Parse(time.RFC3339, asString(row["timestamp"]))
+		events = append(events, ResourceEvent{
+			Timestamp: timestamp,
+			Event:     asString(row["event"]),
+			Resource: Resource{
+				APIVersion: asString(row["apiVersion"]),
+				Kind:       asString(row["objectKind"]),
+				Namespace:  asString(row["namespace"]),
+				Name:       asString(row["name"]),
+				Object:     object,
+			},
+		})
+	}
+	return events
+}
+
+func (i *Inspector) inspectResources(ctx context.Context, namespace string) error {
+	rows, err := i.runNamespaceQuery(ctx, resourcesQueryName, namespace)
+	if err != nil {
+		return err
+	}
+	return i.writer.WriteResources(ctx, namespace, rowsToResources(rows))
 }
 
 func (i *Inspector) inspectEvents(ctx context.Context, namespace string) error {

--- a/tooling/hcpctl/pkg/ocadminspect/inspect_test.go
+++ b/tooling/hcpctl/pkg/ocadminspect/inspect_test.go
@@ -133,6 +133,114 @@ func TestRenderedResourceQuery(t *testing.T) {
 	}
 }
 
+// TestRenderedResourceQuery_WholeCluster verifies that leaving Namespace unset
+// (no WithNamespace call — the whole-cluster export path) drops the namespace
+// filter entirely, rather than rendering an empty/broken clause, while every
+// other clause (collapse, delete/grace-period filtering) is untouched.
+func TestRenderedResourceQuery_WholeCluster(t *testing.T) {
+	factory, err := kusto.NewQueryFactory()
+	if err != nil {
+		t.Fatalf("failed to build query factory: %v", err)
+	}
+	def, err := factory.GetBuiltinQueryDefinition("ocAdmInspectResources")
+	if err != nil {
+		t.Fatalf("failed to get query definition: %v", err)
+	}
+	data := kusto.NewTemplateDataFromOptions(kusto.NewQueryOptions(), kusto.WithClusterName("aro-hcp-mgmt-1"))
+	queries, err := factory.Build(*def, data)
+	if err != nil {
+		t.Fatalf("failed to build query: %v", err)
+	}
+	rendered := queries[0].GetQuery().String()
+
+	if strings.Contains(rendered, "namespace ==") {
+		t.Errorf("whole-cluster rendered resource query should have no namespace filter:\n%s", rendered)
+	}
+	for _, want := range []string{"kubernetesResourceSnapshots", "cluster == 'aro-hcp-mgmt-1'", "event != 'Delete'", "deletionGracePeriodSeconds"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("whole-cluster rendered resource query missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+// TestRenderedResourceHistoryQuery verifies the uncollapsed changelog query
+// (feeding watch-index) carries the event column and ordering, and does not
+// collapse to "state as of" or drop deleted objects the way
+// ocAdmInspectResources does.
+func TestRenderedResourceHistoryQuery(t *testing.T) {
+	factory, err := kusto.NewQueryFactory()
+	if err != nil {
+		t.Fatalf("failed to build query factory: %v", err)
+	}
+	def, err := factory.GetBuiltinQueryDefinition("ocAdmInspectResourceHistory")
+	if err != nil {
+		t.Fatalf("failed to get query definition: %v", err)
+	}
+	data := kusto.NewTemplateDataFromOptions(kusto.NewQueryOptions(), kusto.WithClusterName("aro-hcp-mgmt-1"))
+	queries, err := factory.Build(*def, data)
+	if err != nil {
+		t.Fatalf("failed to build query: %v", err)
+	}
+	rendered := queries[0].GetQuery().String()
+
+	for _, notWant := range []string{"arg_max", "event != 'Delete'", "deletionTimestamp", "namespace =="} {
+		if strings.Contains(rendered, notWant) {
+			t.Errorf("rendered resource history query should not contain %q:\n%s", notWant, rendered)
+		}
+	}
+	for _, want := range []string{"kubernetesResourceSnapshots", "cluster == 'aro-hcp-mgmt-1'", "project timestamp, event,", "order by timestamp asc"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered resource history query missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+// TestRenderedEventsQuery verifies the events template projects eventNamespace
+// (needed to route each event to the right archive path in whole-cluster
+// mode) both with and without a namespace filter.
+func TestRenderedEventsQuery(t *testing.T) {
+	factory, err := kusto.NewQueryFactory()
+	if err != nil {
+		t.Fatalf("failed to build query factory: %v", err)
+	}
+	def, err := factory.GetBuiltinQueryDefinition("ocAdmInspectEvents")
+	if err != nil {
+		t.Fatalf("failed to get query definition: %v", err)
+	}
+
+	t.Run("namespaced", func(t *testing.T) {
+		data := kusto.NewTemplateDataFromOptions(kusto.NewQueryOptions(),
+			kusto.WithClusterName("aro-hcp-mgmt-1"),
+			kusto.WithNamespace("kube-system"),
+		)
+		queries, err := factory.Build(*def, data)
+		if err != nil {
+			t.Fatalf("failed to build query: %v", err)
+		}
+		rendered := queries[0].GetQuery().String()
+		for _, want := range []string{"eventNamespace == 'kube-system'", "eventNamespace,", "cluster == 'aro-hcp-mgmt-1'"} {
+			if !strings.Contains(rendered, want) {
+				t.Errorf("rendered events query missing %q:\n%s", want, rendered)
+			}
+		}
+	})
+
+	t.Run("whole cluster", func(t *testing.T) {
+		data := kusto.NewTemplateDataFromOptions(kusto.NewQueryOptions(), kusto.WithClusterName("aro-hcp-mgmt-1"))
+		queries, err := factory.Build(*def, data)
+		if err != nil {
+			t.Fatalf("failed to build query: %v", err)
+		}
+		rendered := queries[0].GetQuery().String()
+		if strings.Contains(rendered, "eventNamespace ==") {
+			t.Errorf("whole-cluster rendered events query should have no namespace filter:\n%s", rendered)
+		}
+		if !strings.Contains(rendered, "eventNamespace,") {
+			t.Errorf("whole-cluster rendered events query should still project eventNamespace:\n%s", rendered)
+		}
+	})
+}
+
 func TestRenderedContainerLogsQuery(t *testing.T) {
 	factory, err := kusto.NewQueryFactory()
 	if err != nil {

--- a/tooling/hcpctl/pkg/ocadminspect/kshrk_writer.go
+++ b/tooling/hcpctl/pkg/ocadminspect/kshrk_writer.go
@@ -1,0 +1,444 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocadminspect
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/kshrk"
+)
+
+// KshrkWriter writes gathered cluster state as a .kshrk archive
+// (github.com/phenixblue/k8shark's portable capture format, via pkg/kshrk)
+// instead of a filesystem tree — used for whole-cluster export rather than
+// one namespace's inspection.
+//
+// Call order matters: WriteResources (the poll baseline) must be called
+// before WriteResourceHistory and WriteEvents, since it builds the
+// CRDNameResolver those calls consult for exact plural/singular/shortNames.
+// Finish must be called last, exactly once, after every Write* call, to seal
+// the archive — it is not part of the Writer interface since no other
+// implementation needs it; callers that construct a KshrkWriter call it
+// directly on the concrete type.
+type KshrkWriter struct {
+	aw          *kshrk.ArchiveWriter
+	clusterName string
+	windowStart time.Time
+	windowEnd   time.Time
+
+	resolver       *CRDNameResolver
+	discovered     map[groupVersion]map[string]CRDNames // group/version -> kind -> names
+	kubeletVersion string                               // best-effort, from the first captured Node
+
+	// pollWritten and watchKinds track which (group,version,resource,namespace)
+	// collections got a real poll-baseline record and which got at least one
+	// watch record, respectively — so Finish can register an empty
+	// poll-baseline placeholder for any collection watch-history touched but
+	// the poll-baseline query returned nothing for (e.g. an ephemeral mgmt
+	// cluster whose resource-watcher started after windowStart). Without an
+	// index.json entry, k8shark's AggregateAcrossNamespaces (the "-A" list
+	// path) can't discover the collection exists at all, even though
+	// ReconstructAt already handles a missing baseline correctly per-path.
+	pollWritten map[collectionKey]bool
+	watchKinds  map[collectionKey]string
+}
+
+type groupVersion struct {
+	group, version string
+}
+
+var _ Writer = (*KshrkWriter)(nil)
+
+// NewKshrkWriter creates a KshrkWriter that will write to outputPath.
+// clusterName is recorded into metadata.json's server_address.
+// windowStart/windowEnd are the user-requested export window: windowStart is
+// used as the poll-baseline records' captured_at and the archive's
+// metadata.json captured_at; windowEnd is captured_until and the timestamp
+// used for the events snapshot (events keep accruing count/lastSeen for the
+// whole window, unlike the resource-snapshot poll baseline).
+func NewKshrkWriter(outputPath, clusterName string, windowStart, windowEnd time.Time) (*KshrkWriter, error) {
+	aw, err := kshrk.NewArchiveWriter(outputPath)
+	if err != nil {
+		return nil, err
+	}
+	return &KshrkWriter{
+		aw:          aw,
+		clusterName: clusterName,
+		windowStart: windowStart,
+		windowEnd:   windowEnd,
+		resolver:    NewCRDNameResolver(nil),
+		discovered:  make(map[groupVersion]map[string]CRDNames),
+		pollWritten: make(map[collectionKey]bool),
+		watchKinds:  make(map[collectionKey]string),
+	}, nil
+}
+
+// NamespaceOutputPath is a no-op for KshrkWriter — an archive has no
+// per-namespace filesystem location to report.
+func (w *KshrkWriter) NamespaceOutputPath(_ string) string {
+	return ""
+}
+
+// WriteContainerLog is a no-op: .kshrk has no log concept.
+func (w *KshrkWriter) WriteContainerLog(_ context.Context, _, _, _ string, _ []LogLine) error {
+	return nil
+}
+
+// WriteResources writes resources as poll-baseline List records, one per
+// (group, version, resource, namespace) collection actually present in
+// resources. It also (re)builds the CRDNameResolver later Write* calls and
+// Finish consult, from any captured CustomResourceDefinition objects here.
+func (w *KshrkWriter) WriteResources(_ context.Context, _ string, resources []Resource) error {
+	w.resolver = NewCRDNameResolver(resources)
+
+	for _, res := range resources {
+		if res.Kind == "Node" && w.kubeletVersion == "" {
+			w.kubeletVersion = nodeKubeletVersion(res.Object)
+		}
+	}
+
+	groups := make(map[collectionKey][]Resource)
+	for _, res := range resources {
+		group, version := splitAPIVersion(res.APIVersion)
+		plural := w.resolver.Plural(group, res.Kind)
+		key := collectionKey{group: group, version: version, plural: plural, namespace: res.Namespace}
+		groups[key] = append(groups[key], res)
+		w.recordDiscovery(group, version, res.Kind, res.Namespace != "")
+	}
+
+	var errs []error
+	for key, group := range groups {
+		apiPath := apiPathFor(key.group, key.version, key.plural, key.namespace)
+		items := make([]any, 0, len(group))
+		for _, res := range group {
+			items = append(items, res.Object)
+		}
+		body := map[string]any{
+			"apiVersion": groupVersionString(key.group, key.version),
+			"kind":       group[0].Kind + "List",
+			"metadata":   map[string]any{},
+			"items":      items,
+		}
+		if err := w.aw.WritePollRecord(apiPath, w.windowStart, body, len(items)); err != nil {
+			errs = append(errs, fmt.Errorf("writing poll record for %s: %w", apiPath, err))
+		}
+		w.pollWritten[key] = true
+	}
+	return joinErrors(errs)
+}
+
+// collectionKey identifies one archive api_path: everything sharing a
+// (group, version, resource, namespace) collapses into one List/watch-index
+// entry, matching k8shark's per-namespace capture shape.
+type collectionKey struct {
+	group, version, plural, namespace string
+}
+
+// WriteResourceHistory writes the raw Add/Update/Delete changelog as
+// watch-index records, one per event, in the order given — the caller is
+// expected to pass events ordered by timestamp ascending, matching the
+// underlying Kusto query's own ORDER BY.
+func (w *KshrkWriter) WriteResourceHistory(_ context.Context, events []ResourceEvent) error {
+	var errs []error
+	for _, ev := range events {
+		eventType, err := watchEventType(ev.Event)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s/%s (%s): %w", ev.Resource.Namespace, ev.Resource.Name, ev.Resource.Kind, err))
+			continue
+		}
+		group, version := splitAPIVersion(ev.Resource.APIVersion)
+		plural := w.resolver.Plural(group, ev.Resource.Kind)
+		w.recordDiscovery(group, version, ev.Resource.Kind, ev.Resource.Namespace != "")
+		key := collectionKey{group: group, version: version, plural: plural, namespace: ev.Resource.Namespace}
+		w.watchKinds[key] = ev.Resource.Kind
+		apiPath := apiPathFor(group, version, plural, ev.Resource.Namespace)
+		if err := w.aw.WriteWatchRecord(apiPath, eventType, ev.Timestamp, ev.Resource.Object); err != nil {
+			errs = append(errs, fmt.Errorf("writing watch record for %s: %w", apiPath, err))
+		}
+	}
+	return joinErrors(errs)
+}
+
+// WriteEvents synthesizes a core/v1 Event object per row — the Kusto
+// kubernetesEvents table stores a distilled view (reason/message/count/
+// firstSeen/lastSeen), not a raw Event object — and writes one poll-baseline
+// List per namespace, captured as of windowEnd.
+func (w *KshrkWriter) WriteEvents(_ context.Context, _ string, events []map[string]any) error {
+	byNamespace := make(map[string][]any)
+	for _, row := range events {
+		namespace := asString(row["eventNamespace"])
+		if namespace == "" {
+			// Real clusters record cluster-scoped-object events (e.g. for a
+			// Node) under "default" — Event objects are always namespaced.
+			namespace = "default"
+		}
+		byNamespace[namespace] = append(byNamespace[namespace], synthesizeEvent(row, namespace))
+	}
+	w.recordDiscovery("", "v1", "Event", true)
+
+	var errs []error
+	for namespace, items := range byNamespace {
+		apiPath := apiPathFor("", "v1", "events", namespace)
+		body := map[string]any{
+			"apiVersion": "v1",
+			"kind":       "EventList",
+			"metadata":   map[string]any{},
+			"items":      items,
+		}
+		if err := w.aw.WritePollRecord(apiPath, w.windowEnd, body, len(items)); err != nil {
+			errs = append(errs, fmt.Errorf("writing events record for namespace %q: %w", namespace, err))
+		}
+	}
+	return joinErrors(errs)
+}
+
+// Finish writes minimal discovery records (one /api/v1 and one
+// /apis/<group>/<version> APIResourceList per group-version actually
+// present) and metadata.json, then seals the archive. Must be called
+// exactly once, after every Write* call. On error the partially-written
+// archive is removed.
+func (w *KshrkWriter) Finish() error {
+	if err := w.writeEmptyBaselinePlaceholders(); err != nil {
+		_ = w.aw.Abort()
+		return err
+	}
+
+	if err := w.writeDiscovery(); err != nil {
+		_ = w.aw.Abort()
+		return err
+	}
+
+	kubernetesVersion := w.kubeletVersion
+	if kubernetesVersion == "" {
+		kubernetesVersion = "unknown"
+	}
+	meta := kshrk.CaptureMetadata{
+		CaptureID:         uuid.NewString(),
+		CapturedAt:        w.windowStart,
+		CapturedUntil:     w.windowEnd,
+		KubernetesVersion: kubernetesVersion,
+		ServerAddress:     "kusto-reconstructed://" + w.clusterName,
+	}
+	if err := w.aw.Finish(meta); err != nil {
+		_ = w.aw.Abort()
+		return fmt.Errorf("sealing archive: %w", err)
+	}
+	return nil
+}
+
+// writeEmptyBaselinePlaceholders registers an empty poll-baseline record (at
+// windowStart, zero items) for every collection watch-history touched but the
+// poll-baseline query returned nothing for. ReconstructAt already reconstructs
+// state correctly for a path with no poll record at all (it synthesizes an
+// empty baseline internally and replays every watch event on top — the exact
+// mechanism this placeholder also produces), so this changes nothing about
+// what any point-in-time query returns; it only makes the collection
+// discoverable to k8shark's cross-namespace "-A" aggregation, which enumerates
+// candidate paths from index.json alone.
+func (w *KshrkWriter) writeEmptyBaselinePlaceholders() error {
+	var errs []error
+	for key, kind := range w.watchKinds {
+		if w.pollWritten[key] {
+			continue
+		}
+		apiPath := apiPathFor(key.group, key.version, key.plural, key.namespace)
+		body := map[string]any{
+			"apiVersion": groupVersionString(key.group, key.version),
+			"kind":       kind + "List",
+			"metadata":   map[string]any{},
+			"items":      []any{},
+		}
+		if err := w.aw.WritePollRecord(apiPath, w.windowStart, body, 0); err != nil {
+			errs = append(errs, fmt.Errorf("writing empty baseline placeholder for %s: %w", apiPath, err))
+			continue
+		}
+		w.pollWritten[key] = true
+	}
+	return joinErrors(errs)
+}
+
+// recordDiscovery notes that kind (in group/version) was seen, keeping the
+// first name resolution found for it (a captured CustomResourceDefinition
+// when available via CRDNameResolver, otherwise the heuristic plural with
+// namespaced reflecting the actual resource instance this call came from).
+func (w *KshrkWriter) recordDiscovery(group, version, kind string, namespaced bool) {
+	gv := groupVersion{group: group, version: version}
+	if w.discovered[gv] == nil {
+		w.discovered[gv] = make(map[string]CRDNames)
+	}
+	if _, ok := w.discovered[gv][kind]; ok {
+		return
+	}
+	names, ok := w.resolver.Resolve(group, kind)
+	if !ok {
+		plural := w.resolver.Plural(group, kind)
+		names = CRDNames{
+			Plural:     plural,
+			Singular:   strings.ToLower(kind),
+			ShortNames: builtinShortNames[plural],
+			Namespaced: namespaced,
+		}
+	}
+	w.discovered[gv][kind] = names
+}
+
+func (w *KshrkWriter) writeDiscovery() error {
+	var errs []error
+	for gv, kinds := range w.discovered {
+		resourceEntries := make([]any, 0, len(kinds))
+		for kind, names := range kinds {
+			entry := map[string]any{
+				"name":       names.Plural,
+				"namespaced": names.Namespaced,
+				"kind":       kind,
+				"verbs":      []string{"get", "list", "watch"},
+			}
+			if names.Singular != "" {
+				entry["singularName"] = names.Singular
+			}
+			if len(names.ShortNames) > 0 {
+				entry["shortNames"] = names.ShortNames
+			}
+			resourceEntries = append(resourceEntries, entry)
+		}
+		body := map[string]any{
+			"kind":         "APIResourceList",
+			"apiVersion":   "v1",
+			"groupVersion": groupVersionString(gv.group, gv.version),
+			"resources":    resourceEntries,
+		}
+		var apiPath string
+		if gv.group == "" {
+			apiPath = "/api/" + gv.version
+		} else {
+			apiPath = "/apis/" + gv.group + "/" + gv.version
+		}
+		if err := w.aw.WritePollRecord(apiPath, w.windowStart, body, len(resourceEntries)); err != nil {
+			errs = append(errs, fmt.Errorf("writing discovery record for %s: %w", apiPath, err))
+		}
+	}
+	return joinErrors(errs)
+}
+
+// splitAPIVersion splits an apiVersion string into its group and version
+// ("hypershift.openshift.io/v1beta1" -> "hypershift.openshift.io",
+// "v1beta1"; "v1" -> "", "v1").
+func splitAPIVersion(apiVersion string) (group, version string) {
+	if g, v, ok := strings.Cut(apiVersion, "/"); ok {
+		return g, v
+	}
+	return "", apiVersion
+}
+
+// apiPathFor builds the REST collection path a group/version/plural/namespace
+// would be listed at ("" namespace omits the /namespaces/<ns> segment, for
+// cluster-scoped resources).
+func apiPathFor(group, version, plural, namespace string) string {
+	var base string
+	if group == "" {
+		base = "/api/" + version
+	} else {
+		base = "/apis/" + group + "/" + version
+	}
+	if namespace != "" {
+		base += "/namespaces/" + namespace
+	}
+	return base + "/" + plural
+}
+
+// groupVersionString renders a group/version pair the way apiVersion/
+// groupVersion fields expect ("" group -> just the version).
+func groupVersionString(group, version string) string {
+	if group == "" {
+		return version
+	}
+	return group + "/" + version
+}
+
+// watchEventType maps a kubernetesResourceSnapshots.event value to the
+// watch-index event_type k8shark expects.
+func watchEventType(event string) (string, error) {
+	switch event {
+	case "Add":
+		return "ADDED", nil
+	case "Update":
+		return "MODIFIED", nil
+	case "Delete":
+		return "DELETED", nil
+	default:
+		return "", fmt.Errorf("unrecognized resource-snapshot event %q", event)
+	}
+}
+
+// nodeKubeletVersion extracts status.nodeInfo.kubeletVersion from a captured
+// Node object, for a best-effort metadata.json kubernetes_version.
+func nodeKubeletVersion(object map[string]any) string {
+	status, _ := object["status"].(map[string]any)
+	if status == nil {
+		return ""
+	}
+	nodeInfo, _ := status["nodeInfo"].(map[string]any)
+	if nodeInfo == nil {
+		return ""
+	}
+	version, _ := nodeInfo["kubeletVersion"].(string)
+	return version
+}
+
+// synthesizeEvent builds a minimal, valid core/v1 Event object from one
+// summarized kubernetesEvents row (see events.kql.gotmpl's projection).
+func synthesizeEvent(row map[string]any, namespace string) map[string]any {
+	return map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Event",
+		"metadata": map[string]any{
+			"name":      uuid.NewString(),
+			"namespace": namespace,
+		},
+		"involvedObject": map[string]any{
+			"apiVersion": asString(row["objectApiVersion"]),
+			"kind":       asString(row["objectKind"]),
+			"name":       asString(row["objectName"]),
+			"namespace":  namespace,
+		},
+		"reason":         asString(row["reason"]),
+		"message":        asString(row["message"]),
+		"type":           asString(row["kubeEventType"]),
+		"source":         map[string]any{"component": asString(row["sourceComponent"])},
+		"firstTimestamp": asString(row["firstSeen"]),
+		"lastTimestamp":  asString(row["lastSeen"]),
+		"count":          asInt(row["count"]),
+	}
+}
+
+// asInt best-effort parses a Kusto row value (rendered as a string by
+// rowToMap) into an int, defaulting to 0 when empty or unparseable.
+func asInt(v any) int {
+	s := asString(v)
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/tooling/hcpctl/pkg/ocadminspect/kshrk_writer_test.go
+++ b/tooling/hcpctl/pkg/ocadminspect/kshrk_writer_test.go
@@ -1,0 +1,462 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocadminspect
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/klauspost/compress/zstd"
+
+	"github.com/Azure/ARO-HCP/tooling/hcpctl/pkg/kshrk"
+)
+
+func TestSplitAPIVersion(t *testing.T) {
+	tests := map[string][2]string{
+		"v1":                              {"", "v1"},
+		"apps/v1":                         {"apps", "v1"},
+		"hypershift.openshift.io/v1beta1": {"hypershift.openshift.io", "v1beta1"},
+		"":                                {"", ""},
+	}
+	for apiVersion, want := range tests {
+		group, version := splitAPIVersion(apiVersion)
+		if group != want[0] || version != want[1] {
+			t.Errorf("splitAPIVersion(%q) = (%q, %q), want (%q, %q)", apiVersion, group, version, want[0], want[1])
+		}
+	}
+}
+
+func TestAPIPathFor(t *testing.T) {
+	tests := []struct {
+		group, version, plural, namespace string
+		want                              string
+	}{
+		{"", "v1", "nodes", "", "/api/v1/nodes"},
+		{"", "v1", "pods", "default", "/api/v1/namespaces/default/pods"},
+		{"hypershift.openshift.io", "v1beta1", "nodepools", "ns1", "/apis/hypershift.openshift.io/v1beta1/namespaces/ns1/nodepools"},
+		{"apiextensions.k8s.io", "v1", "customresourcedefinitions", "", "/apis/apiextensions.k8s.io/v1/customresourcedefinitions"},
+	}
+	for _, tt := range tests {
+		if got := apiPathFor(tt.group, tt.version, tt.plural, tt.namespace); got != tt.want {
+			t.Errorf("apiPathFor(%q,%q,%q,%q) = %q, want %q", tt.group, tt.version, tt.plural, tt.namespace, got, tt.want)
+		}
+	}
+}
+
+func TestWatchEventType(t *testing.T) {
+	tests := map[string]string{"Add": "ADDED", "Update": "MODIFIED", "Delete": "DELETED"}
+	for event, want := range tests {
+		got, err := watchEventType(event)
+		if err != nil {
+			t.Errorf("watchEventType(%q) unexpected error: %v", event, err)
+		}
+		if got != want {
+			t.Errorf("watchEventType(%q) = %q, want %q", event, got, want)
+		}
+	}
+	if _, err := watchEventType("Bogus"); err == nil {
+		t.Error("watchEventType(\"Bogus\") expected an error, got nil")
+	}
+}
+
+// readKshrkEntry reads and zstd-decompresses (unless raw) a single entry from
+// a .kshrk archive, exactly as a third-party reader following
+// docs/archive-format.md would.
+func readKshrkEntry(t *testing.T, archivePath, name string, raw bool) []byte {
+	t.Helper()
+	zr, err := zip.OpenReader(archivePath)
+	if err != nil {
+		t.Fatalf("opening archive: %v", err)
+	}
+	defer zr.Close()
+	for _, f := range zr.File {
+		if f.Name != name {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("opening entry %s: %v", name, err)
+		}
+		defer rc.Close()
+		data, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("reading entry %s: %v", name, err)
+		}
+		if raw {
+			return data
+		}
+		dec, err := zstd.NewReader(nil)
+		if err != nil {
+			t.Fatalf("creating zstd decoder: %v", err)
+		}
+		defer dec.Close()
+		decompressed, err := dec.DecodeAll(data, nil)
+		if err != nil {
+			t.Fatalf("decompressing entry %s: %v", name, err)
+		}
+		return decompressed
+	}
+	t.Fatalf("entry %s not found in archive", name)
+	return nil
+}
+
+func kshrkPathDir(apiPath string) string {
+	sum := sha256.Sum256([]byte(apiPath))
+	return fmt.Sprintf("%x", sum[:8])
+}
+
+// TestKshrkWriter_EmptyBaselinePlaceholder_ForWatchOnlyCollection covers the
+// case oc-adm-inspect hits against a freshly-booted (or otherwise
+// baseline-empty) mgmt cluster: a collection with real watch history but zero
+// poll-baseline rows. Finish should register an empty poll placeholder so
+// k8shark's cross-namespace "-A" aggregation (which enumerates candidates
+// from index.json only) can discover the collection at all.
+func TestKshrkWriter_EmptyBaselinePlaceholder_ForWatchOnlyCollection(t *testing.T) {
+	ctx := context.Background()
+	archivePath := filepath.Join(t.TempDir(), "capture.kshrk")
+	windowStart := time.Date(2026, 9, 5, 6, 20, 0, 0, time.UTC)
+	windowEnd := windowStart.Add(time.Hour)
+
+	w, err := NewKshrkWriter(archivePath, "ci01-mgmt-1", windowStart, windowEnd)
+	if err != nil {
+		t.Fatalf("NewKshrkWriter: %v", err)
+	}
+
+	// No Pod in the poll baseline at all (e.g. no row within the lookback —
+	// the cluster only booted around windowStart).
+	if err := w.WriteResources(ctx, "", nil); err != nil {
+		t.Fatalf("WriteResources: %v", err)
+	}
+
+	history := []ResourceEvent{
+		{
+			Timestamp: windowStart.Add(time.Minute),
+			Event:     "Add",
+			Resource: Resource{
+				APIVersion: "v1",
+				Kind:       "Pod",
+				Namespace:  "arobit",
+				Name:       "arobit-forwarder-abcde",
+				Object:     map[string]any{"metadata": map[string]any{"name": "arobit-forwarder-abcde", "namespace": "arobit"}},
+			},
+		},
+	}
+	if err := w.WriteResourceHistory(ctx, history); err != nil {
+		t.Fatalf("WriteResourceHistory: %v", err)
+	}
+	if err := w.Finish(); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	podPath := "/api/v1/namespaces/arobit/pods"
+
+	var index struct {
+		Entries map[string]struct {
+			Seqs   []int `json:"seqs"`
+			Counts []int `json:"counts"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(readKshrkEntry(t, archivePath, "k8shark-capture/index.json.zst", false), &index); err != nil {
+		t.Fatalf("unmarshaling index.json.zst: %v", err)
+	}
+	entry, ok := index.Entries[podPath]
+	if !ok {
+		t.Fatalf("index.json.zst missing placeholder entry for %s — \"-A\" aggregation would never discover this collection", podPath)
+	}
+	if len(entry.Counts) != 1 || entry.Counts[0] != 0 {
+		t.Errorf("placeholder entry Counts = %v, want [0]", entry.Counts)
+	}
+
+	// The placeholder record itself is an empty, well-formed PodList.
+	dir := kshrkPathDir(podPath)
+	var rec kshrk.Record
+	if err := json.Unmarshal(readKshrkEntry(t, archivePath, "k8shark-capture/records/"+dir+"/"+fmt.Sprint(entry.Seqs[0])+".json.zst", false), &rec); err != nil {
+		t.Fatalf("unmarshaling placeholder record: %v", err)
+	}
+	var list struct {
+		Kind  string           `json:"kind"`
+		Items []map[string]any `json:"items"`
+	}
+	bodyBytes, err := json.Marshal(rec.ResponseBody)
+	if err != nil {
+		t.Fatalf("marshaling response_body: %v", err)
+	}
+	if err := json.Unmarshal(bodyBytes, &list); err != nil {
+		t.Fatalf("unmarshaling PodList: %v", err)
+	}
+	if list.Kind != "PodList" {
+		t.Errorf("placeholder Kind = %q, want PodList", list.Kind)
+	}
+	if len(list.Items) != 0 {
+		t.Errorf("placeholder Items = %v, want empty", list.Items)
+	}
+
+	// Sanity: the real watch record is still there too.
+	var watchIndex struct {
+		Entries map[string]struct {
+			EventTypes []string `json:"event_types"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(readKshrkEntry(t, archivePath, "k8shark-capture/watch-index.json.zst", false), &watchIndex); err != nil {
+		t.Fatalf("unmarshaling watch-index.json.zst: %v", err)
+	}
+	if _, ok := watchIndex.Entries[podPath]; !ok {
+		t.Fatalf("watch-index.json.zst missing entry for %s", podPath)
+	}
+}
+
+func TestKshrkWriter_WholeClusterExport(t *testing.T) {
+	ctx := context.Background()
+	archivePath := filepath.Join(t.TempDir(), "capture.kshrk")
+	windowStart := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	windowEnd := windowStart.Add(time.Hour)
+
+	w, err := NewKshrkWriter(archivePath, "mgmt-1", windowStart, windowEnd)
+	if err != nil {
+		t.Fatalf("NewKshrkWriter: %v", err)
+	}
+
+	node := Resource{
+		APIVersion: "v1",
+		Kind:       "Node",
+		Namespace:  "",
+		Name:       "node-1",
+		Object: map[string]any{
+			"metadata": map[string]any{"name": "node-1"},
+			"status": map[string]any{
+				"nodeInfo": map[string]any{"kubeletVersion": "v1.30.2"},
+			},
+		},
+	}
+	nodePoolCRD := crdResource("hypershift.openshift.io", "NodePool", "nodepools", "nodepool", []string{"np"}, true)
+	nodePool := Resource{
+		APIVersion: "hypershift.openshift.io/v1beta1",
+		Kind:       "NodePool",
+		Namespace:  "ocm-hcp-abc123",
+		Name:       "workers",
+		Object:     map[string]any{"metadata": map[string]any{"name": "workers"}},
+	}
+
+	if err := w.WriteResources(ctx, "", []Resource{node, nodePoolCRD, nodePool}); err != nil {
+		t.Fatalf("WriteResources: %v", err)
+	}
+
+	history := []ResourceEvent{
+		{
+			Timestamp: windowStart.Add(5 * time.Minute),
+			Event:     "Update",
+			Resource: Resource{
+				APIVersion: "hypershift.openshift.io/v1beta1",
+				Kind:       "NodePool",
+				Namespace:  "ocm-hcp-abc123",
+				Name:       "workers",
+				Object:     map[string]any{"metadata": map[string]any{"name": "workers"}, "spec": map[string]any{"replicas": 3}},
+			},
+		},
+	}
+	if err := w.WriteResourceHistory(ctx, history); err != nil {
+		t.Fatalf("WriteResourceHistory: %v", err)
+	}
+
+	events := []map[string]any{
+		{
+			"eventNamespace":   "ocm-hcp-abc123",
+			"reason":           "ScalingReplicaSet",
+			"message":          "Scaled up replica set",
+			"objectKind":       "NodePool",
+			"objectApiVersion": "hypershift.openshift.io/v1beta1",
+			"objectName":       "workers",
+			"kubeEventType":    "Normal",
+			"sourceComponent":  "hypershift-operator",
+			"firstSeen":        "2026-09-05T10:05:00Z",
+			"lastSeen":         "2026-09-05T10:05:00Z",
+			"count":            "1",
+		},
+		{
+			// No eventNamespace: a cluster-scoped involved object (e.g. Node).
+			"eventNamespace":   "",
+			"reason":           "NodeReady",
+			"objectKind":       "Node",
+			"objectApiVersion": "v1",
+			"objectName":       "node-1",
+			"kubeEventType":    "Normal",
+			"count":            "1",
+		},
+	}
+	if err := w.WriteEvents(ctx, "", events); err != nil {
+		t.Fatalf("WriteEvents: %v", err)
+	}
+
+	if err := w.Finish(); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// metadata.json: kubernetes_version resolved from the captured Node.
+	var meta struct {
+		KubernetesVersion string `json:"kubernetes_version"`
+		ServerAddress     string `json:"server_address"`
+	}
+	if err := json.Unmarshal(readKshrkEntry(t, archivePath, "k8shark-capture/metadata.json", true), &meta); err != nil {
+		t.Fatalf("unmarshaling metadata.json: %v", err)
+	}
+	if meta.KubernetesVersion != "v1.30.2" {
+		t.Errorf("metadata.json kubernetes_version = %q, want %q", meta.KubernetesVersion, "v1.30.2")
+	}
+	if meta.ServerAddress != "kusto-reconstructed://mgmt-1" {
+		t.Errorf("metadata.json server_address = %q, want %q", meta.ServerAddress, "kusto-reconstructed://mgmt-1")
+	}
+
+	// index.json.zst: the cluster-scoped Node list and the namespaced NodePool
+	// list both got poll records, at distinct api_paths.
+	var index struct {
+		Entries map[string]struct {
+			Seqs []int `json:"seqs"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(readKshrkEntry(t, archivePath, "k8shark-capture/index.json.zst", false), &index); err != nil {
+		t.Fatalf("unmarshaling index.json.zst: %v", err)
+	}
+	for _, path := range []string{
+		"/api/v1/nodes",
+		"/apis/hypershift.openshift.io/v1beta1/namespaces/ocm-hcp-abc123/nodepools",
+		"/apis/apiextensions.k8s.io/v1/customresourcedefinitions",
+		"/api/v1/namespaces/ocm-hcp-abc123/events",
+		"/api/v1/namespaces/default/events",     // the cluster-scoped-object event falls back to "default"
+		"/apis/hypershift.openshift.io/v1beta1", // discovery record
+		"/api/v1",                               // discovery record
+	} {
+		if _, ok := index.Entries[path]; !ok {
+			t.Errorf("index.json.zst missing expected api_path %q", path)
+		}
+	}
+
+	// watch-index.json.zst: the one history event, MODIFIED, under the
+	// NodePool's namespaced path.
+	var watchIndex struct {
+		Entries map[string]struct {
+			EventTypes []string `json:"event_types"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(readKshrkEntry(t, archivePath, "k8shark-capture/watch-index.json.zst", false), &watchIndex); err != nil {
+		t.Fatalf("unmarshaling watch-index.json.zst: %v", err)
+	}
+	nodePoolPath := "/apis/hypershift.openshift.io/v1beta1/namespaces/ocm-hcp-abc123/nodepools"
+	entry, ok := watchIndex.Entries[nodePoolPath]
+	if !ok {
+		t.Fatalf("watch-index.json.zst missing entry for %s", nodePoolPath)
+	}
+	if len(entry.EventTypes) != 1 || entry.EventTypes[0] != "MODIFIED" {
+		t.Errorf("watch-index EventTypes = %v, want [MODIFIED]", entry.EventTypes)
+	}
+
+	// Discovery: the NodePool CRD's exact name/shortNames won, not the
+	// heuristic (which would also happen to guess "nodepools" here, but the
+	// singular/shortNames only come from the captured CRD).
+	dir := kshrkPathDir("/apis/hypershift.openshift.io/v1beta1")
+	var discoveryList struct {
+		Resources []struct {
+			Name         string   `json:"name"`
+			SingularName string   `json:"singularName"`
+			ShortNames   []string `json:"shortNames"`
+			Namespaced   bool     `json:"namespaced"`
+		} `json:"resources"`
+	}
+	var rec kshrk.Record
+	if err := json.Unmarshal(readKshrkEntry(t, archivePath, "k8shark-capture/records/"+dir+"/0.json.zst", false), &rec); err != nil {
+		t.Fatalf("unmarshaling discovery record: %v", err)
+	}
+	bodyBytes, err := json.Marshal(rec.ResponseBody)
+	if err != nil {
+		t.Fatalf("marshaling response_body: %v", err)
+	}
+	if err := json.Unmarshal(bodyBytes, &discoveryList); err != nil {
+		t.Fatalf("unmarshaling APIResourceList: %v", err)
+	}
+	if len(discoveryList.Resources) != 1 {
+		t.Fatalf("discovery list has %d resources, want 1", len(discoveryList.Resources))
+	}
+	got := discoveryList.Resources[0]
+	if got.Name != "nodepools" || got.SingularName != "nodepool" || !got.Namespaced {
+		t.Errorf("discovery entry = %+v, want name=nodepools singular=nodepool namespaced=true", got)
+	}
+	if len(got.ShortNames) != 1 || got.ShortNames[0] != "np" {
+		t.Errorf("discovery entry ShortNames = %v, want [np]", got.ShortNames)
+	}
+}
+
+// TestKshrkWriter_Discovery_BuiltinShortNames covers "kubectl get ns" (short
+// name) working, not just "kubectl get namespaces" (exact plural). Built-in
+// Kinds have no CustomResourceDefinition, so CRDNameResolver can never supply
+// ShortNames for them — and because we capture our own /api/v1 discovery
+// record, k8shark serves it verbatim instead of falling back to its own
+// built-in short-name table, so this tool must supply ShortNames itself.
+func TestKshrkWriter_Discovery_BuiltinShortNames(t *testing.T) {
+	ctx := context.Background()
+	archivePath := filepath.Join(t.TempDir(), "capture.kshrk")
+	windowStart := time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC)
+	windowEnd := windowStart.Add(time.Hour)
+
+	w, err := NewKshrkWriter(archivePath, "mgmt-1", windowStart, windowEnd)
+	if err != nil {
+		t.Fatalf("NewKshrkWriter: %v", err)
+	}
+
+	namespace := Resource{
+		APIVersion: "v1",
+		Kind:       "Namespace",
+		Namespace:  "",
+		Name:       "arobit",
+		Object:     map[string]any{"metadata": map[string]any{"name": "arobit"}},
+	}
+	if err := w.WriteResources(ctx, "", []Resource{namespace}); err != nil {
+		t.Fatalf("WriteResources: %v", err)
+	}
+	if err := w.Finish(); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	dir := kshrkPathDir("/api/v1")
+	var rec kshrk.Record
+	if err := json.Unmarshal(readKshrkEntry(t, archivePath, "k8shark-capture/records/"+dir+"/0.json.zst", false), &rec); err != nil {
+		t.Fatalf("unmarshaling discovery record: %v", err)
+	}
+	bodyBytes, err := json.Marshal(rec.ResponseBody)
+	if err != nil {
+		t.Fatalf("marshaling response_body: %v", err)
+	}
+	var discoveryList struct {
+		Resources []struct {
+			Name       string   `json:"name"`
+			ShortNames []string `json:"shortNames"`
+		} `json:"resources"`
+	}
+	if err := json.Unmarshal(bodyBytes, &discoveryList); err != nil {
+		t.Fatalf("unmarshaling APIResourceList: %v", err)
+	}
+	if len(discoveryList.Resources) != 1 || discoveryList.Resources[0].Name != "namespaces" {
+		t.Fatalf("discovery resources = %+v, want exactly one entry named namespaces", discoveryList.Resources)
+	}
+	shortNames := discoveryList.Resources[0].ShortNames
+	if len(shortNames) != 1 || shortNames[0] != "ns" {
+		t.Errorf("namespaces ShortNames = %v, want [ns] (this is what makes \"kubectl get ns\" resolve)", shortNames)
+	}
+}

--- a/tooling/hcpctl/pkg/ocadminspect/plural.go
+++ b/tooling/hcpctl/pkg/ocadminspect/plural.go
@@ -1,0 +1,174 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocadminspect
+
+import "strings"
+
+// irregularResourcePlurals maps a lowercased Kind to its resource (plural)
+// name where the naive rules below would be wrong. Real discovery derives
+// this exactly; snapshot telemetry only carries the Kind for built-in types,
+// so this approximates it.
+var irregularResourcePlurals = map[string]string{
+	"endpoints": "endpoints", // already plural
+}
+
+// ResourcePlural approximates the plural resource name for a Kind (e.g. "Pod"
+// -> "pods", "NetworkPolicy" -> "networkpolicies", "Ingress" -> "ingresses").
+// It is an approximation of the discovery-derived resource name a real API
+// server uses — good enough for file/path naming when no exact name is known.
+// See CRDNameResolver for the exact alternative when a CustomResourceDefinition
+// was captured.
+func ResourcePlural(kind string) string {
+	lower := strings.ToLower(kind)
+	if lower == "" {
+		return ""
+	}
+	if plural, ok := irregularResourcePlurals[lower]; ok {
+		return plural
+	}
+	switch {
+	case strings.HasSuffix(lower, "s"), strings.HasSuffix(lower, "x"),
+		strings.HasSuffix(lower, "ch"), strings.HasSuffix(lower, "sh"):
+		return lower + "es"
+	case strings.HasSuffix(lower, "y") && len(lower) > 1 && !isVowel(lower[len(lower)-2]):
+		return lower[:len(lower)-1] + "ies"
+	default:
+		return lower + "s"
+	}
+}
+
+// builtinShortNames maps a plural resource name to its well-known kubectl
+// short alias, for the built-in Kinds this tool ever captures. There is no
+// CustomResourceDefinition for a built-in type, so CRDNameResolver can never
+// supply ShortNames for one — and unlike a real API server, k8shark serves a
+// captured discovery record verbatim rather than falling back to its own
+// built-in short-name table once we've captured one ourselves, so omitting
+// these here means "kubectl get ns"/"po"/... simply don't resolve.
+var builtinShortNames = map[string][]string{
+	"pods":         {"po"},
+	"nodes":        {"no"},
+	"namespaces":   {"ns"},
+	"events":       {"ev"},
+	"deployments":  {"deploy"},
+	"daemonsets":   {"ds"},
+	"replicasets":  {"rs"},
+	"statefulsets": {"sts"},
+}
+
+func isVowel(b byte) bool {
+	switch b {
+	case 'a', 'e', 'i', 'o', 'u':
+		return true
+	}
+	return false
+}
+
+// CRDNames holds the exact naming/scope facts a CustomResourceDefinition
+// declares for one Kind.
+type CRDNames struct {
+	Plural     string
+	Singular   string
+	ShortNames []string
+	Namespaced bool
+}
+
+type groupKind struct {
+	group string
+	kind  string
+}
+
+// CRDNameResolver resolves a group/Kind's exact plural/singular/shortNames/
+// scope from captured CustomResourceDefinition objects (sourced from
+// mgmt-agent's resource watcher, see resourcewatcher.go), falling back to the
+// ResourcePlural heuristic when no matching CRD was captured in the query
+// window — an archive predating the mgmt-agent CRD-logging change, or a
+// quiescent CRD with no row in the lookback window.
+type CRDNameResolver struct {
+	byGroupKind map[groupKind]CRDNames
+}
+
+// NewCRDNameResolver builds a resolver from any captured
+// CustomResourceDefinition resources found in resources. Non-CRD resources
+// and CRDs with malformed/missing spec fields are skipped.
+func NewCRDNameResolver(resources []Resource) *CRDNameResolver {
+	r := &CRDNameResolver{byGroupKind: make(map[groupKind]CRDNames)}
+	for _, res := range resources {
+		if res.Kind != "CustomResourceDefinition" {
+			continue
+		}
+		group, kind, names, ok := parseCRDSpec(res.Object)
+		if !ok {
+			continue
+		}
+		r.byGroupKind[groupKind{group: group, kind: kind}] = names
+	}
+	return r
+}
+
+// Resolve returns the exact CRDNames captured for group/kind, or false if no
+// matching CustomResourceDefinition was captured.
+func (r *CRDNameResolver) Resolve(group, kind string) (CRDNames, bool) {
+	if r == nil {
+		return CRDNames{}, false
+	}
+	names, ok := r.byGroupKind[groupKind{group: group, kind: kind}]
+	return names, ok
+}
+
+// Plural returns the exact plural from a captured CustomResourceDefinition
+// when available, otherwise the ResourcePlural heuristic.
+func (r *CRDNameResolver) Plural(group, kind string) string {
+	if names, ok := r.Resolve(group, kind); ok && names.Plural != "" {
+		return names.Plural
+	}
+	return ResourcePlural(kind)
+}
+
+// parseCRDSpec extracts the group/kind/names/scope facts from a captured
+// CustomResourceDefinition object. Best-effort: any missing/malformed field
+// causes ok=false rather than a partially-populated, possibly-misleading
+// result.
+func parseCRDSpec(object map[string]any) (group, kind string, names CRDNames, ok bool) {
+	spec, _ := object["spec"].(map[string]any)
+	if spec == nil {
+		return "", "", CRDNames{}, false
+	}
+	group, _ = spec["group"].(string)
+	namesSpec, _ := spec["names"].(map[string]any)
+	if group == "" || namesSpec == nil {
+		return "", "", CRDNames{}, false
+	}
+	kind, _ = namesSpec["kind"].(string)
+	plural, _ := namesSpec["plural"].(string)
+	if kind == "" || plural == "" {
+		return "", "", CRDNames{}, false
+	}
+	singular, _ := namesSpec["singular"].(string)
+	var shortNames []string
+	if raw, ok := namesSpec["shortNames"].([]any); ok {
+		for _, v := range raw {
+			if s, ok := v.(string); ok {
+				shortNames = append(shortNames, s)
+			}
+		}
+	}
+
+	return group, kind, CRDNames{
+		Plural:     plural,
+		Singular:   singular,
+		ShortNames: shortNames,
+		Namespaced: spec["scope"] == "Namespaced",
+	}, true
+}

--- a/tooling/hcpctl/pkg/ocadminspect/plural_test.go
+++ b/tooling/hcpctl/pkg/ocadminspect/plural_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocadminspect
+
+import "testing"
+
+func TestResourcePlural(t *testing.T) {
+	tests := map[string]string{
+		"Pod":           "pods",
+		"ConfigMap":     "configmaps",
+		"Service":       "services",
+		"Endpoints":     "endpoints",
+		"Ingress":       "ingresses",
+		"NetworkPolicy": "networkpolicies",
+		"Deployment":    "deployments",
+		"HostedCluster": "hostedclusters",
+		"EgressQoS":     "egressqoses",
+		"Namespace":     "namespaces",
+		"NodePool":      "nodepools",
+		"MachineSet":    "machinesets",
+	}
+	for kind, want := range tests {
+		if got := ResourcePlural(kind); got != want {
+			t.Errorf("ResourcePlural(%q) = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+func crdResource(group, kind, plural, singular string, shortNames []string, namespaced bool) Resource {
+	names := map[string]any{
+		"kind":     kind,
+		"plural":   plural,
+		"singular": singular,
+	}
+	if len(shortNames) > 0 {
+		sn := make([]any, len(shortNames))
+		for i, s := range shortNames {
+			sn[i] = s
+		}
+		names["shortNames"] = sn
+	}
+	scope := "Cluster"
+	if namespaced {
+		scope = "Namespaced"
+	}
+	return Resource{
+		APIVersion: "apiextensions.k8s.io/v1",
+		Kind:       "CustomResourceDefinition",
+		Name:       plural + "." + group,
+		Object: map[string]any{
+			"spec": map[string]any{
+				"group": group,
+				"names": names,
+				"scope": scope,
+			},
+		},
+	}
+}
+
+func TestCRDNameResolver_ResolvesFromCapturedCRD(t *testing.T) {
+	resources := []Resource{
+		crdResource("hypershift.openshift.io", "NodePool", "nodepools", "nodepool", []string{"np"}, true),
+		{Kind: "NodePool", Name: "worker-1"}, // a non-CRD resource, should be ignored
+	}
+	resolver := NewCRDNameResolver(resources)
+
+	names, ok := resolver.Resolve("hypershift.openshift.io", "NodePool")
+	if !ok {
+		t.Fatalf("Resolve() ok = false, want true")
+	}
+	if names.Plural != "nodepools" || names.Singular != "nodepool" || !names.Namespaced {
+		t.Errorf("Resolve() = %+v, want plural=nodepools singular=nodepool namespaced=true", names)
+	}
+	if len(names.ShortNames) != 1 || names.ShortNames[0] != "np" {
+		t.Errorf("Resolve().ShortNames = %v, want [np]", names.ShortNames)
+	}
+
+	if got := resolver.Plural("hypershift.openshift.io", "NodePool"); got != "nodepools" {
+		t.Errorf("Plural() = %q, want %q (from captured CRD, not the heuristic)", got, "nodepools")
+	}
+}
+
+func TestCRDNameResolver_FallsBackToHeuristicWhenNoCRDCaptured(t *testing.T) {
+	resolver := NewCRDNameResolver(nil)
+
+	if _, ok := resolver.Resolve("hypershift.openshift.io", "HostedCluster"); ok {
+		t.Fatalf("Resolve() ok = true with no captured CRDs, want false")
+	}
+	if got := resolver.Plural("hypershift.openshift.io", "HostedCluster"); got != "hostedclusters" {
+		t.Errorf("Plural() = %q, want heuristic result %q", got, "hostedclusters")
+	}
+}
+
+func TestCRDNameResolver_NilResolverFallsBackSafely(t *testing.T) {
+	var resolver *CRDNameResolver
+	if got := resolver.Plural("cluster.x-k8s.io", "MachineSet"); got != "machinesets" {
+		t.Errorf("Plural() on nil resolver = %q, want heuristic result %q", got, "machinesets")
+	}
+}
+
+func TestCRDNameResolver_SkipsMalformedCRD(t *testing.T) {
+	resources := []Resource{
+		{Kind: "CustomResourceDefinition", Name: "broken", Object: map[string]any{"spec": map[string]any{"group": "example.com"}}},
+	}
+	resolver := NewCRDNameResolver(resources)
+	if _, ok := resolver.Resolve("example.com", ""); ok {
+		t.Fatalf("Resolve() should not find an entry for a CRD missing spec.names")
+	}
+}

--- a/tooling/hcpctl/pkg/ocadminspect/writer.go
+++ b/tooling/hcpctl/pkg/ocadminspect/writer.go
@@ -96,7 +96,7 @@ func (w *FilesystemWriter) WriteResources(_ context.Context, namespace string, r
 			}
 		}
 		group := apiGroup(resource.APIVersion)
-		fileKey := filepath.Join(group, resourcePlural(resource.Kind)+".yaml")
+		fileKey := filepath.Join(group, ResourcePlural(resource.Kind)+".yaml")
 		byFile[fileKey] = append(byFile[fileKey], resource)
 	}
 
@@ -138,6 +138,12 @@ func (w *FilesystemWriter) writeObjectFile(path string, obj any) error {
 	if err := os.WriteFile(path, append([]byte("---\n"), data...), 0o644); err != nil {
 		return fmt.Errorf("failed to write %s: %w", path, err)
 	}
+	return nil
+}
+
+// WriteResourceHistory is a no-op: FilesystemWriter mirrors oc adm inspect's
+// point-in-time layout, which has no place for a per-event changelog.
+func (w *FilesystemWriter) WriteResourceHistory(_ context.Context, _ []ResourceEvent) error {
 	return nil
 }
 
@@ -184,44 +190,6 @@ func apiGroup(apiVersion string) string {
 		return apiVersion[:idx]
 	}
 	return "core"
-}
-
-// irregularResourcePlurals maps a lowercased Kind to its resource (plural) name
-// where the naive rules below would be wrong. oc derives this from discovery; the
-// snapshot telemetry only carries the Kind, so we approximate.
-var irregularResourcePlurals = map[string]string{
-	"endpoints": "endpoints", // already plural
-}
-
-// resourcePlural approximates the plural resource name for a Kind (e.g. "Pod" ->
-// "pods", "NetworkPolicy" -> "networkpolicies", "Ingress" -> "ingresses"), used
-// for the list file names. It is an approximation of the discovery-derived
-// resource name oc uses, sufficient for the file layout.
-func resourcePlural(kind string) string {
-	lower := strings.ToLower(kind)
-	if lower == "" {
-		return ""
-	}
-	if plural, ok := irregularResourcePlurals[lower]; ok {
-		return plural
-	}
-	switch {
-	case strings.HasSuffix(lower, "s"), strings.HasSuffix(lower, "x"),
-		strings.HasSuffix(lower, "ch"), strings.HasSuffix(lower, "sh"):
-		return lower + "es"
-	case strings.HasSuffix(lower, "y") && len(lower) > 1 && !isVowel(lower[len(lower)-2]):
-		return lower[:len(lower)-1] + "ies"
-	default:
-		return lower + "s"
-	}
-}
-
-func isVowel(b byte) bool {
-	switch b {
-	case 'a', 'e', 'i', 'o', 'u':
-		return true
-	}
-	return false
 }
 
 // renderLogLine renders a container log payload: a plain string is emitted as-is

--- a/tooling/hcpctl/pkg/ocadminspect/writer_test.go
+++ b/tooling/hcpctl/pkg/ocadminspect/writer_test.go
@@ -48,26 +48,6 @@ func TestRenderLogLine(t *testing.T) {
 	}
 }
 
-func TestResourcePlural(t *testing.T) {
-	tests := map[string]string{
-		"Pod":           "pods",
-		"ConfigMap":     "configmaps",
-		"Service":       "services",
-		"Endpoints":     "endpoints",
-		"Ingress":       "ingresses",
-		"NetworkPolicy": "networkpolicies",
-		"Deployment":    "deployments",
-		"HostedCluster": "hostedclusters",
-		"EgressQoS":     "egressqoses",
-		"Namespace":     "namespaces",
-	}
-	for kind, want := range tests {
-		if got := resourcePlural(kind); got != want {
-			t.Errorf("resourcePlural(%q) = %q, want %q", kind, got, want)
-		}
-	}
-}
-
 func TestFilesystemWriter_Layout(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()


### PR DESCRIPTION
## Why

Debugging pod/node placement and scheduling issues on a management cluster
today means reconstructing state by hand from scattered Kusto queries.
[k8shark](https://github.com/phenixblue/k8shark) already provides an offline,
Wireshark-style replay tool for Kubernetes clusters (mock API server +
time-travel scrubber) — this teaches `oc-adm-inspect` to export an entire
management cluster's history into k8shark's `.kshrk` archive format, so it
can be opened with `kshrk open`/`kshrk ui` and queried with `kubectl` exactly
like a live (past) cluster, with no live-cluster access required (Kusto-only,
consistent with the rest of `oc-adm-inspect`).

No tracking ticket yet — will file one and link it here.

## What

- `hcpctl oc-adm-inspect --out <path>.kshrk` (no namespace args) switches into
  whole-cluster mode instead of the existing single-namespace/filesystem-tree
  mode. Existing behavior for `oc-adm-inspect ns/<name> ...` is unchanged.
- New `pkg/kshrk` implements the `.kshrk` archive format (ZIP + Zstd) from
  scratch, per k8shark's own documented format — its writer lives entirely
  under `internal/` and can't be imported.
- `Inspector.InspectCluster` + the new `KshrkWriter` reuse the existing
  oc-adm-inspect query/`Writer` plumbing: the namespace filter on the
  existing KQL templates (`resource_snapshots.kql.gotmpl`, `events.kql.gotmpl`)
  becomes optional, so one query covers the whole cluster instead of looping
  per namespace. A new `resource_history.kql.gotmpl` feeds an uncollapsed
  Add/Update/Delete changelog into `watch-index.json`, alongside a single
  "as of window start" poll baseline — verified sufficient by reading
  k8shark's own `ReconstructAt` (nearest poll + replay watch events forward).
- Kind → plural resource-name resolution now prefers an exact match from a
  captured `CustomResourceDefinition` object over the existing heuristic
  (`ResourcePlural`, extracted from `FilesystemWriter` into `pkg/ocadminspect/plural.go`).
  This required a small `mgmt-agent` change: its resource-watcher already runs
  an informer for CRDs (to detect newly-registered CRDs and restart), but never
  logged CRD events — it's now added to the same `logResourceEvent` pipeline
  every other watched GVR already goes through.
- `KshrkWriter.Finish` registers an empty poll-baseline placeholder for any
  collection that has watch history but no poll-baseline row (common for
  short-lived/ephemeral mgmt clusters, since "as of window start" may predate
  the cluster's own resource-watcher startup) — this makes k8shark's
  cross-namespace `-A` listing able to discover the collection at all;
  `ReconstructAt` already reconstructs state correctly for a path with no
  poll record, so this doesn't change what any point-in-time query returns.

Verified end-to-end against a real dev-CI management cluster's Kusto data:
`kubectl get pods -A`, `kubectl get nodes`, `kubectl get managedclusters`,
and `kubectl api-resources` (correct CRD group/version/kind/shortNames) all
work correctly against the replayed archive.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` clean in both
      `tooling/hcpctl` and `mgmt-agent`
- [x] `golangci-lint run` clean
- [x] Existing single-namespace `oc-adm-inspect` path confirmed byte-for-byte
      unaffected (every current call site still sets an explicit namespace)
- [x] New unit tests: `pkg/kshrk` archive round-trip, `KshrkWriter`
      path-construction/discovery/placeholder logic, `CRDNameResolver`,
      golden-style KQL template rendering tests for the namespace-optional
      and new history query
- [x] Manual end-to-end run against a real Prow e2e-parallel job's mgmt
      cluster, replayed with `kshrk open`/`kshrk ui`