### PR TITLE
refactor(fleet): add Controller interface, WriteController

### DIFF
--- a/fleet/pkg/controllers/base/controller.go
+++ b/fleet/pkg/controllers/base/controller.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package base
+
+import (
+	"context"
+	"time"
+
+	"github.com/Azure/ARO-HCP/internal/controllerutils"
+)
+
+// Controller is the common interface for all fleet controllers.
+type Controller interface {
+	QueueForInformers(resyncDuration time.Duration, notifiers ...controllerutils.Notifier) error
+	Run(ctx context.Context, threadiness int)
+	EnqueueAfter(keyObj any, duration time.Duration)
+}

--- a/fleet/pkg/controllers/base/management_cluster_watching_controller.go
+++ b/fleet/pkg/controllers/base/management_cluster_watching_controller.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package base
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/fleetapi"
+	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
+	"github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/fleetcosmosstorage"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// ManagementClusterKey identifies a management cluster in the workqueue.
+type ManagementClusterKey struct {
+	StampIdentifier string
+}
+
+func (k ManagementClusterKey) GetResourceID() *azcorearm.ResourceID {
+	return metadataapi.Must(fleetapi.ToManagementClusterResourceID(k.StampIdentifier))
+}
+
+func (k ManagementClusterKey) AddLoggerValues(logger logr.Logger) logr.Logger {
+	return logger.WithValues(
+		utils.LogValues{}.
+			AddLogValuesForResourceID(k.GetResourceID())...)
+}
+
+func (k ManagementClusterKey) InitialController(controllerName string) *coreapi.Controller {
+	resourceID := metadataapi.Must(azcorearm.ParseResourceID(
+		k.GetResourceID().String() + "/" + fleetapi.ControllerResourceTypeName + "/" + controllerName,
+	))
+	return &coreapi.Controller{
+		CosmosMetadata: coreapi.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(k.StampIdentifier),
+		},
+		ExternalID: k.GetResourceID(),
+		Status: coreapi.ControllerStatus{
+			Conditions: []metav1.Condition{},
+		},
+	}
+}
+
+// ManagementClusterSyncer is the interface that concrete management cluster
+// controllers implement.
+type ManagementClusterSyncer interface {
+	SyncOnce(ctx context.Context, key ManagementClusterKey) error
+	CooldownChecker() controllerutils.CooldownChecker
+}
+
+type managementClusterWatchingController struct {
+	name          string
+	syncer        ManagementClusterSyncer
+	fleetDBClient fleetcosmosstorage.FleetDBClient
+}
+
+// NewManagementClusterWatchingController creates a controller that watches
+// management cluster informers and automatically writes a controller document
+// under the management cluster after each sync.
+func NewManagementClusterWatchingController(
+	name string,
+	fleetDBClient fleetcosmosstorage.FleetDBClient,
+	managementClusterInformer cache.SharedIndexInformer,
+	resyncDuration time.Duration,
+	syncer ManagementClusterSyncer,
+) Controller {
+	mcSyncer := &managementClusterWatchingController{
+		name:          name,
+		syncer:        syncer,
+		fleetDBClient: fleetDBClient,
+	}
+	mcController := controllerutils.NewGenericWatchingController(
+		name, fleetapi.ManagementClusterResourceType, mcSyncer, ReconcileTotal,
+	)
+
+	if err := mcController.QueueForInformers(resyncDuration, managementClusterInformer); err != nil {
+		panic(err) // coding error
+	}
+
+	return mcController
+}
+
+func (c *managementClusterWatchingController) SyncOnce(ctx context.Context, key ManagementClusterKey) error {
+	controllerCRUD := c.fleetDBClient.Stamps().ManagementClusters(key.StampIdentifier).Controllers()
+
+	defer utilruntime.HandleCrash(DegradedControllerPanicHandler(
+		ctx,
+		controllerCRUD,
+		c.name,
+		key.InitialController))
+
+	syncErr := c.syncer.SyncOnce(ctx, key)
+
+	controllerWriteErr := WriteController(
+		ctx,
+		controllerCRUD,
+		c.name,
+		key.InitialController,
+		ReportSyncError(syncErr),
+	)
+
+	return errors.Join(syncErr, controllerWriteErr)
+}
+
+func (c *managementClusterWatchingController) CooldownChecker() controllerutils.CooldownChecker {
+	return c.syncer.CooldownChecker()
+}
+
+func (c *managementClusterWatchingController) MakeKey(resourceID *azcorearm.ResourceID) ManagementClusterKey {
+	if resourceID.Parent == nil {
+		panic(fmt.Sprintf("management cluster resource ID %q has no parent", resourceID.String()))
+	}
+	return ManagementClusterKey{
+		StampIdentifier: resourceID.Parent.Name,
+	}
+}

