### PR TITLE
[ARO-28373] Reintroduce ClusterResourcesController

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -40,6 +40,7 @@ require (
 	k8s.io/component-base v0.35.3
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
+	open-cluster-management.io/api v1.3.0
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -96,6 +97,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/openshift-online/ocm-api-model/clientapi v0.0.464 // indirect
 	github.com/openshift-online/ocm-api-model/model v0.0.464 // indirect
+	github.com/openshift/library-go v0.0.0-20260504190829-2dd4388d7b89 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -182,6 +182,7 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.28.3 h1:4JvMdwtFU0imd8fHx25OJXoDMRexnf8v5NHKYSTTji4=
 github.com/onsi/ginkgo/v2 v2.28.3/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
 github.com/onsi/gomega v1.40.0 h1:Vtol0e1MghCD2ZVIilPDIg44XSL9l2QAn8ZNaljWcJc=
@@ -198,6 +199,8 @@ github.com/openshift/cluster-version-operator v1.0.1-0.20260202115537-557510ea06
 github.com/openshift/cluster-version-operator v1.0.1-0.20260202115537-557510ea0603/go.mod h1:5HPAGcvwDreflw2OjJTEz7MicVZ/mTJQv6zYykB+f+M=
 github.com/openshift/hypershift/api v0.0.0-20260708113917-8b5103a5875b h1:JEAHE8tV+h+7QmPELrhoKxzzUuHAMPJzsNBunzwM6O8=
 github.com/openshift/hypershift/api v0.0.0-20260708113917-8b5103a5875b/go.mod h1:XO2zWpuo0rqxljntdt4aI5ZKhQCIeMYRDWtRNTo+bSE=
+github.com/openshift/library-go v0.0.0-20260504190829-2dd4388d7b89 h1:etWee1jfkT93YVB+aYDhCARlokHGvWsRKXgKPcGrSZQ=
+github.com/openshift/library-go v0.0.0-20260504190829-2dd4388d7b89/go.mod h1:k1tefCr+PAZ7kY8TJjpE6rW6t6Yu4iOmBwO+1+3qD2s=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -370,6 +373,8 @@ k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a h1:xCeOEAOoGYl2jnJoHkC3hk
 k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a/go.mod h1:uGBT7iTA6c6MvqUvSXIaYZo9ukscABYi2btjhvgKGZ0=
 k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 h1:kBawHLSnx/mYHmRnNUf9d4CpjREbeZuxoSGOX/J+aYM=
 k8s.io/utils v0.0.0-20260319190234-28399d86e0b5/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
+open-cluster-management.io/api v1.3.0 h1:Q3miH38BE3N5+PesHQ0kcFi5nhX5350m7OJWapZcVqY=
+open-cluster-management.io/api v1.3.0/go.mod h1:t0DsBv4gjIo9ojd7GYfA2tcEMpNf0h5Ix68pFDXwNSk=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=
 sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -59,6 +59,7 @@ import (
 	clusterupdate "github.com/Azure/ARO-HCP/backend/pkg/controllers/cluster/update"
 	clustervalidation "github.com/Azure/ARO-HCP/backend/pkg/controllers/cluster/validation"
 	clusterversion "github.com/Azure/ARO-HCP/backend/pkg/controllers/cluster/version"
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterresources"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/cosmosmigration"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/datadump"
 	"github.com/Azure/ARO-HCP/backend/pkg/controllers/example"
@@ -975,6 +976,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.ResourcesDBClient,
 		backendInformers,
 		unionKubeApplierInformers,
+		b.options.KubeApplierDBClients,
 	)
 
 	externalAuthDeletionClusterServiceDeleteDispatchController := externalauthdeletion.NewExternalAuthClusterServiceDeleteDispatchController(
@@ -1018,6 +1020,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.ResourcesDBClient,
 		b.options.ClustersServiceClient,
 		backendInformers,
+		unionKubeApplierInformers,
 	)
 
 	clusterClusterServiceIDClearerController := clusterdeletion.NewClusterClusterServiceIDClearerController(
@@ -1043,6 +1046,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.ResourcesDBClient,
 		b.options.BillingDBClient,
 		backendInformers,
+		b.options.KubeApplierDBClients,
 	)
 
 	clusterClusterServiceUpdateDispatchController := clusterupdate.NewClusterClusterServiceUpdateDispatchController(
@@ -1085,6 +1089,14 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 		b.options.ClusterScopedIdentitiesConfig,
 		backendInformers,
 		unionKubeApplierInformers,
+	)
+
+	clusterResourcesController := clusterresources.NewClusterResourcesController(
+		b.options.ResourcesDBClient,
+		b.options.KubeApplierDBClients,
+		backendInformers,
+		unionKubeApplierInformers,
+		b.options.ClustersServiceClient,
 	)
 
 	leaderElectionConfig := leaderelection.LeaderElectionConfig{
@@ -1207,6 +1219,7 @@ func (b *Backend) runBackendControllersUnderLeaderElection(ctx context.Context, 
 				go fetchDataPlaneOperatorsManagedIdentitiesInfoController.Run(ctx, 20)
 				go observeRoleAssignmentsController.Run(ctx, 20)
 				go keyRotationBackupController.Run(ctx, 20)
+				go clusterResourcesController.Run(ctx, 20)
 			},
 			OnStoppedLeading: func() {
 				// This needs to be defined even though it does nothing.

--- a/backend/pkg/controllers/cluster/deletion/cluster_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/cluster/deletion/cluster_child_resources_cleanup_controller.go
@@ -373,10 +373,26 @@ func (c *clusterChildResourcesCleanupController) ensureClusterScopedKubeApplierR
 		}
 		return true, nil
 	}
+
+	// Combined gate for ClusterScopedApplyDesire: first check ownership (owned desires
+	// must be torn down by their controller), then check if it's a backup desire.
+	applyDesireGate := func(ctx context.Context, resourceID *azcorearm.ResourceID) (bool, error) {
+		// Check ownership first
+		shouldDeleteBasedOnOwnership, err := c.extraDeleteGateShouldDeleteApplyDesire(kaClient, clusterResourceID)(ctx, resourceID)
+		if err != nil {
+			return false, err
+		}
+		if !shouldDeleteBasedOnOwnership {
+			return false, nil
+		}
+		// Then check if it's a backup desire
+		return skipBackupDesires(ctx, resourceID)
+	}
+
 	// extraDeleteGates uses lowercased kubeapplier.*DesireResourceTypeName keys. Types not
 	// in the map are deleted unconditionally.
 	extraDeleteGates := map[string]func(ctx context.Context, resourceID *azcorearm.ResourceID) (bool, error){
-		strings.ToLower(kubeapplierapi.ClusterScopedApplyDesireResourceType.String()): skipBackupDesires,
+		strings.ToLower(kubeapplierapi.ClusterScopedApplyDesireResourceType.String()): applyDesireGate,
 		strings.ToLower(kubeapplierapi.ClusterScopedReadDesireResourceType.String()):  skipBackupDesires,
 	}
 
@@ -474,4 +490,51 @@ func deletePreconditionAllCredentialRevocationsDeleted(ctx context.Context, dbCl
 		return false, utils.TrackError(fmt.Errorf("error iterating credential revocations: %w", err))
 	}
 	return true, nil
+}
+
+// extraDeleteGateShouldDeleteApplyDesire reports whether a cluster-scoped
+// ApplyDesire document may be removed here.
+//
+// An ApplyDesire that records an owning controller in Tags[TagControllerName]
+// belongs to that controller's teardown: the owner flips it to Type=Delete and
+// purges the document only once the kube-applier reports the object gone from
+// the management cluster. Deleting the document here would strand that object,
+// because nothing else asks the kube-applier to remove it. So we leave those
+// alone and let the owner converge - today that is the ClusterResources
+// controller, via kubeapplierhelpers.EnsureApplyDesireRemoved.
+//
+// Untagged desires have no owner left to reap them, so they are deleted here.
+func (c *clusterChildResourcesCleanupController) extraDeleteGateShouldDeleteApplyDesire(
+	kaClient kubeappliercosmosstorage.KubeApplierDBClient,
+	clusterResourceID *azcorearm.ResourceID,
+) func(ctx context.Context, applyDesireResourceID *azcorearm.ResourceID) (bool, error) {
+	return func(ctx context.Context, applyDesireResourceID *azcorearm.ResourceID) (bool, error) {
+		logger := utils.LoggerFromContext(ctx)
+
+		applyDesireCRUD, err := kaClient.ApplyDesiresForCluster(
+			clusterResourceID.SubscriptionID,
+			clusterResourceID.ResourceGroupName,
+			clusterResourceID.Name,
+		)
+		if err != nil {
+			return false, utils.TrackError(fmt.Errorf("failed to create cluster-scoped ApplyDesire CRUD: %w", err))
+		}
+
+		applyDesire, err := applyDesireCRUD.Get(ctx, strings.ToLower(applyDesireResourceID.Name))
+		if cosmosstorageutils.IsNotFoundError(err) {
+			// Raced with the owner purging it; nothing left to delete.
+			return false, nil
+		}
+		if err != nil {
+			return false, utils.TrackError(fmt.Errorf("failed to get ApplyDesire %q: %w", applyDesireResourceID.String(), err))
+		}
+
+		if owningController := applyDesire.Tags[kubeapplierapi.TagControllerName]; len(owningController) > 0 {
+			logger.Info("waiting for owning controller to tear down cluster-scoped ApplyDesire",
+				"applyDesireResourceID", applyDesireResourceID.String(), "owningController", owningController)
+			return false, nil
+		}
+
+		return true, nil
+	}
 }

