### PR TITLE
feat: expose structured Copilot session errors

### DIFF
--- a/tooling/hcpctl/pkg/agent/agent.go
+++ b/tooling/hcpctl/pkg/agent/agent.go
@@ -157,6 +157,7 @@ type Session struct {
 	client          *CopilotClient
 	logger          logr.Logger
 	lastMessages    json.RawMessage
+	sendGate        chan struct{}
 	usageMu         sync.RWMutex
 	usage           UsageReport
 	usageProvider   string
@@ -219,6 +220,7 @@ func (c *CopilotClient) CreateSession(ctx context.Context, logger logr.Logger, c
 		inner:           session,
 		client:          c,
 		logger:          logger,
+		sendGate:        make(chan struct{}, 1),
 		usageProvider:   usageProvider,
 		usageDimensions: usageDimensions,
 		usageModel:      sessionCfg.Model,
@@ -336,7 +338,18 @@ func (s *Session) Usage() UsageReport {
 // If ctx is cancelled, the in-flight work is aborted.
 // Returns the final assistant message content.
 func (s *Session) SendAndWait(ctx context.Context, prompt string) (string, error) {
+	// A temporary event subscription associates provider errors with this
+	// request, so calls must not overlap on the same session.
+	if err := s.acquireSendGate(ctx); err != nil {
+		return "", err
+	}
+	defer s.releaseSendGate()
+
 	s.logger.V(1).Info("Sending message to Copilot session.", "promptLength", len(prompt))
+
+	errorCapture := &copilotSessionErrorCapture{provider: s.usageProvider}
+	unsubscribe := s.inner.On(errorCapture.record)
+	defer unsubscribe()
 
 	// The SDK applies a 60s default timeout when the context has no deadline.
 	// Analysis turns routinely take 10+ minutes, so set a generous deadline
@@ -376,7 +389,7 @@ func (s *Session) SendAndWait(ctx context.Context, prompt string) (string, error
 		return "", ctx.Err()
 	case r := <-ch:
 		if r.err != nil {
-			return "", fmt.Errorf("copilot session failed: %w", r.err)
+			return "", wrapCopilotSessionError(errorCapture, r.err)
 		}
 		if r.event == nil {
 			return "", fmt.Errorf("copilot session returned no response")
@@ -389,6 +402,26 @@ func (s *Session) SendAndWait(ctx context.Context, prompt string) (string, error
 		s.snapshotMessages()
 		return data.Content, nil
 	}
+}
+
+func (s *Session) acquireSendGate(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	select {
+	case s.sendGate <- struct{}{}:
+		if err := ctx.Err(); err != nil {
+			s.releaseSendGate()
+			return err
+		}
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *Session) releaseSendGate() {
+	<-s.sendGate
 }
 
 // Disconnect releases in-memory session resources. Session state is preserved

--- a/tooling/hcpctl/pkg/agent/copilot_session_error.go
+++ b/tooling/hcpctl/pkg/agent/copilot_session_error.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"fmt"
+	"sync"
+
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+const (
+	// CopilotSessionErrorTypeRateLimit identifies a Copilot rate-limit response.
+	CopilotSessionErrorTypeRateLimit = "rate_limit"
+)
+
+// CopilotSessionError preserves structured error details reported by the
+// Copilot SDK. Callers can inspect it with errors.As while continuing to handle
+// it as a standard error.
+type CopilotSessionError struct {
+	Provider              string
+	ErrorType             string
+	ErrorCode             *string
+	StatusCode            *int32
+	Message               string
+	ProviderCallID        *string
+	ServiceRequestID      *string
+	Stack                 *string
+	URL                   *string
+	EligibleForAutoSwitch *bool
+	Err                   error
+}
+
+// Error returns the underlying provider error text when available.
+func (e *CopilotSessionError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return e.Message
+}
+
+// Unwrap returns the original provider error.
+func (e *CopilotSessionError) Unwrap() error {
+	return e.Err
+}
+
+type copilotSessionErrorCapture struct {
+	provider string
+
+	mu    sync.Mutex
+	first *CopilotSessionError
+}
+
+func (c *copilotSessionErrorCapture) record(event copilot.SessionEvent) {
+	data, ok := event.Data.(*copilot.SessionErrorData)
+	if !ok {
+		return
+	}
+
+	captured := &CopilotSessionError{
+		Provider:              c.provider,
+		ErrorType:             data.ErrorType,
+		ErrorCode:             clonePointer(data.ErrorCode),
+		StatusCode:            clonePointer(data.StatusCode),
+		Message:               data.Message,
+		ProviderCallID:        clonePointer(data.ProviderCallID),
+		ServiceRequestID:      clonePointer(data.ServiceRequestID),
+		Stack:                 clonePointer(data.Stack),
+		URL:                   clonePointer(data.URL),
+		EligibleForAutoSwitch: clonePointer(data.EligibleForAutoSwitch),
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.first == nil {
+		c.first = captured
+	}
+}
+
+func (c *copilotSessionErrorCapture) withCause(cause error) *CopilotSessionError {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.first == nil {
+		return nil
+	}
+
+	captured := *c.first
+	captured.Err = cause
+	return &captured
+}
+
+func wrapCopilotSessionError(capture *copilotSessionErrorCapture, cause error) error {
+	if sessionErr := capture.withCause(cause); sessionErr != nil {
+		return fmt.Errorf("copilot session failed: %w", sessionErr)
+	}
+	return fmt.Errorf("copilot session failed: %w", cause)
+}
+
+func clonePointer[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}

--- a/tooling/hcpctl/pkg/agent/copilot_session_error_test.go
+++ b/tooling/hcpctl/pkg/agent/copilot_session_error_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+func TestCopilotSessionErrorCapture(t *testing.T) {
+	errorCode := "user_global_rate_limited"
+	statusCode := int32(429)
+	providerCallID := "provider-call-id"
+	serviceRequestID := "service-request-id"
+	stack := "provider stack"
+	url := "https://example.invalid/rate-limit"
+	eligibleForAutoSwitch := true
+	capture := &copilotSessionErrorCapture{provider: "github-copilot"}
+	capture.record(copilot.SessionEvent{
+		Data: &copilot.SessionErrorData{
+			ErrorType:             CopilotSessionErrorTypeRateLimit,
+			ErrorCode:             &errorCode,
+			StatusCode:            &statusCode,
+			Message:               "request rate limited",
+			ProviderCallID:        &providerCallID,
+			ServiceRequestID:      &serviceRequestID,
+			Stack:                 &stack,
+			URL:                   &url,
+			EligibleForAutoSwitch: &eligibleForAutoSwitch,
+		},
+	})
+
+	providerErr := errors.New("CAPIError: 429")
+	err := wrapCopilotSessionError(capture, providerErr)
+
+	var sessionErr *CopilotSessionError
+	if !errors.As(err, &sessionErr) {
+		t.Fatalf("errors.As() = false, want true")
+	}
+	if sessionErr.Provider != "github-copilot" {
+		t.Errorf("Provider = %q, want %q", sessionErr.Provider, "github-copilot")
+	}
+	if sessionErr.ErrorType != CopilotSessionErrorTypeRateLimit {
+		t.Errorf("ErrorType = %q, want %q", sessionErr.ErrorType, CopilotSessionErrorTypeRateLimit)
+	}
+	if sessionErr.ErrorCode == nil || *sessionErr.ErrorCode != errorCode {
+		t.Errorf("ErrorCode = %v, want %q", sessionErr.ErrorCode, errorCode)
+	}
+	if sessionErr.StatusCode == nil || *sessionErr.StatusCode != statusCode {
+		t.Errorf("StatusCode = %v, want %d", sessionErr.StatusCode, statusCode)
+	}
+	if sessionErr.Message != "request rate limited" {
+		t.Errorf("Message = %q, want %q", sessionErr.Message, "request rate limited")
+	}
+	if sessionErr.ProviderCallID == nil || *sessionErr.ProviderCallID != providerCallID {
+		t.Errorf("ProviderCallID = %v, want %q", sessionErr.ProviderCallID, providerCallID)
+	}
+	if sessionErr.ServiceRequestID == nil || *sessionErr.ServiceRequestID != serviceRequestID {
+		t.Errorf("ServiceRequestID = %v, want %q", sessionErr.ServiceRequestID, serviceRequestID)
+	}
+	if sessionErr.Stack == nil || *sessionErr.Stack != stack {
+		t.Errorf("Stack = %v, want %q", sessionErr.Stack, stack)
+	}
+	if sessionErr.URL == nil || *sessionErr.URL != url {
+		t.Errorf("URL = %v, want %q", sessionErr.URL, url)
+	}
+	if sessionErr.EligibleForAutoSwitch == nil || *sessionErr.EligibleForAutoSwitch != eligibleForAutoSwitch {
+		t.Errorf("EligibleForAutoSwitch = %v, want %t", sessionErr.EligibleForAutoSwitch, eligibleForAutoSwitch)
+	}
+	if !errors.Is(err, providerErr) {
+		t.Fatal("errors.Is() = false, want original provider error in the chain")
+	}
+	if got, want := err.Error(), "copilot session failed: CAPIError: 429"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestCopilotSessionErrorCapturePreservesMissingOptionalFields(t *testing.T) {
+	capture := &copilotSessionErrorCapture{provider: "github-copilot"}
+	capture.record(copilot.SessionEvent{
+		Data: &copilot.SessionErrorData{
+			ErrorType: CopilotSessionErrorTypeRateLimit,
+			Message:   "request rate limited",
+		},
+	})
+
+	sessionErr := capture.withCause(errors.New("session failed"))
+	if sessionErr == nil {
+		t.Fatal("withCause() = nil, want CopilotSessionError")
+	}
+	if sessionErr.ErrorCode != nil ||
+		sessionErr.StatusCode != nil ||
+		sessionErr.ProviderCallID != nil ||
+		sessionErr.ServiceRequestID != nil ||
+		sessionErr.Stack != nil ||
+		sessionErr.URL != nil ||
+		sessionErr.EligibleForAutoSwitch != nil {
+		t.Fatalf("optional fields = %#v, want all nil", sessionErr)
+	}
+}
+
+func TestCopilotSessionErrorCapturePreservesFirstError(t *testing.T) {
+	capture := &copilotSessionErrorCapture{provider: "github-copilot"}
+	capture.record(copilot.SessionEvent{
+		Data: &copilot.SessionErrorData{
+			ErrorType: CopilotSessionErrorTypeRateLimit,
+			Message:   "first error",
+		},
+	})
+	capture.record(copilot.SessionEvent{
+		Data: &copilot.SessionErrorData{
+			ErrorType: "authentication",
+			Message:   "second error",
+		},
+	})
+
+	sessionErr := capture.withCause(errors.New("session failed"))
+	if sessionErr == nil {
+		t.Fatal("withCause() = nil, want CopilotSessionError")
+	}
+	if sessionErr.ErrorType != CopilotSessionErrorTypeRateLimit {
+		t.Errorf("ErrorType = %q, want %q", sessionErr.ErrorType, CopilotSessionErrorTypeRateLimit)
+	}
+	if sessionErr.Message != "first error" {
+		t.Errorf("Message = %q, want %q", sessionErr.Message, "first error")
+	}
+}
+
+func TestCopilotSessionErrorCaptureIgnoresUnrelatedEvents(t *testing.T) {
+	capture := &copilotSessionErrorCapture{provider: "github-copilot"}
+	capture.record(copilot.SessionEvent{Data: &copilot.SessionIdleData{}})
+
+	providerErr := errors.New("session failed")
+	err := wrapCopilotSessionError(capture, providerErr)
+	var sessionErr *CopilotSessionError
+	if errors.As(err, &sessionErr) {
+		t.Fatalf("errors.As() = true with %#v, want false", sessionErr)
+	}
+	if !errors.Is(err, providerErr) {
+		t.Fatal("errors.Is() = false, want original provider error in the chain")
+	}
+	if got, want := err.Error(), "copilot session failed: session failed"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestCopilotSendGateHonorsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	for _, gateOccupied := range []bool{false, true} {
+		session := &Session{sendGate: make(chan struct{}, 1)}
+		if gateOccupied {
+			session.sendGate <- struct{}{}
+		}
+
+		if err := session.acquireSendGate(ctx); !errors.Is(err, context.Canceled) {
+			t.Errorf("acquireSendGate() with gateOccupied=%t error = %v, want context.Canceled", gateOccupied, err)
+		}
+	}
+}
+
+func TestCopilotSessionErrorWithoutCauseUsesProviderMessage(t *testing.T) {
+	err := &CopilotSessionError{Message: "request rate limited"}
+	if got, want := err.Error(), "request rate limited"; got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-2011

### What

- Add an exported `agent.CopilotSessionError` carrying structured Copilot SDK error details.
- Capture Copilot SDK `SessionErrorData` events while `Session.SendAndWait` is active.
- Preserve optional SDK fields as pointers so callers can distinguish missing values from explicit zero values.
- Expose the provider message, error type and code, HTTP status, request IDs, stack, URL, and automatic model-switch eligibility.
- Preserve the original SDK error in the Go error chain.
- Serialize sends on an individual session so error events cannot be attributed to another concurrent request.

### Why

The Release Dashboard consumes the Copilot implementation in `tooling/hcpctl/pkg/agent` as a Go library. Copilot SDK v1.0.1 reports structured failure information through session events, but its `SendAndWait` convenience method returns only a plain error.

Without preserving the event, Copilot consumers must classify failures such as rate limiting by matching human-readable error text. Returning a `CopilotSessionError` through the existing `error` result allows callers to use `errors.As` without changing the `LLMSession` interface or breaking existing callers.

### Testing

- `cd tooling/hcpctl && go test ./... -count=1`
- `cd tooling/hcpctl && go test -race ./pkg/agent/... -count=1`

### Special notes for your reviewer

The existing `SendAndWait` signature and `copilot session failed:` error prefix are unchanged. The original SDK error remains reachable through `errors.Is`. This type is explicitly Copilot-specific; the existing Claude provider and its error behavior are unchanged.

Suggested reviewers: @deads2k, @geoberle

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [ ] Screenshots included (not applicable: library-only change)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (draft; checks pending)
- [x] Draft PR used for WIP
- [x] Commit history is clean
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge
