### PR TITLE
TEST: revert: restore September 6 E2E-green snapshot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,7 +13,6 @@ Key points to remember:
 - Ignore Tide when evaluating CI/CD status — it is not a CI check.
 - Screenshots are required for graph, UI, metrics, and performance changes.
 - The PR checklist is built into `.github/PULL_REQUEST_TEMPLATE.md` — it appears automatically.
-- For a PR that claims to be a revert, verify that it is a clean revert created with `git revert`. The description must explicitly say so and identify the reverted commit or PR; otherwise, flag a critical issue.
 
 ## Security Review (Mandatory for all PR reviews)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,11 +130,6 @@ All pull requests must follow these standards. Reviewers will check for complian
 - If you disagree with feedback, reply with your reasoning before resolving — do not silently dismiss.
 - A PR should have zero open threads before merging.
 
-### 13. Revert PRs Must Be Clean Reverts
-- A PR that claims to be a revert must be created using `git revert` and must cleanly reverse the intended prior change.
-- Its description must explicitly state that it is a clean revert created with `git revert`, and identify the reverted commit or PR.
-- Reviewers must verify these requirements. Treat a missing explicit statement or a revert that was not created with `git revert` as a critical issue.
-
 
 ## AI Skills
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,7 @@
-filters:
-  '.*':
-    approvers:
-      - deads2k
-      - stevekuznetsov
-      - geoberle
-      - bennerv
-      - service-lifecycle-global-approvers
-  # Intended to support autoowners generation in openshift/release; in this repo it will apply to any file paths that match the regex below.
-  # See https://github.com/openshift/release/blob/main/ci-operator/config/Azure/ARO-HCP/OWNERS
-  '.*capz.*':
-    approvers:
-      - capz-approvers
+approvers:
+  - deads2k
+  - stevekuznetsov
+  - geoberle
+  - bennerv
+  - service-lifecycle-global-approvers
+reviewers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -17,10 +17,6 @@ aliases:
   - sclarkso 
   - venkateshsredhat 
   - weherdh
-  capz-approvers:
-  - RadekCap
-  - marek-veber
-  - mzazrivec
   sre-approvers:
   - SudoBrendan
   - ehvs

--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
-appVersion: v2.16.5
-version: v2.16.5
+appVersion: v2.16.4
+version: v2.16.4
 description: A Helm chart for ACM addons
 name: policy
 dependencies:
 - name: grc
-  version: v2.16.5
+  version: v2.16.4
 - name: cluster-lifecycle
-  version: v2.16.5
+  version: v2.16.4

--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/cluster-lifecycle/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/cluster-lifecycle/Chart.yaml
@@ -1,8 +1,8 @@
 # Copyright (c) 2024 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 apiVersion: v2
-appVersion: v2.16.5
+appVersion: v2.16.4
 description: Helm chart for deploying the cluster lifecycle
 kubeVersion: ">=1.11.0-0"
 name: cluster-lifecycle
-version: v2.16.5
+version: v2.16.4

--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/grc/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/charts/grc/Chart.yaml
@@ -1,10 +1,10 @@
 # Copyright (c) 2024 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 apiVersion: v2
-appVersion: v2.16.5
+appVersion: v2.16.4
 description: A Helm chart for multicloud grc
 keywords:
 - acm
 - grc
 name: grc
-version: v2.16.5
+version: v2.16.4

--- a/acm/deploy/helm/multicluster-engine-config/charts/policy/values.yaml
+++ b/acm/deploy/helm/multicluster-engine-config/charts/policy/values.yaml
@@ -2,7 +2,7 @@ global:
   registryOverride: "registry.redhat.io/rhacm2"
   imageOverrides:
     governance_policy_propagator: "governance-policy-propagator-rhel9@sha256:21e57c2f6b9556b45ef33934b35edb8c563385b591cb557fecd6322e1a635768"
-    governance_policy_addon_controller: "acm-governance-policy-addon-controller-rhel9@sha256:226041eb9c2c4424edd1fbec83c1a2041e6626d4e29907e15a1f4ce0d11ba54d"
+    governance_policy_addon_controller: "acm-governance-policy-addon-controller-rhel9@sha256:c48babbfe45a6df7dd88f08c6304f019fe60c4059d18d16f744cfae4ac8c8ea7"
     config_policy_controller: "config-policy-controller-rhel9@sha256:730d8bcc0bc45e93682d5a24a6825100559920216edbff161c2cc48af1f16993"
     governance_policy_framework_addon: "acm-governance-policy-framework-addon-rhel9@sha256:f5d5dde4b41e4946f306cb7539a55a673ae47a1988b865e4d2e7a5849a9dd4c5"
     klusterlet_addon_controller: "klusterlet-addon-controller-rhel9@sha256:8f63faa54bd2c261b81ccd289ed1e801decaeb85fa86d537404153f1cacc8f7d"

--- a/acm/deploy/helm/multicluster-engine-crds/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine-crds/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.11.7
+appVersion: 2.11.6
 description: A Helm chart for multicluster-engine - CRDs
 keywords:
 - mce
@@ -7,6 +7,6 @@ keywords:
 - multiclusterengine
 name: multicluster-engine-crds
 sources:
-- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:ca617909e348bddf30ebbe49c8bbc6c7ef622192c1af6594653b0979b3498343
+- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18
 type: application
-version: 2.11.7
+version: 2.11.6

--- a/acm/deploy/helm/multicluster-engine/Chart.yaml
+++ b/acm/deploy/helm/multicluster-engine/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.11.7
+appVersion: 2.11.6
 description: A Helm chart for multicluster-engine
 keywords:
 - mce
@@ -7,6 +7,6 @@ keywords:
 - multiclusterengine
 name: multicluster-engine
 sources:
-- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:ca617909e348bddf30ebbe49c8bbc6c7ef622192c1af6594653b0979b3498343
+- quay.io/redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211@sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18
 type: application
-version: 2.11.7
+version: 2.11.6

--- a/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-operator.deployment.yaml
+++ b/acm/deploy/helm/multicluster-engine/templates/multicluster-engine-operator.deployment.yaml
@@ -56,43 +56,43 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: OPERAND_IMAGE_ADDON_MANAGER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/addon-manager-rhel9@sha256:4919a70599f967e396290ebc00a1a35dddebfa7a3b9107c259be0fbafd7d493f'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/addon-manager-rhel9@sha256:dde21beb44c32882e09766d59a13d07d8442844463fca4c9655d7b4d447587b1'
         - name: OPERAND_IMAGE_AZURE_SERVICE_OPERATOR_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/azure-service-operator-rhel9@sha256:e65c9c211ba061fc772e368c315d2390cfc245ab403325beed2ec15c91a4cf24'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/azure-service-operator-rhel9@sha256:0b8c0d6554ab0537ec274923a124d46b4d3d97b5f5d015519565a9ea2a222aab'
         - name: OPERAND_IMAGE_BACKPLANE_MUST_GATHER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/must-gather-rhel9@sha256:8ed2459dc27a9248be4c4c3a316abb5194d8b5d26856928130afed5cdef77902'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/must-gather-rhel9@sha256:189fe907052598270b45323bb286cd4675b9c19cfd411dae4f2952c7249ec77d'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AGENT
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-agent-rhel9@sha256:7eb1a6562cdfe51e649bc993aecc86892c94ea8af084592fc4c556123ef254b8'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AWS_RHEL9
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-aws-rhel9@sha256:cedc5d27bd611cb2357419416464ff20824168348aee627d86e168143dd8fdf5'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_AZURE_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-azure-rhel9@sha256:3cfcaccd65dd904e3b4ac93f4056a8208850fffddcdfa8d6c53c762a1019ee35'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-azure-rhel9@sha256:ef696bb15a0d8ca0f528032eeec7e5a09b3bd30bb38559284a88ee6e67feb171'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_KUBEVIRT
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-api-provider-kubevirt-rhel9@sha256:aa076770d211915d7a6b12118e4aa63fa01a27842bbc1734ab8b7ce8f263b837'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_OPENSHIFT_ASSISTED_BOOTSTRAP
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/capoa-bootstrap-rhel9@sha256:10a28cd23ab4e0fd72d8e337c7e904b1bb499da59c35b1b9f9bc2b5a8328cba0'
         - name: OPERAND_IMAGE_CLUSTER_API_PROVIDER_OPENSHIFT_ASSISTED_CONTROL_PLANE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/capoa-control-plane-rhel9@sha256:e76e5a4cac6b9ee396bb5419598e7bc4fe443e2df8df2c1811f119ae7480a56e'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/capoa-control-plane-rhel9@sha256:270c985fb8b9adbdd0f7fad109c11f4f1b868634603cf09674b2ac65694720fd'
         - name: OPERAND_IMAGE_MCE_CAPI_WEBHOOK_CONFIG_RHEL9
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/mce-capi-webhook-config-rhel9@sha256:4a0d1acfbd56cf2f7f3c30d2ce7ce3d7f040f7c4744a0b292787d5f5f43dd5aa'
         - name: OPERAND_IMAGE_CLUSTERCLAIMS_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/clusterclaims-controller-rhel9@sha256:e51c1cd26215b6e7aec5f3b5c47633400e9a0ad1da6ceaa20d7b64053750f467'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/clusterclaims-controller-rhel9@sha256:652be33ec98de64ea578aef9b9b08a4c594c44419ccf3925dd4864d35b1d03b3'
         - name: OPERAND_IMAGE_CLUSTER_CURATOR_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-curator-controller-rhel9@sha256:759dbffea7531c0bddddea97d3e51ba3de222bcabadd00fcffd8ecb3c9256e4c'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-curator-controller-rhel9@sha256:0073473d233a571a9d0b4dd23c3c94731d3c4213e9caba84171b009669689307'
         - name: OPERAND_IMAGE_CLUSTER_IMAGE_SET_CONTROLLER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-image-set-controller-rhel9@sha256:56e4361440bab6066509b871bce1e9941b10bde55b789ed83448fa80b7f1f478'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-image-set-controller-rhel9@sha256:27fd5de3c58b3f17c69445f3d6bf48862a366aa294cb6b8744b970c1c0afc51d'
         - name: OPERAND_IMAGE_CLUSTERLIFECYCLE_STATE_METRICS
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/clusterlifecycle-state-metrics-rhel9@sha256:b1f00cdca8ac6a04c6609a13a09d5c32a22cbb5758832629d73bdb40c8069bcb'
         - name: OPERAND_IMAGE_CLUSTER_PROXY
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/cluster-proxy-rhel9@sha256:9fa3ade43abc8dc164e3cedf91ac881e440d9d810d6ecbcdfabea1ceec153f0f'
         - name: OPERAND_IMAGE_CONSOLE_MCE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/console-mce-rhel9@sha256:8339fe72636f4307b071a6c88fca11448a7e897556ec1c5f08ba526dc4ab045d'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/console-mce-rhel9@sha256:49c8398c6d3e68a001a028fca6b10303c78c917aa913299650e7ad79c871a710'
         - name: OPERAND_IMAGE_DISCOVERY_OPERATOR
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/discovery-rhel9@sha256:dfb3deb181dceb12f427f7bafe950305c4e58263dcc538f76fa25eef5dcb7816'
         - name: OPERAND_IMAGE_OPENSHIFT_HIVE
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hive-rhel9@sha256:4bacf1269df6d0e7c292944f1040f5a5e9016a2a462182b8c9d92763c3e2552f'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hive-rhel9@sha256:5b534749630cabf09dfbb14287ed4b9fdaa8295cc95371adf611f9f1fa3a8abb'
         - name: OPERAND_IMAGE_HYPERSHIFT_ADDON_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-addon-rhel9-operator@sha256:0e7c4e8d7a4e9eb5e7b310425c1806bed43769c4180fa8b1785aae302f178a52'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-addon-rhel9-operator@sha256:d8fcc7c22bcb8db2606fcebaf05f4c1a684ae899d982b055314abb900af73020'
         - name: OPERAND_IMAGE_HYPERSHIFT_CLI
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/hypershift-cli-rhel9@sha256:dbe4cbe742025c856aae31c5eb5ac841cd9fabca6edebc7171f938ba2783da7e'
         - name: OPERAND_IMAGE_HYPERSHIFT_OPERATOR
@@ -106,17 +106,17 @@ spec:
         - name: OPERAND_IMAGE_MANAGED_SERVICEACCOUNT
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/managed-serviceaccount-rhel9@sha256:206deca0716a54e239d0ab0d91c8e9a9f21fdf1dc1b1546a6c933a12dcafbea6'
         - name: OPERAND_IMAGE_MULTICLOUD_MANAGER
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/multicloud-manager-rhel9@sha256:10061c3e5900ae9068cd148e9bc04d2dea08697ce974acebe4c8a45568916012'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/multicloud-manager-rhel9@sha256:e82bddd0888636a414970c461833f61ce31b02892e9541470c59f6d20cf93ebf'
         - name: OPERAND_IMAGE_PROVIDER_CREDENTIAL_CONTROLLER
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/provider-credential-controller-rhel9@sha256:9d4aa6b492727c2aaa2c7d0e047d41d279a88f2aaeacaec3658471c67278d46f'
         - name: OPERAND_IMAGE_PLACEMENT
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/placement-rhel9@sha256:5e2a4ba2eeff6a9ca864d5dcd322b42d9156851741f97d0d008a167fc194f3b8'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/placement-rhel9@sha256:6686007f4656bb4049ca70397c290d12fb9d33551b59004a8c73155b217fbd92'
         - name: OPERAND_IMAGE_REGISTRATION
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-rhel9@sha256:82348c4fc33619b8ec621718bf97d473a62dfb0bc9cd236170a6c30779f9cd95'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-rhel9@sha256:a9f27fb8e1b0a4466ceab011a35abde76ee3f213f1c43863cdecc1a1669fead1'
         - name: OPERAND_IMAGE_REGISTRATION_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-operator-rhel9@sha256:47257894132346453ba99cc945ff1959ecf02eb3702faa9ba36a83a7086a276c'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/registration-operator-rhel9@sha256:ff918172773de7995a355e768d13d5f64daeaee022644a93e26af69b07cee9bb'
         - name: OPERAND_IMAGE_WORK
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/work-rhel9@sha256:564501ff40f0f6cebd6fb36de856ed83b3ccce1a95b4802123533de8c53f734c'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/work-rhel9@sha256:49e6dbc3782264f94fa0d0b802213f3d678aa9b2367d23aa07e38558378850d6'
         - name: OPERAND_IMAGE_ASSISTED_IMAGE_SERVICE
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-image-service-rhel9@sha256:56cd39d85b9814dffee4a595e93b2c145c622491608c93c5f85537346c4a1e89'
         - name: OPERAND_IMAGE_ASSISTED_INSTALLER
@@ -128,18 +128,18 @@ spec:
         - name: OPERAND_IMAGE_ASSISTED_SERVICE_9
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/assisted-service-9-rhel9@sha256:cc6e93b403f94d87f7e4e2c159fd0633c5b107071f52415c7fa7baa8777fd910'
         - name: OPERAND_IMAGE_OSE_CLUSTER_API_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/ose-cluster-api-rhel9@sha256:da702340f05c0cefd0eb0896e3dfb6896cdc26abaebffd13e7711900a4843cf4'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/ose-cluster-api-rhel9@sha256:ba4da29ef8097031f3b24ca92d892674217773d75e73d5ff3e00590127246811'
         - name: OPERAND_IMAGE_OSE_BAREMETAL_CLUSTER_API_CONTROLLERS_RHEL9
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/ose-baremetal-cluster-api-controllers-rhel9@sha256:824a9d3c4bee40bd894e7fa4f40e56c021e232cc73ca1c59151323e6c6139fe2'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/ose-baremetal-cluster-api-controllers-rhel9@sha256:471b7a0cdf8933317bec4c98265ac908f93ad656a531baffb30a5bbec391f156'
         - name: OPERAND_IMAGE_POSTGRESQL_13
           value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/postgresql-13@sha256:97b64c18a32944b86fd1a118aa0d1aa04ff1fad8068c3c20f6e94af24712ff36'
         - name: OPERATOR_VERSION
-          value: 2.11.7
+          value: 2.11.6
         - name: OPERATOR_PACKAGE
           value: multicluster-engine
         - name: OPERAND_IMAGE_BACKPLANE_OPERATOR
-          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:6d4f83990a3e26fb20097e26cadd5ffabeab2b39b2f6669f2794bc341b21b2a5'
-        image: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:6d4f83990a3e26fb20097e26cadd5ffabeab2b39b2f6669f2794bc341b21b2a5'
+          value: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:62b7e08e6cef9554878ff6def3b250f106846d6a0347388fb03802ad5155a030'
+        image: '{{ .Values.imageRegistry }}/{{ .Values.imageRootRepository }}/backplane-rhel9-operator@sha256:62b7e08e6cef9554878ff6def3b250f106846d6a0347388fb03802ad5155a030'
         livenessProbe:
           httpGet:
             path: /healthz

--- a/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce.yaml
+++ b/acm/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_mce.yaml
@@ -3571,7 +3571,7 @@ spec:
         - name: OPERAND_IMAGE_POSTGRESQL_13
           value: 'arohcpsvcdev.azurecr.io/acm-d-cache/postgresql-13@sha256:1234567890'
         - name: OPERATOR_VERSION