--- a/backend/pkg/controllers/cluster/deletion/cluster_cluster_service_delete_dispatch_controller.go
+++ b/backend/pkg/controllers/cluster/deletion/cluster_cluster_service_delete_dispatch_controller.go
@@ -28,12 +28,16 @@ import (
 
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterresources"
 	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
 	"github.com/Azure/ARO-HCP/internal/database/informers/coreinformers"
 	"github.com/Azure/ARO-HCP/internal/database/listers/corelisters"
+	"github.com/Azure/ARO-HCP/internal/database/listers/kubeapplierlisters"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -52,11 +56,16 @@ const missingClusterServiceIDTimeout = 120 * time.Second
 // waiting for a ClusterServiceID), it stamps ClusterServiceDeletionTimestamp
 // on the Cluster to record that this step is complete and avoid re-issuing
 // the delete on subsequent syncs.
+//
+// Before dispatching the delete, this controller waits until the
+// ClusterResourcesController has cleaned up all its tagged ApplyDesires,
+// so that kube resources are torn down before the cluster itself.
 type clusterClusterServiceDeleteDispatchSyncer struct {
 	clock                utilsclock.PassiveClock
 	clusterLister        corelisters.ClusterLister
 	resourcesDBClient    corecosmosstorage.ResourcesDBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
+	applyDesireLister    kubeapplierlisters.ApplyDesireLister
 	// firstSeenDeletionTimestampCache is a cache that contains the time the controller
 	// has first seen the serviceProviderProperties.deletionTimestamp being set
 	// for a cluster. The cache key is the lowercased cluster's resource ID and
@@ -71,13 +80,16 @@ func NewClusterClusterServiceDeleteDispatchController(
 	resourcesDBClient corecosmosstorage.ResourcesDBClient,
 	clusterServiceClient ocm.ClusterServiceClientSpec,
 	informers coreinformers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 	_, clusterLister := informers.Clusters()
+	_, applyDesireLister := kubeApplierInformers.ApplyDesires()
 	syncer := &clusterClusterServiceDeleteDispatchSyncer{
 		clock:                           clock,
 		clusterLister:                   clusterLister,
 		resourcesDBClient:               resourcesDBClient,
 		clusterServiceClient:            clusterServiceClient,
+		applyDesireLister:               applyDesireLister,
 		firstSeenDeletionTimestampCache: lru.New(50000),
 	}
 
@@ -85,7 +97,7 @@ func NewClusterClusterServiceDeleteDispatchController(
 		"ClusterClusterServiceDeleteDispatch",
 		resourcesDBClient,
 		informers,
-		nil, // no kubeApplierInformers needed for deletion
+		kubeApplierInformers,
 		time.Minute,
 		syncer,
 	)
@@ -138,6 +150,16 @@ func (c *clusterClusterServiceDeleteDispatchSyncer) SyncOnce(ctx context.Context
 		return utils.TrackError(fmt.Errorf("failed to get cluster: %w", err))
 	}
 	if !c.NeedsWork(cluster) {
+		return nil
+	}
+
+	// Wait until ClusterResourcesController has deleted all its tagged ApplyDesires.
+	hasTaggedDesires, err := c.hasClusterResourceApplyDesires(ctx, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check ClusterResource ApplyDesires: %w", err))
+	}
+	if hasTaggedDesires {
+		logger.Info("waiting for ClusterResourcesController to delete its ApplyDesires before dispatching CS delete")
 		return nil
 	}
 
@@ -194,4 +216,18 @@ func (c *clusterClusterServiceDeleteDispatchSyncer) SyncOnce(ctx context.Context
 	c.firstSeenDeletionTimestampCache.Remove(cacheKey)
 
 	return nil
+}
+
+func (c *clusterClusterServiceDeleteDispatchSyncer) hasClusterResourceApplyDesires(ctx context.Context, key controllerutils.HCPClusterKey) (bool, error) {
+	desires, err := c.applyDesireLister.ListForCluster(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return false, err
+	}
+	for _, desire := range desires {
+		if desire.Tags != nil &&
+			desire.Tags[kubeapplierapi.TagControllerName] == clusterresources.ClusterResourcesControllerName {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/backend/pkg/controllers/cluster/deletion/cluster_cluster_service_delete_dispatch_controller.go
+++ b/backend/pkg/controllers/cluster/deletion/cluster_cluster_service_delete_dispatch_controller.go
@@ -57,9 +57,8 @@ const missingClusterServiceIDTimeout = 120 * time.Second
 // on the Cluster to record that this step is complete and avoid re-issuing
 // the delete on subsequent syncs.
 //
-// Before dispatching the delete, this controller waits until the
-// ClusterResourcesController has cleaned up all its tagged ApplyDesires,
-// so that kube resources are torn down before the cluster itself.
+// ClusterResourcesController has purged its tagged ApplyDesire documents,
+// so it won't recreate them during cluster deletion.
 type clusterClusterServiceDeleteDispatchSyncer struct {
 	clock                utilsclock.PassiveClock
 	clusterLister        corelisters.ClusterLister

--- a/backend/pkg/controllers/cluster/deletion/cluster_cluster_service_delete_dispatch_controller_test.go
+++ b/backend/pkg/controllers/cluster/deletion/cluster_cluster_service_delete_dispatch_controller_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/corecosmosstoragetesting"
 	"github.com/Azure/ARO-HCP/internal/database/listertesting/corelistertesting"
+	kubeapplierlistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting/kubeapplierlistertesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -272,6 +273,7 @@ func TestClusterClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
 				clusterLister:                   &corelistertesting.SliceClusterLister{Clusters: clustersForLister},
 				resourcesDBClient:               mockResourcesDBClient,
 				clusterServiceClient:            mockCSClient,
+				applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 				firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 			}
 
@@ -311,6 +313,7 @@ func TestClusterClusterServiceDeleteDispatchSyncer_SyncOnce_cacheShortCircuit(t 
 		clusterLister:                   &corelistertesting.SliceClusterLister{Clusters: []*coreapi.HCPOpenShiftCluster{cachedCluster}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
+		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: lru.New(10),
 	}
 
@@ -345,6 +348,7 @@ func TestClusterClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCac
 		clusterLister:                   &corelistertesting.SliceClusterLister{Clusters: []*coreapi.HCPOpenShiftCluster{cluster}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
+		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 	}
 
@@ -387,6 +391,7 @@ func TestClusterClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCac
 		clusterLister:                   &corelistertesting.SliceClusterLister{Clusters: []*coreapi.HCPOpenShiftCluster{cluster}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            mockCSClient,
+		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 	}
 

--- a/backend/pkg/controllers/cluster/deletion/cluster_deletion_controller.go
+++ b/backend/pkg/controllers/cluster/deletion/cluster_deletion_controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -27,9 +28,11 @@ import (
 
 	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/billingcosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/kubeappliercosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/informers/coreinformers"
 	"github.com/Azure/ARO-HCP/internal/database/listers/corelisters"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -45,6 +48,7 @@ type clusterDeletionController struct {
 	serviceProviderClusterLister corelisters.ServiceProviderClusterLister
 	resourcesDBClient            corecosmosstorage.ResourcesDBClient
 	billingDBClient              billingcosmosstorage.BillingDBClient
+	kubeApplierDBClients         kubeappliercosmosstorage.KubeApplierDBClients
 	passiveClock                 utilsclock.PassiveClock
 }
 
@@ -55,6 +59,7 @@ func NewClusterDeletionController(
 	resourcesDBClient corecosmosstorage.ResourcesDBClient,
 	billingDBClient billingcosmosstorage.BillingDBClient,
 	informers coreinformers.BackendInformers,
+	kubeApplierDBClients kubeappliercosmosstorage.KubeApplierDBClients,
 ) controllerutils.Controller {
 	_, clusterLister := informers.Clusters()
 	_, serviceProviderClusterLister := informers.ServiceProviderClusters()
@@ -63,6 +68,7 @@ func NewClusterDeletionController(
 		serviceProviderClusterLister: serviceProviderClusterLister,
 		resourcesDBClient:            resourcesDBClient,
 		billingDBClient:              billingDBClient,
+		kubeApplierDBClients:         kubeApplierDBClients,
 		passiveClock:                 clock,
 	}
 
@@ -134,8 +140,18 @@ func (c *clusterDeletionController) SyncOnce(ctx context.Context, key controller
 		return nil
 	}
 
+	// Precondition: all ApplyDesires for this cluster must be gone.
+	// Each controller is responsible for deleting its own desires during cluster deletion.
+	preconditionMet, err := c.deletePreconditionAllApplyDesiresGone(ctx, key, cachedSPC)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check ApplyDesire precondition: %w", err))
+	}
+	if !preconditionMet {
+		return nil
+	}
+
 	// Precondition: all cluster-scoped Maestro readonly bundles must be cleared
-	preconditionMet, err := c.deletePreconditionAllMaestroClusterScopedReadonlyBundlesCleared(ctx, key)
+	preconditionMet, err = c.deletePreconditionAllMaestroClusterScopedReadonlyBundlesCleared(ctx, key)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
 	}
@@ -277,5 +293,61 @@ func (c *clusterDeletionController) deletePreconditionCosmosChildResourcesDelete
 		return false, utils.TrackError(fmt.Errorf("error iterating child resources: %w", err))
 	}
 
+	return true, nil
+}
+
+// deletePreconditionAllApplyDesiresGone checks that no ApplyDesires remain for
+// this cluster. Each controller that creates ApplyDesires is responsible for
+// cleaning up its own; this method only verifies they are all gone before
+// proceeding. The log message reports remaining counts per controller so
+// operators can see which controller is lagging.
+func (c *clusterDeletionController) deletePreconditionAllApplyDesiresGone(ctx context.Context, key controllerutils.HCPClusterKey, spc *coreapi.ServiceProviderCluster) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	if spc == nil || spc.Status.ManagementClusterResourceID == nil {
+		return true, nil
+	}
+
+	managementClusterID := spc.Status.ManagementClusterResourceID
+	kubeApplierDBClient := c.kubeApplierDBClients.For(ctx, managementClusterID)
+	if kubeApplierDBClient == nil {
+		logger.Info("waiting for kube-applier DB client to be available for ApplyDesire precondition", "managementCluster", managementClusterID.String())
+		return false, nil
+	}
+
+	kubeApplierCRUD, err := kubeApplierDBClient.ApplyDesiresForCluster(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return false, fmt.Errorf("failed to get kube-applier CRUD for ApplyDesire precondition: %w", err)
+	}
+
+	applyDesireIterator, err := kubeApplierCRUD.List(ctx, &cosmosstorageutils.DBClientListResourceDocsOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to list ApplyDesire documents for precondition check: %w", err)
+	}
+
+	controllerCounts := map[string]int{}
+	for _, desire := range applyDesireIterator.Items(ctx) {
+		controller := "unknown"
+		if desire.Tags != nil {
+			if name := desire.Tags[kubeapplierapi.TagControllerName]; name != "" {
+				controller = name
+			}
+		}
+		controllerCounts[controller]++
+	}
+	if err := applyDesireIterator.GetError(); err != nil {
+		return false, fmt.Errorf("error iterating ApplyDesires for precondition check: %w", err)
+	}
+
+	if len(controllerCounts) > 0 {
+		var parts []string
+		for controller, count := range controllerCounts {
+			parts = append(parts, fmt.Sprintf("%d from %s", count, controller))
+		}
+		slices.Sort(parts)
+		logger.Info("waiting for all ApplyDesires to be deleted",
+			"remaining", strings.Join(parts, ", "))
+		return false, nil
+	}
 	return true, nil
 }

--- a/backend/pkg/controllers/cluster/deletion/cluster_deletion_controller.go
+++ b/backend/pkg/controllers/cluster/deletion/cluster_deletion_controller.go
@@ -140,8 +140,8 @@ func (c *clusterDeletionController) SyncOnce(ctx context.Context, key controller
 		return nil
 	}
 
-	// Precondition: all ApplyDesires for this cluster must be gone.
-	// Each controller is responsible for deleting its own desires during cluster deletion.
+	// Precondition: all cluster-scoped ApplyDesires for this cluster must be gone.
+	// Node-pool-scoped desires are handled by the node pool deletion pipeline.
 	preconditionMet, err := c.deletePreconditionAllApplyDesiresGone(ctx, key, cachedSPC)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to check ApplyDesire precondition: %w", err))

--- a/backend/pkg/controllers/clusterresources/cluster_resources_controller.go
+++ b/backend/pkg/controllers/clusterresources/cluster_resources_controller.go
@@ -1,0 +1,531 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterresources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	ocmv1 "open-cluster-management.io/api/work/v1"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/kubeapplierhelpers"
+	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
+	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/kubeappliercosmosstorage"
+	"github.com/Azure/ARO-HCP/internal/database/informers/coreinformers"
+	"github.com/Azure/ARO-HCP/internal/database/listers/corelisters"
+	"github.com/Azure/ARO-HCP/internal/database/listers/kubeapplierlisters"
+	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/restmapper"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	ClusterResourcesControllerName = "ClusterResources"
+)
+
+// clusterResourcesController polls the Cluster Service SDK endpoint for cluster resources information
+type clusterResourcesController struct {
+	clusterLister                corelisters.ClusterLister
+	serviceProviderClusterLister corelisters.ServiceProviderClusterLister
+	nodePoolLister               corelisters.NodePoolLister
+	clustersServiceClient        ocm.ClusterServiceClientSpec
+	kubeApplierDBClients         kubeappliercosmosstorage.KubeApplierDBClients
+	applyDesireLister            kubeapplierlisters.ApplyDesireLister
+}
+
+var _ controllerutils.ClusterSyncer = (*clusterResourcesController)(nil)
+
+func NewClusterResourcesController(
+	resourcesDBClient corecosmosstorage.ResourcesDBClient,
+	kubeApplierDBClients kubeappliercosmosstorage.KubeApplierDBClients,
+	informers coreinformers.BackendInformers,
+	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
+	clustersServiceClient ocm.ClusterServiceClientSpec,
+) controllerutils.Controller {
+	_, clusterLister := informers.Clusters()
+	_, serviceProviderClusterLister := informers.ServiceProviderClusters()
+	_, nodePoolLister := informers.NodePools()
+	_, applyDesireLister := kubeApplierInformers.ApplyDesires()
+
+	syncer := &clusterResourcesController{
+		clusterLister:                clusterLister,
+		serviceProviderClusterLister: serviceProviderClusterLister,
+		nodePoolLister:               nodePoolLister,
+		clustersServiceClient:        clustersServiceClient,
+		kubeApplierDBClients:         kubeApplierDBClients,
+		applyDesireLister:            applyDesireLister,
+	}
+
+	return controllerutils.NewClusterWatchingController(
+		ClusterResourcesControllerName,
+		resourcesDBClient,
+		informers,
+		nil,
+		30*time.Second, // Poll every 30 seconds.
+		syncer,
+	)
+}
+
+// NeedsWork reports whether the controller has work to do for the given cluster.
+// It requires the cluster to be placed on a management cluster. Beyond that:
+// - Clusters being deleted need ApplyDesire cleanup
+// - Clusters with a ClusterServiceID need resource syncing
+func (c *clusterResourcesController) NeedsWork(cluster *coreapi.HCPOpenShiftCluster, managementCluster *azcorearm.ResourceID) bool {
+	if managementCluster == nil {
+		return false
+	}
+
+	if cluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return true
+	}
+
+	if cluster.ServiceProviderProperties.ClusterServiceID == nil {
+		return false
+	}
+
+	return true
+}
+
+// SyncOnce polls the cluster resources endpoint and updates any relevant state.
+// When the cluster is being deleted, it cleans up all ApplyDesires it owns
+// instead of polling for resources.
+func (c *clusterResourcesController) SyncOnce(ctx context.Context, key controllerutils.HCPClusterKey) error {
+	cluster, err := c.clusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if cosmosstorageutils.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster from cache: %w", err))
+	}
+
+	spc, err := c.serviceProviderClusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if cosmosstorageutils.IsNotFoundError(err) {
+		return nil
+	}
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster from cache: %w", err))
+	}
+	managementCluster := spc.Status.ManagementClusterResourceID
+
+	if !c.NeedsWork(cluster, managementCluster) {
+		return nil
+	}
+
+	if cluster.ServiceProviderProperties.DeletionTimestamp != nil {
+		return c.deleteAllOwnedApplyDesires(ctx, key, managementCluster)
+	}
+
+	clusterServiceID := *cluster.ServiceProviderProperties.ClusterServiceID
+	if err := c.fetchAndProcessClusterResources(ctx, key, managementCluster, clusterServiceID); err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get cluster resources: %w", err))
+	}
+
+	return nil
+}
+
+// deleteAllOwnedApplyDesires removes all ApplyDesire Cosmos documents owned by
+// this controller for the given cluster. Called during cluster deletion — the
+// underlying kube resources are cleaned up separately by the
+// ClusterChildResourcesCleanupController, so we only need to purge the docs.
+func (c *clusterResourcesController) deleteAllOwnedApplyDesires(ctx context.Context, key controllerutils.HCPClusterKey, managementCluster *azcorearm.ResourceID) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	existing, err := c.applyDesireLister.ListForCluster(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("list ApplyDesires for deletion cleanup: %w", err))
+	}
+
+	kubeApplierDBClient := c.kubeApplierDBClients.For(ctx, managementCluster)
+	if kubeApplierDBClient == nil {
+		return nil
+	}
+
+	for _, desire := range existing {
+		if desire.Tags == nil ||
+			desire.Tags[kubeapplierapi.TagControllerName] != ClusterResourcesControllerName {
+			continue
+		}
+		scope, err := kubeappliercosmosstorage.ParseDesireScope(desire.ResourceID.Parent)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("parse scope for ApplyDesire %s: %w", desire.ResourceID.Name, err))
+		}
+		crud, err := kubeApplierDBClient.ApplyDesiresFor(scope)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("get CRUD for ApplyDesire %s: %w", desire.ResourceID.Name, err))
+		}
+		if err := crud.Delete(ctx, desire.ResourceID.Name); err != nil && !cosmosstorageutils.IsNotFoundError(err) {
+			return utils.TrackError(fmt.Errorf("delete ApplyDesire %s: %w", desire.ResourceID.Name, err))
+		}
+		logger.Info("deleted ApplyDesire document", "desireName", desire.ResourceID.Name)
+	}
+
+	return nil
+}
+
+// fetchAndProcessClusterResources calls the Cluster Service SDK to get cluster resources information
+// and processes the resources.
+func (c *clusterResourcesController) fetchAndProcessClusterResources(ctx context.Context,
+	key controllerutils.HCPClusterKey, managementCluster *azcorearm.ResourceID, clusterServiceID metadataapi.InternalID) error {
+	// Get cluster resources from the Cluster Service SDK
+	resources, err := c.clustersServiceClient.GetClusterResources(ctx, clusterServiceID)
+	if err != nil {
+		return utils.TrackError(err)
+	}
+
+	if resources != nil {
+		if err := c.processClusterResources(ctx, key, managementCluster, resources); err != nil {
+			return utils.TrackError(fmt.Errorf("failed to process cluster resources: %w", err))
+		}
+	}
+
+	return nil
+}
+
+// processClusterResources converts each resource to ApplyDesire documents
+func (c *clusterResourcesController) processClusterResources(ctx context.Context, key controllerutils.HCPClusterKey,
+	managementCluster *azcorearm.ResourceID, resources *arohcpv1alpha1.ClusterResources) error {
+
+	kubeApplierDBClient := c.kubeApplierDBClients.For(ctx, managementCluster)
+	if kubeApplierDBClient == nil {
+		return nil
+	}
+	applyDesireCRUD, err := kubeApplierDBClient.ApplyDesiresForCluster(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to get kube-applier CRUD: %w", err))
+	}
+
+	tags := map[string]string{kubeapplierapi.TagControllerName: ClusterResourcesControllerName}
+
+	resourceMap := resources.Resources()
+	desiredResourceIDs := make(map[string]bool, len(resourceMap))
+	var errs []error
+	for resourceKey, resourceValue := range resourceMap {
+		var unstructuredObj unstructured.Unstructured
+		if err := json.Unmarshal([]byte(resourceValue), &unstructuredObj); err != nil {
+			errs = append(errs, utils.TrackError(fmt.Errorf("failed to unmarshal resource %s: %w", resourceKey, err)))
+			continue
+		}
+
+		gvr, err := restmapper.ResourceFor(unstructuredObj.GroupVersionKind())
+		if err != nil {
+			errs = append(errs, utils.TrackError(fmt.Errorf("failed to resolve resource %s: %w", resourceKey, err)))
+			continue
+		}
+
+		classified, err := classifyClusterResource(&unstructuredObj)
+		if err != nil {
+			errs = append(errs, utils.TrackError(err))
+			continue
+		}
+
+		target := kubeapplierapi.ResourceReference{
+			Group:     gvr.Group,
+			Version:   gvr.Version,
+			Resource:  gvr.Resource,
+			Name:      unstructuredObj.GetName(),
+			Namespace: unstructuredObj.GetNamespace(),
+		}
+
+		var desire *kubeapplierapi.ApplyDesire
+		var crud cosmosstorageutils.ResourceCRUD[kubeapplierapi.ApplyDesire, *kubeapplierapi.ApplyDesire]
+
+		switch {
+		case len(classified.nodePoolName) != 0:
+			np, npErr := c.nodePoolLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, classified.nodePoolName)
+			if npErr != nil && !cosmosstorageutils.IsNotFoundError(npErr) {
+				errs = append(errs, utils.TrackError(fmt.Errorf("failed to get nodepool %s: %w", classified.nodePoolName, npErr)))
+				continue
+			}
+			if np == nil || np.ServiceProviderProperties.DeletionTimestamp != nil {
+				continue
+			}
+
+			crud, err = kubeApplierDBClient.ApplyDesiresForNodePool(
+				key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, classified.nodePoolName,
+			)
+			if err != nil {
+				errs = append(errs, utils.TrackError(fmt.Errorf("failed to get node pool kube-applier CRUD for %s: %w", classified.nodePoolName, err)))
+				continue
+			}
+
+			desire, err = buildNodePoolResourceApplyDesire(
+				key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName,
+				classified.nodePoolName, classified.desireName,
+				managementCluster, target, &unstructuredObj, tags,
+			)
+		default:
+			crud = applyDesireCRUD
+
+			desire, err = buildClusterResourceApplyDesire(
+				key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName,
+				classified.desireName, managementCluster, target, &unstructuredObj, tags,
+			)
+		}
+
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		desiredResourceIDs[strings.ToLower(desire.ResourceID.String())] = true
+
+		if err := kubeapplierhelpers.EnsureApplyDesire(ctx, crud, c.applyDesireLister, desire); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if err := c.deleteStaleApplyDesires(ctx, key, managementCluster, desiredResourceIDs); err != nil {
+		errs = append(errs, err)
+	}
+
+	return errors.Join(errs...)
+}
+
+type classifiedResource struct {
+	desireName   string
+	nodePoolName string
+}
+
+// classifyClusterResource maps a kube object from the Cluster Service
+// GetClusterResources response to an intent-based desire name. Every
+// recognized resource gets a stable, human-readable name; unrecognized
+// resources return an error so new resource types surface immediately
+// instead of getting an opaque auto-derived name.
+//
+// Recognized resources (group / kind → desireName):
+//
+//	hypershift.openshift.io    HostedCluster          → HostedCluster
+//	hypershift.openshift.io    NodePool               → NodePool                 (nodePoolName set, scoped under nodepool)
+//	core/v1                    Namespace              → HostedClusterNamespace | ControlPlaneNamespace
+//	core/v1                    ConfigMap              → DefaultIngressConfigMap
+//	core/v1                    Secret                 → OCPPullSecret
+//	multitenancy.acn.azure.com PodNetwork             → PodNetwork
+//	multitenancy.acn.azure.com PodNetworkInstance      → PodNetworkInstance
+//	secret-sync.x-k8s.io      SecretSync             → {BoundServiceAccountSigningKey,DefaultIngressWildcardCert,KubeAPIServerServingCert}SecretSync
+//	secrets-store.csi.x-k8s.io SecretProviderClass    → {BoundServiceAccountSigningKey,DefaultIngressWildcardCert,KubeAPIServerServingCert}SecretProviderClass
+func classifyClusterResource(obj *unstructured.Unstructured) (classifiedResource, error) {
+	gvk := obj.GroupVersionKind()
+	name := obj.GetName()
+
+	switch gvk.Kind {
+	case "HostedCluster":
+		return classifiedResource{desireName: "HostedCluster"}, nil
+
+	case "NodePool":
+		// HyperShift names kube NodePool CRs as "<spec.clusterName>-<armName>".
+		// Strip the prefix to recover the ARM nodepool name used in Cosmos.
+		clusterName, _, _ := unstructured.NestedString(obj.Object, "spec", "clusterName")
+		armName := strings.TrimPrefix(name, clusterName+"-")
+		return classifiedResource{desireName: "NodePool", nodePoolName: armName}, nil
+
+	case "Namespace":
+		// CS returns two Namespaces: the HostedCluster namespace
+		// (e.g. "ocm-arohcppers-2sdm6b8jke9sm3h8ukc8mbaahngnre5c") and the
+		// ControlPlane namespace
+		// (e.g. "ocm-arohcppers-2sdm6b8jke9sm3h8ukc8mbaahngnre5c-j7h3t4w0u1t3b4b").
+		// The ControlPlane namespace carries the "hypershift.openshift.io/cluster" label.
+		if _, ok := obj.GetLabels()["hypershift.openshift.io/cluster"]; ok {
+			return classifiedResource{desireName: "ControlPlaneNamespace"}, nil
+		}
+		return classifiedResource{desireName: "HostedClusterNamespace"}, nil
+
+	case "ConfigMap":
+		return classifiedResource{desireName: "DefaultIngressConfigMap"}, nil
+
+	case "Secret":
+		return classifiedResource{desireName: "OCPPullSecret"}, nil
+
+	case "PodNetwork":
+		return classifiedResource{desireName: "PodNetwork"}, nil
+
+	case "PodNetworkInstance":
+		return classifiedResource{desireName: "PodNetworkInstance"}, nil
+
+	case "SecretSync":
+		switch {
+		case strings.Contains(name, "signing-key"):
+			return classifiedResource{desireName: "BoundServiceAccountSigningKeySecretSync"}, nil
+		case strings.Contains(name, "default-ingress"):
+			return classifiedResource{desireName: "DefaultIngressWildcardCertSecretSync"}, nil
+		case strings.Contains(name, "kube-apiserver"):
+			return classifiedResource{desireName: "KubeAPIServerServingCertSecretSync"}, nil
+		}
+
+	case "SecretProviderClass":
+		switch {
+		case strings.Contains(name, "signing-key"):
+			return classifiedResource{desireName: "BoundServiceAccountSigningKeySecretProviderClass"}, nil
+		case strings.Contains(name, "default-ingress"):
+			return classifiedResource{desireName: "DefaultIngressWildcardCertSecretProviderClass"}, nil
+		case strings.Contains(name, "kube-apiserver"):
+			return classifiedResource{desireName: "KubeAPIServerServingCertSecretProviderClass"}, nil
+		}
+	}
+
+	return classifiedResource{}, fmt.Errorf(
+		"unrecognized cluster resource: group=%q version=%q kind=%q namespace=%q name=%q",
+		gvk.Group, gvk.Version, gvk.Kind, obj.GetNamespace(), name,
+	)
+}
+
+func buildClusterResourceApplyDesire(
+	subscriptionID, resourceGroupName, clusterName, desireName string,
+	managementCluster *azcorearm.ResourceID,
+	target kubeapplierapi.ResourceReference,
+	obj *unstructured.Unstructured,
+	tags map[string]string,
+) (*kubeapplierapi.ApplyDesire, error) {
+	resourceIDStr := kubeapplierapi.ToClusterScopedApplyDesireResourceIDString(
+		subscriptionID, resourceGroupName, clusterName, desireName,
+	)
+	resourceID, err := azcorearm.ParseResourceID(resourceIDStr)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to parse ApplyDesire resource ID %q: %w", resourceIDStr, err))
+	}
+
+	rawJSON, err := json.Marshal(obj)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to marshal kube object: %w", err))
+	}
+
+	return &kubeapplierapi.ApplyDesire{
+		CosmosMetadata: coreapi.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(managementCluster.String()),
+		},
+		Spec: kubeapplierapi.ApplyDesireSpec{
+			ManagementCluster: managementCluster,
+			Type:              kubeapplierapi.ApplyDesireTypeServerSideApply,
+			TargetItem:        target,
+			ServerSideApply: &kubeapplierapi.ServerSideApplyConfig{
+				KubeContent: &runtime.RawExtension{Raw: rawJSON},
+				// Use "fieldManager": "work-agent" to avoid conflicting declarations due to
+				// the eventual consistency nature of the ResourcesController.
+				// This way fields that are not claimed will automatically be garbage collected.
+				//  TODO: remove this once ACM and Maestro are removed.
+				FieldManager: ptr.To(ocmv1.DefaultFieldManager),
+			},
+		},
+		Tags: tags,
+	}, nil
+}
+
+func buildNodePoolResourceApplyDesire(
+	subscriptionID, resourceGroupName, clusterName, nodePoolName, desireName string,
+	managementCluster *azcorearm.ResourceID,
+	target kubeapplierapi.ResourceReference,
+	obj *unstructured.Unstructured,
+	tags map[string]string,
+) (*kubeapplierapi.ApplyDesire, error) {
+	resourceIDStr := kubeapplierapi.ToNodePoolScopedApplyDesireResourceIDString(
+		subscriptionID, resourceGroupName, clusterName, nodePoolName, desireName,
+	)
+	resourceID, err := azcorearm.ParseResourceID(resourceIDStr)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to parse ApplyDesire resource ID %q: %w", resourceIDStr, err))
+	}
+
+	rawJSON, err := json.Marshal(obj)
+	if err != nil {
+		return nil, utils.TrackError(fmt.Errorf("failed to marshal kube object: %w", err))
+	}
+
+	return &kubeapplierapi.ApplyDesire{
+		CosmosMetadata: coreapi.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(managementCluster.String()),
+		},
+		Spec: kubeapplierapi.ApplyDesireSpec{
+			ManagementCluster: managementCluster,
+			Type:              kubeapplierapi.ApplyDesireTypeServerSideApply,
+			TargetItem:        target,
+			ServerSideApply: &kubeapplierapi.ServerSideApplyConfig{
+				KubeContent: &runtime.RawExtension{Raw: rawJSON},
+				// Use "fieldManager": "work-agent" to avoid conflicting declarations due to
+				// the eventual consistency nature of the ResourcesController.
+				// This way fields that are not claimed will automatically be garbage collected.
+				//  TODO: remove this once ACM and Maestro are removed.
+				FieldManager: ptr.To(ocmv1.DefaultFieldManager),
+			},
+		},
+		Tags: tags,
+	}, nil
+}
+
+func (c *clusterResourcesController) deleteStaleApplyDesires(
+	ctx context.Context,
+	key controllerutils.HCPClusterKey,
+	managementCluster *azcorearm.ResourceID,
+	currentDesiredResourceIDs map[string]bool,
+) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	existing, err := c.applyDesireLister.ListForCluster(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("list ApplyDesires for stale cleanup: %w", err))
+	}
+
+	kubeApplierDBClient := c.kubeApplierDBClients.For(ctx, managementCluster)
+	if kubeApplierDBClient == nil {
+		return nil
+	}
+
+	for _, desire := range existing {
+		if desire.Tags == nil ||
+			desire.Tags[kubeapplierapi.TagControllerName] != ClusterResourcesControllerName {
+			continue
+		}
+		if currentDesiredResourceIDs[strings.ToLower(desire.ResourceID.String())] {
+			continue
+		}
+
+		scope, err := kubeappliercosmosstorage.ParseDesireScope(desire.ResourceID.Parent)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("parse scope for ApplyDesire %s: %w", desire.ResourceID.Name, err))
+		}
+		crud, err := kubeApplierDBClient.ApplyDesiresFor(scope)
+		if err != nil {
+			return utils.TrackError(fmt.Errorf("get CRUD for ApplyDesire %s: %w", desire.ResourceID.Name, err))
+		}
+		removed, err := kubeapplierhelpers.EnsureApplyDesireRemoved(ctx, desire.ResourceID.Name, crud)
+		if err != nil {
+			return err
+		}
+		if removed {
+			logger.Info("purged stale ApplyDesire", "desireName", desire.ResourceID.Name)
+		} else {
+			logger.Info("stale ApplyDesire pending deletion", "desireName", desire.ResourceID.Name)
+		}
+	}
+
+	return nil
+}

