### PR TITLE
docs: require clean revert PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,6 +13,7 @@ Key points to remember:
 - Ignore Tide when evaluating CI/CD status — it is not a CI check.
 - Screenshots are required for graph, UI, metrics, and performance changes.
 - The PR checklist is built into `.github/PULL_REQUEST_TEMPLATE.md` — it appears automatically.
+- For a PR that claims to be a revert, verify that it is a clean revert created with `git revert`. The description must explicitly say so and identify the reverted commit or PR; otherwise, flag a critical issue.
 
 ## Security Review (Mandatory for all PR reviews)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,11 @@ All pull requests must follow these standards. Reviewers will check for complian
 - If you disagree with feedback, reply with your reasoning before resolving — do not silently dismiss.
 - A PR should have zero open threads before merging.
 
+### 13. Revert PRs Must Be Clean Reverts
+- A PR that claims to be a revert must be created using `git revert` and must cleanly reverse the intended prior change.
+- Its description must explicitly state that it is a clean revert created with `git revert`, and identify the reverted commit or PR.
+- Reviewers must verify these requirements. Treat a missing explicit statement or a revert that was not created with `git revert` as a critical issue.
+
 
 ## AI Skills
 


### PR DESCRIPTION
No tracking ticket exists; this documentation-governance update was requested directly.

### What

Adds a Pull Request Standard and Copilot review instruction for PRs claiming to be reverts.

### Why

Revert PRs must be mechanically clean and explicitly documented so reviewers can distinguish true reversals from manually reconstructed changes.

### Testing

Not run: documentation-only change.

### Special notes for your reviewer

No UI, dashboard, pipeline, or executable-script changes.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the Why behind the change
- [x] Linked to relevant ticket/issue, or explained why none exists
- [x] Screenshots included (not applicable: no UI changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (not applicable: documentation-only change; Tide ignored)
- [x] Draft PR used for WIP (not applicable: complete change)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented (not applicable: no code changes)
- [ ] Specific reviewers tagged
- [x] All comment threads resolved before merge (no existing threads)