### PR TITLE
feat(observability): add CNS and konnectivity PodMonitors (ARO-25382)

### DIFF
--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_mgmt_1_arohcp_monitor.yaml
@@ -68596,6 +68596,40 @@ webhooks:
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
 ---
+# Source: hcp-prometheus/templates/azure-cns.podmonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: azure-cns
+  name: azure-cns
+  namespace: kube-system
+spec:
+  podMetricsEndpoints:
+  - port: metrics
+    path: /metrics
+  selector:
+    matchLabels:
+      k8s-app: azure-cns
+---
+# Source: hcp-prometheus/templates/konnectivity-server.podmonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: konnectivity-server
+  name: konnectivity-server
+  namespace: 'prometheus'
+spec:
+  podMetricsEndpoints:
+  - portNumber: 8093
+    path: /metrics
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app: kube-apiserver
+---
 # Source: hcp-prometheus/templates/prometheus.podmonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arohcp_monitor.yaml
+++ b/dev-infrastructure/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_arohcp_monitor.yaml
@@ -68415,6 +68415,40 @@ webhooks:
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
 ---
+# Source: hcp-prometheus/templates/azure-cns.podmonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: azure-cns
+  name: azure-cns
+  namespace: kube-system
+spec:
+  podMetricsEndpoints:
+  - port: metrics
+    path: /metrics
+  selector:
+    matchLabels:
+      k8s-app: azure-cns
+---
+# Source: hcp-prometheus/templates/konnectivity-server.podmonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: konnectivity-server
+  name: konnectivity-server
+  namespace: 'prometheus'
+spec:
+  podMetricsEndpoints:
+  - portNumber: 8093
+    path: /metrics
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app: kube-apiserver
+---
 # Source: hcp-prometheus/templates/prometheus.podmonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/observability/prometheus/deploy/templates/azure-cns.podmonitor.yaml
+++ b/observability/prometheus/deploy/templates/azure-cns.podmonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: azure-cns
+  name: azure-cns
+  namespace: kube-system
+spec:
+  podMetricsEndpoints:
+  - port: metrics
+    path: /metrics
+  selector:
+    matchLabels:
+      k8s-app: azure-cns

--- a/observability/prometheus/deploy/templates/konnectivity-server.podmonitor.yaml
+++ b/observability/prometheus/deploy/templates/konnectivity-server.podmonitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: konnectivity-server
+  name: konnectivity-server
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  podMetricsEndpoints:
+  - portNumber: 8093
+    path: /metrics
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app: kube-apiserver

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources.yaml
@@ -68596,6 +68596,40 @@ webhooks:
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
 ---
+# Source: hcp-prometheus/templates/azure-cns.podmonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: azure-cns
+  name: azure-cns
+  namespace: kube-system
+spec:
+  podMetricsEndpoints:
+  - port: metrics
+    path: /metrics
+  selector:
+    matchLabels:
+      k8s-app: azure-cns
+---
+# Source: hcp-prometheus/templates/konnectivity-server.podmonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: konnectivity-server
+  name: konnectivity-server
+  namespace: 'prometheus'
+spec:
+  podMetricsEndpoints:
+  - portNumber: 8093
+    path: /metrics
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app: kube-apiserver
+---
 # Source: hcp-prometheus/templates/prometheus.podmonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_mgmt_resources_unset.yaml
@@ -68596,6 +68596,40 @@ webhooks:
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
 ---
+# Source: hcp-prometheus/templates/azure-cns.podmonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: azure-cns
+  name: azure-cns
+  namespace: kube-system
+spec:
+  podMetricsEndpoints:
+  - port: metrics
+    path: /metrics
+  selector:
+    matchLabels:
+      k8s-app: azure-cns
+---
+# Source: hcp-prometheus/templates/konnectivity-server.podmonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: konnectivity-server
+  name: konnectivity-server
+  namespace: 'prometheus'
+spec:
+  podMetricsEndpoints:
+  - portNumber: 8093
+    path: /metrics
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app: kube-apiserver
+---
 # Source: hcp-prometheus/templates/prometheus.podmonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources.yaml
@@ -68415,6 +68415,40 @@ webhooks:
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
 ---
+# Source: hcp-prometheus/templates/azure-cns.podmonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: azure-cns
+  name: azure-cns
+  namespace: kube-system
+spec:
+  podMetricsEndpoints:
+  - port: metrics
+    path: /metrics
+  selector:
+    matchLabels:
+      k8s-app: azure-cns
+---
+# Source: hcp-prometheus/templates/konnectivity-server.podmonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: konnectivity-server
+  name: konnectivity-server
+  namespace: 'prometheus'
+spec:
+  podMetricsEndpoints:
+  - portNumber: 8093
+    path: /metrics
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app: kube-apiserver
+---
 # Source: hcp-prometheus/templates/prometheus.podmonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources_unset.yaml
+++ b/observability/prometheus/testdata/zz_fixture_TestHelmTemplate_helmtest_svc_resources_unset.yaml
@@ -68415,6 +68415,40 @@ webhooks:
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
 ---
+# Source: hcp-prometheus/templates/azure-cns.podmonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: azure-cns
+  name: azure-cns
+  namespace: kube-system
+spec:
+  podMetricsEndpoints:
+  - port: metrics
+    path: /metrics
+  selector:
+    matchLabels:
+      k8s-app: azure-cns
+---
+# Source: hcp-prometheus/templates/konnectivity-server.podmonitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: konnectivity-server
+  name: konnectivity-server
+  namespace: 'prometheus'
+spec:
+  podMetricsEndpoints:
+  - portNumber: 8093
+    path: /metrics
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app: kube-apiserver
+---
 # Source: hcp-prometheus/templates/prometheus.podmonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-25382

## What

- **CNS PodMonitor**: scrapes CNS metrics (`ip_assignment_latency_seconds`, `cx_pending_programming_ips_v2`) from `azure-cns` pods in `kube-system` on the management cluster
- **Konnectivity PodMonitor**: scrapes konnectivity-server metrics (stream errors, dial failures) from KAS pods on port 8093, across all HCP namespaces

## Why

SWIFT provides the private network path between customer VNets and hosted control planes. CNS and konnectivity-server both run on the management cluster but are not currently scraped by Prometheus. These PodMonitors are foundational infrastructure for the SWIFT networking user journey SLIs — the recording rules, alerts, and Grafana dashboard in PR #6359 depend on these metrics being available.

Splitting into a separate PR so the metrics can be verified flowing in INT before the dependent observability lands.

## Test plan

- [ ] Verify `ip_assignment_latency_seconds` metrics appear in the services AMW after deploy
- [ ] Verify `konnectivity_network_proxy_server_stream_errors_total` metrics appear in the HCP AMW after deploy