--- a/backend/pkg/controllers/clusterresources/cluster_resources_controller.go
+++ b/backend/pkg/controllers/clusterresources/cluster_resources_controller.go
@@ -154,9 +154,10 @@ func (c *clusterResourcesController) SyncOnce(ctx context.Context, key controlle
 }
 
 // deleteAllOwnedApplyDesires removes all ApplyDesire Cosmos documents owned by
-// this controller for the given cluster. Called during cluster deletion — the
-// underlying kube resources are cleaned up separately by the
-// ClusterChildResourcesCleanupController, so we only need to purge the docs.
+// this controller for the given cluster during cluster deletion.
+// Note: deleting an ApplyDesire document does not trigger deletion of the
+// underlying Kubernetes object;
+// TODO: Teardown of underlying Kubernetes resources.
 func (c *clusterResourcesController) deleteAllOwnedApplyDesires(ctx context.Context, key controllerutils.HCPClusterKey, managementCluster *azcorearm.ResourceID) error {
 	logger := utils.LoggerFromContext(ctx)
 
@@ -266,6 +267,18 @@ func (c *clusterResourcesController) processClusterResources(ctx context.Context
 				errs = append(errs, utils.TrackError(fmt.Errorf("failed to get nodepool %s: %w", classified.nodePoolName, npErr)))
 				continue
 			}
+			// Skipping here drops the desire out of desiredResourceIDs, so
+			// deleteStaleApplyDesires reaps it below.
+			//
+			// While Cluster Service still owns the NodePool it is also still
+			// reporting it here, and its ManifestWork keeps the CR materialized
+			// through the work-agent, so the CR can be re-applied a couple of times
+			// after kube-applier deletes it. That churn is bounded: it stops once
+			// Cluster Service removes the ManifestWork, and it cannot stall the
+			// delete pipeline, because NodePoolClusterServiceDeleteDispatch issues
+			// the Cluster Service delete without waiting on these desires. The churn
+			// disappears entirely once the backend owns NodePool deletion directly.
+			//  TODO: remove this comment once ACM and Maestro are removed.
 			if np == nil || np.ServiceProviderProperties.DeletionTimestamp != nil {
 				continue
 			}

--- a/backend/pkg/controllers/clusterresources/cluster_resources_controller_test.go
+++ b/backend/pkg/controllers/clusterresources/cluster_resources_controller_test.go
@@ -1,0 +1,716 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterresources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	arohcpv1alpha1 "github.com/openshift-online/ocm-sdk-go/arohcp/v1alpha1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/fleetapi"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
+	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/kubeappliercosmosstoragetesting"
+	"github.com/Azure/ARO-HCP/internal/database/listertesting/corelistertesting"
+	fleetlistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting/fleetlistertesting"
+	kubeapplierlistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting/kubeapplierlistertesting"
+	"github.com/Azure/ARO-HCP/internal/ocm"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	testSubscriptionID    = "00000000-0000-0000-0000-000000000000"
+	testResourceGroupName = "test-rg"
+	testClusterName       = "test-cluster"
+	testClusterServiceID  = "/api/clusters_mgmt/v1/clusters/abc123"
+)
+
+var testManagementClusterResourceID = metadataapi.Must(azcorearm.ParseResourceID(
+	"/providers/microsoft.redhatopenshift/stamps/1/managementclusters/default",
+))
+
+func testKey() controllerutils.HCPClusterKey {
+	return controllerutils.HCPClusterKey{
+		SubscriptionID:    testSubscriptionID,
+		ResourceGroupName: testResourceGroupName,
+		HCPClusterName:    testClusterName,
+	}
+}
+
+func newCluster(opts ...func(*coreapi.HCPOpenShiftCluster)) *coreapi.HCPOpenShiftCluster {
+	resourceID := metadataapi.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName,
+	))
+	cluster := &coreapi.HCPOpenShiftCluster{
+		CosmosMetadata: coreapi.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+		},
+		TrackedResource: coreapi.TrackedResource{
+			Resource: coreapi.Resource{
+				ID:   resourceID,
+				Name: testClusterName,
+				Type: resourceID.ResourceType.String(),
+			},
+		},
+		ServiceProviderProperties: coreapi.HCPOpenShiftClusterServiceProviderProperties{
+			ClusterServiceID: metadataapi.Ptr(metadataapi.Must(metadataapi.NewInternalID(testClusterServiceID))),
+		},
+	}
+	for _, opt := range opts {
+		opt(cluster)
+	}
+	return cluster
+}
+
+func newSPC(mcResourceID *azcorearm.ResourceID) *coreapi.ServiceProviderCluster {
+	spcResourceID := metadataapi.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + testSubscriptionID +
+			"/resourceGroups/" + testResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+			"/serviceProviderClusters/" + coreapi.ServiceProviderClusterResourceName,
+	))
+	return &coreapi.ServiceProviderCluster{
+		CosmosMetadata: coreapi.CosmosMetadata{
+			ResourceID:   spcResourceID,
+			PartitionKey: strings.ToLower(spcResourceID.SubscriptionID),
+		},
+		Status: coreapi.ServiceProviderClusterStatus{
+			ManagementClusterResourceID: mcResourceID,
+		},
+	}
+}
+
+func buildClusterResources(resources map[string]string) *arohcpv1alpha1.ClusterResources {
+	cr, err := arohcpv1alpha1.NewClusterResources().
+		Resources(resources).
+		Build()
+	if err != nil {
+		panic(fmt.Sprintf("failed to build ClusterResources: %v", err))
+	}
+	return cr
+}
+
+func TestNeedsWork(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		cluster           *coreapi.HCPOpenShiftCluster
+		managementCluster *azcorearm.ResourceID
+		want              bool
+	}{
+		{
+			name:              "returns true for cluster with ClusterServiceID and management cluster",
+			cluster:           newCluster(),
+			managementCluster: testManagementClusterResourceID,
+			want:              true,
+		},
+		{
+			name: "returns true for cluster being deleted with management cluster",
+			cluster: newCluster(func(c *coreapi.HCPOpenShiftCluster) {
+				now := metav1.Now()
+				c.ServiceProviderProperties.DeletionTimestamp = &now
+			}),
+			managementCluster: testManagementClusterResourceID,
+			want:              true,
+		},
+		{
+			name: "returns false for cluster without ClusterServiceID",
+			cluster: newCluster(func(c *coreapi.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			managementCluster: testManagementClusterResourceID,
+			want:              false,
+		},
+		{
+			name:              "returns false when management cluster is nil",
+			cluster:           newCluster(),
+			managementCluster: nil,
+			want:              false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := &clusterResourcesController{}
+			got := c.NeedsWork(tt.cluster, tt.managementCluster)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSyncOnce(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cluster     *coreapi.HCPOpenShiftCluster
+		dbResources []any
+		setupCSMock func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec
+		wantErr     bool
+		verifyDB    func(t *testing.T, ctx context.Context, kaClient *kubeappliercosmosstoragetesting.MockKubeApplierDBClient)
+	}{
+		{
+			name:    "skips cluster not found in cache",
+			cluster: nil,
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				return ocm.NewMockClusterServiceClientSpec(ctrl)
+			},
+			wantErr: false,
+		},
+		{
+			name: "skips cluster without ClusterServiceID",
+			cluster: newCluster(func(c *coreapi.HCPOpenShiftCluster) {
+				c.ServiceProviderProperties.ClusterServiceID = nil
+			}),
+			dbResources: []any{
+				newSPC(testManagementClusterResourceID),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				return ocm.NewMockClusterServiceClientSpec(ctrl)
+			},
+			wantErr: false,
+		},
+		{
+			name: "skips cluster being deleted",
+			cluster: newCluster(func(c *coreapi.HCPOpenShiftCluster) {
+				now := metav1.Now()
+				c.ServiceProviderProperties.DeletionTimestamp = &now
+			}),
+			dbResources: []any{
+				newSPC(testManagementClusterResourceID),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				return ocm.NewMockClusterServiceClientSpec(ctrl)
+			},
+			wantErr: false,
+		},
+		{
+			name:    "returns error when GetClusterResources fails",
+			cluster: newCluster(),
+			dbResources: []any{
+				newSPC(testManagementClusterResourceID),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					GetClusterResources(gomock.Any(), gomock.Any()).
+					Return(nil, fmt.Errorf("connection refused"))
+				return mock
+			},
+			wantErr: true,
+		},
+		{
+			name:    "returns error on timestamp parsing errors from OCM SDK",
+			cluster: newCluster(),
+			dbResources: []any{
+				newSPC(testManagementClusterResourceID),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					GetClusterResources(gomock.Any(), gomock.Any()).
+					Return(nil, fmt.Errorf("parsing time \"invalid\" as creation_timestamp failed"))
+				return mock
+			},
+			wantErr: true,
+		},
+		{
+			name:    "no-op when GetClusterResources returns nil",
+			cluster: newCluster(),
+			dbResources: []any{
+				newSPC(testManagementClusterResourceID),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					GetClusterResources(gomock.Any(), gomock.Any()).
+					Return(nil, nil)
+				return mock
+			},
+			wantErr: false,
+		},
+		{
+			name:    "creates ApplyDesire for a single resource",
+			cluster: newCluster(),
+			dbResources: []any{
+				newSPC(testManagementClusterResourceID),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				configMap := `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"default-ingress","namespace":"ocm-env-abc"},"data":{"key":"value"}}`
+				mock.EXPECT().
+					GetClusterResources(gomock.Any(), gomock.Any()).
+					Return(buildClusterResources(map[string]string{
+						"default-ingress-configmap": configMap,
+					}), nil)
+				return mock
+			},
+			wantErr: false,
+			verifyDB: func(t *testing.T, ctx context.Context, kaClient *kubeappliercosmosstoragetesting.MockKubeApplierDBClient) {
+				t.Helper()
+				crud, err := kaClient.ApplyDesiresForCluster(testSubscriptionID, testResourceGroupName, testClusterName)
+				require.NoError(t, err, "failed to get ApplyDesires CRUD")
+
+				desire, err := crud.Get(ctx, "defaultingressconfigmap")
+				require.NoError(t, err, "ApplyDesire for DefaultIngressConfigMap should exist")
+
+				assert.Equal(t, kubeapplierapi.ApplyDesireTypeServerSideApply, desire.Spec.Type, "desire type should be ServerSideApply")
+				assert.Equal(t, testManagementClusterResourceID.String(), desire.Spec.ManagementCluster.String(), "management cluster should match")
+				assert.Equal(t, "default-ingress", desire.Spec.TargetItem.Name, "target name should match")
+				assert.Equal(t, "ocm-env-abc", desire.Spec.TargetItem.Namespace, "target namespace should match")
+				assert.Equal(t, "configmaps", desire.Spec.TargetItem.Resource, "target resource should be the plural resource name")
+				assert.NotNil(t, desire.Spec.ServerSideApply, "ServerSideApply config should be set")
+				assert.NotNil(t, desire.Spec.ServerSideApply.KubeContent, "KubeContent should be set")
+			},
+		},
+		{
+			name:    "creates ApplyDesires for multiple resources",
+			cluster: newCluster(),
+			dbResources: []any{
+				newSPC(testManagementClusterResourceID),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					GetClusterResources(gomock.Any(), gomock.Any()).
+					Return(buildClusterResources(map[string]string{
+						"pull-secret":       `{"apiVersion":"v1","kind":"Secret","metadata":{"name":"pull-secret","namespace":"ocm-env-abc"}}`,
+						"ingress-configmap": `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"default-ingress","namespace":"ocm-env-abc"}}`,
+					}), nil)
+				return mock
+			},
+			wantErr: false,
+			verifyDB: func(t *testing.T, ctx context.Context, kaClient *kubeappliercosmosstoragetesting.MockKubeApplierDBClient) {
+				t.Helper()
+				crud, err := kaClient.ApplyDesiresForCluster(testSubscriptionID, testResourceGroupName, testClusterName)
+				require.NoError(t, err, "failed to get ApplyDesires CRUD")
+
+				desireA, err := crud.Get(ctx, "ocppullsecret")
+				require.NoError(t, err, "ApplyDesire for OCPPullSecret should exist")
+				assert.Equal(t, "pull-secret", desireA.Spec.TargetItem.Name, "secret target name should match")
+				assert.Equal(t, "secrets", desireA.Spec.TargetItem.Resource, "secret target resource should match")
+
+				desireB, err := crud.Get(ctx, "defaultingressconfigmap")
+				require.NoError(t, err, "ApplyDesire for DefaultIngressConfigMap should exist")
+				assert.Equal(t, "default-ingress", desireB.Spec.TargetItem.Name, "configmap target name should match")
+				assert.Equal(t, "configmaps", desireB.Spec.TargetItem.Resource, "configmap target resource should match")
+			},
+		},
+		{
+			name:    "skips when management cluster is not placed",
+			cluster: newCluster(),
+			dbResources: []any{
+				newSPC(nil),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				return ocm.NewMockClusterServiceClientSpec(ctrl)
+			},
+			wantErr: false,
+		},
+		{
+			name:    "replaces existing ApplyDesire when content changes",
+			cluster: newCluster(),
+			dbResources: []any{
+				newSPC(testManagementClusterResourceID),
+			},
+			setupCSMock: func(ctrl *gomock.Controller) ocm.ClusterServiceClientSpec {
+				mock := ocm.NewMockClusterServiceClientSpec(ctrl)
+				mock.EXPECT().
+					GetClusterResources(gomock.Any(), gomock.Any()).
+					Return(buildClusterResources(map[string]string{
+						"ingress-configmap": `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"default-ingress","namespace":"ocm-env-abc"},"data":{"key":"updated-value"}}`,
+					}), nil)
+				return mock
+			},
+			wantErr: false,
+			verifyDB: func(t *testing.T, ctx context.Context, kaClient *kubeappliercosmosstoragetesting.MockKubeApplierDBClient) {
+				t.Helper()
+				crud, err := kaClient.ApplyDesiresForCluster(testSubscriptionID, testResourceGroupName, testClusterName)
+				require.NoError(t, err, "failed to get ApplyDesires CRUD")
+
+				desire, err := crud.Get(ctx, "defaultingressconfigmap")
+				require.NoError(t, err, "ApplyDesire should exist after replacement")
+
+				var content map[string]interface{}
+				err = json.Unmarshal(desire.Spec.ServerSideApply.KubeContent.Raw, &content)
+				require.NoError(t, err, "should unmarshal KubeContent")
+				data, ok := content["data"].(map[string]interface{})
+				require.True(t, ok, "data field should be a map")
+				assert.Equal(t, "updated-value", data["key"], "KubeContent should reflect the updated value")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+			ctrl := gomock.NewController(t)
+
+			mockKubeApplierDBClients := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClients()
+			mockKubeApplierClient := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClient()
+			mockKubeApplierDBClients.Register(testManagementClusterResourceID, mockKubeApplierClient)
+
+			// Seed the cluster lister (used by SyncOnce to look up the cluster)
+			clusterLister := &corelistertesting.SliceClusterLister{}
+			if tt.cluster != nil {
+				clusterLister.Clusters = []*coreapi.HCPOpenShiftCluster{tt.cluster}
+			}
+
+			// Seed the SPC lister from dbResources
+			spcLister := &corelistertesting.SliceServiceProviderClusterLister{}
+			for _, r := range tt.dbResources {
+				if spc, ok := r.(*coreapi.ServiceProviderCluster); ok {
+					spcLister.ServiceProviderClusters = append(spcLister.ServiceProviderClusters, spc)
+				}
+			}
+
+			mcLister := &fleetlistertesting.SliceManagementClusterLister{
+				ManagementClusters: []*fleetapi.ManagementCluster{
+					{ResourceID: testManagementClusterResourceID},
+				},
+			}
+
+			syncer := &clusterResourcesController{
+				clusterLister:                clusterLister,
+				serviceProviderClusterLister: spcLister,
+				clustersServiceClient:        tt.setupCSMock(ctrl),
+				kubeApplierDBClients:         mockKubeApplierDBClients,
+				applyDesireLister:            &kubeapplierlistertesting.DBApplyDesireLister{Clients: mockKubeApplierDBClients, Lister: mcLister},
+			}
+
+			err := syncer.SyncOnce(ctx, testKey())
+			if tt.wantErr {
+				require.Error(t, err, "expected SyncOnce to return an error")
+				return
+			}
+			require.NoError(t, err, "expected SyncOnce to succeed")
+			if tt.verifyDB != nil {
+				tt.verifyDB(t, ctx, mockKubeApplierClient)
+			}
+		})
+	}
+}
+
+func TestDeleteStaleApplyDesires(t *testing.T) {
+	t.Parallel()
+
+	makeTaggedDesire := func(name string) *kubeapplierapi.ApplyDesire {
+		resourceIDStr := kubeapplierapi.ToClusterScopedApplyDesireResourceIDString(
+			testSubscriptionID, testResourceGroupName, testClusterName, name,
+		)
+		return &kubeapplierapi.ApplyDesire{
+			CosmosMetadata: coreapi.CosmosMetadata{
+				ResourceID:   metadataapi.Must(azcorearm.ParseResourceID(resourceIDStr)),
+				PartitionKey: strings.ToLower(testManagementClusterResourceID.String()),
+			},
+			Tags: map[string]string{kubeapplierapi.TagControllerName: ClusterResourcesControllerName},
+			Spec: kubeapplierapi.ApplyDesireSpec{
+				ManagementCluster: testManagementClusterResourceID,
+				Type:              kubeapplierapi.ApplyDesireTypeServerSideApply,
+				TargetItem: kubeapplierapi.ResourceReference{
+					Group: "", Version: "v1", Resource: "configmaps",
+					Name: name, Namespace: "ns",
+				},
+				ServerSideApply: &kubeapplierapi.ServerSideApplyConfig{
+					KubeContent: &runtime.RawExtension{Raw: []byte(`{}`)},
+				},
+			},
+		}
+	}
+
+	makeUntaggedDesire := func(name string) *kubeapplierapi.ApplyDesire {
+		d := makeTaggedDesire(name)
+		d.Tags = nil
+		return d
+	}
+
+	t.Run("marks stale tagged desire for deletion", func(t *testing.T) {
+		t.Parallel()
+		ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+		mockKubeApplierClient := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClient()
+		mockClients := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClients()
+		mockClients.Register(testManagementClusterResourceID, mockKubeApplierClient)
+
+		crud, _ := mockKubeApplierClient.ApplyDesiresForCluster(testSubscriptionID, testResourceGroupName, testClusterName)
+		_, _ = crud.Create(ctx, makeTaggedDesire("configmaps.ns.current"), nil)
+		_, _ = crud.Create(ctx, makeTaggedDesire("configmaps.ns.stale"), nil)
+
+		mcLister := &fleetlistertesting.SliceManagementClusterLister{
+			ManagementClusters: []*fleetapi.ManagementCluster{{ResourceID: testManagementClusterResourceID}},
+		}
+		syncer := &clusterResourcesController{
+			kubeApplierDBClients: mockClients,
+			applyDesireLister:    &kubeapplierlistertesting.DBApplyDesireLister{Clients: mockClients, Lister: mcLister},
+		}
+
+		currentResourceID := kubeapplierapi.ToClusterScopedApplyDesireResourceIDString(
+			testSubscriptionID, testResourceGroupName, testClusterName, "configmaps.ns.current",
+		)
+		err := syncer.deleteStaleApplyDesires(ctx, testKey(), testManagementClusterResourceID,
+			map[string]bool{currentResourceID: true})
+		require.NoError(t, err, "deleteStaleApplyDesires should succeed")
+
+		stale, err := crud.Get(ctx, "configmaps.ns.stale")
+		require.NoError(t, err, "stale desire should still exist")
+		assert.Equal(t, kubeapplierapi.ApplyDesireTypeDelete, stale.Spec.Type, "stale desire should be marked for deletion")
+		assert.Nil(t, stale.Spec.ServerSideApply, "ServerSideApply should be cleared")
+
+		current, err := crud.Get(ctx, "configmaps.ns.current")
+		require.NoError(t, err, "current desire should still exist")
+		assert.Equal(t, kubeapplierapi.ApplyDesireTypeServerSideApply, current.Spec.Type, "current desire should be unchanged")
+	})
+
+	t.Run("does not touch untagged desires", func(t *testing.T) {
+		t.Parallel()
+		ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+		mockKubeApplierClient := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClient()
+		mockClients := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClients()
+		mockClients.Register(testManagementClusterResourceID, mockKubeApplierClient)
+
+		crud, _ := mockKubeApplierClient.ApplyDesiresForCluster(testSubscriptionID, testResourceGroupName, testClusterName)
+		_, _ = crud.Create(ctx, makeUntaggedDesire("configmaps.ns.other-controller"), nil)
+
+		mcLister := &fleetlistertesting.SliceManagementClusterLister{
+			ManagementClusters: []*fleetapi.ManagementCluster{{ResourceID: testManagementClusterResourceID}},
+		}
+		syncer := &clusterResourcesController{
+			kubeApplierDBClients: mockClients,
+			applyDesireLister:    &kubeapplierlistertesting.DBApplyDesireLister{Clients: mockClients, Lister: mcLister},
+		}
+
+		err := syncer.deleteStaleApplyDesires(ctx, testKey(), testManagementClusterResourceID, map[string]bool{})
+		require.NoError(t, err, "deleteStaleApplyDesires should succeed")
+
+		desire, err := crud.Get(ctx, "configmaps.ns.other-controller")
+		require.NoError(t, err, "untagged desire should still exist")
+		assert.Equal(t, kubeapplierapi.ApplyDesireTypeServerSideApply, desire.Spec.Type, "untagged desire should be untouched")
+	})
+
+	t.Run("waits for Delete-type desire without successful condition", func(t *testing.T) {
+		t.Parallel()
+		ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+		mockKubeApplierClient := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClient()
+		mockClients := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClients()
+		mockClients.Register(testManagementClusterResourceID, mockKubeApplierClient)
+
+		crud, _ := mockKubeApplierClient.ApplyDesiresForCluster(testSubscriptionID, testResourceGroupName, testClusterName)
+
+		staleDesire := makeTaggedDesire("nodepools.ns.pending")
+		staleDesire.Spec.Type = kubeapplierapi.ApplyDesireTypeDelete
+		staleDesire.Spec.ServerSideApply = nil
+		_, _ = crud.Create(ctx, staleDesire, nil)
+
+		mcLister := &fleetlistertesting.SliceManagementClusterLister{
+			ManagementClusters: []*fleetapi.ManagementCluster{{ResourceID: testManagementClusterResourceID}},
+		}
+		syncer := &clusterResourcesController{
+			kubeApplierDBClients: mockClients,
+			applyDesireLister:    &kubeapplierlistertesting.DBApplyDesireLister{Clients: mockClients, Lister: mcLister},
+		}
+
+		err := syncer.deleteStaleApplyDesires(ctx, testKey(), testManagementClusterResourceID, map[string]bool{})
+		require.NoError(t, err, "deleteStaleApplyDesires should succeed")
+
+		_, err = crud.Get(ctx, "nodepools.ns.pending")
+		require.NoError(t, err, "desire should still exist while delete is pending")
+	})
+
+	t.Run("purges Delete-type desire when SuccessfullyDeleted condition is true", func(t *testing.T) {
+		t.Parallel()
+		ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+		mockKubeApplierClient := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClient()
+		mockClients := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClients()
+		mockClients.Register(testManagementClusterResourceID, mockKubeApplierClient)
+
+		crud, _ := mockKubeApplierClient.ApplyDesiresForCluster(testSubscriptionID, testResourceGroupName, testClusterName)
+
+		staleDesire := makeTaggedDesire("configmaps.ns.gone")
+		staleDesire.Spec.Type = kubeapplierapi.ApplyDesireTypeDelete
+		staleDesire.Spec.ServerSideApply = nil
+		staleDesire.Status.Conditions = []metav1.Condition{
+			{Type: kubeapplierapi.ConditionTypeSuccessfullyDeleted, Status: metav1.ConditionTrue},
+		}
+		_, _ = crud.Create(ctx, staleDesire, nil)
+
+		mcLister := &fleetlistertesting.SliceManagementClusterLister{
+			ManagementClusters: []*fleetapi.ManagementCluster{{ResourceID: testManagementClusterResourceID}},
+		}
+		syncer := &clusterResourcesController{
+			kubeApplierDBClients: mockClients,
+			applyDesireLister:    &kubeapplierlistertesting.DBApplyDesireLister{Clients: mockClients, Lister: mcLister},
+		}
+
+		err := syncer.deleteStaleApplyDesires(ctx, testKey(), testManagementClusterResourceID, map[string]bool{})
+		require.NoError(t, err, "deleteStaleApplyDesires should succeed")
+
+		_, err = crud.Get(ctx, "configmaps.ns.gone")
+		assert.Error(t, err, "purged ApplyDesire should no longer exist")
+	})
+}
+
+func TestClassifyClusterResource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		resource     string
+		wantDesire   string
+		wantNodePool string
+		wantErr      bool
+	}{
+		{
+			name:       "HostedCluster",
+			resource:   `{"apiVersion":"hypershift.openshift.io/v1beta1","kind":"HostedCluster","metadata":{"name":"my-hc","namespace":"ocm-env-abc"}}`,
+			wantDesire: "HostedCluster",
+		},
+		{
+			name:         "NodePool with spec.clusterName prefix",
+			resource:     `{"apiVersion":"hypershift.openshift.io/v1beta1","kind":"NodePool","metadata":{"name":"q2e1p3b8m8a3s6l-np-2dz967","namespace":"ocm-env-abc"},"spec":{"clusterName":"q2e1p3b8m8a3s6l"}}`,
+			wantDesire:   "NodePool",
+			wantNodePool: "np-2dz967",
+		},
+		{
+			name:         "NodePool without spec.clusterName",
+			resource:     `{"apiVersion":"hypershift.openshift.io/v1beta1","kind":"NodePool","metadata":{"name":"worker","namespace":"ocm-env-abc"}}`,
+			wantDesire:   "NodePool",
+			wantNodePool: "worker",
+		},
+		{
+			name:       "HostedCluster Namespace",
+			resource:   `{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"ocm-arohcppers-2sdm6b8jke9sm3h8ukc8mbaahngnre5c","labels":{"api.openshift.com/environment":"arohcppers","api.openshift.com/id":"2sdm6b8jke9sm3h8ukc8mbaahngnre5c","api.openshift.com/name":"cluster-hs-pre-rxhvsd"}}}`,
+			wantDesire: "HostedClusterNamespace",
+		},
+		{
+			name:       "ControlPlane Namespace",
+			resource:   `{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"ocm-arohcppers-2sdm6b8jke9sm3h8ukc8mbaahngnre5c-j7h3t4w0u1t3b4b","labels":{"app.kubernetes.io/managed-by":"aro-hcp-clusters-service","hypershift.openshift.io/cluster":"2sdm6b8jke9sm3h8ukc8mbaahngnre5c"}}}`,
+			wantDesire: "ControlPlaneNamespace",
+		},
+		{
+			name:       "ConfigMap → DefaultIngressConfigMap",
+			resource:   `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"default-ingress","namespace":"ocm-env-abc"}}`,
+			wantDesire: "DefaultIngressConfigMap",
+		},
+		{
+			name:       "Secret → OCPPullSecret",
+			resource:   `{"apiVersion":"v1","kind":"Secret","metadata":{"name":"pull-secret","namespace":"ocm-env-abc"}}`,
+			wantDesire: "OCPPullSecret",
+		},
+		{
+			name:       "PodNetwork",
+			resource:   `{"apiVersion":"multitenancy.acn.azure.com/v1alpha1","kind":"PodNetwork","metadata":{"name":"pn-abc123"}}`,
+			wantDesire: "PodNetwork",
+		},
+		{
+			name:       "PodNetworkInstance",
+			resource:   `{"apiVersion":"multitenancy.acn.azure.com/v1alpha1","kind":"PodNetworkInstance","metadata":{"name":"pni-abc123","namespace":"ocm-env-abc-cp"}}`,
+			wantDesire: "PodNetworkInstance",
+		},
+		{
+			name:       "SecretSync bound-sa-signing-key",
+			resource:   `{"apiVersion":"secret-sync.x-k8s.io/v1alpha1","kind":"SecretSync","metadata":{"name":"bound-sa-signing-key","namespace":"ocm-env-abc"}}`,
+			wantDesire: "BoundServiceAccountSigningKeySecretSync",
+		},
+		{
+			name:       "SecretSync bound-service-account-signing-key",
+			resource:   `{"apiVersion":"secret-sync.x-k8s.io/v1alpha1","kind":"SecretSync","metadata":{"name":"bound-service-account-signing-key","namespace":"ocm-env-abc"}}`,
+			wantDesire: "BoundServiceAccountSigningKeySecretSync",
+		},
+		{
+			name:       "SecretSync default-ingress",
+			resource:   `{"apiVersion":"secret-sync.x-k8s.io/v1alpha1","kind":"SecretSync","metadata":{"name":"default-ingress-cert","namespace":"ocm-env-abc"}}`,
+			wantDesire: "DefaultIngressWildcardCertSecretSync",
+		},
+		{
+			name:       "SecretSync kube-apiserver",
+			resource:   `{"apiVersion":"secret-sync.x-k8s.io/v1alpha1","kind":"SecretSync","metadata":{"name":"kube-apiserver-server-cert","namespace":"ocm-env-abc"}}`,
+			wantDesire: "KubeAPIServerServingCertSecretSync",
+		},
+		{
+			name:       "SecretProviderClass bound-sa-signing-key",
+			resource:   `{"apiVersion":"secrets-store.csi.x-k8s.io/v1","kind":"SecretProviderClass","metadata":{"name":"bound-sa-signing-key","namespace":"ocm-env-abc"}}`,
+			wantDesire: "BoundServiceAccountSigningKeySecretProviderClass",
+		},
+		{
+			name:       "SecretProviderClass bound-service-account-signing-key",
+			resource:   `{"apiVersion":"secrets-store.csi.x-k8s.io/v1","kind":"SecretProviderClass","metadata":{"name":"bound-service-account-signing-key","namespace":"ocm-env-abc"}}`,
+			wantDesire: "BoundServiceAccountSigningKeySecretProviderClass",
+		},
+		{
+			name:       "SecretProviderClass default-ingress",
+			resource:   `{"apiVersion":"secrets-store.csi.x-k8s.io/v1","kind":"SecretProviderClass","metadata":{"name":"default-ingress-cert","namespace":"ocm-env-abc"}}`,
+			wantDesire: "DefaultIngressWildcardCertSecretProviderClass",
+		},
+		{
+			name:       "SecretProviderClass kube-apiserver",
+			resource:   `{"apiVersion":"secrets-store.csi.x-k8s.io/v1","kind":"SecretProviderClass","metadata":{"name":"kube-apiserver-server-cert","namespace":"ocm-env-abc"}}`,
+			wantDesire: "KubeAPIServerServingCertSecretProviderClass",
+		},
+		{
+			name:     "unrecognized kind errors",
+			resource: `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"web","namespace":"app"}}`,
+			wantErr:  true,
+		},
+		{
+			name:     "unrecognized SecretSync name errors",
+			resource: `{"apiVersion":"secret-sync.x-k8s.io/v1alpha1","kind":"SecretSync","metadata":{"name":"unknown-sync","namespace":"ns"}}`,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var obj unstructured.Unstructured
+			err := json.Unmarshal([]byte(tt.resource), &obj)
+			require.NoError(t, err, "failed to unmarshal test resource")
+
+			classified, err := classifyClusterResource(&obj)
+			if tt.wantErr {
+				require.Error(t, err, "expected classifyClusterResource to error")
+				return
+			}
+			require.NoError(t, err, "classifyClusterResource should not error")
+			assert.Equal(t, tt.wantDesire, classified.desireName, "desireName mismatch")
+			assert.Equal(t, tt.wantNodePool, classified.nodePoolName, "nodePoolName mismatch")
+		})
+	}
+}