--- a/fleet/pkg/controllers/base/management_cluster_watching_controller_test.go
+++ b/fleet/pkg/controllers/base/management_cluster_watching_controller_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package base
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/internal/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/fleetcosmosstoragetesting"
+)
+
+// fakeManagementClusterSyncer is a ManagementClusterSyncer whose SyncOnce
+// returns a configured error.
+type fakeManagementClusterSyncer struct {
+	err error
+}
+
+func (f *fakeManagementClusterSyncer) SyncOnce(_ context.Context, _ ManagementClusterKey) error {
+	return f.err
+}
+
+func (f *fakeManagementClusterSyncer) CooldownChecker() controllerutils.CooldownChecker {
+	return nil
+}
+
+func TestManagementClusterKeyGetResourceID(t *testing.T) {
+	key := ManagementClusterKey{StampIdentifier: "s1"}
+	rid := key.GetResourceID()
+	require.NotNil(t, rid, "expected non-nil resource ID")
+	assert.Equal(t, "/providers/microsoft.redhatopenshift/stamps/s1/managementclusters/default", rid.String())
+}
+
+func TestManagementClusterKeyInitialController(t *testing.T) {
+	key := ManagementClusterKey{StampIdentifier: "S1"}
+
+	controller := key.InitialController("NodePoolController")
+
+	require.NotNil(t, controller)
+	assert.Equal(t, "s1", controller.PartitionKey, "partition key must be lowercased")
+	assert.Equal(t, key.GetResourceID(), controller.ExternalID)
+	assert.Equal(t,
+		"/providers/microsoft.redhatopenshift/stamps/s1/managementclusters/default/controllers/NodePoolController",
+		controller.ResourceID.String())
+	assert.Empty(t, controller.Status.Conditions)
+}
+
+func TestManagementClusterWatchingControllerMakeKey(t *testing.T) {
+	adapter := &managementClusterWatchingController{}
+
+	t.Run("management cluster resource ID", func(t *testing.T) {
+		rid, err := azcorearm.ParseResourceID("/providers/microsoft.redhatopenshift/stamps/s1/managementclusters/default")
+		require.NoError(t, err)
+
+		key := adapter.MakeKey(rid)
+		assert.Equal(t, "s1", key.StampIdentifier)
+	})
+
+	t.Run("resource ID with no parent panics", func(t *testing.T) {
+		assert.Panics(t, func() { adapter.MakeKey(azcorearm.RootResourceID) })
+	})
+}
+
+func TestManagementClusterWatchingControllerSyncOnce(t *testing.T) {
+	const stampID = "s1"
+	const controllerName = "NodePoolController"
+	key := ManagementClusterKey{StampIdentifier: stampID}
+
+	t.Run("successful sync writes Degraded=False and returns nil", func(t *testing.T) {
+		mockDB := fleetcosmosstoragetesting.NewMockFleetDBClient()
+		c := &managementClusterWatchingController{
+			name:          controllerName,
+			fleetDBClient: mockDB,
+			syncer:        &fakeManagementClusterSyncer{},
+		}
+
+		err := c.SyncOnce(testContext(), key)
+		require.NoError(t, err, "SyncOnce")
+
+		stored, err := mockDB.Stamps().ManagementClusters(stampID).Controllers().Get(testContext(), controllerName)
+		require.NoError(t, err, "Get controller document")
+		cond := apimeta.FindStatusCondition(stored.Status.Conditions, "Degraded")
+		require.NotNil(t, cond, "expected Degraded condition")
+		assert.Equal(t, metav1.ConditionFalse, cond.Status, "Degraded status")
+	})
+
+	t.Run("sync error is returned and written as Degraded=True", func(t *testing.T) {
+		mockDB := fleetcosmosstoragetesting.NewMockFleetDBClient()
+		syncErr := errors.New("sync boom")
+		c := &managementClusterWatchingController{
+			name:          controllerName,
+			fleetDBClient: mockDB,
+			syncer:        &fakeManagementClusterSyncer{err: syncErr},
+		}
+
+		err := c.SyncOnce(testContext(), key)
+		assert.ErrorIs(t, err, syncErr, "SyncOnce must return the syncer error")
+
+		stored, err := mockDB.Stamps().ManagementClusters(stampID).Controllers().Get(testContext(), controllerName)
+		require.NoError(t, err, "Get controller document")
+		cond := apimeta.FindStatusCondition(stored.Status.Conditions, "Degraded")
+		require.NotNil(t, cond, "expected Degraded condition")
+		assert.Equal(t, metav1.ConditionTrue, cond.Status, "Degraded status")
+		assert.Contains(t, cond.Message, "sync boom", "Degraded message carries the sync error")
+	})
+}