-          value: 2.11.7
+          value: 2.11.6
         - name: OPERATOR_PACKAGE
           value: multicluster-engine
         - name: OPERAND_IMAGE_BACKPLANE_OPERATOR

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -40,6 +40,7 @@ require (
 	k8s.io/component-base v0.35.3
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
+	open-cluster-management.io/api v1.3.0
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -96,6 +97,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/openshift-online/ocm-api-model/clientapi v0.0.464 // indirect
 	github.com/openshift-online/ocm-api-model/model v0.0.464 // indirect
+	github.com/openshift/library-go v0.0.0-20260504190829-2dd4388d7b89 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -182,6 +182,7 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.28.3 h1:4JvMdwtFU0imd8fHx25OJXoDMRexnf8v5NHKYSTTji4=
 github.com/onsi/ginkgo/v2 v2.28.3/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
 github.com/onsi/gomega v1.40.0 h1:Vtol0e1MghCD2ZVIilPDIg44XSL9l2QAn8ZNaljWcJc=
@@ -198,6 +199,8 @@ github.com/openshift/cluster-version-operator v1.0.1-0.20260202115537-557510ea06
 github.com/openshift/cluster-version-operator v1.0.1-0.20260202115537-557510ea0603/go.mod h1:5HPAGcvwDreflw2OjJTEz7MicVZ/mTJQv6zYykB+f+M=
 github.com/openshift/hypershift/api v0.0.0-20260708113917-8b5103a5875b h1:JEAHE8tV+h+7QmPELrhoKxzzUuHAMPJzsNBunzwM6O8=
 github.com/openshift/hypershift/api v0.0.0-20260708113917-8b5103a5875b/go.mod h1:XO2zWpuo0rqxljntdt4aI5ZKhQCIeMYRDWtRNTo+bSE=
+github.com/openshift/library-go v0.0.0-20260504190829-2dd4388d7b89 h1:etWee1jfkT93YVB+aYDhCARlokHGvWsRKXgKPcGrSZQ=
+github.com/openshift/library-go v0.0.0-20260504190829-2dd4388d7b89/go.mod h1:k1tefCr+PAZ7kY8TJjpE6rW6t6Yu4iOmBwO+1+3qD2s=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -370,6 +373,8 @@ k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a h1:xCeOEAOoGYl2jnJoHkC3hk
 k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a/go.mod h1:uGBT7iTA6c6MvqUvSXIaYZo9ukscABYi2btjhvgKGZ0=
 k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 h1:kBawHLSnx/mYHmRnNUf9d4CpjREbeZuxoSGOX/J+aYM=
 k8s.io/utils v0.0.0-20260319190234-28399d86e0b5/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
+open-cluster-management.io/api v1.3.0 h1:Q3miH38BE3N5+PesHQ0kcFi5nhX5350m7OJWapZcVqY=
+open-cluster-management.io/api v1.3.0/go.mod h1:t0DsBv4gjIo9ojd7GYfA2tcEMpNf0h5Ix68pFDXwNSk=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
 sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -59,6 +59,7 @@ import (
 	clusterupdate "github.com/Azure/ARO-HCP/backend/pkg/controllers/cluster/update"
 	clustervalidation "github.com/Azure/ARO-HCP/backend/pkg/controllers/cluster/validation"
 	clusterversion "github.com/Azure/ARO-HCP/backend/pkg/controllers/cluster/version"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterresources"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/cosmosmigration"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/datadump"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/example"
@@ -975,6 +976,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.ResourcesDBClient,
 		backendInformers,
 		unionKubeApplierInformers,
+		b.options.KubeApplierDBClients,
 	)
 
 	externalAuthDeletionClusterServiceDeleteDispatchController := externalauthdeletion.NewExternalAuthClusterServiceDeleteDispatchController(
@@ -1018,6 +1020,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
 		backendInformers,
+		unionKubeApplierInformers,
 	)
 
 	clusterClusterServiceIDClearerController := clusterdeletion.NewClusterClusterServiceIDClearerController(
@@ -1043,6 +1046,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.ResourcesDBClient,
 		b.options.BillingDBClient,
 		backendInformers,
+		b.options.KubeApplierDBClients,
 	)
 
 	clusterClusterServiceUpdateDispatchController := clusterupdate.NewClusterClusterServiceUpdateDispatchController(
@@ -1085,6 +1089,14 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.ClusterScopedIdentitiesConfig,
 		backendInformers,
 		unionKubeApplierInformers,
+	)
+
+	clusterResourcesController := clusterresources.NewClusterResourcesController(
+		b.options.ResourcesDBClient,
+		b.options.KubeApplierDBClients,
+		backendInformers,
+		unionKubeApplierInformers,
+		b.options.ClustersServiceClient,
 	)
 
 	leaderElectionConfig := leaderelection.LeaderElectionConfig{
@@ -1207,6 +1219,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go fetchDataPlaneOperatorsManagedIdentitiesInfoController.Run(ctx, 20)
 				go observeRoleAssignmentsController.Run(ctx, 20)
 				go keyRotationBackupController.Run(ctx, 20)
+				go clusterResourcesController.Run(ctx, 20)
 			},
 			OnStoppedLeading: func() {
 				// This needs to be defined even though it does nothing.

--- a/backend/pkg/controllers/cluster/deletion/cluster_cluster_service_delete_dispatch_controller.go
+++ b/backend/pkg/controllers/cluster/deletion/cluster_cluster_service_delete_dispatch_controller.go
@@ -28,12 +28,16 @@ import (
 
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterresources"
 	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
 	"github.com/Azure/ARO-HCP/internal/database/informers/coreinformers"
 	"github.com/Azure/ARO-HCP/internal/database/listers/corelisters"
+	"github.com/Azure/ARO-HCP/internal/database/listers/kubeapplierlisters"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -52,11 +56,16 @@ const missingClusterServiceIDTimeout = 120 * time.Second
 // waiting for a ClusterServiceID), it stamps ClusterServiceDeletionTimestamp
 // on the Cluster to record that this step is complete and avoid re-issuing
 // the delete on subsequent syncs.
+//
+// Before dispatching the delete, this controller waits until the
+// ClusterResourcesController has cleaned up all its tagged ApplyDesires,
+// so that kube resources are torn down before the cluster itself.
 type clusterClusterServiceDeleteDispatchSyncer struct {
 	clock                utilsclock.PassiveClock
 	clusterLister        corelisters.ClusterLister
 	resourcesDBClient    corecosmosstorage.ResourcesDBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
+	applyDesireLister    kubeapplierlisters.ApplyDesireLister
 	// firstSeenDeletionTimestampCache is a cache that contains the time the controller
 	// has first seen the serviceProviderProperties.deletionTimestamp being set
 	// for a cluster. The cache key is the lowercased cluster's resource ID and
@@ -71,13 +80,16 @@ func NewClusterClusterServiceDeleteDispatchController(
 	resourcesDBClient corecosmosstorage.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	informers coreinformers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 	_, clusterLister := informers.Clusters()
+	_, applyDesireLister := kubeApplierInformers.ApplyDesires()
 	syncer := &clusterClusterServiceDeleteDispatchSyncer{
 		clock:                           clock,
 		clusterLister:                   clusterLister,
 		resourcesDBClient:               resourcesDBClient,
 		clusterServiceClient:            clusterServiceClient,
+		applyDesireLister:               applyDesireLister,
 		firstSeenDeletionTimestampCache: lru.New(50000),
 	}
 
@@ -85,7 +97,7 @@ func NewClusterClusterServiceDeleteDispatchController(
 		"ClusterClusterServiceDeleteDispatch",
 		resourcesDBClient,
 		informers,
-		nil, // no kubeApplierInformers needed for deletion
+		kubeApplierInformers,
 		time.Minute,
 		syncer,
 	)
@@ -138,6 +150,16 @@ func (c *clusterClusterServiceDeleteDispatchSyncer) SyncOnce(ctx context.Context
 		return utils.TrackError(fmt.Errorf("failed to get cluster: %w", err))
 	}
 	if !c.NeedsWork(cluster) {
+		return nil
+	}
+
+	// Wait until ClusterResourcesController has deleted all its tagged ApplyDesires.
+	hasTaggedDesires, err := c.hasClusterResourceApplyDesires(ctx, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check ClusterResource ApplyDesires: %w", err))
+	}
+	if hasTaggedDesires {
+		logger.Info("waiting for ClusterResourcesController to delete its ApplyDesires before dispatching CS delete")
 		return nil
 	}
 
@@ -194,4 +216,18 @@ func (c *clusterClusterServiceDeleteDispatchSyncer) SyncOnce(ctx context.Context
 	c.firstSeenDeletionTimestampCache.Remove(cacheKey)
 
 	return nil
+}
+
+func (c *clusterClusterServiceDeleteDispatchSyncer) hasClusterResourceApplyDesires(ctx context.Context, key controllerutils.HCPClusterKey) (bool, error) {
+	desires, err := c.applyDesireLister.ListForCluster(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return false, err
+	}
+	for _, desire := range desires {
+		if desire.Tags != nil &&
+			desire.Tags[kubeapplierapi.TagControllerName] == clusterresources.ClusterResourcesControllerName {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/backend/pkg/controllers/cluster/deletion/cluster_cluster_service_delete_dispatch_controller_test.go
+++ b/backend/pkg/controllers/cluster/deletion/cluster_cluster_service_delete_dispatch_controller_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/corecosmosstoragetesting"
 	"github.com/Azure/ARO-HCP/internal/database/listertesting/corelistertesting"
+	kubeapplierlistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting/kubeapplierlistertesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -272,6 +273,7 @@ func TestClusterClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
 				clusterLister:                   &corelistertesting.SliceClusterLister{Clusters: clustersForLister},
 				resourcesDBClient:               mockResourcesDBClient,
 				clusterServiceClient:            mockCSClient,
+				applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 				firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 			}
 
@@ -311,6 +313,7 @@ func TestClusterClusterServiceDeleteDispatchSyncer_SyncOnce_cacheShortCircuit(t 
 		clusterLister:                   &corelistertesting.SliceClusterLister{Clusters: []*coreapi.HCPOpenShiftCluster{cachedCluster}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
+		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: lru.New(10),
 	}
 
@@ -345,6 +348,7 @@ func TestClusterClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCac
 		clusterLister:                   &corelistertesting.SliceClusterLister{Clusters: []*coreapi.HCPOpenShiftCluster{cluster}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
+		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 	}
 
@@ -387,6 +391,7 @@ func TestClusterClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCac
 		clusterLister:                   &corelistertesting.SliceClusterLister{Clusters: []*coreapi.HCPOpenShiftCluster{cluster}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            mockCSClient,
+		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 	}
 

--- a/backend/pkg/controllers/cluster/deletion/cluster_deletion_controller.go
+++ b/backend/pkg/controllers/cluster/deletion/cluster_deletion_controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -27,9 +28,11 @@ import (
 
 	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/billingcosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/kubeappliercosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/informers/coreinformers"
 	"github.com/Azure/ARO-HCP/internal/database/listers/corelisters"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -45,6 +48,7 @@ type clusterDeletionController struct {
 	serviceProviderClusterLister corelisters.ServiceProviderClusterLister
 	resourcesDBClient            corecosmosstorage.ResourcesDBClient
 	billingDBClient              billingcosmosstorage.BillingDBClient
+	kubeApplierDBClients         kubeappliercosmosstorage.KubeApplierDBClients
 	passiveClock                 utilsclock.PassiveClock
 }
 
@@ -55,6 +59,7 @@ func NewClusterDeletionController(
 	resourcesDBClient corecosmosstorage.ResourcesDBClient,
 	billingDBClient billingcosmosstorage.BillingDBClient,
 	informers coreinformers.BackendInformers,
+	kubeApplierDBClients kubeappliercosmosstorage.KubeApplierDBClients,
 ) controllerutils.Controller {
 	_, clusterLister := informers.Clusters()
 	_, serviceProviderClusterLister := informers.ServiceProviderClusters()
@@ -63,6 +68,7 @@ func NewClusterDeletionController(
 		serviceProviderClusterLister: serviceProviderClusterLister,
 		resourcesDBClient:            resourcesDBClient,
 		billingDBClient:              billingDBClient,
+		kubeApplierDBClients:         kubeApplierDBClients,
 		passiveClock:                 clock,
 	}
 
@@ -134,8 +140,18 @@ func (c *clusterDeletionController) SyncOnce(ctx context.Context, key controller
 		return nil
 	}
 
+	// Precondition: all ApplyDesires for this cluster must be gone.
+	// Each controller is responsible for deleting its own desires during cluster deletion.
+	preconditionMet, err := c.deletePreconditionAllApplyDesiresGone(ctx, key, cachedSPC)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check ApplyDesire precondition: %w", err))
+	}
+	if !preconditionMet {
+		return nil
+	}
+
 	// Precondition: all cluster-scoped Maestro readonly bundles must be cleared
-	preconditionMet, err := c.deletePreconditionAllMaestroClusterScopedReadonlyBundlesCleared(ctx, key)
+	preconditionMet, err = c.deletePreconditionAllMaestroClusterScopedReadonlyBundlesCleared(ctx, key)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
 	}
@@ -277,5 +293,61 @@ func (c *clusterDeletionController) deletePreconditionCosmosChildResourcesDelete
 		return false, utils.TrackError(fmt.Errorf("error iterating child resources: %w", err))
 	}
 
+	return true, nil
+}
+
+// deletePreconditionAllApplyDesiresGone checks that no ApplyDesires remain for
+// this cluster. Each controller that creates ApplyDesires is responsible for
+// cleaning up its own; this method only verifies they are all gone before
+// proceeding. The log message reports remaining counts per controller so
+// operators can see which controller is lagging.
+func (c *clusterDeletionController) deletePreconditionAllApplyDesiresGone(ctx context.Context, key controllerutils.HCPClusterKey, spc *coreapi.ServiceProviderCluster) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	if spc == nil || spc.Status.ManagementClusterResourceID == nil {
+		return true, nil
+	}
+
+	managementClusterID := spc.Status.ManagementClusterResourceID
+	kubeApplierDBClient := c.kubeApplierDBClients.For(ctx, managementClusterID)
+	if kubeApplierDBClient == nil {
+		logger.Info("waiting for kube-applier DB client to be available for ApplyDesire precondition", "managementCluster", managementClusterID.String())
+		return false, nil
+	}
+
+	kubeApplierCRUD, err := kubeApplierDBClient.ApplyDesiresForCluster(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return false, fmt.Errorf("failed to get kube-applier CRUD for ApplyDesire precondition: %w", err)
+	}
+
+	applyDesireIterator, err := kubeApplierCRUD.List(ctx, &cosmosstorageutils.DBClientListResourceDocsOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to list ApplyDesire documents for precondition check: %w", err)
+	}
+
+	controllerCounts := map[string]int{}
+	for _, desire := range applyDesireIterator.Items(ctx) {
+		controller := "unknown"
+		if desire.Tags != nil {
+			if name := desire.Tags[kubeapplierapi.TagControllerName]; name != "" {
+				controller = name
+			}
+		}
+		controllerCounts[controller]++
+	}
+	if err := applyDesireIterator.GetError(); err != nil {
+		return false, fmt.Errorf("error iterating ApplyDesires for precondition check: %w", err)
+	}
+
+	if len(controllerCounts) > 0 {
+		var parts []string
+		for controller, count := range controllerCounts {
+			parts = append(parts, fmt.Sprintf("%d from %s", count, controller))
+		}
+		slices.Sort(parts)
+		logger.Info("waiting for all ApplyDesires to be deleted",
+			"remaining", strings.Join(parts, ", "))
+		return false, nil
+	}
 	return true, nil
 }

--- a/backend/pkg/controllers/clusterresources/cluster_resources_controller.go
+++ b/backend/pkg/controllers/clusterresources/cluster_resources_controller.go
@@ -1,0 +1,531 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterresources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	ocmv1 "open-cluster-management.io/api/work/v1"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/kubeapplierhelpers"
+	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
+	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/kubeappliercosmosstorage"
+	"github.com/Azure/ARO-HCP/internal/database/informers/coreinformers"
+	"github.com/Azure/ARO-HCP/internal/database/listers/corelisters"
+	"github.com/Azure/ARO-HCP/internal/database/listers/kubeapplierlisters"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/restmapper"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	ClusterResourcesControllerName = "ClusterResources"
+)
+
+// clusterResourcesController polls the Cluster Service SDK endpoint for cluster resources information
+type clusterResourcesController struct {
+	clusterLister                corelisters.ClusterLister
+	serviceProviderClusterLister corelisters.ServiceProviderClusterLister
+	nodePoolLister               corelisters.NodePoolLister
+	clustersServiceClient        ocm.ClusterServiceClientSpec
+	kubeApplierDBClients         kubeappliercosmosstorage.KubeApplierDBClients
+	applyDesireLister            kubeapplierlisters.ApplyDesireLister
+}
+
+var _ controllerutils.ClusterSyncer = (*clusterResourcesController)(nil)
+
+func NewClusterResourcesController(
+	resourcesDBClient corecosmosstorage.ResourcesDBClient,
+	kubeApplierDBClients kubeappliercosmosstorage.KubeApplierDBClients,
+	informers coreinformers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
+	clustersServiceClient ocm.ClusterServiceClientSpec,
+) controllerutils.Controller {
+	_, clusterLister := informers.Clusters()
+	_, serviceProviderClusterLister := informers.ServiceProviderClusters()
+	_, nodePoolLister := informers.NodePools()
+	_, applyDesireLister := kubeApplierInformers.ApplyDesires()
+
+	syncer := &clusterResourcesController{
+		clusterLister:                clusterLister,
+		serviceProviderClusterLister: serviceProviderClusterLister,
+		nodePoolLister:               nodePoolLister,
+		clustersServiceClient:        clustersServiceClient,
+		kubeApplierDBClients:         kubeApplierDBClients,
+		applyDesireLister:            applyDesireLister,
+	}
+
+	return controllerutils.NewClusterWatchingController(
+		ClusterResourcesControllerName,
+		resourcesDBClient,
+		informers,
+		nil,
+		30*time.Second, // Poll every 30 seconds.
+		syncer,
+	)
+}
+
+// NeedsWork reports whether the controller has work to do for the given cluster.
+// It requires the cluster to be placed on a management cluster. Beyond that:
+// - Clusters being deleted need ApplyDesire cleanup
+// - Clusters with a ClusterServiceID need resource syncing
+func (c *clusterResourcesController) NeedsWork(cluster *coreapi.HCPOpenShiftCluster, managementCluster *azcorearm.ResourceID) bool {
+	if managementCluster == nil {
+		return false
+	}
+
+	if cluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return true
+	}
+
+	if cluster.ServiceProviderProperties.ClusterServiceID == nil {
+		return false
+	}
+
+	return true
+}
+
+// SyncOnce polls the cluster resources endpoint and updates any relevant state.
+// When the cluster is being deleted, it cleans up all ApplyDesires it owns
+// instead of polling for resources.
+func (c *clusterResourcesController) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
+	cluster, err := c.clusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if cosmosstorageutils.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster from cache: %w", err))
+	}
+
+	spc, err := c.serviceProviderClusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if cosmosstorageutils.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster from cache: %w", err))
+	}
+	managementCluster := spc.Status.ManagementClusterResourceID
+
+	if !c.NeedsWork(cluster, managementCluster) {
+		return nil
+	}
+
+	if cluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return c.deleteAllOwnedApplyDesires(ctx, key, managementCluster)
+	}
+
+	clusterServiceID := *cluster.ServiceProviderProperties.ClusterServiceID
+	if err := c.fetchAndProcessClusterResources(ctx, key, managementCluster, clusterServiceID); err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster resources: %w", err))
+	}
+
+	return nil
+}
+
+// deleteAllOwnedApplyDesires removes all ApplyDesire Cosmos documents owned by
+// this controller for the given cluster. Called during cluster deletion — the
+// underlying kube resources are cleaned up separately by the
+// ClusterChildResourcesCleanupController, so we only need to purge the docs.
+func (c *clusterResourcesController) deleteAllOwnedApplyDesires(ctx context.Context, key controllerutils.HCPClusterKey, managementCluster *azcorearm.ResourceID) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	existing, err := c.applyDesireLister.ListForCluster(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("list ApplyDesires for deletion cleanup: %w", err))
+	}
+
+	kubeApplierDBClient := c.kubeApplierDBClients.For(ctx, managementCluster)
+	if kubeApplierDBClient == nil {
+		return nil
+	}
+
+	for _, desire := range existing {
+		if desire.Tags == nil ||
+			desire.Tags[kubeapplierapi.TagControllerName] != ClusterResourcesControllerName {
+			continue
+		}
+		scope, err := kubeappliercosmosstorage.ParseDesireScope(desire.ResourceID.Parent)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("parse scope for ApplyDesire %s: %w", desire.ResourceID.Name, err))
+		}
+		crud, err := kubeApplierDBClient.ApplyDesiresFor(scope)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("get CRUD for ApplyDesire %s: %w", desire.ResourceID.Name, err))
+		}
+		if err := crud.Delete(ctx, desire.ResourceID.Name); err != nil && !cosmosstorageutils.IsNotFoundError(err) {
+			return utils.TrackError(fmt.Errorf("delete ApplyDesire %s: %w", desire.ResourceID.Name, err))
+		}
+		logger.Info("deleted ApplyDesire document", "desireName", desire.ResourceID.Name)
+	}
+
+	return nil
+}
+
+// fetchAndProcessClusterResources calls the Cluster Service SDK to get cluster resources information
+// and processes the resources.
+func (c *clusterResourcesController) fetchAndProcessClusterResources(ctx context.Context,
+	key controllerutils.HCPClusterKey, managementCluster *azcorearm.ResourceID, clusterServiceID metadataapi.InternalID) error {
+	// Get cluster resources from the Cluster Service SDK
+	resources, err := c.clustersServiceClient.GetClusterResources(ctx, clusterServiceID)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	if resources != nil {
+		if err := c.processClusterResources(ctx, key, managementCluster, resources); err != nil {
+			return utils.TrackError(fmt.Errorf("failed to process cluster resources: %w", err))
+		}
+	}
+
+	return nil
+}
+
+// processClusterResources converts each resource to ApplyDesire documents
+func (c *clusterResourcesController) processClusterResources(ctx context.Context, key controllerutils.HCPClusterKey,
+	managementCluster *azcorearm.ResourceID, resources *arohcpv1alpha1.ClusterResources) error {
+
+	kubeApplierDBClient := c.kubeApplierDBClients.For(ctx, managementCluster)
+	if kubeApplierDBClient == nil {
+		return nil
+	}
+	applyDesireCRUD, err := kubeApplierDBClient.ApplyDesiresForCluster(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get kube-applier CRUD: %w", err))
+	}
+
+	tags := map[string]string{kubeapplierapi.TagControllerName: ClusterResourcesControllerName}
+
+	resourceMap := resources.Resources()
+	desiredResourceIDs := make(map[string]bool, len(resourceMap))
+	var errs []error
+	for resourceKey, resourceValue := range resourceMap {
+		var unstructuredObj unstructured.Unstructured
+		if err := json.Unmarshal([]byte(resourceValue), &unstructuredObj); err != nil {
+			errs = append(errs, utils.TrackError(fmt.Errorf("failed to unmarshal resource %s: %w", resourceKey, err)))
+			continue
+		}
+
+		gvr, err := restmapper.ResourceFor(unstructuredObj.GroupVersionKind())
+		if err != nil {
+			errs = append(errs, utils.TrackError(fmt.Errorf("failed to resolve resource %s: %w", resourceKey, err)))
+			continue
+		}
+
+		classified, err := classifyClusterResource(&unstructuredObj)
+		if err != nil {
+			errs = append(errs, utils.TrackError(err))
+			continue
+		}
+
+		target := kubeapplierapi.ResourceReference{
+			Group:     gvr.Group,
+			Version:   gvr.Version,
+			Resource:  gvr.Resource,
+			Name:      unstructuredObj.GetName(),
+			Namespace: unstructuredObj.GetNamespace(),
+		}
+
+		var desire *kubeapplierapi.ApplyDesire
+		var crud cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire]
+
+		switch {
+		case len(classified.nodePoolName) != 0:
+			np, npErr := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, classified.nodePoolName)
+			if npErr != nil && !cosmosstorageutils.IsNotFoundError(npErr) {
+				errs = append(errs, utils.TrackError(fmt.Errorf("failed to get nodepool %s: %w", classified.nodePoolName, npErr)))
+				continue
+			}
+			if np == nil || np.ServiceProviderProperties.DeletionTimestamp != nil {
+				continue
+			}
+
+			crud, err = kubeApplierDBClient.ApplyDesiresForNodePool(
+				key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, classified.nodePoolName,
+			)
+			if err != nil {
+				errs = append(errs, utils.TrackError(fmt.Errorf("failed to get node pool kube-applier CRUD for %s: %w", classified.nodePoolName, err)))
+				continue
+			}
+
+			desire, err = buildNodePoolResourceApplyDesire(
+				key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName,
+				classified.nodePoolName, classified.desireName,
+				managementCluster, target, &unstructuredObj, tags,
+			)
+		default:
+			crud = applyDesireCRUD
+
+			desire, err = buildClusterResourceApplyDesire(
+				key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName,
+				classified.desireName, managementCluster, target, &unstructuredObj, tags,
+			)
+		}
+
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		desiredResourceIDs[strings.ToLower(desire.ResourceID.String())] = true
+
+		if err := kubeapplierhelpers.EnsureApplyDesire(ctx, crud, c.applyDesireLister, desire); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if err := c.deleteStaleApplyDesires(ctx, key, managementCluster, desiredResourceIDs); err != nil {
+		errs = append(errs, err)
+	}
+
+	return errors.Join(errs...)
+}
+
+type classifiedResource struct {
+	desireName   string
+	nodePoolName string
+}
+
+// classifyClusterResource maps a kube object from the Cluster Service
+// GetClusterResources response to an intent-based desire name. Every
+// recognized resource gets a stable, human-readable name; unrecognized
+// resources return an error so new resource types surface immediately
+// instead of getting an opaque auto-derived name.
+//
+// Recognized resources (group / kind → desireName):
+//
+//	hypershift.openshift.io    HostedCluster          → HostedCluster
+//	hypershift.openshift.io    NodePool               → NodePool                 (nodePoolName set, scoped under nodepool)
+//	core/v1                    Namespace              → HostedClusterNamespace | ControlPlaneNamespace
+//	core/v1                    ConfigMap              → DefaultIngressConfigMap
+//	core/v1                    Secret                 → OCPPullSecret
+//	multitenancy.acn.azure.com PodNetwork             → PodNetwork
+//	multitenancy.acn.azure.com PodNetworkInstance      → PodNetworkInstance
+//	secret-sync.x-k8s.io      SecretSync             → {BoundServiceAccountSigningKey,DefaultIngressWildcardCert,KubeAPIServerServingCert}SecretSync
+//	secrets-store.csi.x-k8s.io SecretProviderClass    → {BoundServiceAccountSigningKey,DefaultIngressWildcardCert,KubeAPIServerServingCert}SecretProviderClass
+func classifyClusterResource(obj *unstructured.Unstructured) (classifiedResource, error) {
+	gvk := obj.GroupVersionKind()
+	name := obj.GetName()
+
+	switch gvk.Kind {
+	case "HostedCluster":
+		return classifiedResource{desireName: "HostedCluster"}, nil
+
+	case "NodePool":
+		// HyperShift names kube NodePool CRs as "<spec.clusterName>-<armName>".
+		// Strip the prefix to recover the ARM nodepool name used in Cosmos.
+		clusterName, _, _ := unstructured.NestedString(obj.Object, "spec", "clusterName")
+		armName := strings.TrimPrefix(name, clusterName+"-")
+		return classifiedResource{desireName: "NodePool", nodePoolName: armName}, nil
+
+	case "Namespace":
+		// CS returns two Namespaces: the HostedCluster namespace
+		// (e.g. "ocm-arohcppers-2sdm6b8jke9sm3h8ukc8mbaahngnre5c") and the
+		// ControlPlane namespace
+		// (e.g. "ocm-arohcppers-2sdm6b8jke9sm3h8ukc8mbaahngnre5c-j7h3t4w0u1t3b4b").
+		// The ControlPlane namespace carries the "hypershift.openshift.io/cluster" label.
+		if _, ok := obj.GetLabels()["hypershift.openshift.io/cluster"]; ok {
+			return classifiedResource{desireName: "ControlPlaneNamespace"}, nil
+		}
+		return classifiedResource{desireName: "HostedClusterNamespace"}, nil
+
+	case "ConfigMap":
+		return classifiedResource{desireName: "DefaultIngressConfigMap"}, nil
+
+	case "Secret":
+		return classifiedResource{desireName: "OCPPullSecret"}, nil
+
+	case "PodNetwork":
+		return classifiedResource{desireName: "PodNetwork"}, nil
+
+	case "PodNetworkInstance":
+		return classifiedResource{desireName: "PodNetworkInstance"}, nil
+
+	case "SecretSync":
+		switch {
+		case strings.Contains(name, "signing-key"):
+			return classifiedResource{desireName: "BoundServiceAccountSigningKeySecretSync"}, nil
+		case strings.Contains(name, "default-ingress"):
+			return classifiedResource{desireName: "DefaultIngressWildcardCertSecretSync"}, nil
+		case strings.Contains(name, "kube-apiserver"):
+			return classifiedResource{desireName: "KubeAPIServerServingCertSecretSync"}, nil
+		}
+
+	case "SecretProviderClass":
+		switch {
+		case strings.Contains(name, "signing-key"):
+			return classifiedResource{desireName: "BoundServiceAccountSigningKeySecretProviderClass"}, nil
+		case strings.Contains(name, "default-ingress"):
+			return classifiedResource{desireName: "DefaultIngressWildcardCertSecretProviderClass"}, nil
+		case strings.Contains(name, "kube-apiserver"):
+			return classifiedResource{desireName: "KubeAPIServerServingCertSecretProviderClass"}, nil
+		}
+	}
+
+	return classifiedResource{}, fmt.Errorf(
+		"unrecognized cluster resource: group=%q version=%q kind=%q namespace=%q name=%q",
+		gvk.Group, gvk.Version, gvk.Kind, obj.GetNamespace(), name,
+	)
+}
+
+func buildClusterResourceApplyDesire(
+	subscriptionID, resourceGroupName, clusterName, desireName string,
+	managementCluster *azcorearm.ResourceID,
+	target kubeapplierapi.ResourceReference,
+	obj *unstructured.Unstructured,
+	tags map[string]string,
+) (*kubeapplierapi.ApplyDesire, error) {
+	resourceIDStr := kubeapplierapi.ToClusterScopedApplyDesireResourceIDString(
+		subscriptionID, resourceGroupName, clusterName, desireName,
+	)
+	resourceID, err := azcorearm.ParseResourceID(resourceIDStr)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to parse ApplyDesire resource ID %q: %w", resourceIDStr, err))
+	}
+
+	rawJSON, err := json.Marshal(obj)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to marshal kube object: %w", err))
+	}
+
+	return &kubeapplierapi.ApplyDesire{
+		CosmosMetadata: coreapi.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(managementCluster.String()),
+		},
+		Spec: kubeapplierapi.ApplyDesireSpec{
+			ManagementCluster: managementCluster,
+			Type:              kubeapplierapi.ApplyDesireTypeServerSideApply,
+			TargetItem:        target,
+			ServerSideApply: &kubeapplierapi.ServerSideApplyConfig{
+				KubeContent: &runtime.RawExtension{Raw: rawJSON},
+				// Use "fieldManager": "work-agent" to avoid conflicting declarations due to
+				// the eventual consistency nature of the ResourcesController.
+				// This way fields that are not claimed will automatically be garbage collected.
+				//  TODO: remove this once ACM and Maestro are removed.
+				FieldManager: ptr.To(ocmv1.DefaultFieldManager),
+			},
+		},
+		Tags: tags,
+	}, nil
+}
+
+func buildNodePoolResourceApplyDesire(
+	subscriptionID, resourceGroupName, clusterName, nodePoolName, desireName string,
+	managementCluster *azcorearm.ResourceID,
+	target kubeapplierapi.ResourceReference,
+	obj *unstructured.Unstructured,
+	tags map[string]string,
+) (*kubeapplierapi.ApplyDesire, error) {
+	resourceIDStr := kubeapplierapi.ToNodePoolScopedApplyDesireResourceIDString(
+		subscriptionID, resourceGroupName, clusterName, nodePoolName, desireName,
+	)
+	resourceID, err := azcorearm.ParseResourceID(resourceIDStr)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to parse ApplyDesire resource ID %q: %w", resourceIDStr, err))
+	}
+
+	rawJSON, err := json.Marshal(obj)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to marshal kube object: %w", err))
+	}
+
+	return &kubeapplierapi.ApplyDesire{
+		CosmosMetadata: coreapi.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(managementCluster.String()),
+		},
+		Spec: kubeapplierapi.ApplyDesireSpec{
+			ManagementCluster: managementCluster,
+			Type:              kubeapplierapi.ApplyDesireTypeServerSideApply,
+			TargetItem:        target,
+			ServerSideApply: &kubeapplierapi.ServerSideApplyConfig{
+				KubeContent: &runtime.RawExtension{Raw: rawJSON},
+				// Use "fieldManager": "work-agent" to avoid conflicting declarations due to
+				// the eventual consistency nature of the ResourcesController.
+				// This way fields that are not claimed will automatically be garbage collected.
+				//  TODO: remove this once ACM and Maestro are removed.
+				FieldManager: ptr.To(ocmv1.DefaultFieldManager),
+			},
+		},
+		Tags: tags,
+	}, nil
+}
+
+func (c *clusterResourcesController) deleteStaleApplyDesires(
+	ctx context.Context,
+	key controllerutils.HCPClusterKey,
+	managementCluster *azcorearm.ResourceID,
+	currentDesiredResourceIDs map[string]bool,
+) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	existing, err := c.applyDesireLister.ListForCluster(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("list ApplyDesires for stale cleanup: %w", err))
+	}
+
+	kubeApplierDBClient := c.kubeApplierDBClients.For(ctx, managementCluster)
+	if kubeApplierDBClient == nil {
+		return nil
+	}
+
+	for _, desire := range existing {
+		if desire.Tags == nil ||
+			desire.Tags[kubeapplierapi.TagControllerName] != ClusterResourcesControllerName {
+			continue
+		}
+		if currentDesiredResourceIDs[strings.ToLower(desire.ResourceID.String())] {
+			continue
+		}
+
+		scope, err := kubeappliercosmosstorage.ParseDesireScope(desire.ResourceID.Parent)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("parse scope for ApplyDesire %s: %w", desire.ResourceID.Name, err))
+		}
+		crud, err := kubeApplierDBClient.ApplyDesiresFor(scope)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("get CRUD for ApplyDesire %s: %w", desire.ResourceID.Name, err))
+		}
+		removed, err := kubeapplierhelpers.EnsureApplyDesireRemoved(ctx, desire.ResourceID.Name, crud)
+		if err != nil {
+			return err
+		}
+		if removed {
+			logger.Info("purged stale ApplyDesire", "desireName", desire.ResourceID.Name)
+		} else {
+			logger.Info("stale ApplyDesire pending deletion", "desireName", desire.ResourceID.Name)
+		}
+	}
+
+	return nil
+}