--- a/backend/pkg/controllers/clusterresources/cluster_resources_controller_test.go
+++ b/backend/pkg/controllers/clusterresources/cluster_resources_controller_test.go
@@ -714,3 +714,114 @@ func TestClassifyClusterResource(t *testing.T) {
 		})
 	}
 }
+
+// TestProcessClusterResourcesNodePoolPath covers the node-pool-scoped branch of
+// processClusterResources. A NodePool marked for deletion is dropped from the
+// desired set and its ApplyDesire is reaped, even while Cluster Service is
+// still reporting the CR. That is deliberate: NodePoolClusterServiceDeleteDispatch
+// does not wait on these desires, so the reap cannot deadlock against the
+// work-agent re-applying the CR from the still-live ManifestWork.
+func TestProcessClusterResourcesNodePoolPath(t *testing.T) {
+	t.Parallel()
+
+	const testNodePoolName = "gpu-np-1"
+
+	nodePoolCR := `{"apiVersion":"hypershift.openshift.io/v1beta1","kind":"NodePool",` +
+		`"metadata":{"name":"` + testClusterName + `-` + testNodePoolName + `","namespace":"ocm-env-abc"},` +
+		`"spec":{"clusterName":"` + testClusterName + `"}}`
+
+	newNodePool := func(deleting bool) *coreapi.HCPOpenShiftClusterNodePool {
+		resourceID := metadataapi.Must(azcorearm.ParseResourceID(
+			"/subscriptions/" + testSubscriptionID +
+				"/resourceGroups/" + testResourceGroupName +
+				"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + testClusterName +
+				"/nodePools/" + testNodePoolName,
+		))
+		np := &coreapi.HCPOpenShiftClusterNodePool{
+			CosmosMetadata: coreapi.CosmosMetadata{
+				ResourceID:   resourceID,
+				PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+			},
+			TrackedResource: coreapi.TrackedResource{
+				Resource: coreapi.Resource{
+					ID:   resourceID,
+					Name: testNodePoolName,
+					Type: resourceID.ResourceType.String(),
+				},
+			},
+		}
+		np.ServiceProviderProperties.ClusterServiceID = metadataapi.Ptr(metadataapi.Must(
+			metadataapi.NewInternalID("/api/clusters_mgmt/v1/clusters/abc123/node_pools/np123")))
+		if deleting {
+			now := metav1.Now()
+			np.ServiceProviderProperties.DeletionTimestamp = &now
+		}
+		return np
+	}
+
+	tests := []struct {
+		name           string
+		nodePool       *coreapi.HCPOpenShiftClusterNodePool
+		wantDesireType kubeapplierapi.ApplyDesireType
+		reason         string
+	}{
+		{
+			name:           "keeps desire applied while NodePool is live",
+			nodePool:       newNodePool(false),
+			wantDesireType: kubeapplierapi.ApplyDesireTypeServerSideApply,
+			reason:         "a live NodePool must keep its ApplyDesire applied",
+		},
+		{
+			name:           "reaps desire once NodePool is marked for deletion",
+			nodePool:       newNodePool(true),
+			wantDesireType: kubeapplierapi.ApplyDesireTypeDelete,
+			reason:         "a deleting NodePool is dropped from the desired set and reaped",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+			mockKubeApplierClient := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClient()
+			mockClients := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClients()
+			mockClients.Register(testManagementClusterResourceID, mockKubeApplierClient)
+
+			npCRUD, err := mockKubeApplierClient.ApplyDesiresForNodePool(
+				testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+			require.NoError(t, err, "failed to get node pool ApplyDesires CRUD")
+
+			mcLister := &fleetlistertesting.SliceManagementClusterLister{
+				ManagementClusters: []*fleetapi.ManagementCluster{{ResourceID: testManagementClusterResourceID}},
+			}
+			syncer := &clusterResourcesController{
+				nodePoolLister:       &corelistertesting.SliceNodePoolLister{NodePools: []*coreapi.HCPOpenShiftClusterNodePool{tt.nodePool}},
+				kubeApplierDBClients: mockClients,
+				applyDesireLister:    &kubeapplierlistertesting.DBApplyDesireLister{Clients: mockClients, Lister: mcLister},
+			}
+
+			// Seed the desire with a pass over a healthy NodePool, so the deletion
+			// case exercises reaping an existing desire rather than never creating one.
+			seedSyncer := *syncer
+			seedSyncer.nodePoolLister = &corelistertesting.SliceNodePoolLister{
+				NodePools: []*coreapi.HCPOpenShiftClusterNodePool{newNodePool(false)},
+			}
+			require.NoError(t, seedSyncer.processClusterResources(ctx, testKey(), testManagementClusterResourceID,
+				buildClusterResources(map[string]string{"node-pool": nodePoolCR})),
+				"seeding the NodePool ApplyDesire should succeed")
+			_, err = npCRUD.Get(ctx, "nodepool")
+			require.NoError(t, err, "seed pass should have created the NodePool ApplyDesire")
+
+			// Cluster Service still reports the CR, as it does until it removes the
+			// ManifestWork.
+			require.NoError(t, syncer.processClusterResources(ctx, testKey(), testManagementClusterResourceID,
+				buildClusterResources(map[string]string{"node-pool": nodePoolCR})),
+				"processClusterResources should succeed")
+
+			desire, err := npCRUD.Get(ctx, "nodepool")
+			require.NoError(t, err, "NodePool ApplyDesire should still exist: %s", tt.reason)
+			assert.Equal(t, tt.wantDesireType, desire.Spec.Type, "unexpected desire type: %s", tt.reason)
+		})
+	}
+}

