### PR TITLE
fix: use v3 system node SKUs in ci01

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1924,7 +1924,7 @@ clouds:
               systemAgentPool:
                 maxCount: 4
                 osDiskSizeGB: 32
-                vmSize: Standard_D8ds_v6
+                vmSize: Standard_D8ds_v3
               userAgentPool:
                 maxCount: 14
                 minCount: 5
@@ -1944,7 +1944,7 @@ clouds:
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
               systemAgentPool:
-                vmSize: Standard_D4ds_v6
+                vmSize: Standard_D4ds_v3
               userAgentPool:
                 name: 'u64d8dsv6'
                 vmSize: Standard_D8ds_v6

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1924,7 +1924,7 @@ clouds:
               systemAgentPool:
                 maxCount: 4
                 osDiskSizeGB: 32
-                vmSize: Standard_D8ds_v3
+                vmSize: Standard_D8s_v3
               userAgentPool:
                 maxCount: 14
                 minCount: 5
@@ -1944,7 +1944,7 @@ clouds:
             aks:
               name: "{{ .ctx.environment }}-{{ .ctx.regionShort }}-svc"
               systemAgentPool:
-                vmSize: Standard_D4ds_v3
+                vmSize: Standard_D4s_v3
               userAgentPool:
                 name: 'u64d8dsv6'
                 vmSize: Standard_D8ds_v6

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -673,7 +673,7 @@ mgmt:
       minCount: 1
       name: system
       osDiskSizeGB: 32
-      vmSize: Standard_D8ds_v6
+      vmSize: Standard_D8ds_v3
       zoneRedundantMode: Auto
       zones: ""
     tags: clusterType=mgmt-cluster,persist=true
@@ -1042,7 +1042,7 @@ svc:
       minCount: 1
       name: system
       osDiskSizeGB: 32
-      vmSize: Standard_D4ds_v6
+      vmSize: Standard_D4ds_v3
       zoneRedundantMode: Auto
       zones: ""
     tags: clusterType=svc-cluster,persist=true

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -673,7 +673,7 @@ mgmt:
       minCount: 1
       name: system
       osDiskSizeGB: 32
-      vmSize: Standard_D8ds_v3
+      vmSize: Standard_D8s_v3
       zoneRedundantMode: Auto
       zones: ""
     tags: clusterType=mgmt-cluster,persist=true
@@ -1042,7 +1042,7 @@ svc:
       minCount: 1
       name: system
       osDiskSizeGB: 32
-      vmSize: Standard_D4ds_v3
+      vmSize: Standard_D4s_v3
       zoneRedundantMode: Auto
       zones: ""
     tags: clusterType=svc-cluster,persist=true


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-2045

### What

Change the ci01 AKS system node pools while preserving their existing sizes:

- SVC: `Standard_D4ds_v6` to `Standard_D4s_v3`
- MGMT: `Standard_D8ds_v6` to `Standard_D8s_v3`

### Why

DEV E2E infrastructure provisioning has been repeatedly timing out while AKS creates v6 system nodes. A controlled ci00 reproduction showed an initial `Standard_D4ds_v6` VM remain stuck in `Creating` until AKS replaced it roughly 15 minutes later, consuming most of the 30-minute provision-step budget.

This change lets the PR-triggered E2E validate whether moving only the ci01 system pools to the v3 family avoids that delayed VM provisioning path while preserving CPU sizing.

No tracking ticket exists yet; this is an incident-mitigation experiment for the 2026-09-07 DEV E2E provision outage.

### Testing

- `cd config && make materialize`
- Confirmed materialized ci01 SVC and MGMT system pools use `Standard_D4s_v3` and `Standard_D8s_v3` respectively.
- Confirmed ci00 remains on its existing v6 SKUs.
- The PR-triggered E2E will validate infrastructure provisioning.

### Special notes for your reviewer

This intentionally changes only ci01 system pools. The v6 user and infra pools remain unchanged so the E2E isolates the system-node provisioning path.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the \"Why\" behind the change
- [x] No ticket exists; incident context is documented above
- [x] Screenshots not applicable
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR not needed; this is ready for the automatic E2E
- [x] Commit history is clean
- [x] No tricky code blocks
- [ ] Specific reviewers tagged
- [x] No open comment threads