### PR TITLE
ARO-29051- KAS API SLO dashboard references non-existent metrics

### DIFF
--- a/dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep
+++ b/dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep
@@ -1,3 +1,4 @@
+
 param azureMonitoring string
 
 param location string = resourceGroup().location
@@ -267,6 +268,32 @@ resource hcpEtcdGrpcLatencyRecordingRules 'Microsoft.AlertsManagement/prometheus
       {
         record: 'etcd:grpc_server_handling:write_latency_p95:rate5m'
         expression: 'histogram_quantile(0.95, sum by (namespace, cluster, le, region) (rate(grpc_server_handling_seconds_bucket{grpc_method="Txn",grpc_service="etcdserverpb.KV",namespace=~"ocm-.*"}[5m])))'
+      }
+    ]
+  }
+}
+
+resource hcpKasProbeAvailabilityRecordingRules 'Microsoft.AlertsManagement/prometheusRuleGroups@2023-03-01' = {
+  name: 'hcp-kas-probe-availability-recording-rules'
+  location: location
+  properties: {
+    scopes: [
+      azureMonitoring
+    ]
+    enabled: true
+    interval: 'PT1M'
+    rules: [
+      {
+        record: 'probe_success'
+        expression: 'avg by (name, namespace, _id, resource_id, cluster) (hostedClusterAPI_kubeapiserver_available{status="True"}) and on (name, namespace, _id, resource_id, cluster) count by (name, namespace, _id, resource_id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+      }
+      {
+        record: 'probe_availability:ratio_avg_7d'
+        expression: 'avg by (name, namespace, _id, resource_id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[1w])) and on (name, namespace, _id, resource_id, cluster) count by (name, namespace, _id, resource_id, cluster) (hostedClusterAPI_kubeapiserver_available)'
+      }
+      {
+        record: 'probe_availability:ratio_avg_30d'
+        expression: 'avg by (name, namespace, _id, resource_id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30d])) and on (name, namespace, _id, resource_id, cluster) count by (name, namespace, _id, resource_id, cluster) (hostedClusterAPI_kubeapiserver_available)'
       }
     ]
   }

--- a/observability/alerts/HCPkasProbeAvailabilityRecord-prometheusRule.yaml
+++ b/observability/alerts/HCPkasProbeAvailabilityRecord-prometheusRule.yaml
@@ -1,0 +1,33 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: hcp-kas-probe-availability-recording-rules
+  namespace: prometheus
+spec:
+  groups:
+  - name: hcp-kas-probe-availability-recording-rules
+    interval: 1m
+    rules:
+    # Compatibility series for the kas-monitor API SLO dashboard.
+    # The dashboard still queries the historical blackbox-probe names;
+    # these rules record them from the HostedCluster kube-apiserver
+    # Available condition without changing existing KSM recording rules.
+    #
+    # All rules are gated on the raw KSM metric currently being reported.
+    # This prevents stale data from deleted clusters.
+
+    - record: probe_success
+      expr: |
+        avg by (name, namespace, _id, resource_id, cluster) (hostedClusterAPI_kubeapiserver_available{status="True"})
+        and on (name, namespace, _id, resource_id, cluster)
+        count by (name, namespace, _id, resource_id, cluster) (hostedClusterAPI_kubeapiserver_available)
+    - record: probe_availability:ratio_avg_7d
+      expr: |
+        avg by (name, namespace, _id, resource_id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[7d]))
+        and on (name, namespace, _id, resource_id, cluster)
+        count by (name, namespace, _id, resource_id, cluster) (hostedClusterAPI_kubeapiserver_available)
+    - record: probe_availability:ratio_avg_30d
+      expr: |
+        avg by (name, namespace, _id, resource_id, cluster) (avg_over_time(hostedClusterAPI_kubeapiserver_available{status="True"}[30d]))
+        and on (name, namespace, _id, resource_id, cluster)
+        count by (name, namespace, _id, resource_id, cluster) (hostedClusterAPI_kubeapiserver_available)

--- a/observability/alerts/HCPkasProbeAvailabilityRecord-prometheusRule_test.yaml
+++ b/observability/alerts/HCPkasProbeAvailabilityRecord-prometheusRule_test.yaml
@@ -1,0 +1,82 @@
+rule_files:
+- HCPkasProbeAvailabilityRecord-prometheusRule.yaml
+evaluation_interval: 1m
+tests:
+# Test 1: 100% availability
+- interval: 1m
+  input_series:
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster", resource_id="test-resource-1"}'
+    values: "1+0x9"
+  promql_expr_test:
+  - expr: probe_success{name="test-cluster-1", namespace="clusters"}
+    eval_time: 10m
+    exp_samples:
+    - labels: '{__name__="probe_success", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster", resource_id="test-resource-1"}'
+      value: 1
+  - expr: probe_availability:ratio_avg_7d{name="test-cluster-1", namespace="clusters"}
+    eval_time: 10m
+    exp_samples:
+    - labels: '{__name__="probe_availability:ratio_avg_7d", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster", resource_id="test-resource-1"}'
+      value: 1
+  - expr: probe_availability:ratio_avg_30d{name="test-cluster-1", namespace="clusters"}
+    eval_time: 10m
+    exp_samples:
+    - labels: '{__name__="probe_availability:ratio_avg_30d", name="test-cluster-1", namespace="clusters", _id="abc-123", cluster="mgmt-cluster", resource_id="test-resource-1"}'
+      value: 1
+# Test 2: 50% availability
+- interval: 1m
+  input_series:
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster", resource_id="test-resource-2"}'
+    values: "1 0 1 0 1 0 1 0 1 0"
+  promql_expr_test:
+  - expr: probe_success{name="test-cluster-2", namespace="clusters"}
+    eval_time: 10m
+    exp_samples:
+    - labels: '{__name__="probe_success", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster", resource_id="test-resource-2"}'
+      value: 0
+  - expr: probe_availability:ratio_avg_7d{name="test-cluster-2", namespace="clusters"}
+    eval_time: 10m
+    exp_samples:
+    - labels: '{__name__="probe_availability:ratio_avg_7d", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster", resource_id="test-resource-2"}'
+      value: 0.5
+  - expr: probe_availability:ratio_avg_30d{name="test-cluster-2", namespace="clusters"}
+    eval_time: 10m
+    exp_samples:
+    - labels: '{__name__="probe_availability:ratio_avg_30d", name="test-cluster-2", namespace="clusters", _id="def-456", cluster="mgmt-cluster", resource_id="test-resource-2"}'
+      value: 0.5
+# Test 3: 0% availability
+- interval: 1m
+  input_series:
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster", resource_id="test-resource-3"}'
+    values: "0+0x9"
+  promql_expr_test:
+  - expr: probe_success{name="test-cluster-3", namespace="clusters"}
+    eval_time: 10m
+    exp_samples:
+    - labels: '{__name__="probe_success", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster", resource_id="test-resource-3"}'
+      value: 0
+  - expr: probe_availability:ratio_avg_7d{name="test-cluster-3", namespace="clusters"}
+    eval_time: 10m
+    exp_samples:
+    - labels: '{__name__="probe_availability:ratio_avg_7d", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster", resource_id="test-resource-3"}'
+      value: 0
+  - expr: probe_availability:ratio_avg_30d{name="test-cluster-3", namespace="clusters"}
+    eval_time: 10m
+    exp_samples:
+    - labels: '{__name__="probe_availability:ratio_avg_30d", name="test-cluster-3", namespace="clusters", _id="ghi-789", cluster="mgmt-cluster", resource_id="test-resource-3"}'
+      value: 0
+# Test 4: deleted cluster is gated out (no currently reported KSM series)
+- interval: 1m
+  input_series:
+  - series: 'hostedClusterAPI_kubeapiserver_available{status="True", name="test-cluster-4", namespace="clusters", _id="stale-000", cluster="mgmt-cluster", resource_id="test-resource-4"}'
+    values: "1+0x4 _x5"
+  promql_expr_test:
+  - expr: probe_success{name="test-cluster-4"}
+    eval_time: 10m
+    exp_samples: []
+  - expr: probe_availability:ratio_avg_7d{name="test-cluster-4"}
+    eval_time: 10m
+    exp_samples: []
+  - expr: probe_availability:ratio_avg_30d{name="test-cluster-4"}
+    eval_time: 10m
+    exp_samples: []

--- a/observability/recording-rules-hcps.yaml
+++ b/observability/recording-rules-hcps.yaml
@@ -5,5 +5,6 @@ prometheusRules:
   - alerts/HCPkasRecord-prometheusRule-latency.yaml
   - alerts/UserJourneyKubeApiserverAvailabilityRecord-prometheusRule-KSM.yaml
   - alerts/UserJourneyEtcdLatencyRecord-prometheusRule.yaml
+  - alerts/HCPkasProbeAvailabilityRecord-prometheusRule.yaml
   untestedRules: []
   outputBicep: ../dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep


### PR DESCRIPTION
<!-- Link to Jira issue -->
https://issues.redhat.com/browse/ARO-29051
### What
Add compatibility Prometheus recording rules so the existing KAS API SLO dashboard keeps working without changing its queries.
The dashboard (`observability/grafana-dashboards/kas-monitor/kas_monitor_api_slo.json`) still queries the old blackbox-probe names:
- `probe_success` (1-day panel)
- `probe_availability:ratio_avg_7d`
- `probe_availability:ratio_avg_30d`
Those series no longer exist. This PR records them from the live KSM signal `hostedClusterAPI_kubeapiserver_available{status="True"}` (HostedCluster `KubeAPIServerAvailable` condition).
Files:
- `observability/alerts/HCPkasProbeAvailabilityRecord-prometheusRule.yaml`
- `observability/alerts/HCPkasProbeAvailabilityRecord-prometheusRule_test.yaml`
- registered in `observability/recording-rules-hcps.yaml`
- generated `dev-infrastructure/modules/metrics/rules/generatedHCPRecordingRules.bicep` (Azure resource `hcp-kas-probe-availability-recording-rules`)
Existing KSM recording rules (`hostedClusterAPI_kubeapiserver_available:ratio_avg_*`) are unchanged. Dashboard JSON is unchanged.
<!-- Briefly describe what this PR does -->

### Why
The KAS API SLO dashboard panels were empty because they still queried retired probe metrics. Availability is already measured from the HostedCluster kube-apiserver Available condition. Recreating the old series from that condition restores the dashboard without a query migration and without rewriting the KSM rules other alerts already depend on.
Rules are gated on a currently reported KSM series so deleted clusters do not leave stale probe values.

<!-- Briefly explain why this change is needed -->