--- a/fleet/pkg/controllers/base/stamp_watching_controller.go
+++ b/fleet/pkg/controllers/base/stamp_watching_controller.go
@@ -81,18 +81,13 @@ func (c StampWatchingControllerConfig) withDefaults() StampWatchingControllerCon
 	return c
 }
 
-// StampWatchingController is a controller base that watches
-// fleet informers, handles etag-based change detection with cooldown gating,
-// and delegates reconciliation to a StampSyncer.
-type StampWatchingController = controllerutils.GenericWatchingController[StampKey]
-
 // NewStampWatchingController creates a controller and delegates
 // reconciliation to the syncer. Call QueueForInformers to register informers.
 func NewStampWatchingController(
 	name string,
 	syncer StampSyncer,
 	cfg StampWatchingControllerConfig,
-) *StampWatchingController {
+) Controller {
 	cfg = cfg.withDefaults()
 
 	var cooldown controllerutils.CooldownChecker

--- a/fleet/pkg/controllers/base/utils.go
+++ b/fleet/pkg/controllers/base/utils.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package base
+
+import (
+	"context"
+	"fmt"
+	"runtime/debug"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// ControllerMutationFunc mutates a controller document in place. It should only
+// perform short calls, not long lookups. It must not fail.
+type ControllerMutationFunc func(controller *coreapi.Controller)
+
+// ReportSyncError returns a mutation that sets the Degraded condition based on
+// whether a sync error occurred.
+func ReportSyncError(syncErr error) ControllerMutationFunc {
+	return func(controller *coreapi.Controller) {
+		if syncErr == nil {
+			apimeta.SetStatusCondition(&controller.Status.Conditions, metav1.Condition{
+				Type:    "Degraded",
+				Status:  metav1.ConditionFalse,
+				Reason:  "NoErrors",
+				Message: "As expected.",
+			})
+			return
+		}
+
+		apimeta.SetStatusCondition(&controller.Status.Conditions, metav1.Condition{
+			Type:    "Degraded",
+			Status:  metav1.ConditionTrue,
+			Reason:  "Failed",
+			Message: fmt.Sprintf("Had an error while syncing: %s", syncErr.Error()),
+		})
+	}
+}
+
+// InitialControllerFunc builds a new coreapi.Controller for the given logical
+// controller name.
+type InitialControllerFunc func(controllerName string) *coreapi.Controller
+
+// DegradedControllerPanicHandler returns a panic handler that writes a
+// Degraded condition to the controller document with the panic stack trace.
+func DegradedControllerPanicHandler(ctx context.Context, controllerCRUD cosmosstorageutils.ResourceCRUD[coreapi.Controller, *coreapi.Controller], controllerName string, initialControllerFn InitialControllerFunc) func(any) {
+	return func(panicVal any) {
+		stack := debug.Stack()
+		err := WriteController(ctx, controllerCRUD, controllerName, initialControllerFn, ReportSyncError(fmt.Errorf("panic caught:\n%v\n\n%s", panicVal, stack)))
+		if err != nil {
+			logger := utils.LoggerFromContext(ctx)
+			logger.Error(err, "failed to write controller after panic")
+		}
+	}
+}
+
+// WriteController reads the existing controller document (creating it if
+// missing), applies mutations in order, and writes back the result. It only
+// tries once — on conflict the control loop will re-run.
+func WriteController(ctx context.Context, controllerCRUD cosmosstorageutils.ResourceCRUD[coreapi.Controller, *coreapi.Controller], controllerName string, initialControllerFn InitialControllerFunc, mutationFns ...ControllerMutationFunc) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	existingController, err := getOrCreateControllerDocument(ctx, controllerCRUD, controllerName, initialControllerFn)
+	if err != nil {
+		return err
+	}
+
+	desiredController := existingController.DeepCopy()
+	for _, mutationFn := range mutationFns {
+		mutationFn(desiredController)
+	}
+
+	if equality.Semantic.DeepEqual(existingController, desiredController) {
+		return nil
+	}
+
+	_, replaceErr := controllerCRUD.Replace(ctx, desiredController, nil)
+	if replaceErr != nil {
+		logger.Error(replaceErr, "failed to replace")
+		return fmt.Errorf("failed to replace existing controller state: %w", replaceErr)
+	}
+	return nil
+}
+
+func getOrCreateControllerDocument(
+	ctx context.Context,
+	controllerCRUD cosmosstorageutils.ResourceCRUD[coreapi.Controller, *coreapi.Controller],
+	controllerName string,
+	initialControllerFn InitialControllerFunc,
+) (*coreapi.Controller, error) {
+	return getOrCreateControllerDocumentAttempt(ctx, controllerCRUD, controllerName, initialControllerFn, false)
+}
+
+func getOrCreateControllerDocumentAttempt(
+	ctx context.Context,
+	controllerCRUD cosmosstorageutils.ResourceCRUD[coreapi.Controller, *coreapi.Controller],
+	controllerName string,
+	initialControllerFn InitialControllerFunc,
+	secondAttempt bool,
+) (*coreapi.Controller, error) {
+	if initialControllerFn == nil {
+		return nil, fmt.Errorf("initialControllerFn is required")
+	}
+
+	existingController, err := controllerCRUD.Get(ctx, controllerName)
+	switch {
+	case err == nil:
+		return existingController, nil
+	case cosmosstorageutils.IsNotFoundError(err):
+		// fall through
+	default:
+		return nil, utils.TrackError(err)
+	}
+
+	existingController, err = controllerCRUD.Create(ctx, initialControllerFn(controllerName), nil)
+	switch {
+	case err == nil:
+		return existingController, nil
+	case cosmosstorageutils.IsConflictError(err):
+		// fall through
+	default:
+		return nil, utils.TrackError(err)
+	}
+
+	existingController, err = controllerCRUD.Get(ctx, controllerName)
+	switch {
+	case err == nil:
+		return existingController, nil
+	case cosmosstorageutils.IsNotFoundError(err):
+		if secondAttempt {
+			return nil, utils.TrackError(fmt.Errorf("second NotFound, Conflict, NotFound error: %w", err))
+		}
+		timer := time.NewTimer((cosmosstorageutils.SoftDeleteTTLSeconds + 1) * time.Second)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return nil, utils.TrackError(ctx.Err())
+		case <-timer.C:
+			return getOrCreateControllerDocumentAttempt(ctx, controllerCRUD, controllerName, initialControllerFn, true)
+		}
+	default:
+		return nil, utils.TrackError(err)
+	}
+}

