### PR TITLE
fix(config): raise ci00/ci01 CosmosDB resourceContainerMaxScale to 20000 (AROSLSRE-2037)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1804,6 +1804,7 @@ clouds:
               connectSocket: false
             cosmosDB:
               private: false
+              resourceContainerMaxScale: 20000
               zoneRedundantMode: 'Disabled'
             tracing:
               address: "http://ingest.observability:4318"
@@ -1905,6 +1906,7 @@ clouds:
               connectSocket: false
             cosmosDB:
               private: false
+              resourceContainerMaxScale: 20000
               zoneRedundantMode: 'Disabled'
             tracing:
               address: "http://ingest.observability:4318"

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -315,7 +315,7 @@ frontend:
     locksContainerMaxScale: 4000
     name: arohcpci00-rp-j7654321
     private: false
-    resourceContainerMaxScale: 15000
+    resourceContainerMaxScale: 20000
     zoneRedundantMode: Disabled
   exitOnPanic: true
   image:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -315,7 +315,7 @@ frontend:
     locksContainerMaxScale: 4000
     name: arohcpci01-rp-j7654321
     private: false
-    resourceContainerMaxScale: 15000
+    resourceContainerMaxScale: 20000
     zoneRedundantMode: Disabled
   exitOnPanic: true
   image:


### PR DESCRIPTION
[AROSLSRE-2037](https://redhat.atlassian.net/browse/AROSLSRE-2037)

### What

Raises `frontend.cosmosDB.resourceContainerMaxScale` from 10000 to 20000 for
the `ci00` and `ci01` environments in `config/config.yaml`, and regenerates
`config/rendered/dev/ci00/centralus.yaml` and
`config/rendered/dev/ci01/centralus.yaml` via `make materialize`.

### Why

Each e2e-parallel test job provisions its own ephemeral CosmosDB account in
the shared `ci00`/`ci01` CI underlay regions (e.g.
`arohcpci01-rp-j5814272`). These accounts are hitting Cosmos DB Throttled
Requests (429) alerts on the Resources container during e2e-parallel runs
and tide batch jobs. Raising the autoscale ceiling gives the container more
headroom to absorb load spikes; autoscale billing only charges for RU/s
actually consumed, so this has no cost impact unless the higher ceiling is
actually needed.

### Testing

- Config-only change; validated with `cd config && make materialize` and
  confirmed the diff is scoped to `config/rendered/dev/ci00/centralus.yaml`
  and `config/rendered/dev/ci01/centralus.yaml` only.

### Special notes for your reviewer

Companion change (enabling CosmosDB burst capacity for the same
environments) is tracked separately in
[AROSLSRE-2038](https://redhat.atlassian.net/browse/AROSLSRE-2038) as its
own PR, kept independent per one-PR-one-change discipline.
