### PR TITLE
feat(mgmt-agent): watch hosted control plane resources

### DIFF
--- a/mgmt-agent/pkg/controller/resourcewatcher.go
+++ b/mgmt-agent/pkg/controller/resourcewatcher.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"os"
 	"strings"
-	"time"
+	"sync"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,8 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
@@ -74,7 +74,7 @@ type ServerResourceDiscoverer interface {
 
 // ResourceWatcher discovers API resources matching a set of group suffixes, also
 // watches a fixed set of additional GroupVersionResources (watchedExplicitGVRs), and
-// logs every event via dynamic informers as structured JSON.
+// logs every event via reflectors as structured JSON.
 type ResourceWatcher struct {
 	dynamicClient   dynamic.Interface
 	discoveryClient ServerResourceDiscoverer
@@ -89,9 +89,9 @@ func NewResourceWatcher(dynamicClient dynamic.Interface, discoveryClient ServerR
 }
 
 // Run discovers GVRs for the configured group suffixes, also watches the GVRs in
-// watchedExplicitGVRs, starts dynamic informers for each, and blocks until
-// the context is cancelled. Events are
-// logged as structured JSON via klog. A CRD informer watches for new CustomResourceDefinitions;
+// watchedExplicitGVRs, starts reflectors for each, and blocks until
+// the context is cancelled. Events are logged as structured JSON via klog. A
+// CRD reflector watches for new CustomResourceDefinitions;
 // if a new CRD is registered whose group matches the watched suffixes and introduces
 // GVRs not known at startup, the process exits so the pod restarts and picks them up.
 func (w *ResourceWatcher) Run(ctx context.Context) error {
@@ -106,8 +106,6 @@ func (w *ResourceWatcher) Run(ctx context.Context) error {
 	logger.Info("Discovered resources to watch", "count", len(gvrs))
 
 	knownGVRs := sets.New[schema.GroupVersionResource](gvrs...)
-
-	factory := dynamicinformer.NewDynamicSharedInformerFactory(w.dynamicClient, 10*time.Hour)
 
 	// Watch CRDs so we can detect when new API resources matching our group
 	// suffixes are registered in the cluster. When that happens, we exit the
@@ -126,42 +124,118 @@ func (w *ResourceWatcher) Run(ctx context.Context) error {
 			os.Exit(1)
 		}
 	}
-	crdInformer := factory.ForResource(crdGVR)
-	if _, err := crdInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    handleCRD,
-		UpdateFunc: func(_, obj interface{}) { handleCRD(obj) },
-	}); err != nil {
-		return err
-	}
+	var syncChannels []<-chan struct{}
+	crdStore := newReflectorStore(
+		handleCRD,
+		handleCRD,
+		func(interface{}) {},
+	)
+	syncChannels = append(syncChannels, crdStore.synced)
+	go newDynamicReflector(w.dynamicClient, crdGVR, crdStore).RunWithContext(ctx)
 
 	for _, gvr := range gvrs {
-		informer := factory.ForResource(gvr)
-		gvr := gvr // capture for closures
-		if _, err := informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				logResourceEvent(ctx, "Add", gvr, obj)
-			},
-			UpdateFunc: func(_, obj interface{}) {
-				logResourceEvent(ctx, "Update", gvr, obj)
-			},
-			DeleteFunc: func(obj interface{}) {
-				if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-					obj = tombstone.Obj
-				}
-				logResourceEvent(ctx, "Delete", gvr, obj)
-			},
-		}); err != nil {
-			return err
+		gvr := gvr
+		store := newReflectorStore(
+			func(obj interface{}) { logResourceEvent(ctx, "Add", gvr, obj) },
+			func(obj interface{}) { logResourceEvent(ctx, "Update", gvr, obj) },
+			func(obj interface{}) { logResourceEvent(ctx, "Delete", gvr, obj) },
+		)
+		syncChannels = append(syncChannels, store.synced)
+		go newDynamicReflector(w.dynamicClient, gvr, store).RunWithContext(ctx)
+	}
+
+	for _, synced := range syncChannels {
+		select {
+		case <-synced:
+		case <-ctx.Done():
+			logger.Info("Shutting down resource watcher")
+			return nil
 		}
 	}
 
-	factory.Start(ctx.Done())
-	factory.WaitForCacheSync(ctx.Done())
-
-	logger.Info("Resource watcher informers synced and running")
+	logger.Info("Resource watcher reflectors synced and running")
 	<-ctx.Done()
 	logger.Info("Shutting down resource watcher")
 	return nil