--- a/backend/pkg/controllers/clusterresources/cluster_resources_controller_test.go
+++ b/backend/pkg/controllers/clusterresources/cluster_resources_controller_test.go
@@ -1,0 +1,716 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterresources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/fleetapi"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
+	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/kubeappliercosmosstoragetesting"
+	"github.com/Azure/ARO-HCP/internal/database/listertesting/corelistertesting"
+	fleetlistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting/fleetlistertesting"
+	kubeapplierlistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting/kubeapplierlistertesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	testSubscriptionID    = "00000000-0000-0000-0000-000000000000"
+	testResourceGroupName = "test-rg"
+	testClusterName       = "test-cluster"
+	testClusterServiceID  = "/api/clusters_mgmt/v1/clusters/abc123"
+)
+
+var testManagementClusterResourceID = metadataapi.Must(azcorearm.ParseResourceID(
+	"/providers/microsoft.redhatopenshift/stamps/1/managementclusters/default",
+))
+
+func testKey() controllerutils.HCPClusterKey {
+	return controllerutils.HCPClusterKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+	}
+}
+
+func newCluster(opts ...func(*coreapi.HCPOpenShiftCluster)) *coreapi.HCPOpenShiftCluster {
+	resourceID := metadataapi.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName,
+	))
+	cluster := &coreapi.HCPOpenShiftCluster{
+		CosmosMetadata: coreapi.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+		},
+		TrackedResource: coreapi.TrackedResource{
+			Resource: coreapi.Resource{
+				ID:   resourceID,
+				Name: testClusterName,
+				Type: resourceID.ResourceType.String(),
+			},
+		},
+		ServiceProviderProperties: coreapi.HCPOpenShiftClusterServiceProviderProperties{
+			ClusterServiceID: metadataapi.Ptr(metadataapi.Must(metadataapi.NewInternalID(testClusterServiceID))),
+		},
+	}
+	for _, opt := range opts {
+		opt(cluster)
+	}
+	return cluster
+}
+
+func newSPC(mcResourceID *azcorearm.ResourceID) *coreapi.ServiceProviderCluster {
+	spcResourceID := metadataapi.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/serviceProviderClusters/" + coreapi.ServiceProviderClusterResourceName,
+	))
+	return &coreapi.ServiceProviderCluster{
+		CosmosMetadata: coreapi.CosmosMetadata{
+			ResourceID:   spcResourceID,
+			PartitionKey: strings.ToLower(spcResourceID.SubscriptionID),
+		},
+		Status: coreapi.ServiceProviderClusterStatus{
+			ManagementClusterResourceID: mcResourceID,
+		},
+	}
+}
+
+func buildClusterResources(resources map[string]string) *arohcpv1alpha1.ClusterResources {
+	cr, err := arohcpv1alpha1.NewClusterResources().
+		Resources(resources).
+		Build()
+	if err != nil {
+		panic(fmt.Sprintf("failed to build ClusterResources: %v", err))
+	}
+	return cr
+}
+
+func TestNeedsWork(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		cluster           *coreapi.HCPOpenShiftCluster
+		managementCluster *azcorearm.ResourceID
+		want              bool
+	}{
+		{
+			name:              "returns true for cluster with ClusterServiceID and management cluster",
+			cluster:           newCluster(),
+			managementCluster: testManagementClusterResourceID,
+			want:              true,
+		},
+		{
+			name: "returns true for cluster being deleted with management cluster",
+			cluster: newCluster(func(c *coreapi.HCPOpenShiftCluster) {
+				now := metav1.Now()
+				c.ServiceProviderProperties.DeletionTimestamp = &now
+			}),
+			managementCluster: testManagementClusterResourceID,
+			want:              true,
+		},
+		{
+			name: "returns false for cluster without ClusterServiceID",
+			cluster: newCluster(func(c *coreapi.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			managementCluster: testManagementClusterResourceID,
+			want:              false,
+		},
+		{
+			name:              "returns false when management cluster is nil",
+			cluster:           newCluster(),
+			managementCluster: nil,
+			want:              false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := &clusterResourcesController{}
+			got := c.NeedsWork(tt.cluster, tt.managementCluster)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSyncOnce(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cluster     *coreapi.HCPOpenShiftCluster
+		dbResources []any
+		setupCSMock func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec
+		wantErr     bool
+		verifyDB    func(t *testing.T, ctx context.Context, kaClient *kubeappliercosmosstoragetesting.MockKubeApplierDBClient)
+	}{
+		{
+			name:    "skips cluster not found in cache",
+			cluster: nil,
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				return ocm.NewMockClusterServiceClientSpec(ctrl)
+			},
+			wantErr: false,
+		},
+		{
+			name: "skips cluster without ClusterServiceID",
+			cluster: newCluster(func(c *coreapi.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			dbResources: []any{
+				newSPC(testManagementClusterResourceID),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				return ocm.NewMockClusterServiceClientSpec(ctrl)
+			},
+			wantErr: false,
+		},
+		{
+			name: "skips cluster being deleted",
+			cluster: newCluster(func(c *coreapi.HCPOpenShiftCluster) {
+				now := metav1.Now()
+				c.ServiceProviderProperties.DeletionTimestamp = &now
+			}),
+			dbResources: []any{
+				newSPC(testManagementClusterResourceID),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				return ocm.NewMockClusterServiceClientSpec(ctrl)
+			},
+			wantErr: false,
+		},
+		{
+			name:    "returns error when GetClusterResources fails",
+			cluster: newCluster(),
+			dbResources: []any{
+				newSPC(testManagementClusterResourceID),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					GetClusterResources(gomock.Any(), gomock.Any()).
+					Return(nil, fmt.Errorf("connection refused"))
+				return mock
+			},
+			wantErr: true,
+		},
+		{
+			name:    "returns error on timestamp parsing errors from OCM SDK",
+			cluster: newCluster(),
+			dbResources: []any{
+				newSPC(testManagementClusterResourceID),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					GetClusterResources(gomock.Any(), gomock.Any()).
+					Return(nil, fmt.Errorf("parsing time \"invalid\" as creation_timestamp failed"))
+				return mock
+			},
+			wantErr: true,
+		},
+		{
+			name:    "no-op when GetClusterResources returns nil",
+			cluster: newCluster(),
+			dbResources: []any{
+				newSPC(testManagementClusterResourceID),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					GetClusterResources(gomock.Any(), gomock.Any()).
+					Return(nil, nil)
+				return mock
+			},
+			wantErr: false,
+		},
+		{
+			name:    "creates ApplyDesire for a single resource",
+			cluster: newCluster(),
+			dbResources: []any{
+				newSPC(testManagementClusterResourceID),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				configMap := `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"default-ingress","namespace":"ocm-env-abc"},"data":{"key":"value"}}`
+				mock.EXPECT().
+					GetClusterResources(gomock.Any(), gomock.Any()).
+					Return(buildClusterResources(map[string]string{
+						"default-ingress-configmap": configMap,
+					}), nil)
+				return mock
+			},
+			wantErr: false,
+			verifyDB: func(t *testing.T, ctx context.Context, kaClient *kubeappliercosmosstoragetesting.MockKubeApplierDBClient) {
+				t.Helper()
+				crud, err := kaClient.ApplyDesiresForCluster(testSubscriptionID, testResourceGroupName, testClusterName)
+				require.NoError(t, err, "failed to get ApplyDesires CRUD")
+
+				desire, err := crud.Get(ctx, "defaultingressconfigmap")
+				require.NoError(t, err, "ApplyDesire for DefaultIngressConfigMap should exist")
+
+				assert.Equal(t, kubeapplierapi.ApplyDesireTypeServerSideApply, desire.Spec.Type, "desire type should be ServerSideApply")
+				assert.Equal(t, testManagementClusterResourceID.String(), desire.Spec.ManagementCluster.String(), "management cluster should match")
+				assert.Equal(t, "default-ingress", desire.Spec.TargetItem.Name, "target name should match")
+				assert.Equal(t, "ocm-env-abc", desire.Spec.TargetItem.Namespace, "target namespace should match")
+				assert.Equal(t, "configmaps", desire.Spec.TargetItem.Resource, "target resource should be the plural resource name")
+				assert.NotNil(t, desire.Spec.ServerSideApply, "ServerSideApply config should be set")
+				assert.NotNil(t, desire.Spec.ServerSideApply.KubeContent, "KubeContent should be set")
+			},
+		},
+		{
+			name:    "creates ApplyDesires for multiple resources",
+			cluster: newCluster(),
+			dbResources: []any{
+				newSPC(testManagementClusterResourceID),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					GetClusterResources(gomock.Any(), gomock.Any()).
+					Return(buildClusterResources(map[string]string{
+						"pull-secret":       `{"apiVersion":"v1","kind":"Secret","metadata":{"name":"pull-secret","namespace":"ocm-env-abc"}}`,
+						"ingress-configmap": `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"default-ingress","namespace":"ocm-env-abc"}}`,
+					}), nil)
+				return mock
+			},
+			wantErr: false,
+			verifyDB: func(t *testing.T, ctx context.Context, kaClient *kubeappliercosmosstoragetesting.MockKubeApplierDBClient) {
+				t.Helper()
+				crud, err := kaClient.ApplyDesiresForCluster(testSubscriptionID, testResourceGroupName, testClusterName)
+				require.NoError(t, err, "failed to get ApplyDesires CRUD")
+
+				desireA, err := crud.Get(ctx, "ocppullsecret")
+				require.NoError(t, err, "ApplyDesire for OCPPullSecret should exist")
+				assert.Equal(t, "pull-secret", desireA.Spec.TargetItem.Name, "secret target name should match")
+				assert.Equal(t, "secrets", desireA.Spec.TargetItem.Resource, "secret target resource should match")
+
+				desireB, err := crud.Get(ctx, "defaultingressconfigmap")
+				require.NoError(t, err, "ApplyDesire for DefaultIngressConfigMap should exist")
+				assert.Equal(t, "default-ingress", desireB.Spec.TargetItem.Name, "configmap target name should match")
+				assert.Equal(t, "configmaps", desireB.Spec.TargetItem.Resource, "configmap target resource should match")
+			},
+		},
+		{
+			name:    "skips when management cluster is not placed",
+			cluster: newCluster(),
+			dbResources: []any{
+				newSPC(nil),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				return ocm.NewMockClusterServiceClientSpec(ctrl)
+			},
+			wantErr: false,
+		},
+		{
+			name:    "replaces existing ApplyDesire when content changes",
+			cluster: newCluster(),
+			dbResources: []any{
+				newSPC(testManagementClusterResourceID),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					GetClusterResources(gomock.Any(), gomock.Any()).
+					Return(buildClusterResources(map[string]string{
+						"ingress-configmap": `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"default-ingress","namespace":"ocm-env-abc"},"data":{"key":"updated-value"}}`,
+					}), nil)
+				return mock
+			},
+			wantErr: false,
+			verifyDB: func(t *testing.T, ctx context.Context, kaClient *kubeappliercosmosstoragetesting.MockKubeApplierDBClient) {
+				t.Helper()
+				crud, err := kaClient.ApplyDesiresForCluster(testSubscriptionID, testResourceGroupName, testClusterName)
+				require.NoError(t, err, "failed to get ApplyDesires CRUD")
+
+				desire, err := crud.Get(ctx, "defaultingressconfigmap")
+				require.NoError(t, err, "ApplyDesire should exist after replacement")
+
+				var content map[string]interface{}
+				err = json.Unmarshal(desire.Spec.ServerSideApply.KubeContent.Raw, &content)
+				require.NoError(t, err, "should unmarshal KubeContent")
+				data, ok := content["data"].(map[string]interface{})
+				require.True(t, ok, "data field should be a map")
+				assert.Equal(t, "updated-value", data["key"], "KubeContent should reflect the updated value")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			ctrl := gomock.NewController(t)
+
+			mockKubeApplierDBClients := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClients()
+			mockKubeApplierClient := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClient()
+			mockKubeApplierDBClients.Register(testManagementClusterResourceID, mockKubeApplierClient)
+
+			// Seed the cluster lister (used by SyncOnce to look up the cluster)
+			clusterLister := &corelistertesting.SliceClusterLister{}
+			if tt.cluster != nil {
+				clusterLister.Clusters = []*coreapi.HCPOpenShiftCluster{tt.cluster}
+			}
+
+			// Seed the SPC lister from dbResources
+			spcLister := &corelistertesting.SliceServiceProviderClusterLister{}
+			for _, r := range tt.dbResources {
+				if spc, ok := r.(*coreapi.ServiceProviderCluster); ok {
+					spcLister.ServiceProviderClusters = append(spcLister.ServiceProviderClusters, spc)
+				}
+			}
+
+			mcLister := &fleetlistertesting.SliceManagementClusterLister{
+				ManagementClusters: []*fleetapi.ManagementCluster{
+					{ResourceID: testManagementClusterResourceID},
+				},
+			}
+
+			syncer := &clusterResourcesController{
+				clusterLister:                clusterLister,
+				serviceProviderClusterLister: spcLister,
+				clustersServiceClient:        tt.setupCSMock(ctrl),
+				kubeApplierDBClients:         mockKubeApplierDBClients,
+				applyDesireLister:            &kubeapplierlistertesting.DBApplyDesireLister{Clients: mockKubeApplierDBClients, Lister: mcLister},
+			}
+
+			err := syncer.SyncOnce(ctx, testKey())
+			if tt.wantErr {
+				require.Error(t, err, "expected SyncOnce to return an error")
+				return
+			}
+			require.NoError(t, err, "expected SyncOnce to succeed")
+			if tt.verifyDB != nil {
+				tt.verifyDB(t, ctx, mockKubeApplierClient)
+			}
+		})
+	}
+}
+
+func TestDeleteStaleApplyDesires(t *testing.T) {
+	t.Parallel()
+
+	makeTaggedDesire := func(name string) *kubeapplierapi.ApplyDesire {
+		resourceIDStr := kubeapplierapi.ToClusterScopedApplyDesireResourceIDString(
+			testSubscriptionID, testResourceGroupName, testClusterName, name,
+		)
+		return &kubeapplierapi.ApplyDesire{
+			CosmosMetadata: coreapi.CosmosMetadata{
+				ResourceID:   metadataapi.Must(azcorearm.ParseResourceID(resourceIDStr)),
+				PartitionKey: strings.ToLower(testManagementClusterResourceID.String()),
+			},
+			Tags: map[string]string{kubeapplierapi.TagControllerName: ClusterResourcesControllerName},
+			Spec: kubeapplierapi.ApplyDesireSpec{
+				ManagementCluster: testManagementClusterResourceID,
+				Type:              kubeapplierapi.ApplyDesireTypeServerSideApply,
+				TargetItem: kubeapplierapi.ResourceReference{
+					Group: "", Version: "v1", Resource: "configmaps",
+					Name: name, Namespace: "ns",
+				},
+				ServerSideApply: &kubeapplierapi.ServerSideApplyConfig{
+					KubeContent: &runtime.RawExtension{Raw: []byte(`{}`)},
+				},
+			},
+		}
+	}
+
+	makeUntaggedDesire := func(name string) *kubeapplierapi.ApplyDesire {
+		d := makeTaggedDesire(name)
+		d.Tags = nil
+		return d
+	}
+
+	t.Run("marks stale tagged desire for deletion", func(t *testing.T) {
+		t.Parallel()
+		ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+		mockKubeApplierClient := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClient()
+		mockClients := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClients()
+		mockClients.Register(testManagementClusterResourceID, mockKubeApplierClient)
+
+		crud, _ := mockKubeApplierClient.ApplyDesiresForCluster(testSubscriptionID, testResourceGroupName, testClusterName)
+		_, _ = crud.Create(ctx, makeTaggedDesire("configmaps.ns.current"), nil)
+		_, _ = crud.Create(ctx, makeTaggedDesire("configmaps.ns.stale"), nil)
+
+		mcLister := &fleetlistertesting.SliceManagementClusterLister{
+			ManagementClusters: []*fleetapi.ManagementCluster{{ResourceID: testManagementClusterResourceID}},
+		}
+		syncer := &clusterResourcesController{
+			kubeApplierDBClients: mockClients,
+			applyDesireLister:    &kubeapplierlistertesting.DBApplyDesireLister{Clients: mockClients, Lister: mcLister},
+		}
+
+		currentResourceID := kubeapplierapi.ToClusterScopedApplyDesireResourceIDString(
+			testSubscriptionID, testResourceGroupName, testClusterName, "configmaps.ns.current",
+		)
+		err := syncer.deleteStaleApplyDesires(ctx, testKey(), testManagementClusterResourceID,
+			map[string]bool{currentResourceID: true})
+		require.NoError(t, err, "deleteStaleApplyDesires should succeed")
+
+		stale, err := crud.Get(ctx, "configmaps.ns.stale")
+		require.NoError(t, err, "stale desire should still exist")
+		assert.Equal(t, kubeapplierapi.ApplyDesireTypeDelete, stale.Spec.Type, "stale desire should be marked for deletion")
+		assert.Nil(t, stale.Spec.ServerSideApply, "ServerSideApply should be cleared")
+
+		current, err := crud.Get(ctx, "configmaps.ns.current")
+		require.NoError(t, err, "current desire should still exist")
+		assert.Equal(t, kubeapplierapi.ApplyDesireTypeServerSideApply, current.Spec.Type, "current desire should be unchanged")
+	})
+
+	t.Run("does not touch untagged desires", func(t *testing.T) {
+		t.Parallel()
+		ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+		mockKubeApplierClient := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClient()
+		mockClients := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClients()
+		mockClients.Register(testManagementClusterResourceID, mockKubeApplierClient)
+
+		crud, _ := mockKubeApplierClient.ApplyDesiresForCluster(testSubscriptionID, testResourceGroupName, testClusterName)
+		_, _ = crud.Create(ctx, makeUntaggedDesire("configmaps.ns.other-controller"), nil)
+
+		mcLister := &fleetlistertesting.SliceManagementClusterLister{
+			ManagementClusters: []*fleetapi.ManagementCluster{{ResourceID: testManagementClusterResourceID}},
+		}
+		syncer := &clusterResourcesController{
+			kubeApplierDBClients: mockClients,
+			applyDesireLister:    &kubeapplierlistertesting.DBApplyDesireLister{Clients: mockClients, Lister: mcLister},
+		}
+
+		err := syncer.deleteStaleApplyDesires(ctx, testKey(), testManagementClusterResourceID, map[string]bool{})
+		require.NoError(t, err, "deleteStaleApplyDesires should succeed")
+
+		desire, err := crud.Get(ctx, "configmaps.ns.other-controller")
+		require.NoError(t, err, "untagged desire should still exist")
+		assert.Equal(t, kubeapplierapi.ApplyDesireTypeServerSideApply, desire.Spec.Type, "untagged desire should be untouched")
+	})
+
+	t.Run("waits for Delete-type desire without successful condition", func(t *testing.T) {
+		t.Parallel()
+		ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+		mockKubeApplierClient := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClient()
+		mockClients := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClients()
+		mockClients.Register(testManagementClusterResourceID, mockKubeApplierClient)
+
+		crud, _ := mockKubeApplierClient.ApplyDesiresForCluster(testSubscriptionID, testResourceGroupName, testClusterName)
+
+		staleDesire := makeTaggedDesire("nodepools.ns.pending")
+		staleDesire.Spec.Type = kubeapplierapi.ApplyDesireTypeDelete
+		staleDesire.Spec.ServerSideApply = nil
+		_, _ = crud.Create(ctx, staleDesire, nil)
+
+		mcLister := &fleetlistertesting.SliceManagementClusterLister{
+			ManagementClusters: []*fleetapi.ManagementCluster{{ResourceID: testManagementClusterResourceID}},
+		}
+		syncer := &clusterResourcesController{
+			kubeApplierDBClients: mockClients,
+			applyDesireLister:    &kubeapplierlistertesting.DBApplyDesireLister{Clients: mockClients, Lister: mcLister},
+		}
+
+		err := syncer.deleteStaleApplyDesires(ctx, testKey(), testManagementClusterResourceID, map[string]bool{})
+		require.NoError(t, err, "deleteStaleApplyDesires should succeed")
+
+		_, err = crud.Get(ctx, "nodepools.ns.pending")
+		require.NoError(t, err, "desire should still exist while delete is pending")
+	})
+
+	t.Run("purges Delete-type desire when SuccessfullyDeleted condition is true", func(t *testing.T) {
+		t.Parallel()
+		ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+		mockKubeApplierClient := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClient()
+		mockClients := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClients()
+		mockClients.Register(testManagementClusterResourceID, mockKubeApplierClient)
+
+		crud, _ := mockKubeApplierClient.ApplyDesiresForCluster(testSubscriptionID, testResourceGroupName, testClusterName)
+
+		staleDesire := makeTaggedDesire("configmaps.ns.gone")
+		staleDesire.Spec.Type = kubeapplierapi.ApplyDesireTypeDelete
+		staleDesire.Spec.ServerSideApply = nil
+		staleDesire.Status.Conditions = []metav1.Condition{
+			{Type: kubeapplierapi.ConditionTypeSuccessfullyDeleted, Status: metav1.ConditionTrue},
+		}
+		_, _ = crud.Create(ctx, staleDesire, nil)
+
+		mcLister := &fleetlistertesting.SliceManagementClusterLister{
+			ManagementClusters: []*fleetapi.ManagementCluster{{ResourceID: testManagementClusterResourceID}},
+		}
+		syncer := &clusterResourcesController{
+			kubeApplierDBClients: mockClients,
+			applyDesireLister:    &kubeapplierlistertesting.DBApplyDesireLister{Clients: mockClients, Lister: mcLister},
+		}
+
+		err := syncer.deleteStaleApplyDesires(ctx, testKey(), testManagementClusterResourceID, map[string]bool{})
+		require.NoError(t, err, "deleteStaleApplyDesires should succeed")
+
+		_, err = crud.Get(ctx, "configmaps.ns.gone")
+		assert.Error(t, err, "purged ApplyDesire should no longer exist")
+	})
+}
+
+func TestClassifyClusterResource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		resource     string
+		wantDesire   string
+		wantNodePool string
+		wantErr      bool
+	}{
+		{
+			name:       "HostedCluster",
+			resource:   `{"apiVersion":"hypershift.openshift.io/v1beta1","kind":"HostedCluster","metadata":{"name":"my-hc","namespace":"ocm-env-abc"}}`,
+			wantDesire: "HostedCluster",
+		},
+		{
+			name:         "NodePool with spec.clusterName prefix",
+			resource:     `{"apiVersion":"hypershift.openshift.io/v1beta1","kind":"NodePool","metadata":{"name":"q2e1p3b8m8a3s6l-np-2dz967","namespace":"ocm-env-abc"},"spec":{"clusterName":"q2e1p3b8m8a3s6l"}}`,
+			wantDesire:   "NodePool",
+			wantNodePool: "np-2dz967",
+		},
+		{
+			name:         "NodePool without spec.clusterName",
+			resource:     `{"apiVersion":"hypershift.openshift.io/v1beta1","kind":"NodePool","metadata":{"name":"worker","namespace":"ocm-env-abc"}}`,
+			wantDesire:   "NodePool",
+			wantNodePool: "worker",
+		},
+		{
+			name:       "HostedCluster Namespace",
+			resource:   `{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"ocm-arohcppers-2sdm6b8jke9sm3h8ukc8mbaahngnre5c","labels":{"api.openshift.com/environment":"arohcppers","api.openshift.com/id":"2sdm6b8jke9sm3h8ukc8mbaahngnre5c","api.openshift.com/name":"cluster-hs-pre-rxhvsd"}}}`,
+			wantDesire: "HostedClusterNamespace",
+		},
+		{
+			name:       "ControlPlane Namespace",
+			resource:   `{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"ocm-arohcppers-2sdm6b8jke9sm3h8ukc8mbaahngnre5c-j7h3t4w0u1t3b4b","labels":{"app.kubernetes.io/managed-by":"aro-hcp-clusters-service","hypershift.openshift.io/cluster":"2sdm6b8jke9sm3h8ukc8mbaahngnre5c"}}}`,
+			wantDesire: "ControlPlaneNamespace",
+		},
+		{
+			name:       "ConfigMap → DefaultIngressConfigMap",
+			resource:   `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"default-ingress","namespace":"ocm-env-abc"}}`,
+			wantDesire: "DefaultIngressConfigMap",
+		},
+		{
+			name:       "Secret → OCPPullSecret",
+			resource:   `{"apiVersion":"v1","kind":"Secret","metadata":{"name":"pull-secret","namespace":"ocm-env-abc"}}`,
+			wantDesire: "OCPPullSecret",
+		},
+		{
+			name:       "PodNetwork",
+			resource:   `{"apiVersion":"multitenancy.acn.azure.com/v1alpha1","kind":"PodNetwork","metadata":{"name":"pn-abc123"}}`,
+			wantDesire: "PodNetwork",
+		},
+		{
+			name:       "PodNetworkInstance",
+			resource:   `{"apiVersion":"multitenancy.acn.azure.com/v1alpha1","kind":"PodNetworkInstance","metadata":{"name":"pni-abc123","namespace":"ocm-env-abc-cp"}}`,
+			wantDesire: "PodNetworkInstance",
+		},
+		{
+			name:       "SecretSync bound-sa-signing-key",
+			resource:   `{"apiVersion":"secret-sync.x-k8s.io/v1alpha1","kind":"SecretSync","metadata":{"name":"bound-sa-signing-key","namespace":"ocm-env-abc"}}`,
+			wantDesire: "BoundServiceAccountSigningKeySecretSync",
+		},
+		{
+			name:       "SecretSync bound-service-account-signing-key",
+			resource:   `{"apiVersion":"secret-sync.x-k8s.io/v1alpha1","kind":"SecretSync","metadata":{"name":"bound-service-account-signing-key","namespace":"ocm-env-abc"}}`,
+			wantDesire: "BoundServiceAccountSigningKeySecretSync",
+		},
+		{
+			name:       "SecretSync default-ingress",
+			resource:   `{"apiVersion":"secret-sync.x-k8s.io/v1alpha1","kind":"SecretSync","metadata":{"name":"default-ingress-cert","namespace":"ocm-env-abc"}}`,
+			wantDesire: "DefaultIngressWildcardCertSecretSync",
+		},
+		{
+			name:       "SecretSync kube-apiserver",
+			resource:   `{"apiVersion":"secret-sync.x-k8s.io/v1alpha1","kind":"SecretSync","metadata":{"name":"kube-apiserver-server-cert","namespace":"ocm-env-abc"}}`,
+			wantDesire: "KubeAPIServerServingCertSecretSync",
+		},
+		{
+			name:       "SecretProviderClass bound-sa-signing-key",
+			resource:   `{"apiVersion":"secrets-store.csi.x-k8s.io/v1","kind":"SecretProviderClass","metadata":{"name":"bound-sa-signing-key","namespace":"ocm-env-abc"}}`,
+			wantDesire: "BoundServiceAccountSigningKeySecretProviderClass",
+		},
+		{
+			name:       "SecretProviderClass bound-service-account-signing-key",
+			resource:   `{"apiVersion":"secrets-store.csi.x-k8s.io/v1","kind":"SecretProviderClass","metadata":{"name":"bound-service-account-signing-key","namespace":"ocm-env-abc"}}`,
+			wantDesire: "BoundServiceAccountSigningKeySecretProviderClass",
+		},
+		{
+			name:       "SecretProviderClass default-ingress",
+			resource:   `{"apiVersion":"secrets-store.csi.x-k8s.io/v1","kind":"SecretProviderClass","metadata":{"name":"default-ingress-cert","namespace":"ocm-env-abc"}}`,
+			wantDesire: "DefaultIngressWildcardCertSecretProviderClass",
+		},
+		{
+			name:       "SecretProviderClass kube-apiserver",
+			resource:   `{"apiVersion":"secrets-store.csi.x-k8s.io/v1","kind":"SecretProviderClass","metadata":{"name":"kube-apiserver-server-cert","namespace":"ocm-env-abc"}}`,
+			wantDesire: "KubeAPIServerServingCertSecretProviderClass",
+		},
+		{
+			name:     "unrecognized kind errors",
+			resource: `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"web","namespace":"app"}}`,
+			wantErr:  true,
+		},
+		{
+			name:     "unrecognized SecretSync name errors",
+			resource: `{"apiVersion":"secret-sync.x-k8s.io/v1alpha1","kind":"SecretSync","metadata":{"name":"unknown-sync","namespace":"ns"}}`,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var obj unstructured.Unstructured
+			err := json.Unmarshal([]byte(tt.resource), &obj)
+			require.NoError(t, err, "failed to unmarshal test resource")
+
+			classified, err := classifyClusterResource(&obj)
+			if tt.wantErr {
+				require.Error(t, err, "expected classifyClusterResource to error")
+				return
+			}
+			require.NoError(t, err, "classifyClusterResource should not error")
+			assert.Equal(t, tt.wantDesire, classified.desireName, "desireName mismatch")
+			assert.Equal(t, tt.wantNodePool, classified.nodePoolName, "nodePoolName mismatch")
+		})
+	}
+}

--- a/backend/pkg/controllers/nodepool/deletion/node_pool_cluster_service_delete_dispatch_controller.go
+++ b/backend/pkg/controllers/nodepool/deletion/node_pool_cluster_service_delete_dispatch_controller.go
@@ -28,12 +28,15 @@ import (
 
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterresources"
 	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
 	"github.com/Azure/ARO-HCP/internal/database/informers/coreinformers"
 	"github.com/Azure/ARO-HCP/internal/database/listers/corelisters"
+	"github.com/Azure/ARO-HCP/internal/database/listers/kubeapplierlisters"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -53,6 +56,10 @@ const missingClusterServiceIDTimeout = 120 * time.Second
 // waiting for a ClusterServiceID), it stamps ClusterServiceDeletionTimestamp
 // on the NodePool to record that this step is complete and avoid re-issuing
 // the delete on subsequent syncs.
+// Before dispatching the delete, this controller waits until the
+// ClusterResourcesController has cleaned up all its tagged ApplyDesires for
+// this NodePool, so that kube resources are torn down before the NodePool itself.
+//
 // The controller also caches the time the controller has first seen the
 // serviceProviderProperties.deletionTimestamp being set for a nodepool. This
 // is used to avoid immediately triggering deletion in scenarios where the
@@ -63,6 +70,7 @@ type nodePoolClusterServiceDeleteDispatchSyncer struct {
 	nodePoolLister       corelisters.NodePoolLister
 	resourcesDBClient    corecosmosstorage.ResourcesDBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
+	applyDesireLister    kubeapplierlisters.ApplyDesireLister
 	// firstSeenDeletionTimestampCache is a cache that contains the time the controller
 	// has first seen the serviceProviderProperties.deletionTimestamp being set
 	// for a nodepool. The cache key is the lowercased node pool's resource ID and
@@ -80,11 +88,13 @@ func NewNodePoolClusterServiceDeleteDispatchController(
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 	_, nodePoolLister := informers.NodePools()
+	_, applyDesireLister := kubeApplierInformers.ApplyDesires()
 	syncer := &nodePoolClusterServiceDeleteDispatchSyncer{
 		clock:                           clock,
 		nodePoolLister:                  nodePoolLister,
 		resourcesDBClient:               resourcesDBClient,
 		clusterServiceClient:            clusterServiceClient,
+		applyDesireLister:               applyDesireLister,
 		firstSeenDeletionTimestampCache: lru.New(50000),
 	}
 
@@ -147,6 +157,16 @@ func (c *nodePoolClusterServiceDeleteDispatchSyncer) SyncOnce(ctx context.Contex
 		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
 	}
 	if !c.NeedsWork(nodePool) {
+		return nil
+	}
+
+	// Wait until ClusterResourcesController has deleted all its tagged ApplyDesires for this NodePool.
+	hasTaggedDesires, err := c.hasNodePoolApplyDesires(ctx, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check NodePool ApplyDesires: %w", err))
+	}
+	if hasTaggedDesires {
+		logger.Info("waiting for ClusterResourcesController to delete its ApplyDesires before dispatching CS delete")
 		return nil
 	}
 
@@ -217,4 +237,18 @@ func (c *nodePoolClusterServiceDeleteDispatchSyncer) SyncOnce(ctx context.Contex
 	c.firstSeenDeletionTimestampCache.Remove(cacheKey)
 
 	return nil
+}
+
+func (c *nodePoolClusterServiceDeleteDispatchSyncer) hasNodePoolApplyDesires(ctx context.Context, key controllerutils.HCPNodePoolKey) (bool, error) {
+	desires, err := c.applyDesireLister.ListForNodePool(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if err != nil {
+		return false, err
+	}
+	for _, desire := range desires {
+		if desire.Tags != nil &&
+			desire.Tags[kubeapplierapi.TagControllerName] == clusterresources.ClusterResourcesControllerName {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/backend/pkg/controllers/nodepool/deletion/node_pool_cluster_service_delete_dispatch_controller_test.go
+++ b/backend/pkg/controllers/nodepool/deletion/node_pool_cluster_service_delete_dispatch_controller_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/corecosmosstoragetesting"
 	"github.com/Azure/ARO-HCP/internal/database/listertesting/corelistertesting"
+	kubeapplierlistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting/kubeapplierlistertesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -257,6 +258,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
 				nodePoolLister:                  &corelistertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
 				resourcesDBClient:               mockResourcesDBClient,
 				clusterServiceClient:            mockCSClient,
+				applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 				firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 			}
 
@@ -296,6 +298,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_cacheShortCircuit(t
 		nodePoolLister:                  &corelistertesting.SliceNodePoolLister{NodePools: []*coreapi.HCPOpenShiftClusterNodePool{cachedNodePool}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
+		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: lru.New(10),
 	}
 
@@ -332,6 +335,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCa
 		nodePoolLister:                  &corelistertesting.SliceNodePoolLister{NodePools: []*coreapi.HCPOpenShiftClusterNodePool{nodePool}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
+		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 	}
 
@@ -375,6 +379,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCa
 		nodePoolLister:                  &corelistertesting.SliceNodePoolLister{NodePools: []*coreapi.HCPOpenShiftClusterNodePool{nodePool}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            mockCSClient,
+		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 	}
 

--- a/backend/pkg/controllers/nodepool/deletion/node_pool_deletion_controller.go
+++ b/backend/pkg/controllers/nodepool/deletion/node_pool_deletion_controller.go
@@ -17,13 +17,16 @@ package deletion
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/kubeappliercosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/informers/coreinformers"
 	"github.com/Azure/ARO-HCP/internal/database/listers/corelisters"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
@@ -38,7 +41,9 @@ import (
 type nodePoolDeletionController struct {
 	nodePoolLister                corelisters.NodePoolLister
 	serviceProviderNodePoolLister corelisters.ServiceProviderNodePoolLister
+	serviceProviderClusterLister  corelisters.ServiceProviderClusterLister
 	resourcesDBClient             corecosmosstorage.ResourcesDBClient
+	kubeApplierDBClients          kubeappliercosmosstorage.KubeApplierDBClients
 }
 
 var _ controllerutils.NodePoolSyncer = (*nodePoolDeletionController)(nil)
@@ -47,13 +52,17 @@ func NewNodePoolDeletionController(
 	resourcesDBClient corecosmosstorage.ResourcesDBClient,
 	informers coreinformers.BackendInformers,
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
+	kubeApplierDBClients kubeappliercosmosstorage.KubeApplierDBClients,
 ) controllerutils.Controller {
 	_, nodePoolLister := informers.NodePools()
 	_, serviceProviderNodePoolLister := informers.ServiceProviderNodePools()
+	_, serviceProviderClusterLister := informers.ServiceProviderClusters()
 	syncer := &nodePoolDeletionController{
 		nodePoolLister:                nodePoolLister,
 		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
+		serviceProviderClusterLister:  serviceProviderClusterLister,
 		resourcesDBClient:             resourcesDBClient,
+		kubeApplierDBClients:          kubeApplierDBClients,
 	}
 
 	return controllerutils.NewNodePoolWatchingController(
@@ -123,8 +132,17 @@ func (c *nodePoolDeletionController) SyncOnce(ctx context.Context, key controlle
 		return nil
 	}
 
+	// Precondition: all ApplyDesires for this NodePool must be gone.
+	preconditionMet, err := c.deletePreconditionAllApplyDesiresGone(ctx, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check ApplyDesire precondition: %w", err))
+	}
+	if !preconditionMet {
+		return nil
+	}
+
 	// We do not proceed until we know that all the maestro readonly bundles have been eliminated
-	preconditionMet, err := c.deletePreconditionAllMaestroNodePoolScopedReadonlyBundlesCleared(ctx, key)
+	preconditionMet, err = c.deletePreconditionAllMaestroNodePoolScopedReadonlyBundlesCleared(ctx, key)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
 	}
@@ -198,5 +216,65 @@ func (c *nodePoolDeletionController) deletePreconditionCosmosChildResourcesDelet
 		return false, utils.TrackError(fmt.Errorf("error iterating child resources: %w", err))
 	}
 
+	return true, nil
+}
+
+// deletePreconditionAllApplyDesiresGone checks that no ApplyDesires remain for
+// this NodePool. The log message reports remaining counts per controller.
+func (c *nodePoolDeletionController) deletePreconditionAllApplyDesiresGone(ctx context.Context, key controllerutils.HCPNodePoolKey) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	spc, err := c.serviceProviderClusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if cosmosstorageutils.IsNotFoundError(err) {
+		return true, nil
+	}
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster from cache: %w", err))
+	}
+	if spc.Status.ManagementClusterResourceID == nil {
+		return true, nil
+	}
+
+	managementClusterID := spc.Status.ManagementClusterResourceID
+	kubeApplierDBClient := c.kubeApplierDBClients.For(ctx, managementClusterID)
+	if kubeApplierDBClient == nil {
+		logger.Info("waiting for kube-applier DB client to be available for ApplyDesire precondition", "managementCluster", managementClusterID.String())
+		return false, nil
+	}
+
+	kubeApplierCRUD, err := kubeApplierDBClient.ApplyDesiresForNodePool(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if err != nil {
+		return false, fmt.Errorf("failed to get kube-applier CRUD for ApplyDesire precondition: %w", err)
+	}
+
+	applyDesireIterator, err := kubeApplierCRUD.List(ctx, &cosmosstorageutils.DBClientListResourceDocsOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to list ApplyDesire documents for precondition check: %w", err)
+	}
+
+	controllerCounts := map[string]int{}
+	for _, desire := range applyDesireIterator.Items(ctx) {
+		controller := "unknown"
+		if desire.Tags != nil {
+			if name := desire.Tags[kubeapplierapi.TagControllerName]; name != "" {
+				controller = name
+			}
+		}
+		controllerCounts[controller]++
+	}
+	if err := applyDesireIterator.GetError(); err != nil {
+		return false, fmt.Errorf("error iterating ApplyDesires for precondition check: %w", err)
+	}
+
+	if len(controllerCounts) > 0 {
+		var parts []string
+		for controller, count := range controllerCounts {
+			parts = append(parts, fmt.Sprintf("%d from %s", count, controller))
+		}
+		slices.Sort(parts)
+		logger.Info("waiting for all ApplyDesires to be deleted",
+			"remaining", strings.Join(parts, ", "))
+		return false, nil
+	}
 	return true, nil
 }

--- a/backend/pkg/controllers/nodepool/deletion/node_pool_deletion_controller_test.go
+++ b/backend/pkg/controllers/nodepool/deletion/node_pool_deletion_controller_test.go
@@ -150,6 +150,7 @@ func TestNodePoolDeletionController_SyncOnce(t *testing.T) {
 			syncer := &nodePoolDeletionController{
 				nodePoolLister:                &corelistertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
 				serviceProviderNodePoolLister: &corelistertesting.SliceServiceProviderNodePoolLister{ServiceProviderNodePools: spnpForLister},
+				serviceProviderClusterLister:  &corelistertesting.SliceServiceProviderClusterLister{},
 				resourcesDBClient:             mockResourcesDBClient,
 			}
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -193,14 +193,14 @@ defaults:
       image:
         registry: mcr.microsoft.com
         repository: geneva/distroless/mdsd
-        digest: sha256:13c33d4e6952e6ddd69d9dd7bb941dc5e8f9fb3d589f016aaca01a9f1067f409 # 1.43.0-20260904-2 (2026-09-04 21:37)
+        digest: sha256:2a250598df9900192e145f5bea8175325f3b14aa69c5150be0c2bd803fdcdec9 # 1.43.0-20260828-1 (2026-08-28 04:45)
   # Kube Events
   kubeEvents:
     enabled: true
     image:
       registry: kubernetesshared.azurecr.io
       repository: shared/kube-events
-      digest: sha256:76b03f4c04291c80a7269474b055cee5f188746c68b444b20c03ea180d0c1348 # 20260906.1 (2026-09-06 03:25)
+      digest: sha256:326a165eb7b65ae43b85c9538d3572c57aa56a1862febd90f293783824c62d5f # 20260830.1 (2026-08-30 03:25)
     k8s:
       namespace: monitoring
       serviceAccountName: ke-serviceaccount
@@ -279,7 +279,7 @@ defaults:
     providerImage:
       registry: mcr.microsoft.com
       repository: oss/v2/azure/secrets-store/provider-azure
-      digest: sha256:f21fca34342808670e8696dffd25efd5ef4347327b30371950b9e08fee2f11f8 # v1.8.2 (2026-09-05 01:44)
+      digest: sha256:407ff33bb445d44db9924eeffa2b61d4adf475e5805bdcda10d33e7f68578217 # v1.8.2 (2026-08-24 20:22)
     k8s:
       namespace: secret-sync-controller
       serviceAccountName: secrets-store-sync-controller-manager
@@ -396,7 +396,7 @@ defaults:
     image:
       registry: quay.io
       repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
-      digest: sha256:cb8bf5c16f961dc9d673a44867a681bdd2d7844a8d12564ad7ff42d8bc22db3b # 6e6cb83772382fca668279ea55316cf74f128c6c (2026-09-05 06:07)
+      digest: sha256:cabce18d0674442c8fb4d931e4d44306b74fbaca5e6c9c23f92c8aa790daf53d # 7334c42fbd88f69fbcf9fbfbdaf7e13d82e16880 (2026-08-31 03:07)
     namespace: hypershift
     additionalInstallArg: '--enable-cpo-overrides --disable-capi-migration'
     # By default we set it to empty as this tag is only required for msft environments. We override
@@ -524,15 +524,15 @@ defaults:
     server:
       registry: registry.stage.redhat.io
       repository: oadp/oadp-velero-rhel9
-      digest: sha256:d712b510c9224d194e3da94bbc87d6ff66f44f2d513dd51c2b10b7d2681eb0d1 # 1.6.2 (2026-09-04 17:56)
+      digest: sha256:857c25afa2fced585ba68ae40248278c6d244f65d72b35b635b8789417d0b9a5 # 1.6.2 (2026-08-28 13:01)
     azurePlugin:
       registry: registry.stage.redhat.io
       repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
-      digest: sha256:908426eb82d213a5a50e7dc499907fbbd47d2dd80f6d5e4ed1472e0a6b9fb460 # 1.6.2 (2026-09-04 17:52)
+      digest: sha256:3cc0fe2d2f0cf66dc8b5346af8ab117046a8abe66bacd29fb3c895d4c3fef7ac # 1.6.2 (2026-08-31 05:50)
     hypershiftPlugin:
       registry: registry.stage.redhat.io
       repository: oadp/oadp-hypershift-velero-plugin-rhel9
-      digest: sha256:fca00f1a9915708bededd250db55b3f954572478c1175c46eb6a350c1344f5bc # 1.6.2 (2026-09-04 17:56)
+      digest: sha256:57afef0f83ea72d8c98808cd894b5adfac336089ddeae9dd0559116de64ba0db # 1.6.2 (2026-08-31 05:32)
   # SVC cluster specifics
   svc:
     subscription:
@@ -578,7 +578,7 @@ defaults:
     # pipeline step had already applied.
     # istioctlVersion and targetVersion will be removed in a future cleanup.
     istio:
-      istioctlVersion: 1.31.0 # 1.31.0 (2026-08-31 15:47)
+      istioctlVersion: 1.30.4 # 1.30.4 (2026-08-27 15:10)
       tag: "prod-stable"
       targetVersion: "asm-1-29"
       versions: "asm-1-29"
@@ -646,7 +646,7 @@ defaults:
         image:
           registry: mcr.microsoft.com/oss/v2
           repository: prometheus/prometheus
-          sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8 # v3.12.0 (2026-08-31 17:47)
+          sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3 # v3.12.0 (2026-08-24 20:42)
         version: ""
         resources:
           requests:
@@ -665,7 +665,7 @@ defaults:
         image:
           registry: mcr.microsoft.com/oss/v2
           repository: kubernetes/kube-state-metrics
-          digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e # v2.20.0 (2026-09-04 22:52)
+          digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de # v2.20.0 (2026-08-25 00:57)
       admissionWebhook:
         patch:
           image:
@@ -778,7 +778,7 @@ defaults:
         image:
           registry: mcr.microsoft.com/oss/v2
           repository: prometheus/prometheus
-          sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8 # v3.12.0 (2026-08-31 17:47)
+          sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3 # v3.12.0 (2026-08-24 20:42)
         resources:
           requests:
             cpu: NONE
@@ -796,7 +796,7 @@ defaults:
         image:
           registry: mcr.microsoft.com/oss/v2
           repository: kubernetes/kube-state-metrics
-          digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e # v2.20.0 (2026-09-04 22:52)
+          digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de # v2.20.0 (2026-08-25 00:57)
       admissionWebhook:
         patch:
           image:
@@ -1086,25 +1086,25 @@ defaults:
     image:
       registry: quay.io
       repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
-      digest: sha256:0053dfaa6931c0c60e343b3b4460c136207f4567b14df9f6a7dbd5f3a5d89ed0 # 8ab737d7f7aad40ca77dcfe36c2b8777ea6a6367 (2026-09-03 08:13)
+      digest: sha256:7dc6bf1b8476e4737a84a5d744bc354d5949b729eeab92039a43507884dd7334 # 530edf9358e92990f92aa06b0ea3c4a08afcfb94 (2026-08-26 15:46)
   # ACM
   acm:
     operator:
       bundle:
         registry: quay.io
         repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
-        digest: sha256:2a939da3ff1da79c5de14109e83c37a6b9c6c14f8696afdb0fb6d0c9bc295b26 # v2.16.5-599 (2026-09-05 13:09)
+        digest: sha256:9dfbee549e5fc354453ff6ecaa3a18f013e3c8976c63af801a58cdaba016d0ce # v2.16.4-587 (2026-08-29 13:09)
     mce:
       bundle:
         registry: quay.io
         repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
-        digest: sha256:a7f8a100505c2a5255719453ce365aa43ef6fec2073054332b9a5d4ad7d359ea # v2.11.7-646 (2026-09-05 13:07)
+        digest: sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18 # v2.11.6-636 (2026-08-30 18:12)
   # Cluster Service
   clustersService:
     image:
       registry: quay.io
       repository: app-sre/aro-hcp-clusters-service
-      digest: sha256:b5c04e35493f5b6ac5bc32b401df0a6f90eff0723fb180181ea777aac0a0a737 # e80b87894dfaf74aca4f1b771da081cf6bd4f5cd (2026-09-03 17:54)
+      digest: sha256:b5c04e35493f5b6ac5bc32b401df0a6f90eff0723fb180181ea777aac0a0a737 # e80b87894dfaf74aca4f1b771da081cf6bd4f5cd (2026-09-03 17:48)
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active
@@ -1823,7 +1823,7 @@ clouds:
                 vmSize: Standard_D8ds_v6
               userAgentPool:
                 maxCount: 14
-                minCount: 5
+                minCount: 4
                 osDiskSizeGB: 100
                 vmSize: Standard_E16ds_v6
                 secondaryNicCount: 7
@@ -1927,7 +1927,7 @@ clouds:
                 vmSize: Standard_D8ds_v6
               userAgentPool:
                 maxCount: 14
-                minCount: 5
+                minCount: 4
                 osDiskSizeGB: 100
                 vmSize: Standard_E16ds_v6
                 secondaryNicCount: 7

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:a7f8a100505c2a5255719453ce365aa43ef6fec2073054332b9a5d4ad7d359ea
+      digest: sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:2a939da3ff1da79c5de14109e83c37a6b9c6c14f8696afdb0fb6d0c9bc295b26
+      digest: sha256:9dfbee549e5fc354453ff6ecaa3a18f013e3c8976c63af801a58cdaba016d0ce
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -98,7 +98,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:13c33d4e6952e6ddd69d9dd7bb941dc5e8f9fb3d589f016aaca01a9f1067f409
+      digest: sha256:2a250598df9900192e145f5bea8175325f3b14aa69c5150be0c2bd803fdcdec9
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -489,7 +489,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
-    digest: sha256:cb8bf5c16f961dc9d673a44867a681bdd2d7844a8d12564ad7ff42d8bc22db3b
+    digest: sha256:cabce18d0674442c8fb4d931e4d44306b74fbaca5e6c9c23f92c8aa790daf53d
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -541,7 +541,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:76b03f4c04291c80a7269474b055cee5f188746c68b444b20c03ea180d0c1348
+    digest: sha256:326a165eb7b65ae43b85c9538d3572c57aa56a1862febd90f293783824c62d5f
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -604,7 +604,7 @@ maestro:
     name: arohcp-ci00-maestro-j7654321
     private: false
   image:
-    digest: sha256:0053dfaa6931c0c60e343b3b4460c136207f4567b14df9f6a7dbd5f3a5d89ed0
+    digest: sha256:7dc6bf1b8476e4737a84a5d744bc354d5949b729eeab92039a43507884dd7334
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -682,7 +682,7 @@ mgmt:
       maxUnavailable: "0"
     userAgentPool:
       maxCount: 14
-      minCount: 5
+      minCount: 4
       name: userswft
       osDiskSizeGB: 100
       poolCount: 3
@@ -713,7 +713,7 @@ mgmt:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
+        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -733,7 +733,7 @@ mgmt:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
+        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
       replicas: 2
       resources:
         limits:
@@ -968,7 +968,7 @@ secretSyncController:
         memory: 100Mi
     serviceAccountName: secrets-store-sync-controller-manager
   providerImage:
-    digest: sha256:f21fca34342808670e8696dffd25efd5ef4347327b30371950b9e08fee2f11f8
+    digest: sha256:407ff33bb445d44db9924eeffa2b61d4adf475e5805bdcda10d33e7f68578217
     registry: mcr.microsoft.com
     repository: oss/v2/azure/secrets-store/provider-azure
 serviceKeyVault:
@@ -1062,7 +1062,7 @@ svc:
   istio:
     ingressGatewayIPAddressIPTags: ""
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
-    istioctlVersion: 1.31.0
+    istioctlVersion: 1.30.4
     tag: prod-stable
     targetVersion: asm-1-29
     versions: asm-1-29
@@ -1084,7 +1084,7 @@ svc:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
+        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -1104,7 +1104,7 @@ svc:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
+        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
       replicas: 2
       resources:
         limits:
@@ -1160,14 +1160,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:908426eb82d213a5a50e7dc499907fbbd47d2dd80f6d5e4ed1472e0a6b9fb460
+    digest: sha256:3cc0fe2d2f0cf66dc8b5346af8ab117046a8abe66bacd29fb3c895d4c3fef7ac
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:fca00f1a9915708bededd250db55b3f954572478c1175c46eb6a350c1344f5bc
+    digest: sha256:57afef0f83ea72d8c98808cd894b5adfac336089ddeae9dd0559116de64ba0db
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:d712b510c9224d194e3da94bbc87d6ff66f44f2d513dd51c2b10b7d2681eb0d1
+    digest: sha256:857c25afa2fced585ba68ae40248278c6d244f65d72b35b635b8789417d0b9a5
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:a7f8a100505c2a5255719453ce365aa43ef6fec2073054332b9a5d4ad7d359ea
+      digest: sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:2a939da3ff1da79c5de14109e83c37a6b9c6c14f8696afdb0fb6d0c9bc295b26
+      digest: sha256:9dfbee549e5fc354453ff6ecaa3a18f013e3c8976c63af801a58cdaba016d0ce
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -98,7 +98,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:13c33d4e6952e6ddd69d9dd7bb941dc5e8f9fb3d589f016aaca01a9f1067f409
+      digest: sha256:2a250598df9900192e145f5bea8175325f3b14aa69c5150be0c2bd803fdcdec9
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -489,7 +489,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
-    digest: sha256:cb8bf5c16f961dc9d673a44867a681bdd2d7844a8d12564ad7ff42d8bc22db3b
+    digest: sha256:cabce18d0674442c8fb4d931e4d44306b74fbaca5e6c9c23f92c8aa790daf53d
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -541,7 +541,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:76b03f4c04291c80a7269474b055cee5f188746c68b444b20c03ea180d0c1348
+    digest: sha256:326a165eb7b65ae43b85c9538d3572c57aa56a1862febd90f293783824c62d5f
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -604,7 +604,7 @@ maestro:
     name: arohcp-ci01-maestro-j7654321
     private: false
   image:
-    digest: sha256:0053dfaa6931c0c60e343b3b4460c136207f4567b14df9f6a7dbd5f3a5d89ed0
+    digest: sha256:7dc6bf1b8476e4737a84a5d744bc354d5949b729eeab92039a43507884dd7334
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -682,7 +682,7 @@ mgmt:
       maxUnavailable: "0"
     userAgentPool:
       maxCount: 14
-      minCount: 5
+      minCount: 4
       name: userswft
       osDiskSizeGB: 100
       poolCount: 3
@@ -713,7 +713,7 @@ mgmt:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
+        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -733,7 +733,7 @@ mgmt:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
+        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
       replicas: 2
       resources:
         limits:
@@ -968,7 +968,7 @@ secretSyncController:
         memory: 100Mi
     serviceAccountName: secrets-store-sync-controller-manager
   providerImage:
-    digest: sha256:f21fca34342808670e8696dffd25efd5ef4347327b30371950b9e08fee2f11f8
+    digest: sha256:407ff33bb445d44db9924eeffa2b61d4adf475e5805bdcda10d33e7f68578217
     registry: mcr.microsoft.com
     repository: oss/v2/azure/secrets-store/provider-azure
 serviceKeyVault:
@@ -1062,7 +1062,7 @@ svc:
   istio:
     ingressGatewayIPAddressIPTags: ""
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
-    istioctlVersion: 1.31.0
+    istioctlVersion: 1.30.4
     tag: prod-stable
     targetVersion: asm-1-29
     versions: asm-1-29
@@ -1084,7 +1084,7 @@ svc:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
+        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -1104,7 +1104,7 @@ svc:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
+        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
       replicas: 2
       resources:
         limits:
@@ -1160,14 +1160,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:908426eb82d213a5a50e7dc499907fbbd47d2dd80f6d5e4ed1472e0a6b9fb460
+    digest: sha256:3cc0fe2d2f0cf66dc8b5346af8ab117046a8abe66bacd29fb3c895d4c3fef7ac
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:fca00f1a9915708bededd250db55b3f954572478c1175c46eb6a350c1344f5bc
+    digest: sha256:57afef0f83ea72d8c98808cd894b5adfac336089ddeae9dd0559116de64ba0db
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:d712b510c9224d194e3da94bbc87d6ff66f44f2d513dd51c2b10b7d2681eb0d1
+    digest: sha256:857c25afa2fced585ba68ae40248278c6d244f65d72b35b635b8789417d0b9a5
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:a7f8a100505c2a5255719453ce365aa43ef6fec2073054332b9a5d4ad7d359ea
+      digest: sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:2a939da3ff1da79c5de14109e83c37a6b9c6c14f8696afdb0fb6d0c9bc295b26
+      digest: sha256:9dfbee549e5fc354453ff6ecaa3a18f013e3c8976c63af801a58cdaba016d0ce
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -98,7 +98,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:13c33d4e6952e6ddd69d9dd7bb941dc5e8f9fb3d589f016aaca01a9f1067f409
+      digest: sha256:2a250598df9900192e145f5bea8175325f3b14aa69c5150be0c2bd803fdcdec9
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -489,7 +489,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
-    digest: sha256:cb8bf5c16f961dc9d673a44867a681bdd2d7844a8d12564ad7ff42d8bc22db3b
+    digest: sha256:cabce18d0674442c8fb4d931e4d44306b74fbaca5e6c9c23f92c8aa790daf53d
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -541,7 +541,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:76b03f4c04291c80a7269474b055cee5f188746c68b444b20c03ea180d0c1348
+    digest: sha256:326a165eb7b65ae43b85c9538d3572c57aa56a1862febd90f293783824c62d5f
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -604,7 +604,7 @@ maestro:
     name: arohcp-cspr-maestro-usw3
     private: false
   image:
-    digest: sha256:0053dfaa6931c0c60e343b3b4460c136207f4567b14df9f6a7dbd5f3a5d89ed0
+    digest: sha256:7dc6bf1b8476e4737a84a5d744bc354d5949b729eeab92039a43507884dd7334
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -711,7 +711,7 @@ mgmt:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
+        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -731,7 +731,7 @@ mgmt:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
+        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
       replicas: 2
       resources:
         limits:
@@ -966,7 +966,7 @@ secretSyncController:
         memory: 100Mi
     serviceAccountName: secrets-store-sync-controller-manager
   providerImage:
-    digest: sha256:f21fca34342808670e8696dffd25efd5ef4347327b30371950b9e08fee2f11f8
+    digest: sha256:407ff33bb445d44db9924eeffa2b61d4adf475e5805bdcda10d33e7f68578217
     registry: mcr.microsoft.com
     repository: oss/v2/azure/secrets-store/provider-azure
 serviceKeyVault:
@@ -1060,7 +1060,7 @@ svc:
   istio:
     ingressGatewayIPAddressIPTags: ""
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
-    istioctlVersion: 1.31.0
+    istioctlVersion: 1.30.4
     tag: prod-stable
     targetVersion: asm-1-29
     versions: asm-1-29
@@ -1080,7 +1080,7 @@ svc:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
+        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -1100,7 +1100,7 @@ svc:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
+        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
       replicas: 2
       resources:
         limits:
@@ -1156,14 +1156,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:908426eb82d213a5a50e7dc499907fbbd47d2dd80f6d5e4ed1472e0a6b9fb460
+    digest: sha256:3cc0fe2d2f0cf66dc8b5346af8ab117046a8abe66bacd29fb3c895d4c3fef7ac
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:fca00f1a9915708bededd250db55b3f954572478c1175c46eb6a350c1344f5bc
+    digest: sha256:57afef0f83ea72d8c98808cd894b5adfac336089ddeae9dd0559116de64ba0db
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:d712b510c9224d194e3da94bbc87d6ff66f44f2d513dd51c2b10b7d2681eb0d1
+    digest: sha256:857c25afa2fced585ba68ae40248278c6d244f65d72b35b635b8789417d0b9a5
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:a7f8a100505c2a5255719453ce365aa43ef6fec2073054332b9a5d4ad7d359ea
+      digest: sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:2a939da3ff1da79c5de14109e83c37a6b9c6c14f8696afdb0fb6d0c9bc295b26
+      digest: sha256:9dfbee549e5fc354453ff6ecaa3a18f013e3c8976c63af801a58cdaba016d0ce
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -98,7 +98,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:13c33d4e6952e6ddd69d9dd7bb941dc5e8f9fb3d589f016aaca01a9f1067f409
+      digest: sha256:2a250598df9900192e145f5bea8175325f3b14aa69c5150be0c2bd803fdcdec9
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -489,7 +489,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
-    digest: sha256:cb8bf5c16f961dc9d673a44867a681bdd2d7844a8d12564ad7ff42d8bc22db3b
+    digest: sha256:cabce18d0674442c8fb4d931e4d44306b74fbaca5e6c9c23f92c8aa790daf53d
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -541,7 +541,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:76b03f4c04291c80a7269474b055cee5f188746c68b444b20c03ea180d0c1348
+    digest: sha256:326a165eb7b65ae43b85c9538d3572c57aa56a1862febd90f293783824c62d5f
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -604,7 +604,7 @@ maestro:
     name: arohcp-dev-maestro-usw3
     private: false
   image:
-    digest: sha256:0053dfaa6931c0c60e343b3b4460c136207f4567b14df9f6a7dbd5f3a5d89ed0
+    digest: sha256:7dc6bf1b8476e4737a84a5d744bc354d5949b729eeab92039a43507884dd7334
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -711,7 +711,7 @@ mgmt:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
+        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -731,7 +731,7 @@ mgmt:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
+        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
       replicas: 2
       resources:
         limits:
@@ -966,7 +966,7 @@ secretSyncController:
         memory: 100Mi
     serviceAccountName: secrets-store-sync-controller-manager
   providerImage:
-    digest: sha256:f21fca34342808670e8696dffd25efd5ef4347327b30371950b9e08fee2f11f8
+    digest: sha256:407ff33bb445d44db9924eeffa2b61d4adf475e5805bdcda10d33e7f68578217
     registry: mcr.microsoft.com
     repository: oss/v2/azure/secrets-store/provider-azure
 serviceKeyVault:
@@ -1060,7 +1060,7 @@ svc:
   istio:
     ingressGatewayIPAddressIPTags: ""
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
-    istioctlVersion: 1.31.0
+    istioctlVersion: 1.30.4
     tag: prod-stable
     targetVersion: asm-1-29
     versions: asm-1-29
@@ -1080,7 +1080,7 @@ svc:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
+        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -1100,7 +1100,7 @@ svc:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
+        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
       replicas: 2
       resources:
         limits:
@@ -1156,14 +1156,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:908426eb82d213a5a50e7dc499907fbbd47d2dd80f6d5e4ed1472e0a6b9fb460
+    digest: sha256:3cc0fe2d2f0cf66dc8b5346af8ab117046a8abe66bacd29fb3c895d4c3fef7ac
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:fca00f1a9915708bededd250db55b3f954572478c1175c46eb6a350c1344f5bc
+    digest: sha256:57afef0f83ea72d8c98808cd894b5adfac336089ddeae9dd0559116de64ba0db
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:d712b510c9224d194e3da94bbc87d6ff66f44f2d513dd51c2b10b7d2681eb0d1
+    digest: sha256:857c25afa2fced585ba68ae40248278c6d244f65d72b35b635b8789417d0b9a5
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:a7f8a100505c2a5255719453ce365aa43ef6fec2073054332b9a5d4ad7d359ea
+      digest: sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:2a939da3ff1da79c5de14109e83c37a6b9c6c14f8696afdb0fb6d0c9bc295b26
+      digest: sha256:9dfbee549e5fc354453ff6ecaa3a18f013e3c8976c63af801a58cdaba016d0ce
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -98,7 +98,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:13c33d4e6952e6ddd69d9dd7bb941dc5e8f9fb3d589f016aaca01a9f1067f409
+      digest: sha256:2a250598df9900192e145f5bea8175325f3b14aa69c5150be0c2bd803fdcdec9
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -489,7 +489,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
-    digest: sha256:cb8bf5c16f961dc9d673a44867a681bdd2d7844a8d12564ad7ff42d8bc22db3b
+    digest: sha256:cabce18d0674442c8fb4d931e4d44306b74fbaca5e6c9c23f92c8aa790daf53d
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -541,7 +541,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:76b03f4c04291c80a7269474b055cee5f188746c68b444b20c03ea180d0c1348
+    digest: sha256:326a165eb7b65ae43b85c9538d3572c57aa56a1862febd90f293783824c62d5f
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -604,7 +604,7 @@ maestro:
     name: arohcp-perf-maestro-usw3ptest
     private: false
   image:
-    digest: sha256:0053dfaa6931c0c60e343b3b4460c136207f4567b14df9f6a7dbd5f3a5d89ed0
+    digest: sha256:7dc6bf1b8476e4737a84a5d744bc354d5949b729eeab92039a43507884dd7334
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -711,7 +711,7 @@ mgmt:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
+        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -731,7 +731,7 @@ mgmt:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
+        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
       replicas: 2
       resources:
         limits:
@@ -966,7 +966,7 @@ secretSyncController:
         memory: 100Mi
     serviceAccountName: secrets-store-sync-controller-manager
   providerImage:
-    digest: sha256:f21fca34342808670e8696dffd25efd5ef4347327b30371950b9e08fee2f11f8
+    digest: sha256:407ff33bb445d44db9924eeffa2b61d4adf475e5805bdcda10d33e7f68578217
     registry: mcr.microsoft.com
     repository: oss/v2/azure/secrets-store/provider-azure
 serviceKeyVault:
@@ -1060,7 +1060,7 @@ svc:
   istio:
     ingressGatewayIPAddressIPTags: ""
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
-    istioctlVersion: 1.31.0
+    istioctlVersion: 1.30.4
     tag: prod-stable
     targetVersion: asm-1-29
     versions: asm-1-29
@@ -1080,7 +1080,7 @@ svc:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
+        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -1100,7 +1100,7 @@ svc:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
+        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
       replicas: 2
       resources:
         limits:
@@ -1156,14 +1156,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:908426eb82d213a5a50e7dc499907fbbd47d2dd80f6d5e4ed1472e0a6b9fb460
+    digest: sha256:3cc0fe2d2f0cf66dc8b5346af8ab117046a8abe66bacd29fb3c895d4c3fef7ac
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:fca00f1a9915708bededd250db55b3f954572478c1175c46eb6a350c1344f5bc
+    digest: sha256:57afef0f83ea72d8c98808cd894b5adfac336089ddeae9dd0559116de64ba0db
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:d712b510c9224d194e3da94bbc87d6ff66f44f2d513dd51c2b10b7d2681eb0d1
+    digest: sha256:857c25afa2fced585ba68ae40248278c6d244f65d72b35b635b8789417d0b9a5
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -1,12 +1,12 @@
 acm:
   mce:
     bundle:
-      digest: sha256:a7f8a100505c2a5255719453ce365aa43ef6fec2073054332b9a5d4ad7d359ea
+      digest: sha256:c9ed6d2e2591467d68b28eb277ce9c073603897f681cfb30f49a0a922d1bca18
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/mce-operator-bundle-mce-211
   operator:
     bundle:
-      digest: sha256:2a939da3ff1da79c5de14109e83c37a6b9c6c14f8696afdb0fb6d0c9bc295b26
+      digest: sha256:9dfbee549e5fc354453ff6ecaa3a18f013e3c8976c63af801a58cdaba016d0ce
       registry: quay.io
       repository: redhat-user-workloads/crt-redhat-acm-tenant/acm-operator-bundle-acm-216
 acr:
@@ -98,7 +98,7 @@ arobit:
   mdsd:
     enabled: false
     image:
-      digest: sha256:13c33d4e6952e6ddd69d9dd7bb941dc5e8f9fb3d589f016aaca01a9f1067f409
+      digest: sha256:2a250598df9900192e145f5bea8175325f3b14aa69c5150be0c2bd803fdcdec9
       registry: mcr.microsoft.com
       repository: geneva/distroless/mdsd
 auditLogsEventHub:
@@ -489,7 +489,7 @@ hcpRecovery:
 hypershift:
   additionalInstallArg: --enable-cpo-overrides --disable-capi-migration
   image:
-    digest: sha256:cb8bf5c16f961dc9d673a44867a681bdd2d7844a8d12564ad7ff42d8bc22db3b
+    digest: sha256:cabce18d0674442c8fb4d931e4d44306b74fbaca5e6c9c23f92c8aa790daf53d
     registry: quay.io
     repository: redhat-services-prod/crt-redhat-acm-tenant/hypershift/hypershift-operator
   limitClusterSizes: true
@@ -541,7 +541,7 @@ kubeApplier:
 kubeEvents:
   enabled: true
   image:
-    digest: sha256:76b03f4c04291c80a7269474b055cee5f188746c68b444b20c03ea180d0c1348
+    digest: sha256:326a165eb7b65ae43b85c9538d3572c57aa56a1862febd90f293783824c62d5f
     registry: kubernetesshared.azurecr.io
     repository: shared/kube-events
   k8s:
@@ -604,7 +604,7 @@ maestro:
     name: arohcp-pers-maestro-usw3test
     private: false
   image:
-    digest: sha256:0053dfaa6931c0c60e343b3b4460c136207f4567b14df9f6a7dbd5f3a5d89ed0
+    digest: sha256:7dc6bf1b8476e4737a84a5d744bc354d5949b729eeab92039a43507884dd7334
     registry: quay.io
     repository: redhat-user-workloads/maestro-rhtap-tenant/maestro/maestro
   postgres:
@@ -713,7 +713,7 @@ mgmt:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
+        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -733,7 +733,7 @@ mgmt:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
+        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
       replicas: 2
       resources:
         limits:
@@ -968,7 +968,7 @@ secretSyncController:
         memory: 100Mi
     serviceAccountName: secrets-store-sync-controller-manager
   providerImage:
-    digest: sha256:f21fca34342808670e8696dffd25efd5ef4347327b30371950b9e08fee2f11f8
+    digest: sha256:407ff33bb445d44db9924eeffa2b61d4adf475e5805bdcda10d33e7f68578217
     registry: mcr.microsoft.com
     repository: oss/v2/azure/secrets-store/provider-azure
 serviceKeyVault:
@@ -1062,7 +1062,7 @@ svc:
   istio:
     ingressGatewayIPAddressIPTags: ""
     ingressGatewayIPAddressName: aro-hcp-istio-ingress
-    istioctlVersion: 1.31.0
+    istioctlVersion: 1.30.4
     tag: prod-stable
     targetVersion: asm-1-29
     versions: asm-1-29
@@ -1084,7 +1084,7 @@ svc:
           sha: 01038e7de14b78d702d2849c3aad72fd25903c4765af63cf16aa3398f5d5f2dd
     kubeStateMetrics:
       image:
-        digest: sha256:f054748b97104dda457fb114d0f5dbe5a716e478e2a4751a3c33576a9ffc8d1e
+        digest: sha256:9b99d6e6e3a52eeb24295f1ebbb62dd2f415b1665ca2235e259bdf79792876de
         registry: mcr.microsoft.com/oss/v2
         repository: kubernetes/kube-state-metrics
     namespace: prometheus
@@ -1104,7 +1104,7 @@ svc:
       image:
         registry: mcr.microsoft.com/oss/v2
         repository: prometheus/prometheus
-        sha: 3821dcf121cf58b0a9916451846b35b6223fc7c20df2c920524f0c3c0f2568d8
+        sha: 4aa428f652d2d6eebfa39981038c7571ee7ed20edb444e23b1b7f41b57e2e8d3
       replicas: 2
       resources:
         limits:
@@ -1160,14 +1160,14 @@ svc:
 tenantId: 64dc69e4-d083-49fc-9569-ebece1dd1408
 velero:
   azurePlugin:
-    digest: sha256:908426eb82d213a5a50e7dc499907fbbd47d2dd80f6d5e4ed1472e0a6b9fb460
+    digest: sha256:3cc0fe2d2f0cf66dc8b5346af8ab117046a8abe66bacd29fb3c895d4c3fef7ac
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-plugin-for-microsoft-azure-rhel9
   hypershiftPlugin:
-    digest: sha256:fca00f1a9915708bededd250db55b3f954572478c1175c46eb6a350c1344f5bc
+    digest: sha256:57afef0f83ea72d8c98808cd894b5adfac336089ddeae9dd0559116de64ba0db
     registry: registry.stage.redhat.io
     repository: oadp/oadp-hypershift-velero-plugin-rhel9
   server:
-    digest: sha256:d712b510c9224d194e3da94bbc87d6ff66f44f2d513dd51c2b10b7d2681eb0d1
+    digest: sha256:857c25afa2fced585ba68ae40248278c6d244f65d72b35b635b8789417d0b9a5
     registry: registry.stage.redhat.io
     repository: oadp/oadp-velero-rhel9

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/openshift/api v0.0.0-20260429122012-1180c0f5c3e9
 	github.com/openshift/cluster-version-operator v1.0.1-0.20260202115537-557510ea0603
 	github.com/openshift/hypershift/api v0.0.0-20260708113917-8b5103a5875b
+	github.com/openshift/library-go v0.0.0-20260504190829-2dd4388d7b89
 	github.com/prometheus/client_golang v1.23.2
 	github.com/segmentio/ksuid v1.0.4
 	github.com/stretchr/testify v1.11.1

--- a/internal/go.sum
+++ b/internal/go.sum
@@ -195,6 +195,8 @@ github.com/openshift/cluster-version-operator v1.0.1-0.20260202115537-557510ea06
 github.com/openshift/cluster-version-operator v1.0.1-0.20260202115537-557510ea0603/go.mod h1:5HPAGcvwDreflw2OjJTEz7MicVZ/mTJQv6zYykB+f+M=
 github.com/openshift/hypershift/api v0.0.0-20260708113917-8b5103a5875b h1:JEAHE8tV+h+7QmPELrhoKxzzUuHAMPJzsNBunzwM6O8=
 github.com/openshift/hypershift/api v0.0.0-20260708113917-8b5103a5875b/go.mod h1:XO2zWpuo0rqxljntdt4aI5ZKhQCIeMYRDWtRNTo+bSE=
+github.com/openshift/library-go v0.0.0-20260504190829-2dd4388d7b89 h1:etWee1jfkT93YVB+aYDhCARlokHGvWsRKXgKPcGrSZQ=
+github.com/openshift/library-go v0.0.0-20260504190829-2dd4388d7b89/go.mod h1:k1tefCr+PAZ7kY8TJjpE6rW6t6Yu4iOmBwO+1+3qD2s=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/internal/ocm/client.go
+++ b/internal/ocm/client.go
@@ -57,6 +57,9 @@ type ClusterServiceClientSpec interface {
 	// GetClusterHypershiftDetails sends a GET request to fetch a cluster's hypershift details from Cluster Service.
 	GetClusterHypershiftDetails(ctx context.Context, internalID InternalID) (*cmv1.HypershiftConfig, error)
 
+	// GetClusterResources sends a GET request to fetch cluster resources from Cluster Service.
+	GetClusterResources(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.ClusterResources, error)
+
 	// PostCluster sends a POST request to create a cluster in Cluster Service.
 	PostCluster(ctx context.Context, clusterBuilder *arohcpv1alpha1.ClusterBuilder) (*arohcpv1alpha1.Cluster, error)
 
@@ -370,6 +373,20 @@ func (csc *clusterServiceClient) GetClusterHypershiftDetails(ctx context.Context
 		return nil, fmt.Errorf("empty response body")
 	}
 	return hypershiftConfig, nil
+}
+
+func (csc *clusterServiceClient) GetClusterResources(ctx context.Context,
+	internalID InternalID) (*arohcpv1alpha1.ClusterResources, error) {
+	client, ok := getAroHCPClusterClient(internalID, csc.conn)
+	if !ok {
+		return nil, fmt.Errorf("OCM path is not a cluster: %s", internalID)
+	}
+
+	resp, err := client.Resources().Get().SendContext(ctx)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	return resp.Body(), nil
 }
 
 func (csc *clusterServiceClient) PostCluster(ctx context.Context, clusterBuilder *arohcpv1alpha1.ClusterBuilder) (*arohcpv1alpha1.Cluster, error) {

--- a/internal/ocm/mock_client.go
+++ b/internal/ocm/mock_client.go
@@ -427,6 +427,45 @@ func (c *MockClusterServiceClientSpecGetClusterProvisionShardCall) DoAndReturn(f
 	return c
 }
 
+// GetClusterResources mocks base method.
+func (m *MockClusterServiceClientSpec) GetClusterResources(ctx context.Context, internalID InternalID) (*v1alpha1.ClusterResources, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterResources", ctx, internalID)
+	ret0, _ := ret[0].(*v1alpha1.ClusterResources)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterResources indicates an expected call of GetClusterResources.
+func (mr *MockClusterServiceClientSpecMockRecorder) GetClusterResources(ctx, internalID any) *MockClusterServiceClientSpecGetClusterResourcesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterResources", reflect.TypeOf((*MockClusterServiceClientSpec)(nil).GetClusterResources), ctx, internalID)
+	return &MockClusterServiceClientSpecGetClusterResourcesCall{Call: call}
+}
+
+// MockClusterServiceClientSpecGetClusterResourcesCall wrap *gomock.Call
+type MockClusterServiceClientSpecGetClusterResourcesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockClusterServiceClientSpecGetClusterResourcesCall) Return(arg0 *v1alpha1.ClusterResources, arg1 error) *MockClusterServiceClientSpecGetClusterResourcesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockClusterServiceClientSpecGetClusterResourcesCall) Do(f func(context.Context, InternalID) (*v1alpha1.ClusterResources, error)) *MockClusterServiceClientSpecGetClusterResourcesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockClusterServiceClientSpecGetClusterResourcesCall) DoAndReturn(f func(context.Context, InternalID) (*v1alpha1.ClusterResources, error)) *MockClusterServiceClientSpecGetClusterResourcesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetClusterStatus mocks base method.
 func (m *MockClusterServiceClientSpec) GetClusterStatus(ctx context.Context, internalID InternalID) (*v1alpha1.ClusterStatus, error) {
 	m.ctrl.T.Helper()

--- a/internal/ocm/tracing.go
+++ b/internal/ocm/tracing.go
@@ -90,6 +90,19 @@ func (csc *clusterServiceClientWithTracing) GetClusterHypershiftDetails(ctx cont
 	return csc.csc.GetClusterHypershiftDetails(ctx, internalID)
 }
 
+func (csc *clusterServiceClientWithTracing) GetClusterResources(ctx context.Context,
+	internalID InternalID) (*arohcpv1alpha1.ClusterResources, error) {
+	ctx, span := csc.startChildSpan(ctx, "ClusterServiceClient.GetClusterResources")
+	defer span.End()
+
+	response, err := csc.csc.GetClusterResources(ctx, internalID)
+	if err != nil {
+		span.RecordError(err)
+	}
+
+	return response, err
+}
+
 func (csc *clusterServiceClientWithTracing) GetClusterProvisionShard(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.ProvisionShard, error) {
 	ctx, span := csc.startChildSpan(ctx, "ClusterServiceClient.GetClusterProvisionShard")
 	defer span.End()

--- a/internal/restmapper/restmapper.go
+++ b/internal/restmapper/restmapper.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restmapper
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/openshift/library-go/pkg/client/openshiftrestmapper"
+)
+
+// additionalRESTMappings contains mappings for standard Kubernetes resources
+// not already covered by library-go's hardcoded OpenShift mapper.
+var additionalRESTMappings = []meta.RESTMapping{
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PersistentVolume"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Endpoints"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "endpoints"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ResourceQuota"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "resourcequotas"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "LimitRange"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "limitranges"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "policy", Version: "v1", Kind: "PodDisruptionBudget"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "cronjobs"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "autoscaling", Version: "v2", Resource: "horizontalpodautoscalers"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "hypershift.openshift.io", Version: "v1beta1", Kind: "HostedCluster"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "hypershift.openshift.io", Version: "v1beta1", Resource: "hostedclusters"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "hypershift.openshift.io", Version: "v1beta1", Kind: "NodePool"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "hypershift.openshift.io", Version: "v1beta1", Resource: "nodepools"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "multitenancy.acn.azure.com", Version: "v1alpha1", Kind: "PodNetwork"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "multitenancy.acn.azure.com", Version: "v1alpha1", Resource: "podnetworks"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "multitenancy.acn.azure.com", Version: "v1alpha1", Kind: "PodNetworkInstance"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "multitenancy.acn.azure.com", Version: "v1alpha1", Resource: "podnetworkinstances"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "secrets-store.csi.x-k8s.io", Version: "v1", Kind: "SecretProviderClass"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "secrets-store.csi.x-k8s.io", Version: "v1", Resource: "secretproviderclasses"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "secret-sync.x-k8s.io", Version: "v1alpha1", Kind: "SecretSync"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "secret-sync.x-k8s.io", Version: "v1alpha1", Resource: "secretsyncs"},
+	},
+}
+
+// Mapper is a package-level RESTMapper that resolves GVK→GVR without API
+// server discovery. It chains:
+//  1. Additional standard Kubernetes mappings not in library-go
+//  2. Library-go's hardcoded OpenShift/Kubernetes mappings
+//  3. An always-error fallback
+var Mapper meta.RESTMapper = newHardCodedRESTMapper()
+
+func newHardCodedRESTMapper() meta.RESTMapper {
+	libraryGoRESTMapping := openshiftrestmapper.NewOpenShiftHardcodedRESTMapper(alwaysErrorRESTMapper{})
+
+	ret := openshiftrestmapper.HardCodedFirstRESTMapper{
+		Mapping:    map[schema.GroupVersionKind]meta.RESTMapping{},
+		RESTMapper: libraryGoRESTMapping,
+	}
+	for i := range additionalRESTMappings {
+		curr := additionalRESTMappings[i]
+		ret.Mapping[curr.GroupVersionKind] = curr
+	}
+	return ret
+}
+
+// ResourceFor resolves a GVK to a GVR using the hardcoded mapper chain.
+func ResourceFor(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+	mapping, err := Mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	return mapping.Resource, nil
+}
+
+// alwaysErrorRESTMapper is a terminal delegate that rejects all lookups.
+type alwaysErrorRESTMapper struct{}
+
+var _ meta.RESTMapper = alwaysErrorRESTMapper{}
+
+func (alwaysErrorRESTMapper) KindFor(schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, &meta.NoResourceMatchError{}
+}
+
+func (alwaysErrorRESTMapper) KindsFor(schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, &meta.NoResourceMatchError{}
+}
+
+func (alwaysErrorRESTMapper) ResourceFor(schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{}, &meta.NoResourceMatchError{}
+}
+
+func (alwaysErrorRESTMapper) ResourcesFor(schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return nil, &meta.NoResourceMatchError{}
+}
+
+func (alwaysErrorRESTMapper) RESTMapping(gk schema.GroupKind, _ ...string) (*meta.RESTMapping, error) {
+	return nil, fmt.Errorf("no hardcoded REST mapping for %v", gk)
+}
+
+func (alwaysErrorRESTMapper) RESTMappings(gk schema.GroupKind, _ ...string) ([]*meta.RESTMapping, error) {
+	return nil, fmt.Errorf("no hardcoded REST mapping for %v", gk)
+}
+
+func (alwaysErrorRESTMapper) ResourceSingularizer(string) (string, error) {
+	return "", fmt.Errorf("no hardcoded singularizer")
+}

--- a/internal/restmapper/restmapper_test.go
+++ b/internal/restmapper/restmapper_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restmapper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestResourceFor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		gvk     schema.GroupVersionKind
+		wantGVR schema.GroupVersionResource
+	}{
+		{
+			name:    "ConfigMap from library-go defaults",
+			gvk:     schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
+			wantGVR: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},
+		},
+		{
+			name:    "Secret from library-go defaults",
+			gvk:     schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"},
+			wantGVR: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"},
+		},
+		{
+			name:    "Deployment from library-go defaults",
+			gvk:     schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			wantGVR: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+		},
+		{
+			name:    "Namespace from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"},
+			wantGVR: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"},
+		},
+		{
+			name:    "Ingress from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress"},
+			wantGVR: schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
+		},
+		{
+			name:    "NetworkPolicy from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"},
+			wantGVR: schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"},
+		},
+		{
+			name:    "Service from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"},
+			wantGVR: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"},
+		},
+		{
+			name:    "HostedCluster from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "hypershift.openshift.io", Version: "v1beta1", Kind: "HostedCluster"},
+			wantGVR: schema.GroupVersionResource{Group: "hypershift.openshift.io", Version: "v1beta1", Resource: "hostedclusters"},
+		},
+		{
+			name:    "NodePool from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "hypershift.openshift.io", Version: "v1beta1", Kind: "NodePool"},
+			wantGVR: schema.GroupVersionResource{Group: "hypershift.openshift.io", Version: "v1beta1", Resource: "nodepools"},
+		},
+		{
+			name:    "PodNetwork from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "multitenancy.acn.azure.com", Version: "v1alpha1", Kind: "PodNetwork"},
+			wantGVR: schema.GroupVersionResource{Group: "multitenancy.acn.azure.com", Version: "v1alpha1", Resource: "podnetworks"},
+		},
+		{
+			name:    "PodNetworkInstance from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "multitenancy.acn.azure.com", Version: "v1alpha1", Kind: "PodNetworkInstance"},
+			wantGVR: schema.GroupVersionResource{Group: "multitenancy.acn.azure.com", Version: "v1alpha1", Resource: "podnetworkinstances"},
+		},
+		{
+			name:    "SecretProviderClass from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "secrets-store.csi.x-k8s.io", Version: "v1", Kind: "SecretProviderClass"},
+			wantGVR: schema.GroupVersionResource{Group: "secrets-store.csi.x-k8s.io", Version: "v1", Resource: "secretproviderclasses"},
+		},
+		{
+			name:    "SecretSync from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "secret-sync.x-k8s.io", Version: "v1alpha1", Kind: "SecretSync"},
+			wantGVR: schema.GroupVersionResource{Group: "secret-sync.x-k8s.io", Version: "v1alpha1", Resource: "secretsyncs"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gvr, err := ResourceFor(tt.gvk)
+			require.NoError(t, err, "ResourceFor should succeed for known type")
+			assert.Equal(t, tt.wantGVR, gvr)
+		})
+	}
+}
+
+func TestResourceForUnknownType(t *testing.T) {
+	t.Parallel()
+	_, err := ResourceFor(schema.GroupVersionKind{Group: "fake.example.com", Version: "v1", Kind: "Unknown"})
+	assert.Error(t, err, "ResourceFor should error for unknown type")
+}

