### PR TITLE
feat(cosmos): enable CosmosDB burst capacity for ci00/ci01 (AROSLSRE-2038)

### DIFF
--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1755,6 +1755,10 @@
             "private": {
               "type": "boolean"
             },
+            "enableBurstCapacity": {
+              "type": "boolean",
+              "description": "Enables Cosmos DB burst capacity, letting the account use banked unused throughput to absorb short RU spikes at no extra cost"
+            },
             "resourceContainerMaxScale": {
               "type": "integer"
             },

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -933,6 +933,7 @@ defaults:
       disableLocalAuth: true
       name: "arohcp{{ .ctx.environment }}-rp-{{ .ctx.regionShort }}" # [globally-unique]
       private: true
+      enableBurstCapacity: false
       zoneRedundantMode: 'Auto'
       resourceContainerMaxScale: 15000
       billingContainerMaxScale: 4000
@@ -1804,6 +1805,7 @@ clouds:
               connectSocket: false
             cosmosDB:
               private: false
+              enableBurstCapacity: true
               zoneRedundantMode: 'Disabled'
             tracing:
               address: "http://ingest.observability:4318"
@@ -1905,6 +1907,7 @@ clouds:
               connectSocket: false
             cosmosDB:
               private: false
+              enableBurstCapacity: true
               zoneRedundantMode: 'Disabled'
             tracing:
               address: "http://ingest.observability:4318"

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -311,6 +311,7 @@ frontend:
   cosmosDB:
     billingContainerMaxScale: 4000
     disableLocalAuth: true
+    enableBurstCapacity: true
     fleetContainerMaxScale: 4000
     locksContainerMaxScale: 4000
     name: arohcpci00-rp-j7654321

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -311,6 +311,7 @@ frontend:
   cosmosDB:
     billingContainerMaxScale: 4000
     disableLocalAuth: true
+    enableBurstCapacity: true
     fleetContainerMaxScale: 4000
     locksContainerMaxScale: 4000
     name: arohcpci01-rp-j7654321

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -311,6 +311,7 @@ frontend:
   cosmosDB:
     billingContainerMaxScale: 4000
     disableLocalAuth: true
+    enableBurstCapacity: false
     fleetContainerMaxScale: 4000
     locksContainerMaxScale: 4000
     name: arohcpcspr-rp-usw3

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -311,6 +311,7 @@ frontend:
   cosmosDB:
     billingContainerMaxScale: 4000
     disableLocalAuth: true
+    enableBurstCapacity: false
     fleetContainerMaxScale: 4000
     locksContainerMaxScale: 4000
     name: arohcpdev-rp-usw3

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -311,6 +311,7 @@ frontend:
   cosmosDB:
     billingContainerMaxScale: 4000
     disableLocalAuth: true
+    enableBurstCapacity: false
     fleetContainerMaxScale: 4000
     locksContainerMaxScale: 4000
     name: arohcpperf-rp-usw3ptest

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -311,6 +311,7 @@ frontend:
   cosmosDB:
     billingContainerMaxScale: 4000
     disableLocalAuth: true
+    enableBurstCapacity: false
     fleetContainerMaxScale: 4000
     locksContainerMaxScale: 4000
     name: arohcppers-rp-usw3test

--- a/dev-infrastructure/configurations/region.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/region.tmpl.bicepparam
@@ -15,6 +15,7 @@ param maestroCertificateIssuer = '{{ .maestro.certIssuer }}'
 param rpCosmosDbName = '{{ .frontend.cosmosDB.name }}'
 param rpCosmosDbPrivate = {{ .frontend.cosmosDB.private }}
 param rpCosmosZoneRedundantMode = '{{ .frontend.cosmosDB.zoneRedundantMode }}'
+param rpCosmosEnableBurstCapacity = {{ .frontend.cosmosDB.enableBurstCapacity }}
 param disableLocalAuth = {{ .frontend.cosmosDB.disableLocalAuth }}
 
 // MI for resource access during pipeline runs

--- a/dev-infrastructure/modules/rp-cosmos-account.bicep
+++ b/dev-infrastructure/modules/rp-cosmos-account.bicep
@@ -4,6 +4,7 @@ param disableLocalAuth bool = true
 param location string
 param zoneRedundant bool
 param private bool
+param enableBurstCapacity bool = false
 
 resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' = {
   kind: 'GlobalDocumentDB'
@@ -44,7 +45,7 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' = {
     defaultIdentity: 'FirstPartyIdentity'
     networkAclBypass: 'None'
     enablePartitionMerge: false
-    enableBurstCapacity: false
+    enableBurstCapacity: enableBurstCapacity
     enablePerRegionPerPartitionAutoscale: true
     minimalTlsVersion: 'Tls12'
   }

--- a/dev-infrastructure/templates/region.bicep
+++ b/dev-infrastructure/templates/region.bicep
@@ -36,6 +36,9 @@ param rpCosmosDbPrivate bool
 @description('The zone redundant mode of the Cosmos DB instance')
 param rpCosmosZoneRedundantMode string
 
+@description('Enables Cosmos DB burst capacity for the RP CosmosDB account')
+param rpCosmosEnableBurstCapacity bool = false
+
 @description('disableLocalAuth for the ARO HCP RP CosmosDB')
 param disableLocalAuth bool
 
@@ -141,6 +144,7 @@ module rpCosmosAccount '../modules/rp-cosmos-account.bicep' = {
     zoneRedundant: determineZoneRedundancyForRegion(location, rpCosmosZoneRedundantMode)
     disableLocalAuth: disableLocalAuth
     private: rpCosmosDbPrivate
+    enableBurstCapacity: rpCosmosEnableBurstCapacity
   }
 }
 


### PR DESCRIPTION
[AROSLSRE-2038](https://redhat.atlassian.net/browse/AROSLSRE-2038)

### What

Parameterizes `enableBurstCapacity` on the RP CosmosDB account (previously
hardcoded `false` in `dev-infrastructure/modules/rp-cosmos-account.bicep`),
threads it through `region.bicep` as `rpCosmosEnableBurstCapacity`, and sets
it via config: `false` by default (all existing environments unaffected),
`true` for `ci00` and `ci01` only.

### Why

Each e2e-parallel test job provisions its own ephemeral CosmosDB account in
the shared `ci00`/`ci01` CI underlay regions. These accounts hit Cosmos DB
Throttled Requests (429) alerts during e2e-parallel runs and tide batch
jobs, and the alerts self-resolve within a few minutes, consistent with
short bursts rather than sustained overload. Cosmos DB burst capacity lets
an account use banked unused RU/s from idle periods to absorb these short
spikes, at no additional provisioning cost.

### Testing

- `az bicep build --file dev-infrastructure/templates/region.bicep` builds
  cleanly with the new param.
- `cd config && make materialize` re-rendered all environments;
  `config/rendered/dev/{ci00,ci01}/centralus.yaml` now show
  `enableBurstCapacity: true`, every other environment's rendered output
  shows `enableBurstCapacity: false` (new default, no behavior change).
- `make verify-schema` passes with the new `enableBurstCapacity` schema
  property.

### Special notes for your reviewer

Companion change (raising `resourceContainerMaxScale` for the same
environments) is [#6844](https://github.com/Azure/ARO-HCP/pull/6844),
tracked under the same parent [AROSLSRE-2036](https://redhat.atlassian.net/browse/AROSLSRE-2036),
kept as an independent PR per one-PR-one-change discipline.