+}
+
+// reflectorStore implements cache.ReflectorStore without implementing a
+// cache. This is deliberately unusual: an informer normally retains the last
+// copy of every watched object so consumers can perform indexed reads and
+// compare old and new values. The resource watcher has no such consumers; its
+// only purpose is to emit every observed snapshot for later must-gather use.
+// Retaining another full copy of all management-cluster resources would waste
+// substantial memory, so each callback logs the object and immediately drops
+// the reference.
+type reflectorStore struct {
+	add      func(interface{})
+	update   func(interface{})
+	delete   func(interface{})
+	synced   chan struct{}
+	syncOnce sync.Once
+}
+
+var _ cache.ReflectorStore = &reflectorStore{}
+
+func newReflectorStore(add, update, delete func(interface{})) *reflectorStore {
+	return &reflectorStore{
+		add:    add,
+		update: update,
+		delete: delete,
+		synced: make(chan struct{}),
+	}
+}
+
+func (s *reflectorStore) Add(obj interface{}) error {
+	s.add(obj)
+	return nil
+}
+
+func (s *reflectorStore) Update(obj interface{}) error {
+	s.update(obj)
+	return nil
+}
+
+func (s *reflectorStore) Delete(obj interface{}) error {
+	s.delete(obj)
+	return nil
+}
+
+func (s *reflectorStore) Replace(objects []interface{}, _ string) error {
+	// Reflector delivers the initial LIST through Replace rather than Add. Log
+	// those objects as additions so startup still produces a complete snapshot,
+	// then release the slice without retaining any of its contents.
+	for _, obj := range objects {
+		s.add(obj)
+	}
+	s.syncOnce.Do(func() { close(s.synced) })
+	return nil
+}
+
+func (s *reflectorStore) Resync() error {
+	// There is intentionally no retained state to replay.
+	return nil
+}
+
+func newDynamicReflector(dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, store cache.ReflectorStore) *cache.Reflector {
+	resourceClient := dynamicClient.Resource(gvr)
+	listWatch := &cache.ListWatch{
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
+			return resourceClient.List(ctx, options)
+		},
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
+			return resourceClient.Watch(ctx, options)
+		},
+	}
+	return cache.NewReflectorWithOptions(
+		listWatch,
+		&unstructured.Unstructured{},
+		store,
+		cache.ReflectorOptions{
+			Name:            "resource-watcher/" + gvr.String(),
+			TypeDescription: gvr.String(),
+		},
+	)
 }
 
 // discoverGVRs uses the discovery API to find all GVRs whose group matches

--- a/mgmt-agent/pkg/controller/resourcewatcher.go
+++ b/mgmt-agent/pkg/controller/resourcewatcher.go
@@ -44,18 +44,27 @@ var watchedGroupSuffixes = []string{
 	"velero.io",
 }
 
