### PR TITLE
fix(backend): don't gate node pool CS delete on ApplyDesire purge

### DIFF
--- a/backend/pkg/controllers/clusterresources/cluster_resources_controller.go
+++ b/backend/pkg/controllers/clusterresources/cluster_resources_controller.go
@@ -266,6 +266,18 @@ func (c *clusterResourcesController) processClusterResources(ctx context.Context
 				errs = append(errs, utils.TrackError(fmt.Errorf("failed to get nodepool %s: %w", classified.nodePoolName, npErr)))
 				continue
 			}
+			// Skipping here drops the desire out of desiredResourceIDs, so
+			// deleteStaleApplyDesires reaps it below.
+			//
+			// While Cluster Service still owns the NodePool it is also still
+			// reporting it here, and its ManifestWork keeps the CR materialized
+			// through the work-agent, so the CR can be re-applied a couple of times
+			// after kube-applier deletes it. That churn is bounded: it stops once
+			// Cluster Service removes the ManifestWork, and it cannot stall the
+			// delete pipeline, because NodePoolClusterServiceDeleteDispatch issues
+			// the Cluster Service delete without waiting on these desires. The churn
+			// disappears entirely once the backend owns NodePool deletion directly.
+			//  TODO: remove this comment once ACM and Maestro are removed.
 			if np == nil || np.ServiceProviderProperties.DeletionTimestamp != nil {
 				continue
 			}

--- a/backend/pkg/controllers/clusterresources/cluster_resources_controller_test.go
+++ b/backend/pkg/controllers/clusterresources/cluster_resources_controller_test.go
@@ -714,3 +714,114 @@ func TestClassifyClusterResource(t *testing.T) {
 		})
 	}
 }