--- a/backend/pkg/controllers/clusterresources/cluster_resources_controller_test.go
+++ b/backend/pkg/controllers/clusterresources/cluster_resources_controller_test.go
@@ -401,7 +401,11 @@ func TestSyncOnce(t *testing.T) {
 
 			mcLister := &fleetlistertesting.SliceManagementClusterLister{
 				ManagementClusters: []*fleetapi.ManagementCluster{
-					{ResourceID: testManagementClusterResourceID},
+					{
+						CosmosMetadata: coreapi.CosmosMetadata{
+							ResourceID: testManagementClusterResourceID,
+						},
+					},
 				},
 			}
 
@@ -472,7 +476,13 @@ func TestDeleteStaleApplyDesires(t *testing.T) {
 		_, _ = crud.Create(ctx, makeTaggedDesire("configmaps.ns.stale"), nil)
 
 		mcLister := &fleetlistertesting.SliceManagementClusterLister{
-			ManagementClusters: []*fleetapi.ManagementCluster{{ResourceID: testManagementClusterResourceID}},
+			ManagementClusters: []*fleetapi.ManagementCluster{
+				{
+					CosmosMetadata: coreapi.CosmosMetadata{
+						ResourceID: testManagementClusterResourceID,
+					},
+				},
+			},
 		}
 		syncer := &clusterResourcesController{
 			kubeApplierDBClients: mockClients,
@@ -508,7 +518,13 @@ func TestDeleteStaleApplyDesires(t *testing.T) {
 		_, _ = crud.Create(ctx, makeUntaggedDesire("configmaps.ns.other-controller"), nil)
 
 		mcLister := &fleetlistertesting.SliceManagementClusterLister{
-			ManagementClusters: []*fleetapi.ManagementCluster{{ResourceID: testManagementClusterResourceID}},
+			ManagementClusters: []*fleetapi.ManagementCluster{
+				{
+					CosmosMetadata: coreapi.CosmosMetadata{
+						ResourceID: testManagementClusterResourceID,
+					},
+				},
+			},
 		}
 		syncer := &clusterResourcesController{
 			kubeApplierDBClients: mockClients,
@@ -539,7 +555,13 @@ func TestDeleteStaleApplyDesires(t *testing.T) {
 		_, _ = crud.Create(ctx, staleDesire, nil)
 
 		mcLister := &fleetlistertesting.SliceManagementClusterLister{
-			ManagementClusters: []*fleetapi.ManagementCluster{{ResourceID: testManagementClusterResourceID}},
+			ManagementClusters: []*fleetapi.ManagementCluster{
+				{
+					CosmosMetadata: coreapi.CosmosMetadata{
+						ResourceID: testManagementClusterResourceID,
+					},
+				},
+			},
 		}
 		syncer := &clusterResourcesController{
 			kubeApplierDBClients: mockClients,
@@ -572,7 +594,13 @@ func TestDeleteStaleApplyDesires(t *testing.T) {
 		_, _ = crud.Create(ctx, staleDesire, nil)
 
 		mcLister := &fleetlistertesting.SliceManagementClusterLister{
-			ManagementClusters: []*fleetapi.ManagementCluster{{ResourceID: testManagementClusterResourceID}},
+			ManagementClusters: []*fleetapi.ManagementCluster{
+				{
+					CosmosMetadata: coreapi.CosmosMetadata{
+						ResourceID: testManagementClusterResourceID,
+					},
+				},
+			},
 		}
 		syncer := &clusterResourcesController{
 			kubeApplierDBClients: mockClients,
@@ -793,7 +821,13 @@ func TestProcessClusterResourcesNodePoolPath(t *testing.T) {
 			require.NoError(t, err, "failed to get node pool ApplyDesires CRUD")
 
 			mcLister := &fleetlistertesting.SliceManagementClusterLister{
-				ManagementClusters: []*fleetapi.ManagementCluster{{ResourceID: testManagementClusterResourceID}},
+				ManagementClusters: []*fleetapi.ManagementCluster{
+					{
+						CosmosMetadata: coreapi.CosmosMetadata{
+							ResourceID: testManagementClusterResourceID,
+						},
+					},
+				},
 			}
 			syncer := &clusterResourcesController{
 				nodePoolLister:       &corelistertesting.SliceNodePoolLister{NodePools: []*coreapi.HCPOpenShiftClusterNodePool{tt.nodePool}},

--- a/backend/pkg/controllers/nodepool/deletion/node_pool_child_resources_cleanup_controller.go
+++ b/backend/pkg/controllers/nodepool/deletion/node_pool_child_resources_cleanup_controller.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/kubeappliercosmosstorage"
@@ -38,8 +39,10 @@ import (
 // the NodePool is marked for deletion and Cluster Service has confirmed the
 // delete on its side. Controller status documents (NodePoolControllerResourceType)
 // are left alone. Nodepool-scoped kube-applier *Desires are deleted here using
-// the parent cluster's ServiceProviderCluster placement. The orphan scraper
-// handles controller status after the NodePool document itself is removed.
+// the parent cluster's ServiceProviderCluster placement, except for ApplyDesires
+// that name an owning controller - those are that controller's to tear down; see
+// extraDeleteGateShouldDeleteApplyDesire. The orphan scraper handles controller
+// status after the NodePool document itself is removed.
 type nodePoolChildResourcesCleanupController struct {
 	nodePoolLister       corelisters.NodePoolLister
 	resourcesDBClient    corecosmosstorage.ResourcesDBClient
@@ -274,11 +277,12 @@ func (c *nodePoolChildResourcesCleanupController) ensureNodePoolScopedKubeApplie
 		return nil
 	}
 
-	// extraDeleteGates uses lowercased kubeapplier.*DesireResourceTypeName keys. Types not
-	// in the map are deleted unconditionally.
+	// extraDeleteGates uses lowercased kubeapplierapi.*DesireResourceType keys. Types not
+	// in the map are deleted unconditionally. ReadDesires are only observed, so
+	// dropping their documents has no effect on the management cluster and needs
+	// no gate; ApplyDesires do, hence the gate below.
 	extraDeleteGates := map[string]func(ctx context.Context, resourceID *azcorearm.ResourceID) (bool, error){
-		// strings.ToLower(kubeapplier.ClusterScopedReadDesireResourceType.String()): c.extraDeleteGateShouldDeleteReadDesire,
-		// strings.ToLower(kubeapplier.ClusterScopedApplyDesireResourceType.String()): c.extraDeleteGateShouldDeleteApplyDesire,
+		strings.ToLower(kubeapplierapi.NodePoolScopedApplyDesireResourceType.String()): c.extraDeleteGateShouldDeleteApplyDesire(kaClient, nodePoolResourceID),
 	}
 
 	desireCRUD, err := kaClient.UntypedCRUD(*nodePoolResourceID)
@@ -317,4 +321,54 @@ func (c *nodePoolChildResourcesCleanupController) ensureNodePoolScopedKubeApplie
 	logger.Info("all included nodepool-scoped kube-applier child resources deleted")
 
 	return nil
+}
+
+// extraDeleteGateShouldDeleteApplyDesire reports whether a nodepool-scoped
+// ApplyDesire document may be removed here.
+//
+// An ApplyDesire that records an owning controller in Tags[TagControllerName]
+// belongs to that controller's teardown: the owner flips it to Type=Delete and
+// purges the document only once the kube-applier reports the object gone from
+// the management cluster. Deleting the document here would strand that object,
+// because nothing else asks the kube-applier to remove it. So we leave those
+// alone and let the owner converge - today that is the ClusterResources
+// controller, via kubeapplierhelpers.EnsureApplyDesireRemoved.
+//
+// Untagged desires have no owner left to reap them, so they are deleted here.
+func (c *nodePoolChildResourcesCleanupController) extraDeleteGateShouldDeleteApplyDesire(
+	kaClient kubeappliercosmosstorage.KubeApplierDBClient,
+	nodePoolResourceID *azcorearm.ResourceID,
+) func(ctx context.Context, applyDesireResourceID *azcorearm.ResourceID) (bool, error) {
+	return func(ctx context.Context, applyDesireResourceID *azcorearm.ResourceID) (bool, error) {
+		logger := utils.LoggerFromContext(ctx)
+
+		clusterResourceID := nodePoolResourceID.Parent
+		if clusterResourceID == nil {
+			return false, utils.TrackError(fmt.Errorf(
+				"node pool resource ID missing cluster parent: %s", nodePoolResourceID.String()))
+		}
+
+		applyDesireCRUD, err := kaClient.ApplyDesiresForNodePool(
+			clusterResourceID.SubscriptionID, clusterResourceID.ResourceGroupName, clusterResourceID.Name, nodePoolResourceID.Name)
+		if err != nil {
+			return false, utils.TrackError(fmt.Errorf("failed to create nodepool-scoped ApplyDesire CRUD: %w", err))
+		}
+
+		applyDesire, err := applyDesireCRUD.Get(ctx, strings.ToLower(applyDesireResourceID.Name))
+		if cosmosstorageutils.IsNotFoundError(err) {
+			// Raced with the owner purging it; nothing left to delete.
+			return false, nil
+		}
+		if err != nil {
+			return false, utils.TrackError(fmt.Errorf("failed to get ApplyDesire %q: %w", applyDesireResourceID.String(), err))
+		}
+
+		if owningController := applyDesire.Tags[kubeapplierapi.TagControllerName]; len(owningController) > 0 {
+			logger.Info("waiting for owning controller to tear down nodepool-scoped ApplyDesire",
+				"applyDesireResourceID", applyDesireResourceID.String(), "owningController", owningController)
+			return false, nil
+		}
+
+		return true, nil
+	}
 }

--- a/backend/pkg/controllers/nodepool/deletion/node_pool_child_resources_cleanup_controller_test.go
+++ b/backend/pkg/controllers/nodepool/deletion/node_pool_child_resources_cleanup_controller_test.go
@@ -151,6 +151,37 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 			},
 		}
 	}
+	// newTestOwnedNodePoolScopedApplyDesire builds a nodepool-scoped ApplyDesire
+	// that names an owning controller, the way every controller that persists a
+	// desire through the kubeapplierhelpers ensure helpers does.
+	newTestOwnedNodePoolScopedApplyDesire := func(name, owningController string) *kubeapplierapi.ApplyDesire {
+		desire := newTestNodePoolScopedApplyDesire(name)
+		desire.Tags = map[string]string{kubeapplierapi.TagControllerName: owningController}
+		return desire
+	}
+	assertNodePoolScopedKubeApplierResourceExists := func(
+		t *testing.T,
+		ctx context.Context,
+		kubeApplierDBClients *kubeappliercosmosstoragetesting.MockKubeApplierDBClients,
+		resourceIDString string,
+	) {
+		t.Helper()
+		client := kubeApplierDBClients.For(ctx, managementClusterResourceID)
+		require.NotNil(t, client)
+		resourceID := metadataapi.Must(azcorearm.ParseResourceID(resourceIDString))
+		untypedCRUD, err := client.UntypedCRUD(*resourceID.Parent)
+		require.NoError(t, err)
+		iter, err := untypedCRUD.List(ctx, nil)
+		require.NoError(t, err)
+		for _, resource := range iter.Items(ctx) {
+			if resource.ResourceID != nil && strings.EqualFold(resource.ResourceID.String(), resourceIDString) {
+				require.NoError(t, iter.GetError())
+				return
+			}
+		}
+		require.NoError(t, iter.GetError())
+		t.Fatalf("expected nodepool-scoped kube-applier resource %q to still exist", resourceIDString)
+	}
 	assertNoNodePoolScopedKubeApplierResources := func(
 		t *testing.T,
 		ctx context.Context,
@@ -471,6 +502,53 @@ func TestNodePoolChildResourcesCleanupController_SyncOnce(t *testing.T) {
 				assertClusterScopedKubeApplierResourceExists(t, ctx, kubeApplierDBClients,
 					kubeapplierapi.ToClusterScopedApplyDesireResourceIDString(
 						testSubscriptionID, testResourceGroupName, testClusterName, "apply-example"))
+			},
+		},
+		{
+			// An ApplyDesire naming an owning controller is that controller's to
+			// tear down: it flips the desire to Type=Delete and purges the document
+			// only once the kube-applier confirms the object is gone from the
+			// management cluster. Deleting the document here would strand the
+			// object, so the desire - and with it the SPNP - has to survive this
+			// pass. ReadDesires have no cluster-side effect and are still removed.
+			name:             "when a nodepool-scoped ApplyDesire names an owning controller it is left for that controller",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources: []any{
+				newTestSPCWithManagementCluster(managementClusterResourceID),
+				newTestSPNP(t, nil),
+			},
+			kubeApplierDesires: []any{
+				newTestOwnedNodePoolScopedApplyDesire("apply-nodepool", "ClusterResources"),
+				newTestNodePoolScopedReadDesire("readonly-nodepool"),
+			},
+			verifyDB: func(t *testing.T, ctx context.Context, db *corecosmosstoragetesting.MockResourcesDBClient, kubeApplierDBClients *kubeappliercosmosstoragetesting.MockKubeApplierDBClients) {
+				assertNodePoolScopedKubeApplierResourceExists(t, ctx, kubeApplierDBClients,
+					kubeapplierapi.ToNodePoolScopedApplyDesireResourceIDString(
+						testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName, "apply-nodepool"))
+
+				spnpCRUD := db.ServiceProviderNodePools(
+					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+				_, err := spnpCRUD.Get(ctx, coreapi.ServiceProviderNodePoolResourceName)
+				require.NoError(t, err, "expected SPNP to be held back while an owned ApplyDesire remains")
+			},
+		},
+		{
+			// No owning controller is recorded, so nothing else will ever reap it.
+			// Removing the document here is the backstop that keeps deletion moving.
+			name:             "when a nodepool-scoped ApplyDesire names no owning controller it is deleted",
+			existingNodePool: newTestNodePoolWithNewDeletionApproach(t, readyToDeleteNodePoolOptsFunc),
+			childResources: []any{
+				newTestSPCWithManagementCluster(managementClusterResourceID),
+				newTestSPNP(t, nil),
+			},
+			kubeApplierDesires: []any{newTestNodePoolScopedApplyDesire("orphaned-apply-nodepool")},
+			verifyDB: func(t *testing.T, ctx context.Context, db *corecosmosstoragetesting.MockResourcesDBClient, kubeApplierDBClients *kubeappliercosmosstoragetesting.MockKubeApplierDBClients) {
+				assertNoNodePoolScopedKubeApplierResources(t, ctx, kubeApplierDBClients)
+
+				spnpCRUD := db.ServiceProviderNodePools(
+					testSubscriptionID, testResourceGroupName, testClusterName, testNodePoolName)
+				_, err := spnpCRUD.Get(ctx, coreapi.ServiceProviderNodePoolResourceName)
+				require.True(t, cosmosstorageutils.IsNotFoundError(err), "expected SPNP to be deleted")
 			},
 		},
 	}

--- a/backend/pkg/controllers/nodepool/deletion/node_pool_cluster_service_delete_dispatch_controller.go
+++ b/backend/pkg/controllers/nodepool/deletion/node_pool_cluster_service_delete_dispatch_controller.go
@@ -28,12 +28,15 @@ import (
 
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterresources"
 	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
 	"github.com/Azure/ARO-HCP/internal/database/informers/coreinformers"
 	"github.com/Azure/ARO-HCP/internal/database/listers/corelisters"
+	"github.com/Azure/ARO-HCP/internal/database/listers/kubeapplierlisters"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -53,6 +56,10 @@ const missingClusterServiceIDTimeout = 120 * time.Second
 // waiting for a ClusterServiceID), it stamps ClusterServiceDeletionTimestamp
 // on the NodePool to record that this step is complete and avoid re-issuing
 // the delete on subsequent syncs.
+// Before dispatching the delete, this controller waits until the
+// ClusterResourcesController has cleaned up all its tagged ApplyDesires for
+// this NodePool, so that kube resources are torn down before the NodePool itself.
+//
 // The controller also caches the time the controller has first seen the
 // serviceProviderProperties.deletionTimestamp being set for a nodepool. This
 // is used to avoid immediately triggering deletion in scenarios where the
@@ -63,6 +70,7 @@ type nodePoolClusterServiceDeleteDispatchSyncer struct {
 	nodePoolLister       corelisters.NodePoolLister
 	resourcesDBClient    corecosmosstorage.ResourcesDBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
+	applyDesireLister    kubeapplierlisters.ApplyDesireLister
 	// firstSeenDeletionTimestampCache is a cache that contains the time the controller
 	// has first seen the serviceProviderProperties.deletionTimestamp being set
 	// for a nodepool. The cache key is the lowercased node pool's resource ID and
@@ -80,11 +88,13 @@ func NewNodePoolClusterServiceDeleteDispatchController(
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 	_, nodePoolLister := informers.NodePools()
+	_, applyDesireLister := kubeApplierInformers.ApplyDesires()
 	syncer := &nodePoolClusterServiceDeleteDispatchSyncer{
 		clock:                           clock,
 		nodePoolLister:                  nodePoolLister,
 		resourcesDBClient:               resourcesDBClient,
 		clusterServiceClient:            clusterServiceClient,
+		applyDesireLister:               applyDesireLister,
 		firstSeenDeletionTimestampCache: lru.New(50000),
 	}
 
@@ -147,6 +157,16 @@ func (c *nodePoolClusterServiceDeleteDispatchSyncer) SyncOnce(ctx context.Contex
 		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
 	}
 	if !c.NeedsWork(nodePool) {
+		return nil
+	}
+
+	// Wait until ClusterResourcesController has deleted all its tagged ApplyDesires for this NodePool.
+	hasTaggedDesires, err := c.hasNodePoolApplyDesires(ctx, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check NodePool ApplyDesires: %w", err))
+	}
+	if hasTaggedDesires {
+		logger.Info("waiting for ClusterResourcesController to delete its ApplyDesires before dispatching CS delete")
 		return nil
 	}
 
@@ -217,4 +237,18 @@ func (c *nodePoolClusterServiceDeleteDispatchSyncer) SyncOnce(ctx context.Contex
 	c.firstSeenDeletionTimestampCache.Remove(cacheKey)
 
 	return nil
+}
+
+func (c *nodePoolClusterServiceDeleteDispatchSyncer) hasNodePoolApplyDesires(ctx context.Context, key controllerutils.HCPNodePoolKey) (bool, error) {
+	desires, err := c.applyDesireLister.ListForNodePool(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if err != nil {
+		return false, err
+	}
+	for _, desire := range desires {
+		if desire.Tags != nil &&
+			desire.Tags[kubeapplierapi.TagControllerName] == clusterresources.ClusterResourcesControllerName {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/backend/pkg/controllers/nodepool/deletion/node_pool_cluster_service_delete_dispatch_controller.go
+++ b/backend/pkg/controllers/nodepool/deletion/node_pool_cluster_service_delete_dispatch_controller.go
@@ -28,15 +28,12 @@ import (
 
 	ocmerrors "github.com/openshift-online/ocm-sdk-go/errors"
 
-	"github.com/Azure/ARO-HCP/backend/pkg/controllers/clusterresources"
 	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
-	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
 	"github.com/Azure/ARO-HCP/internal/database/informers/coreinformers"
 	"github.com/Azure/ARO-HCP/internal/database/listers/corelisters"
-	"github.com/Azure/ARO-HCP/internal/database/listers/kubeapplierlisters"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
@@ -56,9 +53,6 @@ const missingClusterServiceIDTimeout = 120 * time.Second
 // waiting for a ClusterServiceID), it stamps ClusterServiceDeletionTimestamp
 // on the NodePool to record that this step is complete and avoid re-issuing
 // the delete on subsequent syncs.
-// Before dispatching the delete, this controller waits until the
-// ClusterResourcesController has cleaned up all its tagged ApplyDesires for
-// this NodePool, so that kube resources are torn down before the NodePool itself.
 //
 // The controller also caches the time the controller has first seen the
 // serviceProviderProperties.deletionTimestamp being set for a nodepool. This
@@ -70,7 +64,6 @@ type nodePoolClusterServiceDeleteDispatchSyncer struct {
 	nodePoolLister       corelisters.NodePoolLister
 	resourcesDBClient    corecosmosstorage.ResourcesDBClient
 	clusterServiceClient ocm.ClusterServiceClientSpec
-	applyDesireLister    kubeapplierlisters.ApplyDesireLister
 	// firstSeenDeletionTimestampCache is a cache that contains the time the controller
 	// has first seen the serviceProviderProperties.deletionTimestamp being set
 	// for a nodepool. The cache key is the lowercased node pool's resource ID and
@@ -88,13 +81,11 @@ func NewNodePoolClusterServiceDeleteDispatchController(
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
 ) controllerutils.Controller {
 	_, nodePoolLister := informers.NodePools()
-	_, applyDesireLister := kubeApplierInformers.ApplyDesires()
 	syncer := &nodePoolClusterServiceDeleteDispatchSyncer{
 		clock:                           clock,
 		nodePoolLister:                  nodePoolLister,
 		resourcesDBClient:               resourcesDBClient,
 		clusterServiceClient:            clusterServiceClient,
-		applyDesireLister:               applyDesireLister,
 		firstSeenDeletionTimestampCache: lru.New(50000),
 	}
 
@@ -157,16 +148,6 @@ func (c *nodePoolClusterServiceDeleteDispatchSyncer) SyncOnce(ctx context.Contex
 		return utils.TrackError(fmt.Errorf("failed to get node pool: %w", err))
 	}
 	if !c.NeedsWork(nodePool) {
-		return nil
-	}
-
-	// Wait until ClusterResourcesController has deleted all its tagged ApplyDesires for this NodePool.
-	hasTaggedDesires, err := c.hasNodePoolApplyDesires(ctx, key)
-	if err != nil {
-		return utils.TrackError(fmt.Errorf("failed to check NodePool ApplyDesires: %w", err))
-	}
-	if hasTaggedDesires {
-		logger.Info("waiting for ClusterResourcesController to delete its ApplyDesires before dispatching CS delete")
 		return nil
 	}
 
@@ -237,18 +218,4 @@ func (c *nodePoolClusterServiceDeleteDispatchSyncer) SyncOnce(ctx context.Contex
 	c.firstSeenDeletionTimestampCache.Remove(cacheKey)
 
 	return nil
-}
-
-func (c *nodePoolClusterServiceDeleteDispatchSyncer) hasNodePoolApplyDesires(ctx context.Context, key controllerutils.HCPNodePoolKey) (bool, error) {
-	desires, err := c.applyDesireLister.ListForNodePool(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
-	if err != nil {
-		return false, err
-	}
-	for _, desire := range desires {
-		if desire.Tags != nil &&
-			desire.Tags[kubeapplierapi.TagControllerName] == clusterresources.ClusterResourcesControllerName {
-			return true, nil
-		}
-	}
-	return false, nil
 }

--- a/backend/pkg/controllers/nodepool/deletion/node_pool_cluster_service_delete_dispatch_controller_test.go
+++ b/backend/pkg/controllers/nodepool/deletion/node_pool_cluster_service_delete_dispatch_controller_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/corecosmosstoragetesting"
 	"github.com/Azure/ARO-HCP/internal/database/listertesting/corelistertesting"
+	kubeapplierlistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting/kubeapplierlistertesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -257,6 +258,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
 				nodePoolLister:                  &corelistertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
 				resourcesDBClient:               mockResourcesDBClient,
 				clusterServiceClient:            mockCSClient,
+				applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 				firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 			}
 
@@ -296,6 +298,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_cacheShortCircuit(t
 		nodePoolLister:                  &corelistertesting.SliceNodePoolLister{NodePools: []*coreapi.HCPOpenShiftClusterNodePool{cachedNodePool}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
+		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: lru.New(10),
 	}
 
@@ -332,6 +335,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCa
 		nodePoolLister:                  &corelistertesting.SliceNodePoolLister{NodePools: []*coreapi.HCPOpenShiftClusterNodePool{nodePool}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
+		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 	}
 
@@ -375,6 +379,7 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCa
 		nodePoolLister:                  &corelistertesting.SliceNodePoolLister{NodePools: []*coreapi.HCPOpenShiftClusterNodePool{nodePool}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            mockCSClient,
+		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 	}
 

--- a/backend/pkg/controllers/nodepool/deletion/node_pool_cluster_service_delete_dispatch_controller_test.go
+++ b/backend/pkg/controllers/nodepool/deletion/node_pool_cluster_service_delete_dispatch_controller_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/corecosmosstoragetesting"
 	"github.com/Azure/ARO-HCP/internal/database/listertesting/corelistertesting"
-	kubeapplierlistertesting "github.com/Azure/ARO-HCP/internal/database/listertesting/kubeapplierlistertesting"
 	"github.com/Azure/ARO-HCP/internal/ocm"
 	"github.com/Azure/ARO-HCP/internal/utils"
 )
@@ -258,7 +257,6 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce(t *testing.T) {
 				nodePoolLister:                  &corelistertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
 				resourcesDBClient:               mockResourcesDBClient,
 				clusterServiceClient:            mockCSClient,
-				applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 				firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 			}
 
@@ -298,7 +296,6 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_cacheShortCircuit(t
 		nodePoolLister:                  &corelistertesting.SliceNodePoolLister{NodePools: []*coreapi.HCPOpenShiftClusterNodePool{cachedNodePool}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
-		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: lru.New(10),
 	}
 
@@ -335,7 +332,6 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCa
 		nodePoolLister:                  &corelistertesting.SliceNodePoolLister{NodePools: []*coreapi.HCPOpenShiftClusterNodePool{nodePool}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            ocm.NewMockClusterServiceClientSpec(ctrl),
-		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 	}
 
@@ -379,7 +375,6 @@ func TestNodePoolClusterServiceDeleteDispatchSyncer_SyncOnce_firstSeenDeletionCa
 		nodePoolLister:                  &corelistertesting.SliceNodePoolLister{NodePools: []*coreapi.HCPOpenShiftClusterNodePool{nodePool}},
 		resourcesDBClient:               mockResourcesDBClient,
 		clusterServiceClient:            mockCSClient,
-		applyDesireLister:               &kubeapplierlistertesting.SliceApplyDesireLister{},
 		firstSeenDeletionTimestampCache: firstSeenDeletionTimestampCache,
 	}
 

--- a/backend/pkg/controllers/nodepool/deletion/node_pool_deletion_controller.go
+++ b/backend/pkg/controllers/nodepool/deletion/node_pool_deletion_controller.go
@@ -17,13 +17,16 @@ package deletion
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
 	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/kubeapplierapi"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/kubeappliercosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/informers/coreinformers"
 	"github.com/Azure/ARO-HCP/internal/database/listers/corelisters"
 	unionkubeapplierinformers "github.com/Azure/ARO-HCP/internal/database/unioninformers/kubeapplier"
@@ -38,7 +41,9 @@ import (
 type nodePoolDeletionController struct {
 	nodePoolLister                corelisters.NodePoolLister
 	serviceProviderNodePoolLister corelisters.ServiceProviderNodePoolLister
+	serviceProviderClusterLister  corelisters.ServiceProviderClusterLister
 	resourcesDBClient             corecosmosstorage.ResourcesDBClient
+	kubeApplierDBClients          kubeappliercosmosstorage.KubeApplierDBClients
 }
 
 var _ controllerutils.NodePoolSyncer = (*nodePoolDeletionController)(nil)
@@ -47,13 +52,17 @@ func NewNodePoolDeletionController(
 	resourcesDBClient corecosmosstorage.ResourcesDBClient,
 	informers coreinformers.BackendInformers,
 	kubeApplierInformers *unionkubeapplierinformers.UnionKubeApplierInformers,
+	kubeApplierDBClients kubeappliercosmosstorage.KubeApplierDBClients,
 ) controllerutils.Controller {
 	_, nodePoolLister := informers.NodePools()
 	_, serviceProviderNodePoolLister := informers.ServiceProviderNodePools()
+	_, serviceProviderClusterLister := informers.ServiceProviderClusters()
 	syncer := &nodePoolDeletionController{
 		nodePoolLister:                nodePoolLister,
 		serviceProviderNodePoolLister: serviceProviderNodePoolLister,
+		serviceProviderClusterLister:  serviceProviderClusterLister,
 		resourcesDBClient:             resourcesDBClient,
+		kubeApplierDBClients:          kubeApplierDBClients,
 	}
 
 	return controllerutils.NewNodePoolWatchingController(
@@ -123,8 +132,17 @@ func (c *nodePoolDeletionController) SyncOnce(ctx context.Context, key controlle
 		return nil
 	}
 
+	// Precondition: all ApplyDesires for this NodePool must be gone.
+	preconditionMet, err := c.deletePreconditionAllApplyDesiresGone(ctx, key)
+	if err != nil {
+		return utils.TrackError(fmt.Errorf("failed to check ApplyDesire precondition: %w", err))
+	}
+	if !preconditionMet {
+		return nil
+	}
+
 	// We do not proceed until we know that all the maestro readonly bundles have been eliminated
-	preconditionMet, err := c.deletePreconditionAllMaestroNodePoolScopedReadonlyBundlesCleared(ctx, key)
+	preconditionMet, err = c.deletePreconditionAllMaestroNodePoolScopedReadonlyBundlesCleared(ctx, key)
 	if err != nil {
 		return utils.TrackError(fmt.Errorf("failed to check precondition: %w", err))
 	}
@@ -198,5 +216,65 @@ func (c *nodePoolDeletionController) deletePreconditionCosmosChildResourcesDelet
 		return false, utils.TrackError(fmt.Errorf("error iterating child resources: %w", err))
 	}
 
+	return true, nil
+}
+
+// deletePreconditionAllApplyDesiresGone checks that no ApplyDesires remain for
+// this NodePool. The log message reports remaining counts per controller.
+func (c *nodePoolDeletionController) deletePreconditionAllApplyDesiresGone(ctx context.Context, key controllerutils.HCPNodePoolKey) (bool, error) {
+	logger := utils.LoggerFromContext(ctx)
+
+	spc, err := c.serviceProviderClusterLister.Get(ctx, key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName)
+	if cosmosstorageutils.IsNotFoundError(err) {
+		return true, nil
+	}
+	if err != nil {
+		return false, utils.TrackError(fmt.Errorf("failed to get ServiceProviderCluster from cache: %w", err))
+	}
+	if spc.Status.ManagementClusterResourceID == nil {
+		return true, nil
+	}
+
+	managementClusterID := spc.Status.ManagementClusterResourceID
+	kubeApplierDBClient := c.kubeApplierDBClients.For(ctx, managementClusterID)
+	if kubeApplierDBClient == nil {
+		logger.Info("waiting for kube-applier DB client to be available for ApplyDesire precondition", "managementCluster", managementClusterID.String())
+		return false, nil
+	}
+
+	kubeApplierCRUD, err := kubeApplierDBClient.ApplyDesiresForNodePool(key.SubscriptionID, key.ResourceGroupName, key.HCPClusterName, key.HCPNodePoolName)
+	if err != nil {
+		return false, fmt.Errorf("failed to get kube-applier CRUD for ApplyDesire precondition: %w", err)
+	}
+
+	applyDesireIterator, err := kubeApplierCRUD.List(ctx, &cosmosstorageutils.DBClientListResourceDocsOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to list ApplyDesire documents for precondition check: %w", err)
+	}
+
+	controllerCounts := map[string]int{}
+	for _, desire := range applyDesireIterator.Items(ctx) {
+		controller := "unknown"
+		if desire.Tags != nil {
+			if name := desire.Tags[kubeapplierapi.TagControllerName]; name != "" {
+				controller = name
+			}
+		}
+		controllerCounts[controller]++
+	}
+	if err := applyDesireIterator.GetError(); err != nil {
+		return false, fmt.Errorf("error iterating ApplyDesires for precondition check: %w", err)
+	}
+
+	if len(controllerCounts) > 0 {
+		var parts []string
+		for controller, count := range controllerCounts {
+			parts = append(parts, fmt.Sprintf("%d from %s", count, controller))
+		}
+		slices.Sort(parts)
+		logger.Info("waiting for all ApplyDesires to be deleted",
+			"remaining", strings.Join(parts, ", "))
+		return false, nil
+	}
 	return true, nil
 }

--- a/backend/pkg/controllers/nodepool/deletion/node_pool_deletion_controller_test.go
+++ b/backend/pkg/controllers/nodepool/deletion/node_pool_deletion_controller_test.go
@@ -150,6 +150,7 @@ func TestNodePoolDeletionController_SyncOnce(t *testing.T) {
 			syncer := &nodePoolDeletionController{
 				nodePoolLister:                &corelistertesting.SliceNodePoolLister{NodePools: nodePoolsForLister},
 				serviceProviderNodePoolLister: &corelistertesting.SliceServiceProviderNodePoolLister{ServiceProviderNodePools: spnpForLister},
+				serviceProviderClusterLister:  &corelistertesting.SliceServiceProviderClusterLister{},
 				resourcesDBClient:             mockResourcesDBClient,
 			}
 

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/openshift/api v0.0.0-20260429122012-1180c0f5c3e9
 	github.com/openshift/cluster-version-operator v1.0.1-0.20260202115537-557510ea0603
 	github.com/openshift/hypershift/api v0.0.0-20260708113917-8b5103a5875b
+	github.com/openshift/library-go v0.0.0-20260504190829-2dd4388d7b89
 	github.com/prometheus/client_golang v1.23.2
 	github.com/segmentio/ksuid v1.0.4
 	github.com/stretchr/testify v1.11.1

--- a/internal/go.sum
+++ b/internal/go.sum
@@ -195,6 +195,8 @@ github.com/openshift/cluster-version-operator v1.0.1-0.20260202115537-557510ea06
 github.com/openshift/cluster-version-operator v1.0.1-0.20260202115537-557510ea0603/go.mod h1:5HPAGcvwDreflw2OjJTEz7MicVZ/mTJQv6zYykB+f+M=
 github.com/openshift/hypershift/api v0.0.0-20260708113917-8b5103a5875b h1:JEAHE8tV+h+7QmPELrhoKxzzUuHAMPJzsNBunzwM6O8=
 github.com/openshift/hypershift/api v0.0.0-20260708113917-8b5103a5875b/go.mod h1:XO2zWpuo0rqxljntdt4aI5ZKhQCIeMYRDWtRNTo+bSE=
+github.com/openshift/library-go v0.0.0-20260504190829-2dd4388d7b89 h1:etWee1jfkT93YVB+aYDhCARlokHGvWsRKXgKPcGrSZQ=
+github.com/openshift/library-go v0.0.0-20260504190829-2dd4388d7b89/go.mod h1:k1tefCr+PAZ7kY8TJjpE6rW6t6Yu4iOmBwO+1+3qD2s=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/internal/ocm/client.go
+++ b/internal/ocm/client.go
@@ -57,6 +57,9 @@ type ClusterServiceClientSpec interface {
 	// GetClusterHypershiftDetails sends a GET request to fetch a cluster's hypershift details from Cluster Service.
 	GetClusterHypershiftDetails(ctx context.Context, internalID InternalID) (*cmv1.HypershiftConfig, error)
 
+	// GetClusterResources sends a GET request to fetch cluster resources from Cluster Service.
+	GetClusterResources(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.ClusterResources, error)
+
 	// PostCluster sends a POST request to create a cluster in Cluster Service.
 	PostCluster(ctx context.Context, clusterBuilder *arohcpv1alpha1.ClusterBuilder) (*arohcpv1alpha1.Cluster, error)
 
@@ -370,6 +373,20 @@ func (csc *clusterServiceClient) GetClusterHypershiftDetails(ctx context.Context
 		return nil, fmt.Errorf("empty response body")
 	}
 	return hypershiftConfig, nil
+}
+
+func (csc *clusterServiceClient) GetClusterResources(ctx context.Context,
+	internalID InternalID) (*arohcpv1alpha1.ClusterResources, error) {
+	client, ok := getAroHCPClusterClient(internalID, csc.conn)
+	if !ok {
+		return nil, fmt.Errorf("OCM path is not a cluster: %s", internalID)
+	}
+
+	resp, err := client.Resources().Get().SendContext(ctx)
+	if err != nil {
+		return nil, utils.TrackError(err)
+	}
+	return resp.Body(), nil
 }
 
 func (csc *clusterServiceClient) PostCluster(ctx context.Context, clusterBuilder *arohcpv1alpha1.ClusterBuilder) (*arohcpv1alpha1.Cluster, error) {

--- a/internal/ocm/mock_client.go
+++ b/internal/ocm/mock_client.go
@@ -427,6 +427,45 @@ func (c *MockClusterServiceClientSpecGetClusterProvisionShardCall) DoAndReturn(f
 	return c
 }
 
+// GetClusterResources mocks base method.
+func (m *MockClusterServiceClientSpec) GetClusterResources(ctx context.Context, internalID InternalID) (*v1alpha1.ClusterResources, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterResources", ctx, internalID)
+	ret0, _ := ret[0].(*v1alpha1.ClusterResources)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterResources indicates an expected call of GetClusterResources.
+func (mr *MockClusterServiceClientSpecMockRecorder) GetClusterResources(ctx, internalID any) *MockClusterServiceClientSpecGetClusterResourcesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterResources", reflect.TypeOf((*MockClusterServiceClientSpec)(nil).GetClusterResources), ctx, internalID)
+	return &MockClusterServiceClientSpecGetClusterResourcesCall{Call: call}
+}
+
+// MockClusterServiceClientSpecGetClusterResourcesCall wrap *gomock.Call
+type MockClusterServiceClientSpecGetClusterResourcesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockClusterServiceClientSpecGetClusterResourcesCall) Return(arg0 *v1alpha1.ClusterResources, arg1 error) *MockClusterServiceClientSpecGetClusterResourcesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockClusterServiceClientSpecGetClusterResourcesCall) Do(f func(context.Context, InternalID) (*v1alpha1.ClusterResources, error)) *MockClusterServiceClientSpecGetClusterResourcesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockClusterServiceClientSpecGetClusterResourcesCall) DoAndReturn(f func(context.Context, InternalID) (*v1alpha1.ClusterResources, error)) *MockClusterServiceClientSpecGetClusterResourcesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetClusterStatus mocks base method.
 func (m *MockClusterServiceClientSpec) GetClusterStatus(ctx context.Context, internalID InternalID) (*v1alpha1.ClusterStatus, error) {
 	m.ctrl.T.Helper()

--- a/internal/ocm/tracing.go
+++ b/internal/ocm/tracing.go
@@ -90,6 +90,19 @@ func (csc *clusterServiceClientWithTracing) GetClusterHypershiftDetails(ctx cont
 	return csc.csc.GetClusterHypershiftDetails(ctx, internalID)
 }
 
+func (csc *clusterServiceClientWithTracing) GetClusterResources(ctx context.Context,
+	internalID InternalID) (*arohcpv1alpha1.ClusterResources, error) {
+	ctx, span := csc.startChildSpan(ctx, "ClusterServiceClient.GetClusterResources")
+	defer span.End()
+
+	response, err := csc.csc.GetClusterResources(ctx, internalID)
+	if err != nil {
+		span.RecordError(err)
+	}
+
+	return response, err
+}
+
 func (csc *clusterServiceClientWithTracing) GetClusterProvisionShard(ctx context.Context, internalID InternalID) (*arohcpv1alpha1.ProvisionShard, error) {
 	ctx, span := csc.startChildSpan(ctx, "ClusterServiceClient.GetClusterProvisionShard")
 	defer span.End()

--- a/internal/restmapper/restmapper.go
+++ b/internal/restmapper/restmapper.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restmapper
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/openshift/library-go/pkg/client/openshiftrestmapper"
+)
+
+// additionalRESTMappings contains mappings for standard Kubernetes resources
+// not already covered by library-go's hardcoded OpenShift mapper.
+var additionalRESTMappings = []meta.RESTMapping{
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PersistentVolume"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumes"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Endpoints"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "endpoints"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ResourceQuota"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "resourcequotas"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "", Version: "v1", Kind: "LimitRange"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "", Version: "v1", Resource: "limitranges"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "policy", Version: "v1", Kind: "PodDisruptionBudget"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "cronjobs"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "autoscaling", Version: "v2", Resource: "horizontalpodautoscalers"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "hypershift.openshift.io", Version: "v1beta1", Kind: "HostedCluster"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "hypershift.openshift.io", Version: "v1beta1", Resource: "hostedclusters"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "hypershift.openshift.io", Version: "v1beta1", Kind: "NodePool"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "hypershift.openshift.io", Version: "v1beta1", Resource: "nodepools"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "multitenancy.acn.azure.com", Version: "v1alpha1", Kind: "PodNetwork"},
+		Scope:            meta.RESTScopeRoot,
+		Resource:         schema.GroupVersionResource{Group: "multitenancy.acn.azure.com", Version: "v1alpha1", Resource: "podnetworks"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "multitenancy.acn.azure.com", Version: "v1alpha1", Kind: "PodNetworkInstance"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "multitenancy.acn.azure.com", Version: "v1alpha1", Resource: "podnetworkinstances"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "secrets-store.csi.x-k8s.io", Version: "v1", Kind: "SecretProviderClass"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "secrets-store.csi.x-k8s.io", Version: "v1", Resource: "secretproviderclasses"},
+	},
+	{
+		GroupVersionKind: schema.GroupVersionKind{Group: "secret-sync.x-k8s.io", Version: "v1alpha1", Kind: "SecretSync"},
+		Scope:            meta.RESTScopeNamespace,
+		Resource:         schema.GroupVersionResource{Group: "secret-sync.x-k8s.io", Version: "v1alpha1", Resource: "secretsyncs"},
+	},
+}
+
+// Mapper is a package-level RESTMapper that resolves GVK→GVR without API
+// server discovery. It chains:
+//  1. Additional standard Kubernetes mappings not in library-go
+//  2. Library-go's hardcoded OpenShift/Kubernetes mappings
+//  3. An always-error fallback
+var Mapper meta.RESTMapper = newHardCodedRESTMapper()
+
+func newHardCodedRESTMapper() meta.RESTMapper {
+	libraryGoRESTMapping := openshiftrestmapper.NewOpenShiftHardcodedRESTMapper(alwaysErrorRESTMapper{})
+
+	ret := openshiftrestmapper.HardCodedFirstRESTMapper{
+		Mapping:    map[schema.GroupVersionKind]meta.RESTMapping{},
+		RESTMapper: libraryGoRESTMapping,
+	}
+	for i := range additionalRESTMappings {
+		curr := additionalRESTMappings[i]
+		ret.Mapping[curr.GroupVersionKind] = curr
+	}
+	return ret
+}
+
+// ResourceFor resolves a GVK to a GVR using the hardcoded mapper chain.
+func ResourceFor(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+	mapping, err := Mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	return mapping.Resource, nil
+}
+
+// alwaysErrorRESTMapper is a terminal delegate that rejects all lookups.
+type alwaysErrorRESTMapper struct{}
+
+var _ meta.RESTMapper = alwaysErrorRESTMapper{}
+
+func (alwaysErrorRESTMapper) KindFor(schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, &meta.NoResourceMatchError{}
+}
+
+func (alwaysErrorRESTMapper) KindsFor(schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, &meta.NoResourceMatchError{}
+}
+
+func (alwaysErrorRESTMapper) ResourceFor(schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{}, &meta.NoResourceMatchError{}
+}
+
+func (alwaysErrorRESTMapper) ResourcesFor(schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return nil, &meta.NoResourceMatchError{}
+}
+
+func (alwaysErrorRESTMapper) RESTMapping(gk schema.GroupKind, _ ...string) (*meta.RESTMapping, error) {
+	return nil, fmt.Errorf("no hardcoded REST mapping for %v", gk)
+}
+
+func (alwaysErrorRESTMapper) RESTMappings(gk schema.GroupKind, _ ...string) ([]*meta.RESTMapping, error) {
+	return nil, fmt.Errorf("no hardcoded REST mapping for %v", gk)
+}
+
+func (alwaysErrorRESTMapper) ResourceSingularizer(string) (string, error) {
+	return "", fmt.Errorf("no hardcoded singularizer")
+}

--- a/internal/restmapper/restmapper_test.go
+++ b/internal/restmapper/restmapper_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package restmapper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestResourceFor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		gvk     schema.GroupVersionKind
+		wantGVR schema.GroupVersionResource
+	}{
+		{
+			name:    "ConfigMap from library-go defaults",
+			gvk:     schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
+			wantGVR: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},
+		},
+		{
+			name:    "Secret from library-go defaults",
+			gvk:     schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"},
+			wantGVR: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"},
+		},
+		{
+			name:    "Deployment from library-go defaults",
+			gvk:     schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			wantGVR: schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+		},
+		{
+			name:    "Namespace from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"},
+			wantGVR: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"},
+		},
+		{
+			name:    "Ingress from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress"},
+			wantGVR: schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"},
+		},
+		{
+			name:    "NetworkPolicy from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"},
+			wantGVR: schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"},
+		},
+		{
+			name:    "Service from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"},
+			wantGVR: schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"},
+		},
+		{
+			name:    "HostedCluster from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "hypershift.openshift.io", Version: "v1beta1", Kind: "HostedCluster"},
+			wantGVR: schema.GroupVersionResource{Group: "hypershift.openshift.io", Version: "v1beta1", Resource: "hostedclusters"},
+		},
+		{
+			name:    "NodePool from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "hypershift.openshift.io", Version: "v1beta1", Kind: "NodePool"},
+			wantGVR: schema.GroupVersionResource{Group: "hypershift.openshift.io", Version: "v1beta1", Resource: "nodepools"},
+		},
+		{
+			name:    "PodNetwork from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "multitenancy.acn.azure.com", Version: "v1alpha1", Kind: "PodNetwork"},
+			wantGVR: schema.GroupVersionResource{Group: "multitenancy.acn.azure.com", Version: "v1alpha1", Resource: "podnetworks"},
+		},
+		{
+			name:    "PodNetworkInstance from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "multitenancy.acn.azure.com", Version: "v1alpha1", Kind: "PodNetworkInstance"},
+			wantGVR: schema.GroupVersionResource{Group: "multitenancy.acn.azure.com", Version: "v1alpha1", Resource: "podnetworkinstances"},
+		},
+		{
+			name:    "SecretProviderClass from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "secrets-store.csi.x-k8s.io", Version: "v1", Kind: "SecretProviderClass"},
+			wantGVR: schema.GroupVersionResource{Group: "secrets-store.csi.x-k8s.io", Version: "v1", Resource: "secretproviderclasses"},
+		},
+		{
+			name:    "SecretSync from additional mappings",
+			gvk:     schema.GroupVersionKind{Group: "secret-sync.x-k8s.io", Version: "v1alpha1", Kind: "SecretSync"},
+			wantGVR: schema.GroupVersionResource{Group: "secret-sync.x-k8s.io", Version: "v1alpha1", Resource: "secretsyncs"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gvr, err := ResourceFor(tt.gvk)
+			require.NoError(t, err, "ResourceFor should succeed for known type")
+			assert.Equal(t, tt.wantGVR, gvr)
+		})
+	}
+}
+
+func TestResourceForUnknownType(t *testing.T) {
+	t.Parallel()
+	_, err := ResourceFor(schema.GroupVersionKind{Group: "fake.example.com", Version: "v1", Kind: "Unknown"})
+	assert.Error(t, err, "ResourceFor should error for unknown type")
+}

--- a/test-integration/backend/launch/metrics_test.go
+++ b/test-integration/backend/launch/metrics_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,6 +76,7 @@ func TestBackendExposesMetrics(t *testing.T) {
 			metadataapi.Must(arohcpv1alpha1.NewCluster().ID("test-cluster").HREF(internalClusterID.String()).Build()),
 		}
 		clusterServiceMock.MockClusterServiceClient.EXPECT().ListProvisionShards().Return(ocm.NewSimpleProvisionShardListIterator(nil, nil)).AnyTimes()
+		clusterServiceMock.MockClusterServiceClient.EXPECT().GetClusterResources(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 		cleanupCtx := utils.ContextWithLogger(context.Background(), integrationutils.DefaultLogger(t))
 		defer storageIntegrationTestInfo.Cleanup(cleanupCtx)
 		defer clusterServiceMock.Cleanup(cleanupCtx)

--- a/test-integration/go.mod
+++ b/test-integration/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/openshift/api v0.0.0-20260429122012-1180c0f5c3e9 // indirect
 	github.com/openshift/cluster-version-operator v1.0.1-0.20260202115537-557510ea0603 // indirect
 	github.com/openshift/hypershift/api v0.0.0-20260708113917-8b5103a5875b // indirect
+	github.com/openshift/library-go v0.0.0-20260504190829-2dd4388d7b89 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
@@ -137,6 +138,7 @@ require (
 	k8s.io/component-base v0.35.3 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
+	open-cluster-management.io/api v1.3.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect

--- a/test-integration/go.sum
+++ b/test-integration/go.sum
@@ -220,6 +220,7 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.28.3 h1:4JvMdwtFU0imd8fHx25OJXoDMRexnf8v5NHKYSTTji4=
 github.com/onsi/ginkgo/v2 v2.28.3/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
 github.com/onsi/gomega v1.40.0 h1:Vtol0e1MghCD2ZVIilPDIg44XSL9l2QAn8ZNaljWcJc=
@@ -469,6 +470,8 @@ k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a h1:xCeOEAOoGYl2jnJoHkC3hk
 k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a/go.mod h1:uGBT7iTA6c6MvqUvSXIaYZo9ukscABYi2btjhvgKGZ0=
 k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 h1:kBawHLSnx/mYHmRnNUf9d4CpjREbeZuxoSGOX/J+aYM=
 k8s.io/utils v0.0.0-20260319190234-28399d86e0b5/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
+open-cluster-management.io/api v1.3.0 h1:Q3miH38BE3N5+PesHQ0kcFi5nhX5350m7OJWapZcVqY=
+open-cluster-management.io/api v1.3.0/go.mod h1:t0DsBv4gjIo9ojd7GYfA2tcEMpNf0h5Ix68pFDXwNSk=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0 h1:qPrZsv1cwQiFeieFlRqT627fVZ+tyfou/+S5S0H5ua0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4iqwZ80=

--- a/test/e2e/nodepool_delete.go
+++ b/test/e2e/nodepool_delete.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+
+	"github.com/Azure/ARO-HCP/test/util/framework"
+	"github.com/Azure/ARO-HCP/test/util/labels"
+	"github.com/Azure/ARO-HCP/test/util/verifiers"
+)
+
+var _ = Describe("Customer", func() {
+	It("should be able to delete a nodepool",
+		labels.RequireNothing,
+		labels.High,
+		labels.Positive,
+		labels.AroRpApiCompatible,
+		labels.MIContainers(1),
+		func(ctx context.Context) {
+			const (
+				customerClusterName   = "np-delete-hcp-cluster"
+				customerNodePoolName  = "np-delete-main"
+				deletableNodePoolName = "np-deletable"
+			)
+
+			tc := framework.NewTestContext()
+
+			if tc.UsePooledIdentities() {
+				err := tc.AssignIdentityContainers(ctx, 1, framework.IdentityContainerAssignmentRetryInterval)
+				Expect(err).NotTo(HaveOccurred(), "failed to assign pooled identity containers")
+			}
+
+			By("creating a resource group")
+			resourceGroup, err := tc.NewResourceGroup(ctx, "nodepool-delete", tc.Location())
+			Expect(err).NotTo(HaveOccurred(), "failed to create resource group nodepool-delete")
+
+			By("creating cluster parameters")
+			clusterParams := framework.NewDefaultClusterParams20260901()
+			clusterParams.ClusterName = customerClusterName
+			clusterParams.ManagedResourceGroupName = framework.SuffixName(*resourceGroup.Name, "-managed", 64)
+
+			By("creating customer resources")
+			clusterParams, err = tc.CreateClusterCustomerResources20260901(ctx,
+				resourceGroup,
+				clusterParams,
+				map[string]interface{}{},
+				TestArtifactsFS,
+				framework.RBACScopeResourceGroup,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create cluster customer resources")
+
+			By("creating the HCP cluster")
+			err = tc.CreateHCPClusterFromParam20260901(ctx,
+				GinkgoLogr,
+				*resourceGroup.Name,
+				clusterParams,
+				nil,
+				framework.ClusterCreationTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to create HCP cluster %s", customerClusterName)
+
+			By("getting admin credentials for the cluster")
+			adminRESTConfig, err := tc.GetAdminRESTConfigForHCPCluster20260901(
+				ctx,
+				tc.Get20260901ClientFactoryOrDie(ctx).NewHcpOpenShiftClustersClient(),
+				*resourceGroup.Name,
+				customerClusterName,
+				framework.GetAdminRESTConfigTimeout,
+			)
+			Expect(err).NotTo(HaveOccurred(), "failed to get admin REST config for cluster %s", customerClusterName)
+
+			// This test needs to create two node pools and delete one because
+			// a cluster can't be left without a node pool i.e you can't delete the last nodepool.
+			// Once https://redhat.atlassian.net/browse/ARO-26333 is implemented,
+			// the test should be able to just create a single node pool and delete it.
+			By("creating two node pools in parallel")
+			mainNodeCount := 2
+			deletableNodeCount := 2
+
+			mainNodePoolParams := framework.NewDefaultNodePoolParams20260901()
+			mainNodePoolParams.NodePoolName = customerNodePoolName
+			mainNodePoolParams.Replicas = int32(mainNodeCount)
+
+			deletableNodePoolParams := framework.NewDefaultNodePoolParams20260901()
+			deletableNodePoolParams.NodePoolName = deletableNodePoolName
+			deletableNodePoolParams.Replicas = int32(deletableNodeCount)
+
+			errCh := make(chan error, 2)
+			group, groupCtx := errgroup.WithContext(ctx)
+			for _, nodePoolParams := range []framework.NodePoolParams20260901{mainNodePoolParams, deletableNodePoolParams} {
+				group.Go(func() error {
+					createErr := tc.CreateNodePoolFromParam20260901(
+						groupCtx,
+						GinkgoLogr,
+						*resourceGroup.Name,
+						clusterParams.ManagedResourceGroupName,
+						customerClusterName,
+						nodePoolParams,
+						framework.NodePoolCreationTimeout,
+					)
+					if createErr != nil {
+						errCh <- createErr
+					}
+					return createErr
+				})
+			}
+			Expect(group.Wait()).To(Succeed(), "failed to create node pools")
+			close(errCh)
+			var creationErrors []error
+			for createErr := range errCh {
+				creationErrors = append(creationErrors, createErr)
+			}
+			Expect(creationErrors).To(BeEmpty(), "nodepool creation errors: %v", creationErrors)
+
+			By("verifying initial nodes count and ready status")
+			totalNodeCount := mainNodeCount + deletableNodeCount
+			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify initial node count of %d", totalNodeCount)
+			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify all nodes are ready after initial creation")
+
+			nodePoolsClient := tc.Get20260901ClientFactoryOrDie(ctx).NewNodePoolsClient()
+
+			By("deleting the deletable nodepool via ARM")
+			poller, err := nodePoolsClient.BeginDelete(ctx, *resourceGroup.Name, customerClusterName, deletableNodePoolName, nil)
+			Expect(err).NotTo(HaveOccurred(), "failed to start deletion of node pool %s", deletableNodePoolName)
+
+			_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{
+				Frequency: framework.StandardPollInterval,
+			})
+			Expect(err).NotTo(HaveOccurred(), "failed to complete deletion of node pool %s", deletableNodePoolName)
+
+			By("verifying nodes count and ready status after nodepool deletion")
+			totalNodeCount = mainNodeCount
+			Expect(verifiers.VerifyNodeCount(customerClusterName, totalNodeCount).Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify node count of %d after deleting nodepool", totalNodeCount)
+			Expect(verifiers.VerifyNodesReady().Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify all nodes are ready after nodepool deletion")
+
+			By("verifying all remaining nodes belong to the main nodepool")
+			Expect(verifiers.VerifyAllNodesFromNodePool(customerNodePoolName).Verify(ctx, adminRESTConfig)).To(Succeed(), "failed to verify all nodes belong to nodepool %s", customerNodePoolName)
+
+			By("verifying the deleted nodepool no longer exists")
+			_, err = nodePoolsClient.Get(ctx, *resourceGroup.Name, customerClusterName, deletableNodePoolName, nil)
+			Expect(err).To(HaveOccurred(), "expected error when getting deleted nodepool %s", deletableNodePoolName)
+		})
+})

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_dev_cd_check_paralleldev_cd_check_parallel.txt
@@ -83,6 +83,7 @@ Customer should be able to create an HCP cluster with Image Registry not present
 Customer should be able to rotate KMS key for a cluster with version >= 4.22
 Engineering should be able to retrieve kusto logs for a cluster and services
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
+Customer should be able to delete a nodepool
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
 Customer should be able to update nodepool replicas and autoscaling

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_integration_parallelintegration_parallel.txt
@@ -79,6 +79,7 @@ Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
 Customer should respect cluster-wide node limits with nodepool autoscaling
+Customer should be able to delete a nodepool
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_prod_parallelprod_parallel.txt
@@ -79,6 +79,7 @@ Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
 Customer should respect cluster-wide node limits with nodepool autoscaling
+Customer should be able to delete a nodepool
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallel_01rp_api_compat_all_parallel_development.txt
@@ -88,6 +88,7 @@ Customer should be able to rotate KMS key for a cluster with version >= 4.22
 Engineering should be able to retrieve kusto logs for a cluster and services
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
 Customer should respect cluster-wide node limits with nodepool autoscaling
+Customer should be able to delete a nodepool
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
 Customer should be able to update nodepool replicas and autoscaling

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_rp_api_compat_all_parallelrp_api_compat_all_parallel.txt
@@ -76,6 +76,7 @@ Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
 Customer should respect cluster-wide node limits with nodepool autoscaling
+Customer should be able to delete a nodepool
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest

--- a/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
+++ b/test/testdata/zz_fixture_TestMainListSuitesForEachSuite_stage_parallelstage_parallel.txt
@@ -79,6 +79,7 @@ Customer should be able to create an HCP cluster and manage ImageDigestMirrors
 Customer should be able to create an HCP cluster with Image Registry not present
 Customer should be able to create a cluster with default autoscaling and a nodepool with autoscaling enabled up to replica limits
 Customer should respect cluster-wide node limits with nodepool autoscaling
+Customer should be able to delete a nodepool
 Nodepool Ephemeral OS Disk should create a nodepool with ephemeral OS disk when autoRepair is enabled
 Customer should be able to update node pool labels and taints
 Customer should upgrade and update a nodepool from 4.20.z to 4.21.zLatest

--- a/test/util/verifiers/nodes.go
+++ b/test/util/verifiers/nodes.go
@@ -113,6 +113,58 @@ func VerifyNodeCount(clusterName string, expected int) HostedClusterVerifier {
 	}
 }
 
+type verifyAllNodesFromNodePool struct {
+	nodePoolName string
+}
+
+func (v verifyAllNodesFromNodePool) Name() string {
+	return fmt.Sprintf("VerifyAllNodesFromNodePool(nodePool=%s)", v.nodePoolName)
+}
+
+func (v verifyAllNodesFromNodePool) Verify(ctx context.Context, adminRESTConfig *rest.Config) error {
+	kubeClient, err := kubernetes.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	nodes, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("can't list nodes in the cluster: %w", err)
+	}
+
+	if len(nodes.Items) == 0 {
+		return fmt.Errorf("no nodes found in the cluster")
+	}
+
+	var nodesFromOtherPools []string
+	for i := range nodes.Items {
+		nodePoolLabel, ok := nodes.Items[i].Labels[hypershiftv1beta1.NodePoolLabel]
+		if !ok {
+			nodesFromOtherPools = append(nodesFromOtherPools, fmt.Sprintf("%s (no nodepool label)", nodes.Items[i].Name))
+			continue
+		}
+		nodePoolName := extractNodePoolName(nodePoolLabel)
+		if nodePoolName != v.nodePoolName {
+			nodesFromOtherPools = append(nodesFromOtherPools, fmt.Sprintf("%s (from nodepool %q)", nodes.Items[i].Name, nodePoolName))
+		}
+	}
+
+	if len(nodesFromOtherPools) > 0 {
+		return fmt.Errorf("expected all nodes to be from nodepool %q, but found nodes from other pools: %s; all nodes by pool: %s",
+			v.nodePoolName, strings.Join(nodesFromOtherPools, ", "), formatNodesByPool(nodes.Items))
+	}
+
+	return nil
+}
+
+// VerifyAllNodesFromNodePool verifies that all nodes in the cluster belong to the specified node pool.
+// This is useful after deleting a nodepool to ensure only nodes from the expected nodepool remain.
+func VerifyAllNodesFromNodePool(nodePoolName string) HostedClusterVerifier {
+	return verifyAllNodesFromNodePool{
+		nodePoolName: nodePoolName,
+	}
+}
+
 // nodePoolNameRegex matches valid ARO-HCP node pool resource names
 // Same pattern as internal/validation/validators.go nodePoolResourceName, which is unexported.
 var nodePoolNameRegex = regexp.MustCompile(`^[a-zA-Z][-a-zA-Z0-9]{1,13}[a-zA-Z0-9]$`)

--- a/test/util/verifiers/nodes_test.go
+++ b/test/util/verifiers/nodes_test.go
@@ -256,3 +256,41 @@ func TestNodeReleaseImagesUpdated(t *testing.T) {
 		t.Errorf("expected the failure message to report the elided count, got: %s", got)
 	}
 }
+
+func TestExtractNodePoolName(t *testing.T) {
+	tests := []struct {
+		name          string
+		nodePoolLabel string
+		want          string
+	}{
+		{
+			name:          "standard format with cluster prefix",
+			nodePoolLabel: "np-delete-hcp-cluster-np-delete-main",
+			want:          "np-delete-main",
+		},
+		{
+			name:          "simple nodepool name",
+			nodePoolLabel: "cluster-workers",
+			want:          "workers",
+		},
+		{
+			name:          "single component fallback",
+			nodePoolLabel: "workers",
+			want:          "workers",
+		},
+		{
+			name:          "multiple dashes in cluster name",
+			nodePoolLabel: "my-long-cluster-name-np-1",
+			want:          "name-np-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractNodePoolName(tt.nodePoolLabel)
+			if got != tt.want {
+				t.Errorf("extractNodePoolName(%q) = %q, want %q", tt.nodePoolLabel, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-28373

### What

Reintroduces the reverted #6070 with the addition of #6848 on top.

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