--- a/test-integration/backend/launch/metrics_test.go
+++ b/test-integration/backend/launch/metrics_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,6 +76,7 @@ func TestBackendExposesMetrics(t *testing.T) {
 			metadataapi.Must(arohcpv1alpha1.NewCluster().ID("test-cluster").HREF(internalClusterID.String()).Build()),
 		}
 		clusterServiceMock.MockClusterServiceClient.EXPECT().ListProvisionShards().Return(ocm.NewSimpleProvisionShardListIterator(nil, nil)).AnyTimes()
+		clusterServiceMock.MockClusterServiceClient.EXPECT().GetClusterResources(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 		cleanupCtx := utils.ContextWithLogger(context.Background(), integrationutils.DefaultLogger(t))
 		defer storageIntegrationTestInfo.Cleanup(cleanupCtx)
 		defer clusterServiceMock.Cleanup(cleanupCtx)

--- a/test-integration/go.mod
+++ b/test-integration/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/openshift/api v0.0.0-20260429122012-1180c0f5c3e9 // indirect
 	github.com/openshift/cluster-version-operator v1.0.1-0.20260202115537-557510ea0603 // indirect
 	github.com/openshift/hypershift/api v0.0.0-20260708113917-8b5103a5875b // indirect
+	github.com/openshift/library-go v0.0.0-20260504190829-2dd4388d7b89 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
@@ -137,6 +138,7 @@ require (
 	k8s.io/component-base v0.35.3 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
+	open-cluster-management.io/api v1.3.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect

--- a/test-integration/go.sum
+++ b/test-integration/go.sum
@@ -220,6 +220,7 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.28.3 h1:4JvMdwtFU0imd8fHx25OJXoDMRexnf8v5NHKYSTTji4=
 github.com/onsi/ginkgo/v2 v2.28.3/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
 github.com/onsi/gomega v1.40.0 h1:Vtol0e1MghCD2ZVIilPDIg44XSL9l2QAn8ZNaljWcJc=
@@ -469,6 +470,8 @@ k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a h1:xCeOEAOoGYl2jnJoHkC3hk
 k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a/go.mod h1:uGBT7iTA6c6MvqUvSXIaYZo9ukscABYi2btjhvgKGZ0=
 k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 h1:kBawHLSnx/mYHmRnNUf9d4CpjREbeZuxoSGOX/J+aYM=
 k8s.io/utils v0.0.0-20260319190234-28399d86e0b5/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
+open-cluster-management.io/api v1.3.0 h1:Q3miH38BE3N5+PesHQ0kcFi5nhX5350m7OJWapZcVqY=
+open-cluster-management.io/api v1.3.0/go.mod h1:t0DsBv4gjIo9ojd7GYfA2tcEMpNf0h5Ix68pFDXwNSk=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0 h1:qPrZsv1cwQiFeieFlRqT627fVZ+tyfou/+S5S0H5ua0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=

--- a/test/e2e/cluster_authorized_cidrs_connectivity.go
+++ b/test/e2e/cluster_authorized_cidrs_connectivity.go
@@ -189,11 +189,9 @@ var _ = Describe("Authorized CIDRs", func() {
 				}, 5*time.Minute, 10*time.Second).Should(Succeed())
 
 				By("verifying aggregated API services from authorized VM")
-				// Filter :True lines on the VM to stay within the 4KB run-command output limit.
-				// Write kubectl output first so a kubectl failure fails the command. Isolate grep
-				// so only its rc=1 ("no matches", the healthy case) is treated as success.
+				// Only output unavailable services (filter out :True lines) to stay within 4KB VM output limit
 				apiServicesCmd := fmt.Sprintf(
-					`echo '%s' | base64 -d > /tmp/kubeconfig && kubectl --kubeconfig=/tmp/kubeconfig get apiservices -o jsonpath='{range .items[*]}{.metadata.name}:{.status.conditions[?(@.type=="Available")].status}{"\n"}{end}' > /tmp/apiservices.status && { grep -v ':True$' /tmp/apiservices.status; rc=$?; [ $rc -le 1 ]; }`,
+					`echo '%s' | base64 -d > /tmp/kubeconfig && kubectl --kubeconfig=/tmp/kubeconfig get apiservices -o jsonpath='{range .items[*]}{.metadata.name}:{.status.conditions[?(@.type=="Available")].status}{"\n"}{end}' | grep -v ':True$'`,
 					kubeconfigB64,
 				)
 
@@ -361,11 +359,9 @@ var _ = Describe("Authorized CIDRs", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to create console OAuth client secret for external auth via VM")
 
 				By("verifying all cluster operators are healthy from authorized VM")
-				// Filter :True lines on the VM to stay within the 4KB run-command output limit.
-				// Write kubectl output first so a kubectl failure fails the command. Isolate grep
-				// so only its rc=1 ("no matches", the healthy case) is treated as success.
+				// Only output unavailable operators (filter out :True lines) to stay within 4KB VM output limit
 				clusterOperatorsCmd := fmt.Sprintf(
-					`echo '%s' | base64 -d > /tmp/kubeconfig && kubectl --kubeconfig=/tmp/kubeconfig get clusteroperators -o jsonpath='{range .items[*]}{.metadata.name}:{.status.conditions[?(@.type=="Available")].status}{"\n"}{end}' > /tmp/clusteroperators.status && { grep -v ':True$' /tmp/clusteroperators.status; rc=$?; [ $rc -le 1 ]; }`,
+					`echo '%s' | base64 -d > /tmp/kubeconfig && kubectl --kubeconfig=/tmp/kubeconfig get clusteroperators -o jsonpath='{range .items[*]}{.metadata.name}:{.status.conditions[?(@.type=="Available")].status}{"\n"}{end}' | grep -v ':True$'`,
 					kubeconfigB64,
 				)
 

--- a/test/e2e/cluster_create_private_kas.go
+++ b/test/e2e/cluster_create_private_kas.go
@@ -126,8 +126,8 @@ var _ = Describe("Customer", func() {
 
 			By("verifying KAS is reachable from VM inside the VNet")
 			// Get admin credentials via ARM and override the server URL with
-			// the internal LB's private IP so kubectl on the VM connects
-			// through the private KAS endpoint rather than the public route.
+			// the internal LB IP so kubectl on the VM connects through the
+			// private KAS endpoint.
 			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20240610(
 				ctx,
 				tc.Get20240610ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
@@ -142,15 +142,6 @@ var _ = Describe("Customer", func() {
 			GinkgoLogr.Info("Found private KAS internal LB", "ip", internalIP, "managedRG", clusterParams.ManagedResourceGroupName)
 
 			adminRESTConfig.Host = fmt.Sprintf("https://%s:443", internalIP)
-			// The admin kubeconfig's CAData does not correspond to the
-			// certificate served directly by the internal LB (it targets the
-			// cluster's public route/CA chain), and the LB IP is not in that
-			// certificate's SAN list either. This check only needs to prove
-			// network reachability of the private KAS endpoint, not validate
-			// the full TLS chain, so skip verification here — matching the
-			// insecureSkipVerify used by the other connectivity checks below.
-			adminRESTConfig.Insecure = true
-			adminRESTConfig.CAData = nil
 
 			kubeconfig, err := framework.GenerateKubeconfig(adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred(), "failed to generate kubeconfig from admin REST config")
@@ -159,31 +150,15 @@ var _ = Describe("Customer", func() {
 			// kubectl version hits /version (unauthenticated) through the
 			// internal LB. A successful response proves the private KAS
 			// network path (VM → customer subnet → internal LB → Swift →
-			// KAS pods) is functional. Combine stderr into stdout so any
-			// failure is visible in the command output rather than silently
-			// discarded.
+			// KAS pods) is functional.
 			versionCmd := fmt.Sprintf(
 				"echo '%s' | base64 -d > /tmp/kubeconfig && "+
-					"kubectl --kubeconfig=/tmp/kubeconfig version 2>&1",
+					"kubectl --kubeconfig=/tmp/kubeconfig version 2>/dev/null",
 				kubeconfigB64,
 			)
-			// The internal LB's backend pool/health probes may take a short
-			// while to become reachable from the customer VM after the
-			// cluster and node pool are provisioned, so retry with
-			// delta-only logging instead of a single one-shot attempt.
-			var versionOutput string
-			var lastErr error
-			Eventually(func(g Gomega) {
-				var runErr error
-				versionOutput, runErr = framework.RunVMCommand(ctx, tc, *resourceGroup.Name, vmName, versionCmd, 2*time.Minute)
-				if runErr != nil && (lastErr == nil || runErr.Error() != lastErr.Error()) {
-					GinkgoLogr.Info("kubectl version via private KAS internal endpoint not yet succeeding", "error", runErr, "output", versionOutput)
-					lastErr = runErr
-				}
-				g.Expect(runErr).NotTo(HaveOccurred(),
-					"kubectl version should succeed from VM via private KAS internal endpoint (output: %s)", versionOutput)
-			}, 5*time.Minute, 15*time.Second).Should(Succeed(),
-				"KAS was never reachable from the VM inside the VNet via the private KAS internal endpoint")
+			versionOutput, err := framework.RunVMCommand(ctx, tc, *resourceGroup.Name, vmName, versionCmd, 2*time.Minute)
+			Expect(err).NotTo(HaveOccurred(),
+				"kubectl version should succeed from VM via private KAS internal LB (output: %s)", versionOutput)
 			GinkgoLogr.Info("KAS is reachable from VM inside VNet", "output", versionOutput)
 
 			By("verifying KAS is NOT reachable from outside the VNet")

--- a/test/util/framework/per_test_framework.go
+++ b/test/util/framework/per_test_framework.go
@@ -811,7 +811,7 @@ func (tc *perItOrDescribeTestContext) purgeDeletedKeyVaultsInResourceGroup(ctx c
 				// A 404 means the vault was already purged or its soft-delete
 				// window expired between the list and the purge; that is the
 				// desired end state, so treat it as a no-op rather than noise.
-				if IsNotFoundError(err) {
+				if isKeyVaultNotFound(err) {
 					continue
 				}
 				ginkgo.GinkgoLogr.Error(err, "failed to start purge of soft-deleted key vault; a colliding name may block a later run until it is purged or expires",
@@ -819,7 +819,7 @@ func (tc *perItOrDescribeTestContext) purgeDeletedKeyVaultsInResourceGroup(ctx c
 				continue
 			}
 			if _, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: StandardPollInterval}); err != nil {
-				if IsNotFoundError(err) {
+				if isKeyVaultNotFound(err) {
 					continue
 				}
 				ginkgo.GinkgoLogr.Error(err, "failed to purge soft-deleted key vault; a colliding name may block a later run until it is purged or expires",
@@ -829,8 +829,10 @@ func (tc *perItOrDescribeTestContext) purgeDeletedKeyVaultsInResourceGroup(ctx c
 	}
 }
 
-// IsNotFoundError reports whether err is an Azure 404 (Not Found) response.
-func IsNotFoundError(err error) bool {
+// isKeyVaultNotFound reports whether err is an Azure 404 response, which for a
+// purge means the vault is already gone (already purged or soft-delete window
+// expired) and can be treated as a successful no-op.
+func isKeyVaultNotFound(err error) bool {
 	var respErr *azcore.ResponseError
 	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }

--- a/test/util/framework/per_test_framework_test.go
+++ b/test/util/framework/per_test_framework_test.go
@@ -94,7 +94,7 @@ func TestIsResourceGroupNotFoundError(t *testing.T) {
 	}
 }
 
-func TestIsNotFoundError(t *testing.T) {
+func TestIsKeyVaultNotFound(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -142,7 +142,7 @@ func TestIsNotFoundError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := IsNotFoundError(tt.err)
+			got := isKeyVaultNotFound(tt.err)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/test/util/framework/vm_helper.go
+++ b/test/util/framework/vm_helper.go
@@ -29,7 +29,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/ptr"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -123,141 +122,75 @@ func RunVMCommand(ctx context.Context, tc interface {
 		return "", err
 	}
 
-	clientFactory, err := armcompute.NewClientFactory(subscriptionID, azCreds, nil)
+	computeClient, err := armcompute.NewVirtualMachinesClient(subscriptionID, azCreds, nil)
 	if err != nil {
 		return "", err
 	}
 
-	vmClient := clientFactory.NewVirtualMachinesClient()
-	runCommandsClient := clientFactory.NewVirtualMachineRunCommandsClient()
-
-	vm, err := vmClient.Get(ctx, resourceGroup, vmName, nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to get VM %q before running command: %w", vmName, err)
-	}
-	if vm.Location == nil || *vm.Location == "" {
-		return "", fmt.Errorf("VM %q has no location set", vmName)
-	}
-
-	runCommandName := fmt.Sprintf("e2e-runcommand-%d", time.Now().UnixNano())
-	timeoutSeconds := int32(max(60, int(pollTimeout.Seconds())+60))
-	// Managed Run Commands accept exactly one script source (script, scriptUri,
-	// or commandId). Custom shell content must use Script only — CommandID is
-	// for predefined gallery/builtin commands, not the old RunShellScript action.
-	runCommand := armcompute.VirtualMachineRunCommand{
-		Location: vm.Location,
-		Properties: &armcompute.VirtualMachineRunCommandProperties{
-			Source: &armcompute.VirtualMachineRunCommandScriptSource{
-				Script: to.Ptr(command),
-			},
-			AsyncExecution:   to.Ptr(false),
-			TimeoutInSeconds: to.Ptr(timeoutSeconds),
+	runCommandInput := armcompute.RunCommandInput{
+		CommandID: to.Ptr("RunShellScript"),
+		Script: []*string{
+			to.Ptr(command),
 		},
 	}
 
-	poller, err := runCommandsClient.BeginCreateOrUpdate(ctx, resourceGroup, vmName, runCommandName, runCommand, nil)
+	poller, err := computeClient.BeginRunCommand(ctx, resourceGroup, vmName, runCommandInput, nil)
 	if err != nil {
 		return "", err
 	}
 
-	// Create a timeout context to avoid waiting too long on VM command failures.
-	// On any PollUntilDone failure (timeout or ARM/LRO error), best-effort delete
-	// the named run command so it cannot block subsequent commands on the VM.
-	// Error messages intentionally omit the script content — callers often pass
-	// secrets such as base64-encoded kubeconfigs.
+	// Create a timeout context to avoid waiting too long on VM command failures
+	// VM commands should complete quickly (within a few minutes at most)
 	pollCtx, cancel := context.WithTimeout(ctx, pollTimeout)
 	defer cancel()
 
-	_, err = poller.PollUntilDone(pollCtx, nil)
+	result, err := poller.PollUntilDone(pollCtx, nil)
 	if err != nil {
-		deleteErr := deleteVirtualMachineRunCommandBestEffort(runCommandsClient, resourceGroup, vmName, runCommandName)
-		timedOut := errors.Is(err, context.DeadlineExceeded) || errors.Is(pollCtx.Err(), context.DeadlineExceeded)
-		switch {
-		case timedOut && deleteErr != nil:
-			return "", fmt.Errorf("timed out waiting for VM run command %q on VM %q and failed to cancel it: %w (cancel error: %v)", runCommandName, vmName, err, deleteErr)
-		case timedOut:
-			return "", fmt.Errorf("timed out waiting for VM run command %q on VM %q; canceled run command", runCommandName, vmName)
-		case deleteErr != nil:
-			return "", fmt.Errorf("VM run command %q on VM %q failed and cleanup also failed: %w (cancel error: %v)", runCommandName, vmName, err, deleteErr)
-		default:
-			return "", fmt.Errorf("VM run command %q on VM %q failed: %w", runCommandName, vmName, err)
+		return "", err
+	}
+
+	if len(result.Value) > 0 && result.Value[0].Message != nil {
+		// Azure Run Command returns output in format:
+		// "Enable succeeded: \n[stdout]\n<actual output>\n[stderr]\n<errors>"
+		// We need to extract stdout and stderr content
+		message := *result.Value[0].Message
+
+		// Find the stdout section
+		stdoutStart := strings.Index(message, "[stdout]\n")
+		if stdoutStart == -1 {
+			// If no stdout marker, return the whole message
+			return message, nil
 		}
-	}
-	defer func() {
-		if deleteErr := deleteVirtualMachineRunCommandBestEffort(runCommandsClient, resourceGroup, vmName, runCommandName); deleteErr != nil {
-			ginkgo.GinkgoLogr.Error(deleteErr, "failed to delete completed VM run command resource", "resourceGroup", resourceGroup, "vmName", vmName, "runCommandName", runCommandName)
+
+		// Skip past the "[stdout]\n" marker
+		stdoutStart += len("[stdout]\n")
+
+		// Find where stderr starts (if present)
+		stderrStart := strings.Index(message[stdoutStart:], "\n[stderr]")
+
+		var output string
+		if stderrStart == -1 {
+			// No stderr marker, take everything after stdout
+			output = message[stdoutStart:]
+		} else {
+			// Take only the stdout section
+			output = message[stdoutStart : stdoutStart+stderrStart]
+
+			// Extract and inspect stderr
+			stderrAbsoluteStart := stdoutStart + stderrStart + len("\n[stderr]\n")
+			if stderrAbsoluteStart < len(message) {
+				stderr := strings.TrimSpace(message[stderrAbsoluteStart:])
+				if stderr != "" {
+					// Return an error if stderr is not empty
+					return "", fmt.Errorf("%s", stderr)
+				}
+			}
 		}
-	}()
 
-	// CreateOrUpdate LRO responses often omit instance view; fetch it explicitly.
-	// Use a fresh timeout — pollCtx may already be near its deadline after PollUntilDone.
-	getCtx, getCancel := context.WithTimeout(ctx, 2*time.Minute)
-	defer getCancel()
-	result, err := runCommandsClient.GetByVirtualMachine(getCtx, resourceGroup, vmName, runCommandName, &armcompute.VirtualMachineRunCommandsClientGetByVirtualMachineOptions{
-		Expand: to.Ptr("instanceView"),
-	})
-	if err != nil {
-		return "", fmt.Errorf("failed to get instance view for run command %q on VM %q: %w", runCommandName, vmName, err)
+		return strings.TrimSpace(output), nil
 	}
 
-	if result.Properties == nil || result.Properties.InstanceView == nil {
-		return "", fmt.Errorf("run command %q on VM %q completed without instance view", runCommandName, vmName)
-	}
-
-	return outputFromRunCommandInstanceView(result.Properties.InstanceView, runCommandName, vmName)
-}
-
-func outputFromRunCommandInstanceView(instanceView *armcompute.VirtualMachineRunCommandInstanceView, runCommandName, vmName string) (string, error) {
-	output := strings.TrimSpace(ptr.Deref(instanceView.Output, ""))
-	errorOutput := strings.TrimSpace(ptr.Deref(instanceView.Error, ""))
-
-	if errorOutput != "" {
-		return "", fmt.Errorf("%s", errorOutput)
-	}
-
-	if instanceView.ExitCode != nil && *instanceView.ExitCode != 0 {
-		return "", fmt.Errorf("run command %q failed with exit code %d on VM %q (output: %q)", runCommandName, *instanceView.ExitCode, vmName, output)
-	}
-
-	if instanceView.ExecutionState != nil && *instanceView.ExecutionState != armcompute.ExecutionStateSucceeded {
-		return "", fmt.Errorf("run command %q finished in unexpected state %q on VM %q (output: %q)", runCommandName, *instanceView.ExecutionState, vmName, output)
-	}
-
-	return output, nil
-}
-
-func deleteVirtualMachineRunCommandBestEffort(
-	runCommandsClient *armcompute.VirtualMachineRunCommandsClient,
-	resourceGroup string,
-	vmName string,
-	runCommandName string,
-) error {
-	deleteCtx, deleteCancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer deleteCancel()
-	return deleteVirtualMachineRunCommand(deleteCtx, runCommandsClient, resourceGroup, vmName, runCommandName)
-}
-
-func deleteVirtualMachineRunCommand(
-	ctx context.Context,
-	runCommandsClient *armcompute.VirtualMachineRunCommandsClient,
-	resourceGroup string,
-	vmName string,
-	runCommandName string,
-) error {
-	poller, err := runCommandsClient.BeginDelete(ctx, resourceGroup, vmName, runCommandName, nil)
-	if err != nil {
-		if IsNotFoundError(err) {
-			return nil
-		}
-		return err
-	}
-
-	_, err = poller.PollUntilDone(ctx, nil)
-	if err != nil && !IsNotFoundError(err) {
-		return err
-	}
-
-	return nil
+	return "", nil
 }
 
 // GetVirtualMachinesInResourceGroup lists all VMs in the given resource group

--- a/test/util/framework/vm_helper_test.go
+++ b/test/util/framework/vm_helper_test.go
@@ -17,12 +17,9 @@ package framework
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 )
 
 func TestIsRetryableBootDiagnosticsError(t *testing.T) {
@@ -86,95 +83,6 @@ func TestIsRetryableBootDiagnosticsError(t *testing.T) {
 			result := isRetryableBootDiagnosticsError(tc.err)
 			if result != tc.expected {
 				t.Errorf("isRetryableBootDiagnosticsError(%v) = %v, want %v", tc.err, result, tc.expected)
-			}
-		})
-	}
-}
-
-func TestOutputFromRunCommandInstanceView(t *testing.T) {
-	const (
-		runCommandName = "e2e-runcommand-1"
-		vmName         = "test-vm"
-	)
-
-	tests := []struct {
-		name         string
-		instanceView *armcompute.VirtualMachineRunCommandInstanceView
-		wantOutput   string
-		wantErr      string
-	}{
-		{
-			name: "returns trimmed stdout on success",
-			instanceView: &armcompute.VirtualMachineRunCommandInstanceView{
-				Output:         to.Ptr("  hello world  \n"),
-				ExitCode:       to.Ptr(int32(0)),
-				ExecutionState: to.Ptr(armcompute.ExecutionStateSucceeded),
-			},
-			wantOutput: "hello world",
-		},
-		{
-			name:         "returns empty stdout when fields are unset",
-			instanceView: &armcompute.VirtualMachineRunCommandInstanceView{},
-			wantOutput:   "",
-		},
-		{
-			name: "whitespace-only stderr is not treated as failure",
-			instanceView: &armcompute.VirtualMachineRunCommandInstanceView{
-				Output: to.Ptr("ok"),
-				Error:  to.Ptr("   \n"),
-			},
-			wantOutput: "ok",
-		},
-		{
-			name: "stderr takes precedence over exit code and execution state",
-			instanceView: &armcompute.VirtualMachineRunCommandInstanceView{
-				Output:         to.Ptr("stdout"),
-				Error:          to.Ptr(" command failed \n"),
-				ExitCode:       to.Ptr(int32(1)),
-				ExecutionState: to.Ptr(armcompute.ExecutionStateFailed),
-			},
-			wantErr: "command failed",
-		},
-		{
-			name: "non-zero exit code is an error",
-			instanceView: &armcompute.VirtualMachineRunCommandInstanceView{
-				Output:         to.Ptr("partial output"),
-				ExitCode:       to.Ptr(int32(2)),
-				ExecutionState: to.Ptr(armcompute.ExecutionStateSucceeded),
-			},
-			wantErr: `run command "e2e-runcommand-1" failed with exit code 2 on VM "test-vm" (output: "partial output")`,
-		},
-		{
-			name: "unexpected execution state is an error",
-			instanceView: &armcompute.VirtualMachineRunCommandInstanceView{
-				Output:         to.Ptr("still running"),
-				ExitCode:       to.Ptr(int32(0)),
-				ExecutionState: to.Ptr(armcompute.ExecutionStateRunning),
-			},
-			wantErr: `run command "e2e-runcommand-1" finished in unexpected state "Running" on VM "test-vm" (output: "still running")`,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := outputFromRunCommandInstanceView(tc.instanceView, runCommandName, vmName)
-			if tc.wantErr == "" {
-				if err != nil {
-					t.Fatalf("outputFromRunCommandInstanceView() unexpected error: %v", err)
-				}
-				if got != tc.wantOutput {
-					t.Errorf("outputFromRunCommandInstanceView() output = %q, want %q", got, tc.wantOutput)
-				}
-				return
-			}
-			if err == nil {
-				t.Fatalf("outputFromRunCommandInstanceView() error = nil, want %q", tc.wantErr)
-			}
-			if got != "" {
-				t.Errorf("outputFromRunCommandInstanceView() output = %q, want empty on error", got)
-			}
-			if err.Error() != tc.wantErr && !strings.Contains(err.Error(), tc.wantErr) {
-				t.Errorf("outputFromRunCommandInstanceView() error = %q, want %q", err.Error(), tc.wantErr)
 			}
 		})
 	}

--- a/tooling/image-updater/config.yaml
+++ b/tooling/image-updater/config.yaml
@@ -91,7 +91,7 @@ images:
     group: platform-utils
     source:
       image: mcr.microsoft.com/aks/command/runtime
-      tag: "master.260813.1" # Pinned: master.260901.1 breaks mgmt provisioning (AROSLSRE-2021). Revert to tagPattern: AROSLSRE-2025
+      tagPattern: "^master\\.\\d+\\.\\d+$"
       multiArch: true
     targets:
     - jsonPath: defaults.aksCommandRuntime.image.digest


### PR DESCRIPTION
## Why

`pull-ci-Azure-ARO-HCP-main-e2e-parallel` entered an uninterrupted ARM/AKS provisioning failure streak on September 7, 2026. ARM accepts the service-cluster deployment, but its `Microsoft.ContainerService/managedClusters` operation remains `Running` without an error payload until the E2E provisioner reaches its polling deadline.

The selected restore point is `074dbff3ae793d48cb9d0b681e996a1ebd2a0595` from September 6, 2026. Its observed E2E sample was 2 successful jobs and 0 failures.

Tracking issue: https://github.com/Azure/ARO-HCP/issues/6853

## What

This is a **clean revert created with `git revert`**. It reverses the six first-parent mainline merges after `074dbff3ae793d48cb9d0b681e996a1ebd2a0595`, restoring the committed tree exactly to that SHA:

- `cf1855bd5478e44f76718bb29025b8d50f28cea5` (PR #6850)
- `0beac38a70f70ac748ee3ee823738fb814cb1e82` (PR #6787)
- `0a11958912358bccb8437caf80ee51f021c3e1eb` (PR #6847)
- `6f6a6a49d6da04612f13fca15e7daf58accd5278` (PR #6833)
- `73c1ed067535ba1e92637a910e4a918f000d079c` (PR #6824)
- `b2c3b4e3e3dd33036b404ebcd03ec967827f7d5a` (PR #6429)

The PR is draft while the shared E2E infrastructure incident is active.

Fixes #6853