### PR TITLE
chore: scope capz OWNERS filter to CI config and job files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,8 @@ filters:
       - service-lifecycle-global-approvers
   # Intended to support autoowners generation in openshift/release; in this repo it will apply to any file paths that match the regex below.
   # See https://github.com/openshift/release/blob/main/ci-operator/config/Azure/ARO-HCP/OWNERS
-  '.*capz.*':
+  # Matches the capz-e2e ci-operator config (config/.../Azure-ARO-HCP-main__capz-e2e.yaml)
+  # and the generated Prow job files (jobs/.../Azure-ARO-HCP-main-p*.yaml) that bundle the capz jobs.
+  'main__capz.*yaml|Azure-ARO-HCP-main-p.*\.yaml':
     approvers:
       - capz-approvers

--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,6 @@ filters:
   # See https://github.com/openshift/release/blob/main/ci-operator/config/Azure/ARO-HCP/OWNERS
   # Matches the capz-e2e ci-operator config (config/.../Azure-ARO-HCP-main__capz-e2e.yaml)
   # and the generated Prow job files (jobs/.../Azure-ARO-HCP-main-p*.yaml) that bundle the capz jobs.
-  'main__capz.*yaml|Azure-ARO-HCP-main-p.*\.yaml':
+  'main__capz.*\.yaml|Azure-ARO-HCP-main-p.*\.yaml':
     approvers:
       - capz-approvers


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-2047

## Why

The `capz` filter in the root `OWNERS` was `.*capz.*`. This has two problems:

- **Too broad in this repo:** the root `OWNERS` filter also applies to ARO-HCP itself, so `.*capz.*` would hand `capz-approvers` any current or future path containing "capz" anywhere in the repo.
- **Broken under `jobs/` in openshift/release:** `autoowners` copies this filter verbatim into both `ci-operator/config/Azure/ARO-HCP/OWNERS` and `ci-operator/jobs/Azure/ARO-HCP/OWNERS`. The generated Prow job files bundle the capz jobs into shared `Azure-ARO-HCP-main-p*.yaml` files (periodics/presubmits) whose names contain no "capz", so `.*capz.*` matched nothing there — `capz-approvers` gated no job changes at all.

## What

Scope the filter to exactly the capz CI files (matching is unanchored substring via prow `repoowners`):

- `main__capz.*yaml` → the `Azure-ARO-HCP-main__capz-e2e.yaml` ci-operator config (and only that; `__` is the variant separator, so it won't match job files or arbitrary repo paths).
- `Azure-ARO-HCP-main-p.*\.yaml` → the generated `-periodics`/`-presubmits`/`-postsubmits` job files that carry the capz jobs.