+
+// TestProcessClusterResourcesNodePoolPath covers the node-pool-scoped branch of
+// processClusterResources. A NodePool marked for deletion is dropped from the
+// desired set and its ApplyDesire is reaped, even while Cluster Service is
+// still reporting the CR. That is deliberate: NodePoolClusterServiceDeleteDispatch
+// does not wait on these desires, so the reap cannot deadlock against the
+// work-agent re-applying the CR from the still-live ManifestWork.
+func TestProcessClusterResourcesNodePoolPath(t *testing.T) {
+	t.Parallel()
+
+	const testNodePoolName = "gpu-np-1"
+
+	nodePoolCR := `{"apiVersion":"hypershift.openshift.io/v1beta1","kind":"NodePool",` +
+		`"metadata":{"name":"` + testClusterName + `-` + testNodePoolName + `","namespace":"ocm-env-abc"},` +
+		`"spec":{"clusterName":"` + testClusterName + `"}}`
+
+	newNodePool := func(deleting bool) *coreapi.HCPOpenShiftClusterNodePool {
+		resourceID := metadataapi.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + testSubscriptionID +
+				"/resourceGroups/" + testResourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+				"/nodePools/" + testNodePoolName,
+		))
+		np := &coreapi.HCPOpenShiftClusterNodePool{
+			CosmosMetadata: coreapi.CosmosMetadata{
+				ResourceID:   resourceID,
+				PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+			},
+			TrackedResource: coreapi.TrackedResource{
+				Resource: coreapi.Resource{
+					ID:   resourceID,
+					Name: testNodePoolName,
+					Type: resourceID.ResourceType.String(),
+				},
+			},
+		}
+		np.ServiceProviderProperties.ClusterServiceID = metadataapi.Ptr(metadataapi.Must(
+			metadataapi.NewInternalID("/api/clusters_mgmt/v1/clusters/abc123/node_pools/np123")))
+		if deleting {
+			now := metav1.Now()
+			np.ServiceProviderProperties.DeletionTimestamp = &now
+		}
+		return np
+	}
+
+	tests := []struct {
+		name           string
+		nodePool       *coreapi.HCPOpenShiftClusterNodePool
+		wantDesireType kubeapplierapi.ApplyDesireType
+		reason         string
+	}{
+		{
+			name:           "keeps desire applied while NodePool is live",
+			nodePool:       newNodePool(false),
+			wantDesireType: kubeapplierapi.ApplyDesireTypeServerSideApply,
+			reason:         "a live NodePool must keep its ApplyDesire applied",
+		},
+		{
+			name:           "reaps desire once NodePool is marked for deletion",
+			nodePool:       newNodePool(true),
+			wantDesireType: kubeapplierapi.ApplyDesireTypeDelete,
+			reason:         "a deleting NodePool is dropped from the desired set and reaped",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+			mockKubeApplierClient := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClient()
+			mockClients := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClients()
+			mockClients.Register(testManagementClusterResourceID, mockKubeApplierClient)
+
+			npCRUD, err := mockKubeApplierClient.ApplyDesiresForNodePool(
+				testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+			require.NoError(t, err, "failed to get node pool ApplyDesires CRUD")
+
+			mcLister := &fleetlistertesting.SliceManagementClusterLister{
+				ManagementClusters: []*fleetapi.ManagementCluster{{ResourceID: testManagementClusterResourceID}},
+			}
+			syncer := &clusterResourcesController{
+				nodePoolLister:       &corelistertesting.SliceNodePoolLister{NodePools: []*coreapi.HCPOpenShiftClusterNodePool{tt.nodePool}},
+				kubeApplierDBClients: mockClients,
+				applyDesireLister:    &kubeapplierlistertesting.DBApplyDesireLister{Clients: mockClients, Lister: mcLister},
+			}
+
+			// Seed the desire with a pass over a healthy NodePool, so the deletion
+			// case exercises reaping an existing desire rather than never creating one.
+			seedSyncer := *syncer
+			seedSyncer.nodePoolLister = &corelistertesting.SliceNodePoolLister{
+				NodePools: []*coreapi.HCPOpenShiftClusterNodePool{newNodePool(false)},
+			}
+			require.NoError(t, seedSyncer.processClusterResources(ctx, testKey(), testManagementClusterResourceID,
+				buildClusterResources(map[string]string{"node-pool": nodePoolCR})),
+				"seeding the NodePool ApplyDesire should succeed")
+			_, err = npCRUD.Get(ctx, "nodepool")
+			require.NoError(t, err, "seed pass should have created the NodePool ApplyDesire")
+
+			// Cluster Service still reports the CR, as it does until it removes the
+			// ManifestWork.
+			require.NoError(t, syncer.processClusterResources(ctx, testKey(), testManagementClusterResourceID,
+				buildClusterResources(map[string]string{"node-pool": nodePoolCR})),
+				"processClusterResources should succeed")
+
+			desire, err := npCRUD.Get(ctx, "nodepool")
+			require.NoError(t, err, "NodePool ApplyDesire should still exist: %s", tt.reason)
+			assert.Equal(t, tt.wantDesireType, desire.Spec.Type, "unexpected desire type: %s", tt.reason)
+		})
+	}
+}