-// watchedBuiltinGVRs is the hardcoded list of built-in (non-CRD)
-// GroupVersionResources to watch in addition to everything discovered via
-// watchedGroupSuffixes. These are core/apps types that are not covered by the
-// CRD group suffixes above but still carry useful management-cluster state. To
-// snapshot another built-in type, add its GVR here.
-var watchedBuiltinGVRs = []schema.GroupVersionResource{
+// watchedExplicitGVRs is the hardcoded list of GroupVersionResources to watch
+// in addition to everything discovered via watchedGroupSuffixes. These APIs
+// are not covered by the group suffixes above but still carry useful
+// management-cluster state.
+var watchedExplicitGVRs = []schema.GroupVersionResource{
 	{Group: "", Version: "v1", Resource: "namespaces"},
 	{Group: "", Version: "v1", Resource: "nodes"},
+	{Group: "", Version: "v1", Resource: "configmaps"},
+	{Group: "", Version: "v1", Resource: "endpoints"},
+	{Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
+	{Group: "", Version: "v1", Resource: "services"},
 	{Group: "apps", Version: "v1", Resource: "deployments"},
 	{Group: "apps", Version: "v1", Resource: "daemonsets"},
 	{Group: "apps", Version: "v1", Resource: "statefulsets"},
 	{Group: "apps", Version: "v1", Resource: "replicasets"},
+	{Group: "batch", Version: "v1", Resource: "cronjobs"},
+	{Group: "batch", Version: "v1", Resource: "jobs"},
+	{Group: "monitoring.coreos.com", Version: "v1", Resource: "podmonitors"},
+	{Group: "monitoring.coreos.com", Version: "v1", Resource: "servicemonitors"},
+	{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"},
+	{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"},
 }
 
 // ServerResourceDiscoverer is the subset of the discovery API that ResourceWatcher needs.
@@ -64,7 +73,7 @@ type ServerResourceDiscoverer interface {
 }
 
 // ResourceWatcher discovers API resources matching a set of group suffixes, also
-// watches a fixed set of built-in GroupVersionResources (watchedBuiltinGVRs), and
+// watches a fixed set of additional GroupVersionResources (watchedExplicitGVRs), and
 // logs every event via dynamic informers as structured JSON.
 type ResourceWatcher struct {
 	dynamicClient   dynamic.Interface
@@ -79,8 +88,8 @@ func NewResourceWatcher(dynamicClient dynamic.Interface, discoveryClient ServerR
 	}
 }
 
-// Run discovers GVRs for the configured group suffixes, also watches the built-in
-// GVRs in watchedBuiltinGVRs, starts dynamic informers for each, and blocks until
+// Run discovers GVRs for the configured group suffixes, also watches the GVRs in
+// watchedExplicitGVRs, starts dynamic informers for each, and blocks until
 // the context is cancelled. Events are
 // logged as structured JSON via klog. A CRD informer watches for new CustomResourceDefinitions;
 // if a new CRD is registered whose group matches the watched suffixes and introduces
@@ -93,7 +102,7 @@ func (w *ResourceWatcher) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	gvrs = append(gvrs, watchedBuiltinGVRs...)
+	gvrs = append(gvrs, watchedExplicitGVRs...)
 	logger.Info("Discovered resources to watch", "count", len(gvrs))
 
 	knownGVRs := sets.New[schema.GroupVersionResource](gvrs...)

--- a/mgmt-agent/pkg/controller/resourcewatcher_test.go
+++ b/mgmt-agent/pkg/controller/resourcewatcher_test.go
@@ -15,6 +15,7 @@
 package controller
 
 import (
+	"reflect"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +23,47 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
+
+func TestReflectorStoreLogsWithoutRetainingObjects(t *testing.T) {
+	var added, updated, deleted []interface{}
+	store := newReflectorStore(
+		func(obj interface{}) { added = append(added, obj) },
+		func(obj interface{}) { updated = append(updated, obj) },
+		func(obj interface{}) { deleted = append(deleted, obj) },
+	)
+
+	initial := []interface{}{"initial-1", "initial-2"}
+	if err := store.Replace(initial, "1"); err != nil {
+		t.Fatalf("Replace() error = %v", err)
+	}
+	if err := store.Add("added"); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+	if err := store.Update("updated"); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if err := store.Delete("deleted"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if err := store.Replace(nil, "2"); err != nil {
+		t.Fatalf("second Replace() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(added, []interface{}{"initial-1", "initial-2", "added"}) {
+		t.Errorf("added = %#v", added)
+	}
+	if !reflect.DeepEqual(updated, []interface{}{"updated"}) {
+		t.Errorf("updated = %#v", updated)
+	}
+	if !reflect.DeepEqual(deleted, []interface{}{"deleted"}) {
+		t.Errorf("deleted = %#v", deleted)
+	}
+	select {
+	case <-store.synced:
+	default:
+		t.Error("store did not report initial synchronization")
+	}
+}
 
 func TestMatchesGroupSuffix(t *testing.T) {
 	tests := []struct {

--- a/mgmt-agent/pkg/controller/resourcewatcher_test.go
+++ b/mgmt-agent/pkg/controller/resourcewatcher_test.go
@@ -137,22 +137,32 @@ func TestDiscoverGVRs(t *testing.T) {
 	}
 }
 
-func TestWatchedBuiltinGVRs(t *testing.T) {
-	// These built-in (non-CRD) resources are not covered by watchedGroupSuffixes,
-	// so they must be listed explicitly in watchedBuiltinGVRs to be snapshotted.
+func TestWatchedExplicitGVRs(t *testing.T) {
+	// These resources are not covered by watchedGroupSuffixes, so they must be
+	// listed explicitly in watchedExplicitGVRs to be snapshotted.
 	required := []schema.GroupVersionResource{
 		{Group: "", Version: "v1", Resource: "namespaces"},
 		{Group: "", Version: "v1", Resource: "nodes"},
+		{Group: "", Version: "v1", Resource: "configmaps"},
+		{Group: "", Version: "v1", Resource: "endpoints"},
+		{Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
+		{Group: "", Version: "v1", Resource: "services"},
 		{Group: "apps", Version: "v1", Resource: "deployments"},
 		{Group: "apps", Version: "v1", Resource: "daemonsets"},
 		{Group: "apps", Version: "v1", Resource: "statefulsets"},
 		{Group: "apps", Version: "v1", Resource: "replicasets"},
+		{Group: "batch", Version: "v1", Resource: "cronjobs"},
+		{Group: "batch", Version: "v1", Resource: "jobs"},
+		{Group: "monitoring.coreos.com", Version: "v1", Resource: "podmonitors"},
+		{Group: "monitoring.coreos.com", Version: "v1", Resource: "servicemonitors"},
+		{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"},
+		{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"},
 	}
 
-	have := sets.New[schema.GroupVersionResource](watchedBuiltinGVRs...)
+	have := sets.New[schema.GroupVersionResource](watchedExplicitGVRs...)
 	for _, want := range required {
 		if !have.Has(want) {
-			t.Errorf("watchedBuiltinGVRs is missing %v", want)
+			t.Errorf("watchedExplicitGVRs is missing %v", want)
 		}
 	}
 }


### PR DESCRIPTION
Adds resources from the management cluster to match the hypershift dump cluster command.