--- a/fleet/pkg/controllers/base/utils_test.go
+++ b/fleet/pkg/controllers/base/utils_test.go
@@ -1,0 +1,244 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package base
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/fleetcosmosstoragetesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+// scriptedControllerCRUD is a ResourceCRUD whose Get and Create return
+// pre-scripted results in order, so getOrCreateControllerDocument's
+// conflict/NotFound branches can be exercised deterministically. All other
+// methods are unused by that code path and panic if called.
+type scriptedControllerCRUD struct {
+	cosmosstorageutils.ResourceCRUD[coreapi.Controller, *coreapi.Controller]
+	getResults    []scriptedResult
+	createResults []scriptedResult
+	getCalls      int
+	createCalls   int
+}
+
+type scriptedResult struct {
+	obj *coreapi.Controller
+	err error
+}
+
+func (f *scriptedControllerCRUD) Get(_ context.Context, _ string) (*coreapi.Controller, error) {
+	r := f.getResults[f.getCalls]
+	f.getCalls++
+	return r.obj, r.err
+}
+
+func (f *scriptedControllerCRUD) Create(_ context.Context, _ *coreapi.Controller, _ *azcosmos.ItemOptions) (*coreapi.Controller, error) {
+	r := f.createResults[f.createCalls]
+	f.createCalls++
+	return r.obj, r.err
+}
+
+func notFoundErr() error { return &azcore.ResponseError{StatusCode: http.StatusNotFound} }
+func conflictErr() error { return &azcore.ResponseError{StatusCode: http.StatusConflict} }
+
+func TestGetOrCreateControllerDocument(t *testing.T) {
+	const controllerName = "TestController"
+	initialFn := func(name string) *coreapi.Controller { return &coreapi.Controller{} }
+
+	t.Run("returns the existing document when Get succeeds", func(t *testing.T) {
+		want := &coreapi.Controller{}
+		crud := &scriptedControllerCRUD{getResults: []scriptedResult{{obj: want}}}
+
+		got, err := getOrCreateControllerDocument(testContext(), crud, controllerName, initialFn)
+		require.NoError(t, err, "getOrCreateControllerDocument")
+		assert.Same(t, want, got, "expected the document returned by Get")
+	})
+
+	t.Run("propagates a non-NotFound Get error", func(t *testing.T) {
+		crud := &scriptedControllerCRUD{getResults: []scriptedResult{{err: errors.New("boom")}}}
+
+		_, err := getOrCreateControllerDocument(testContext(), crud, controllerName, initialFn)
+		assert.Error(t, err, "expected the Get error to propagate")
+	})
+
+	t.Run("creates the document when Get returns NotFound", func(t *testing.T) {
+		want := &coreapi.Controller{}
+		crud := &scriptedControllerCRUD{
+			getResults:    []scriptedResult{{err: notFoundErr()}},
+			createResults: []scriptedResult{{obj: want}},
+		}
+
+		got, err := getOrCreateControllerDocument(testContext(), crud, controllerName, initialFn)
+		require.NoError(t, err, "getOrCreateControllerDocument")
+		assert.Same(t, want, got, "expected the created document")
+	})
+
+	t.Run("re-reads after a Create conflict (lost creation race)", func(t *testing.T) {
+		want := &coreapi.Controller{}
+		crud := &scriptedControllerCRUD{
+			getResults:    []scriptedResult{{err: notFoundErr()}, {obj: want}},
+			createResults: []scriptedResult{{err: conflictErr()}},
+		}
+
+		got, err := getOrCreateControllerDocument(testContext(), crud, controllerName, initialFn)
+		require.NoError(t, err, "getOrCreateControllerDocument")
+		assert.Same(t, want, got, "expected the document read after the create conflict")
+	})
+
+	t.Run("propagates a non-Conflict Create error", func(t *testing.T) {
+		crud := &scriptedControllerCRUD{
+			getResults:    []scriptedResult{{err: notFoundErr()}},
+			createResults: []scriptedResult{{err: errors.New("boom")}},
+		}
+
+		_, err := getOrCreateControllerDocument(testContext(), crud, controllerName, initialFn)
+		assert.Error(t, err, "expected the Create error to propagate")
+	})
+
+	t.Run("returns ctx error when cancelled during the soft-delete TTL wait", func(t *testing.T) {
+		crud := &scriptedControllerCRUD{
+			getResults:    []scriptedResult{{err: notFoundErr()}, {err: notFoundErr()}},
+			createResults: []scriptedResult{{err: conflictErr()}},
+		}
+		ctx, cancel := context.WithCancel(testContext())
+		cancel() // TTL-wait select must observe the cancelled context immediately
+
+		_, err := getOrCreateControllerDocument(ctx, crud, controllerName, initialFn)
+		assert.ErrorIs(t, err, context.Canceled, "expected the cancelled context error during the TTL wait")
+	})
+
+	t.Run("errors when initialControllerFn is nil", func(t *testing.T) {
+		crud := &scriptedControllerCRUD{}
+		_, err := getOrCreateControllerDocument(testContext(), crud, controllerName, nil)
+		assert.Error(t, err, "expected an error when initialControllerFn is nil")
+	})
+}
+
+func testContext() context.Context {
+	return utils.ContextWithLogger(context.Background(), logr.Discard())
+}
+
+func TestReportSyncError(t *testing.T) {
+	tests := []struct {
+		name       string
+		syncErr    error
+		wantStatus metav1.ConditionStatus
+		wantReason string
+	}{
+		{
+			name:       "nil error sets Degraded=False",
+			syncErr:    nil,
+			wantStatus: metav1.ConditionFalse,
+			wantReason: "NoErrors",
+		},
+		{
+			name:       "non-nil error sets Degraded=True",
+			syncErr:    errors.New("boom"),
+			wantStatus: metav1.ConditionTrue,
+			wantReason: "Failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := &coreapi.Controller{}
+			ReportSyncError(tt.syncErr)(controller)
+
+			cond := apimeta.FindStatusCondition(controller.Status.Conditions, "Degraded")
+			require.NotNil(t, cond, "expected Degraded condition to be set")
+			assert.Equal(t, tt.wantStatus, cond.Status, "condition status")
+			assert.Equal(t, tt.wantReason, cond.Reason, "condition reason")
+		})
+	}
+}
+
+func TestWriteController(t *testing.T) {
+	const stampID = "s1"
+	const controllerName = "TestController"
+
+	t.Run("creates the controller document when missing", func(t *testing.T) {
+		mockDB := fleetcosmosstoragetesting.NewMockFleetDBClient()
+		controllerCRUD := mockDB.Stamps().ManagementClusters(stampID).Controllers()
+		key := ManagementClusterKey{StampIdentifier: stampID}
+
+		err := WriteController(testContext(), controllerCRUD, controllerName, key.InitialController, ReportSyncError(nil))
+		require.NoError(t, err, "WriteController")
+
+		stored, err := controllerCRUD.Get(testContext(), controllerName)
+		require.NoError(t, err, "Get after WriteController")
+
+		cond := apimeta.FindStatusCondition(stored.Status.Conditions, "Degraded")
+		require.NotNil(t, cond, "expected Degraded condition to be set")
+		assert.Equal(t, metav1.ConditionFalse, cond.Status, "condition status")
+	})
+
+	t.Run("updates the controller document when a mutation changes it", func(t *testing.T) {
+		mockDB := fleetcosmosstoragetesting.NewMockFleetDBClient()
+		controllerCRUD := mockDB.Stamps().ManagementClusters(stampID).Controllers()
+		key := ManagementClusterKey{StampIdentifier: stampID}
+		ctx := testContext()
+
+		require.NoError(t, WriteController(ctx, controllerCRUD, controllerName, key.InitialController, ReportSyncError(nil)))
+		require.NoError(t, WriteController(ctx, controllerCRUD, controllerName, key.InitialController, ReportSyncError(errors.New("boom"))))
+
+		stored, err := controllerCRUD.Get(ctx, controllerName)
+		require.NoError(t, err, "Get after second WriteController")
+
+		cond := apimeta.FindStatusCondition(stored.Status.Conditions, "Degraded")
+		require.NotNil(t, cond, "expected Degraded condition to be set")
+		assert.Equal(t, metav1.ConditionTrue, cond.Status, "condition status")
+		assert.Equal(t, "Failed", cond.Reason, "condition reason")
+	})
+
+	t.Run("is a no-op when the mutation produces no change", func(t *testing.T) {
+		mockDB := fleetcosmosstoragetesting.NewMockFleetDBClient()
+		controllerCRUD := mockDB.Stamps().ManagementClusters(stampID).Controllers()
+		key := ManagementClusterKey{StampIdentifier: stampID}
+		ctx := testContext()
+
+		require.NoError(t, WriteController(ctx, controllerCRUD, controllerName, key.InitialController, ReportSyncError(nil)))
+		before, err := controllerCRUD.Get(ctx, controllerName)
+		require.NoError(t, err, "Get before repeated WriteController")
+
+		require.NoError(t, WriteController(ctx, controllerCRUD, controllerName, key.InitialController, ReportSyncError(nil)))
+		after, err := controllerCRUD.Get(ctx, controllerName)
+		require.NoError(t, err, "Get after repeated WriteController")
+
+		assert.Equal(t, before.CosmosETag, after.CosmosETag, "no-op write should not replace the document")
+	})
+
+	t.Run("errors when initialControllerFn is nil", func(t *testing.T) {
+		mockDB := fleetcosmosstoragetesting.NewMockFleetDBClient()
+		controllerCRUD := mockDB.Stamps().ManagementClusters(stampID).Controllers()
+
+		err := WriteController(testContext(), controllerCRUD, controllerName, nil, ReportSyncError(nil))
+		assert.Error(t, err, "expected error when initialControllerFn is nil")
+	})
+}