--- a/backend/pkg/controllers/nodepool/deletion/node_pool_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/nodepool/deletion/node_pool_child_resources_cleanup_controller.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/kubeappliercosmosstorage"
@@ -38,8 +39,10 @@ import (
 // the NodePool is marked for deletion and Cluster Service has confirmed the
 // delete on its side. Controller status documents (NodePoolControllerResourceType)
 // are left alone. Nodepool-scoped kube-applier *Desires are deleted here using
-// the parent cluster's ServiceProviderCluster placement. The orphan scraper
-// handles controller status after the NodePool document itself is removed.
+// the parent cluster's ServiceProviderCluster placement, except for ApplyDesires
+// that name an owning controller - those are that controller's to tear down; see
+// extraDeleteGateShouldDeleteApplyDesire. The orphan scraper handles controller
+// status after the NodePool document itself is removed.
 type nodePoolChildResourcesCleanupController struct {
 	nodePoolLister       corelisters.NodePoolLister
 	resourcesDBClient    corecosmosstorage.ResourcesDBClient
@@ -274,11 +277,12 @@ func (c *nodePoolChildResourcesCleanupController) ensureNodePoolScopedKubeApplie
 		return nil
 	}
 
-	// extraDeleteGates uses lowercased kubeapplier.*DesireResourceTypeName keys. Types not
-	// in the map are deleted unconditionally.
+	// extraDeleteGates uses lowercased kubeapplierapi.*DesireResourceType keys. Types not
+	// in the map are deleted unconditionally. ReadDesires are only observed, so
+	// dropping their documents has no effect on the management cluster and needs
+	// no gate; ApplyDesires do, hence the gate below.
 	extraDeleteGates := map[string]func(ctx context.Context, resourceID *azcorearm.ResourceID) (bool, error){
-		// strings.ToLower(kubeapplier.ClusterScopedReadDesireResourceType.String()): c.extraDeleteGateShouldDeleteReadDesire,
-		// strings.ToLower(kubeapplier.ClusterScopedApplyDesireResourceType.String()): c.extraDeleteGateShouldDeleteApplyDesire,
+		strings.ToLower(kubeapplierapi.NodePoolScopedApplyDesireResourceType.String()): c.extraDeleteGateShouldDeleteApplyDesire(kaClient, nodePoolResourceID),
 	}
 
 	desireCRUD, err := kaClient.UntypedCRUD(*nodePoolResourceID)
@@ -317,4 +321,54 @@ func (c *nodePoolChildResourcesCleanupController) ensureNodePoolScopedKubeApplie
 	logger.Info("all included nodepool-scoped kube-applier child resources deleted")
 
 	return nil
+}
+
+// extraDeleteGateShouldDeleteApplyDesire reports whether a nodepool-scoped
+// ApplyDesire document may be removed here.
+//
+// An ApplyDesire that records an owning controller in Tags[TagControllerName]
+// belongs to that controller's teardown: the owner flips it to Type=Delete and
+// purges the document only once the kube-applier reports the object gone from
+// the management cluster. Deleting the document here would strand that object,
+// because nothing else asks the kube-applier to remove it. So we leave those
+// alone and let the owner converge - today that is the ClusterResources
+// controller, via kubeapplierhelpers.EnsureApplyDesireRemoved.
+//
+// Untagged desires have no owner left to reap them, so they are deleted here.
+func (c *nodePoolChildResourcesCleanupController) extraDeleteGateShouldDeleteApplyDesire(
+	kaClient kubeappliercosmosstorage.KubeApplierDBClient,
+	nodePoolResourceID *azcorearm.ResourceID,
+) func(ctx context.Context, applyDesireResourceID *azcorearm.ResourceID) (bool, error) {
+	return func(ctx context.Context, applyDesireResourceID *azcorearm.ResourceID) (bool, error) {
+		logger := utils.LoggerFromContext(ctx)
+
+		clusterResourceID := nodePoolResourceID.Parent
+		if clusterResourceID == nil {
+			return false, utils.TrackError(fmt.Errorf(
+				"node pool resource ID missing cluster parent: %s", nodePoolResourceID.String()))
+		}
+
+		applyDesireCRUD, err := kaClient.ApplyDesiresForNodePool(
+			clusterResourceID.SubscriptionID, clusterResourceID.ResourceGroupName, clusterResourceID.Name, nodePoolResourceID.Name)
+		if err != nil {
+			return false, utils.TrackError(fmt.Errorf("failed to create nodepool-scoped ApplyDesire CRUD: %w", err))
+		}
+
+		applyDesire, err := applyDesireCRUD.Get(ctx, strings.ToLower(applyDesireResourceID.Name))
+		if cosmosstorageutils.IsNotFoundError(err) {
+			// Raced with the owner purging it; nothing left to delete.
+			return false, nil
+		}
+		if err != nil {
+			return false, utils.TrackError(fmt.Errorf("failed to get ApplyDesire %q: %w", applyDesireResourceID.String(), err))
+		}
+
+		if owningController := applyDesire.Tags[kubeapplierapi.TagControllerName]; len(owningController) > 0 {
+			logger.Info("waiting for owning controller to tear down nodepool-scoped ApplyDesire",
+				"applyDesireResourceID", applyDesireResourceID.String(), "owningController", owningController)
+			return false, nil
+		}
+
+		return true, nil
+	}
 }

