### PR TITLE
test: retry Cincinnati SelectControlPlaneVersion on transient errors

### DIFF
--- a/test/e2e/complete_cluster_create_multiversion.go
+++ b/test/e2e/complete_cluster_create_multiversion.go
@@ -34,7 +34,6 @@ import (
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 
 	clusterversion "github.com/Azure/ARO-HCP/backend/pkg/controllers/cluster/version"
-	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controlplaneversion"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
 	"github.com/Azure/ARO-HCP/test/util/verifiers"
@@ -75,7 +74,7 @@ var _ = Describe("ARO-HCP", func() {
 				Expect(err).NotTo(HaveOccurred(), "failed to resolve nightly install version for %s", version)
 				clusterParams.OpenshiftVersionId = resolved
 			} else {
-				desiredVersion, err := controlplaneversion.SelectControlPlaneVersion(ctx, http.DefaultTransport.RoundTrip, nil, fmt.Sprintf("%s-%s", channelGroup, version), clusterversion.GetZStreamOffset(channelGroup))
+				desiredVersion, err := framework.SelectControlPlaneVersion(ctx, http.DefaultTransport.RoundTrip, nil, fmt.Sprintf("%s-%s", channelGroup, version), clusterversion.GetZStreamOffset(channelGroup))
 				if err != nil {
 					Skip(fmt.Sprintf("failed to resolve a version for channel %s-%s: %v", channelGroup, version, err))
 				}

--- a/test/e2e/control_plane_automated_z_stream_upgrade.go
+++ b/test/e2e/control_plane_automated_z_stream_upgrade.go
@@ -29,7 +29,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
 	clusterversion "github.com/Azure/ARO-HCP/backend/pkg/controllers/cluster/version"
-	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controlplaneversion"
 	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
 	"github.com/Azure/ARO-HCP/test/util/labels"
@@ -62,7 +61,7 @@ var _ = Describe("Service Provider", func() {
 			// channel has no release at that offset (err) or none is resolved (nil), there is no
 			// automated z-stream upgrade to exercise, so skip.
 			normalOffset := clusterversion.GetZStreamOffset(channelGroup)
-			desiredVersion, err := controlplaneversion.SelectControlPlaneVersion(ctx, http.DefaultTransport.RoundTrip, nil, fmt.Sprintf("%s-%s", channelGroup, minorVersion), normalOffset+1)
+			desiredVersion, err := framework.SelectControlPlaneVersion(ctx, http.DefaultTransport.RoundTrip, nil, fmt.Sprintf("%s-%s", channelGroup, minorVersion), normalOffset+1)
 			if err != nil {
 				Skip(fmt.Sprintf("no version resolved for channel %s-%s at offset %d: %v", channelGroup, minorVersion, normalOffset+1, err))
 			}

--- a/test/e2e/control_plane_minor_upgrade.go
+++ b/test/e2e/control_plane_minor_upgrade.go
@@ -32,7 +32,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
 	clusterversion "github.com/Azure/ARO-HCP/backend/pkg/controllers/cluster/version"
-	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controlplaneversion"
 	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
 	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
@@ -77,7 +76,7 @@ var _ = Describe("Customer", func() {
 				upgradeVersionId = resolvedUpgrade
 			} else {
 				for _, minorLine := range []string{installVersionId, upgradeVersionId} {
-					desiredVersion, err := controlplaneversion.SelectControlPlaneVersion(ctx, http.DefaultTransport.RoundTrip, nil, fmt.Sprintf("%s-%s", channelGroup, minorLine), clusterversion.GetZStreamOffset(channelGroup))
+					desiredVersion, err := framework.SelectControlPlaneVersion(ctx, http.DefaultTransport.RoundTrip, nil, fmt.Sprintf("%s-%s", channelGroup, minorLine), clusterversion.GetZStreamOffset(channelGroup))
 					if err != nil {
 						Skip(fmt.Sprintf("failed to resolve a version for channel %s-%s: %v", channelGroup, minorLine, err))
 					}

--- a/test/e2e/nodepool_version_upgrade.go
+++ b/test/e2e/nodepool_version_upgrade.go
@@ -32,7 +32,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
 	clusterversion "github.com/Azure/ARO-HCP/backend/pkg/controllers/cluster/version"
-	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controlplaneversion"
 	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
 	hcpsdk20240610preview "github.com/Azure/ARO-HCP/test/sdk/resourcemanager/redhatopenshifthcp/armredhatopenshifthcp"
 	"github.com/Azure/ARO-HCP/test/util/framework"
@@ -53,7 +52,7 @@ func resolveNodePoolTestVersion(ctx context.Context, channelGroup, minor string,
 		}
 		return framework.GetLatestNightlyInstallVersion(ctx, channelGroup, minor)
 	}
-	release, err := controlplaneversion.SelectControlPlaneVersion(ctx, http.DefaultTransport.RoundTrip, nil, fmt.Sprintf("%s-%s", channelGroup, minor), offset)
+	release, err := framework.SelectControlPlaneVersion(ctx, http.DefaultTransport.RoundTrip, nil, fmt.Sprintf("%s-%s", channelGroup, minor), offset)
 	if err != nil {
 		return "", err
 	}

--- a/test/util/framework/deployment_params.go
+++ b/test/util/framework/deployment_params.go
@@ -31,7 +31,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 
 	clusterversion "github.com/Azure/ARO-HCP/backend/pkg/controllers/cluster/version"
-	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controlplaneversion"
 	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
 )
 
@@ -119,7 +118,7 @@ func resolveDefaultControlPlaneVersion() (string, error) {
 			return
 		}
 
-		release, err := controlplaneversion.SelectControlPlaneVersion(context.Background(), http.DefaultTransport.RoundTrip, nil, fmt.Sprintf("%s-%s", channelGroup, resultingControlPlaneMinorVersion), zStreamOffset)
+		release, err := SelectControlPlaneVersion(context.Background(), http.DefaultTransport.RoundTrip, nil, fmt.Sprintf("%s-%s", channelGroup, resultingControlPlaneMinorVersion), zStreamOffset)
 		if err != nil {
 			defaultCPVersionErr = fmt.Errorf("failed getting controlPlaneVersion: %w", err)
 			return
@@ -201,8 +200,9 @@ func DefaultOpenshiftNodePoolVersionId() string {
 	}
 
 	// Every other channel group selects the tip of the channel via the OpenShift update
-	// service — the same selector the control plane version controller uses.
-	release, err := controlplaneversion.SelectControlPlaneVersion(context.Background(), http.DefaultTransport.RoundTrip, nil, fmt.Sprintf("%s-%s", channelGroup, minor), clusterversion.GetZStreamOffset(channelGroup))
+	// service — the same selector the control plane version controller uses. The framework
+	// wrapper retries transient DNS/network errors internally.
+	release, err := SelectControlPlaneVersion(context.Background(), http.DefaultTransport.RoundTrip, nil, fmt.Sprintf("%s-%s", channelGroup, minor), clusterversion.GetZStreamOffset(channelGroup))
 	if err != nil {
 		Fail(fmt.Sprintf("failed to select node pool install version for %s-%s channel: %s", channelGroup, minor, err.Error()))
 	}

--- a/test/util/framework/version_helper.go
+++ b/test/util/framework/version_helper.go
@@ -27,6 +27,9 @@ import (
 
 	"github.com/blang/semver/v4"
 
+	configv1 "github.com/openshift/api/config/v1"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/controllers/controlplaneversion"
 	"github.com/Azure/ARO-HCP/internal/cincinnati"
 )
 
@@ -87,6 +90,16 @@ func isRetryableVersionError(err error) bool {
 		return false
 	}
 	return true
+}
+
+// SelectControlPlaneVersion wraps controlplaneversion.SelectControlPlaneVersion with the same
+// transient-error retry policy as GetLatestNightlyInstallVersion, so tests survive brief DNS or
+// network hiccups when the test pod resolves api.openshift.com. Non-transient errors (context
+// cancellation/deadline, cincinnati "version not found") are returned immediately.
+func SelectControlPlaneVersion(ctx context.Context, roundTripper controlplaneversion.RoundTrip, updateService *url.URL, channel string, offset uint) (*configv1.Release, error) {
+	return retryOnTransientError(ctx, func() (*configv1.Release, error) {
+		return controlplaneversion.SelectControlPlaneVersion(ctx, roundTripper, updateService, channel, offset)
+	})
 }
 
 // GetLatestNightlyInstallVersion returns the latest accepted nightly tag for the given minor version


### PR DESCRIPTION
## Summary

E2E tests resolve OpenShift install versions by calling the Cincinnati graph API at `https://api.openshift.com/api/upgrades_info/graph` from the test pod. A transient DNS timeout there currently fails the test even though no product component is broken.

Example failure on 2026-09-09 (ARM64 node-pool test):
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-Azure-ARO-HCP-main-e2e-integration-e2e-parallel/2097552958542581760

```
fail [test/util/framework/deployment_params.go:207]: failed to select node pool install version for candidate-4.21 channel: Get "https://api.openshift.com/api/upgrades_info/graph?arch=multi&channel=candidate-4.21": dial tcp: lookup api.openshift.com on 172.30.0.10:53: read udp 10.128.224.73:44833->172.30.0.10:53: i/o timeout
```

The product path succeeded end-to-end (Clusters Service `ready` at 05:41:22Z, RP backend `Succeeded` at 05:43:01Z). The failure was a test-side external dependency timeout during node-pool version selection.

## Why

The nightly version path (`GetLatestNightlyInstallVersion`) already retries transient errors via `retryOnTransientError` in `test/util/framework/version_helper.go` (added in 198e625e4 for ARO-26732/ARO-26733). The Cincinnati path (`controlplaneversion.SelectControlPlaneVersion`) has no retry today, so any DNS/network hiccup in the test pod hard-fails tests that call it.

## Change

- Add `framework.SelectControlPlaneVersion` — a thin wrapper that reuses the existing `retryOnTransientError` helper (3 retries, exponential 1s→2s→4s backoff, skips non-transient errors like context cancellation and cincinnati "version not found").
- Swap the 5 direct call sites to use the wrapper (`test/util/framework/deployment_params.go` + 4 e2e files).
- Drop the now-unused `controlplaneversion` import from those e2e files.

Jira: [AROSLSRE-2054](https://issues.redhat.com/browse/AROSLSRE-2054)

## Test plan

- [ ] `make lint` and `go build ./...` under `test/` pass
- [ ] Existing e2e tests continue to resolve versions correctly on the happy path
- [ ] Under a simulated DNS blip, the wrapper retries and the test proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)