--- a/fleet/pkg/controllers/capacityreporting/capacity_reporting_controller.go
+++ b/fleet/pkg/controllers/capacityreporting/capacity_reporting_controller.go
@@ -75,7 +75,7 @@ func NewCapacityReportingController(
 	fleetDBClient fleetcosmosstorage.FleetDBClient,
 	readDesireLister kubeapplierlisters.ReadDesireLister,
 	cfg fleetcontrollers.StampWatchingControllerConfig,
-) *fleetcontrollers.StampWatchingController {
+) fleetcontrollers.Controller {
 	syncer := &capacityReportingSyncer{
 		fleetDBClient:    fleetDBClient,
 		readDesireLister: readDesireLister,

--- a/fleet/pkg/controllers/capacityreporting/create_capacity_report_read_desire_controller.go
+++ b/fleet/pkg/controllers/capacityreporting/create_capacity_report_read_desire_controller.go
@@ -48,7 +48,7 @@ func NewEnsureCapacityReadDesireController(
 	managementClusterInformer cache.SharedIndexInformer,
 	kubeApplierDBClients kubeappliercosmosstorage.KubeApplierDBClients,
 	cfg fleetcontrollers.StampWatchingControllerConfig,
-) *fleetcontrollers.StampWatchingController {
+) fleetcontrollers.Controller {
 	syncer := &ensureReadDesireSyncer{
 		kubeApplierDBClients: kubeApplierDBClients,
 	}

--- a/fleet/pkg/controllers/capacityreporting/scale_ceiling_controller.go
+++ b/fleet/pkg/controllers/capacityreporting/scale_ceiling_controller.go
@@ -59,7 +59,7 @@ func NewManagementClusterScaleCeilingReportingController(
 	credential azcore.TokenCredential,
 	clientOptions *policy.ClientOptions,
 	cfg fleetcontrollers.StampWatchingControllerConfig,
-) *fleetcontrollers.StampWatchingController {
+) fleetcontrollers.Controller {
 	if clientOptions == nil {
 		clientOptions = &policy.ClientOptions{}
 	}

--- a/fleet/pkg/controllers/clustersserviceregistration/controller.go
+++ b/fleet/pkg/controllers/clustersserviceregistration/controller.go
@@ -62,7 +62,7 @@ func NewClustersServiceRegistrationController(
 	stampLister fleetlisters.StampLister,
 	region string,
 	cfg fleetcontrollers.StampWatchingControllerConfig,
-) *fleetcontrollers.StampWatchingController {
+) fleetcontrollers.Controller {
 	syncer := &clustersServiceRegistrationSyncer{
 		fleetDBClient:         fleetDBClient,
 		clustersServiceClient: clustersServiceClient,

--- a/fleet/pkg/controllers/datadump/stamp_data_dumper.go
+++ b/fleet/pkg/controllers/datadump/stamp_data_dumper.go
@@ -39,7 +39,7 @@ func NewStampDataDumpController(
 	stampLister fleetlisters.StampLister,
 	managementClusterLister fleetlisters.ManagementClusterLister,
 	cfg fleetcontrollers.StampWatchingControllerConfig,
-) *fleetcontrollers.StampWatchingController {
+) fleetcontrollers.Controller {
 	syncer := &stampDataDumpSyncer{
 		stampLister:             stampLister,
 		managementClusterLister: managementClusterLister,

--- a/fleet/pkg/controllers/lifecycle/controller.go
+++ b/fleet/pkg/controllers/lifecycle/controller.go
@@ -39,7 +39,7 @@ func NewManagementClusterLifecycleController(
 	managementClusterInformer cache.SharedIndexInformer,
 	fleetDBClient fleetcosmosstorage.FleetDBClient,
 	cfg fleetcontrollers.StampWatchingControllerConfig,
-) *fleetcontrollers.StampWatchingController {
+) fleetcontrollers.Controller {
 	syncer := &lifecycleSyncer{
 		fleetDBClient: fleetDBClient,
 	}

--- a/fleet/pkg/controllers/maestroregistration/controller.go
+++ b/fleet/pkg/controllers/maestroregistration/controller.go
@@ -45,7 +45,7 @@ func NewMaestroRegistrationController(
 	maestroConsumerClientFactory MaestroConsumerClientFactory,
 	stampLister fleetlisters.StampLister,
 	cfg fleetcontrollers.StampWatchingControllerConfig,
-) *fleetcontrollers.StampWatchingController {
+) fleetcontrollers.Controller {
 	syncer := &maestroRegistrationSyncer{
 		fleetDBClient:                fleetDBClient,
 		maestroConsumerClientFactory: maestroConsumerClientFactory,


### PR DESCRIPTION
### What

Port controller mechanics from the backend pattern: a common Controller interface (Run, QueueForInformers, EnqueueAfter), WriteController for persisting controller Degraded conditions to Cosmos, and a ManagementClusterWatchingController base that automatically writes controller documents after each sync. All existing stamp-watching controllers now return the Controller interface.

### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