--- a/backend/pkg/controllers/nodepool/deletion/node_pool_child_resources_cleanup_controller_test.go
+++ b/backend/pkg/controllers/nodepool/deletion/node_pool_child_resources_cleanup_controller_test.go
@@ -151,6 +151,37 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 			},
 		}
 	}
+	// newTestOwnedNodePoolScopedApplyDesire builds a nodepool-scoped ApplyDesire
+	// that names an owning controller, the way every controller that persists a
+	// desire through the kubeapplierhelpers ensure helpers does.
+	newTestOwnedNodePoolScopedApplyDesire := func(name, owningController string) *kubeapplierapi.ApplyDesire {
+		desire := newTestNodePoolScopedApplyDesire(name)
+		desire.Tags = map[string]string{kubeapplierapi.TagControllerName: owningController}
+		return desire
+	}
+	assertNodePoolScopedKubeApplierResourceExists := func(
+		t *testing.T,
+		ctx context.Context,
+		kubeApplierDBClients *kubeappliercosmosstoragetesting.MockKubeApplierDBClients,
+		resourceIDString string,
+	) {
+		t.Helper()
+		client := kubeApplierDBClients.For(ctx, managementClusterResourceID)
+		require.NotNil(t, client)
+		resourceID := metadataapi.Must(azcorearm.ParseResourceID(resourceIDString))
+		untypedCRUD, err := client.UntypedCRUD(*resourceID.Parent)
+		require.NoError(t, err)
+		iter, err := untypedCRUD.List(ctx, nil)
+		require.NoError(t, err)
+		for _, resource := range iter.Items(ctx) {
+			if resource.ResourceID != nil && strings.EqualFold(resource.ResourceID.String(), resourceIDString) {
+				require.NoError(t, iter.GetError())
+				return
+			}
+		}
+		require.NoError(t, iter.GetError())
+		t.Fatalf("expected nodepool-scoped kube-applier resource %q to still exist", resourceIDString)
+	}
 	assertNoNodePoolScopedKubeApplierResources := func(
 		t *testing.T,
 		ctx context.Context,
@@ -471,6 +502,53 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 				assertClusterScopedKubeApplierResourceExists(t, ctx, kubeApplierDBClients,
 					kubeapplierapi.ToClusterScopedApplyDesireResourceIDString(
 						testSubscriptionID, testResourceGroupName, testClusterName, "apply-example"))
+			},
+		},
+		{
+			// An ApplyDesire naming an owning controller is that controller's to
+			// tear down: it flips the desire to Type=Delete and purges the document
+			// only once the kube-applier confirms the object is gone from the
+			// management cluster. Deleting the document here would strand the
+			// object, so the desire - and with it the SPNP - has to survive this
+			// pass. ReadDesires have no cluster-side effect and are still removed.
+			name:             "when a nodepool-scoped ApplyDesire names an owning controller it is left for that controller",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources: []any{
+				newTestSPCWithManagementCluster(managementClusterResourceID),
+				newTestSPNP(t, nil),
+			},
+			kubeApplierDesires: []any{
+				newTestOwnedNodePoolScopedApplyDesire("apply-nodepool", "ClusterResources"),
+				newTestNodePoolScopedReadDesire("readonly-nodepool"),
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *corecosmosstoragetesting.MockResourcesDBClient, kubeApplierDBClients *kubeappliercosmosstoragetesting.MockKubeApplierDBClients) {
+				assertNodePoolScopedKubeApplierResourceExists(t, ctx, kubeApplierDBClients,
+					kubeapplierapi.ToNodePoolScopedApplyDesireResourceIDString(
+						testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName, "apply-nodepool"))
+
+				spnpCRUD := db.ServiceProviderNodePools(
+					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+				_, err := spnpCRUD.Get(ctx, coreapi.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err, "expected SPNP to be held back while an owned ApplyDesire remains")
+			},
+		},
+		{
+			// No owning controller is recorded, so nothing else will ever reap it.
+			// Removing the document here is the backstop that keeps deletion moving.
+			name:             "when a nodepool-scoped ApplyDesire names no owning controller it is deleted",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources: []any{
+				newTestSPCWithManagementCluster(managementClusterResourceID),
+				newTestSPNP(t, nil),
+			},
+			kubeApplierDesires: []any{newTestNodePoolScopedApplyDesire("orphaned-apply-nodepool")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *corecosmosstoragetesting.MockResourcesDBClient, kubeApplierDBClients *kubeappliercosmosstoragetesting.MockKubeApplierDBClients) {
+				assertNoNodePoolScopedKubeApplierResources(t, ctx, kubeApplierDBClients)
+
+				spnpCRUD := db.ServiceProviderNodePools(
+					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+				_, err := spnpCRUD.Get(ctx, coreapi.ServiceProviderNodePoolResourceName)
+				require.True(t, cosmosstorageutils.IsNotFoundError(err), "expected SPNP to be deleted")
 			},
 		},
 	}

--- a/backend/pkg/controllers/nodepool/deletion/node_pool_cluster_service_delete_dispatch_controller.go
+++ b/backend/pkg/controllers/nodepool/deletion/node_pool_cluster_service_delete_dispatch_controller.go
@@ -28,15 +28,12 @@ import (
 
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
-	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterresources"
 	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
-	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
 	"github.com/Azure/ARO-HCP/internal/database/informers/coreinformers"
 	"github.com/Azure/ARO-HCP/internal/database/listers/corelisters"
-	"github.com/Azure/ARO-HCP/internal/database/listers/kubeapplierlisters"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -56,9 +53,6 @@ const missingClusterServiceIDTimeout = 120 * time.Second
 // waiting for a ClusterServiceID), it stamps ClusterServiceDeletionTimestamp
 // on the NodePool to record that this step is complete and avoid re-issuing
 // the delete on subsequent syncs.
-// Before dispatching the delete, this controller waits until the
-// ClusterResourcesController has cleaned up all its tagged ApplyDesires for
-// this NodePool, so that kube resources are torn down before the NodePool itself.
 //
 // The controller also caches the time the controller has first seen the
 // serviceProviderProperties.deletionTimestamp being set for a nodepool. This
@@ -70,7 +64,6 @@ type nodePoolClusterServiceDeleteDispatchSyncer struct {
 	nodePoolLister       corelisters.NodePoolLister
 	resourcesDBClient    corecosmosstorage.ResourcesDBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
-	applyDesireLister    kubeapplierlisters.ApplyDesireLister
 	// firstSeenDeletionTimestampCache is a cache that contains the time the controller
 	// has first seen the serviceProviderProperties.deletionTimestamp being set
 	// for a nodepool. The cache key is the lowercased node pool's resource ID and
@@ -88,13 +81,11 @@ func NewNodePoolClusterServiceDeleteDispatchController(
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 	_, nodePoolLister := informers.NodePools()
-	_, applyDesireLister := kubeApplierInformers.ApplyDesires()
 	syncer := &nodePoolClusterServiceDeleteDispatchSyncer{
 		clock:                           clock,
 		nodePoolLister:                  nodePoolLister,
 		resourcesDBClient:               resourcesDBClient,
 		clusterServiceClient:            clusterServiceClient,
-		applyDesireLister:               applyDesireLister,
 		firstSeenDeletionTimestampCache: lru.New(50000),
 	}
 
@@ -157,16 +148,6 @@ func (c *nodePoolClusterServiceDeleteDispatchSyncer) SyncOnce(ctx context.Contex
 		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
 	}
 	if !c.NeedsWork(nodePool) {
-		return nil
-	}
-
-	// Wait until ClusterResourcesController has deleted all its tagged ApplyDesires for this NodePool.
-	hasTaggedDesires, err := c.hasNodePoolApplyDesires(ctx, key)
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to check NodePool ApplyDesires: %w", err))
-	}
-	if hasTaggedDesires {
-		logger.Info("waiting for ClusterResourcesController to delete its ApplyDesires before dispatching CS delete")
 		return nil
 	}
 
@@ -237,18 +218,4 @@ func (c *nodePoolClusterServiceDeleteDispatchSyncer) SyncOnce(ctx context.Contex
 	c.firstSeenDeletionTimestampCache.Remove(cacheKey)
 
 	return nil
-}
-
-func (c *nodePoolClusterServiceDeleteDispatchSyncer) hasNodePoolApplyDesires(ctx context.Context, key controllerutils.HCPNodePoolKey) (bool, error) {
-	desires, err := c.applyDesireLister.ListForNodePool(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
-	if err != nil {
-		return false, err
-	}
-	for _, desire := range desires {
-		if desire.Tags != nil &&
-			desire.Tags[kubeapplierapi.TagControllerName] == clusterresources.ClusterResourcesControllerName {
-			return true, nil
-		}
-	}
-	return false, nil
 }

--- a/backend/pkg/controllers/nodepool/deletion/node_pool_cluster_service_delete_dispatch_controller_test.go
+++ b/backend/pkg/controllers/nodepool/deletion/node_pool_cluster_service_delete_dispatch_controller_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/corecosmosstoragetesting"
 	"github.com/Azure/ARO-HCP/internal/database/listertesting/corelistertesting"
-	kubeapplierlistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting/kubeapplierlistertesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -258,7 +257,6 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
 				nodePoolLister:                  &corelistertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
 				resourcesDBClient:               mockResourcesDBClient,
 				clusterServiceClient:            mockCSClient,
-				applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 				firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 			}
 
@@ -298,7 +296,6 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_cacheShortCircuit(t
 		nodePoolLister:                  &corelistertesting.SliceNodePoolLister{NodePools: []*coreapi.HCPOpenShiftClusterNodePool{cachedNodePool}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
-		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: lru.New(10),
 	}
 
@@ -335,7 +332,6 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCa
 		nodePoolLister:                  &corelistertesting.SliceNodePoolLister{NodePools: []*coreapi.HCPOpenShiftClusterNodePool{nodePool}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
-		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 	}
 
@@ -379,7 +375,6 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCa
 		nodePoolLister:                  &corelistertesting.SliceNodePoolLister{NodePools: []*coreapi.HCPOpenShiftClusterNodePool{nodePool}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            mockCSClient,
-		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 	}
 


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

Don't gate node pool CS delete on ApplyDesire purge; Dispatch `CS.DeleteNodePool` immediately on `DeletionTimestamp`. 

### Why

NodePoolClusterServiceDeleteDispatch refused to call CS.DeleteNodePool
until every kube-applier ApplyDesire tagged for the NodePool had been
purged from Cosmos. Those two conditions cannot both be satisfied.

On a per-node-pool ARM DELETE, ClusterResourcesController drops the
NodePool from its desired set and flips the ApplyDesire to Type=Delete.
kube-applier deletes the HyperShift NodePool CR, but Cluster Service
still owns the ManifestWork that materializes it, so the work-agent
re-applies the CR a couple of minutes later. kube-applier goes back to
SuccessfullyDeleted=False (WaitingForDeletion), the desire never
converges, and so it is never purged -- meaning the CS delete that
would have removed the ManifestWork is never dispatched. Observed as
the same NodePool CR recreated under four UIDs over 25 minutes, broken
only by the cluster teardown at the end of the E2E run.

Remove the gate: dispatch now fires as soon as DeletionTimestamp is
set. Teardown ordering is still enforced downstream --
NodePoolChildResourcesCleanupController removes the node-pool-scoped
desires only once Cluster Service confirms the NodePool is gone, and
NodePoolDeletionController will not delete the Cosmos NodePool document
while any ApplyDesire remains.

Also adds coverage for the node-pool branch of processClusterResources,
which had none: a NodePool marked for deletion is reaped even while
Cluster Service is still reporting the CR. That reap is now safe
precisely because dispatch no longer waits on it.

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
