### PR TITLE
feat(dev-infra): provision cleanup-sweeper directory-write Entra app (AROSLSRE-2053)

### DIFF
--- a/config/config-dev-ci.schema.json
+++ b/config/config-dev-ci.schema.json
@@ -413,6 +413,10 @@
         },
         "mockIdentities": {
           "$ref": "#/$defs/MockIdentities"
+        },
+        "cleanupSweeperDirectoryWriteApp": {
+          "$ref": "#/$defs/CIBot",
+          "description": "Dedicated Entra app (DEV-only today) granted Microsoft Graph Application.ReadWrite.All, used by the cleanup-sweeper shared-leftovers workflow to purge aged soft-deleted apps/SPs so their orphaned role assignments stop lingering for Entra's full 30-day recycle-bin window. Requires manual tenant-admin consent after deployment; see docs/ci/dev-mock-identities.md."
         }
       },
       "required": ["bot", "e2eSubscriptions"]

--- a/config/config-dev-ci.schema.json
+++ b/config/config-dev-ci.schema.json
@@ -416,7 +416,7 @@
         },
         "cleanupSweeperDirectoryWriteApp": {
           "$ref": "#/$defs/CIBot",
-          "description": "Dedicated Entra app (DEV-only today) granted Microsoft Graph Application.ReadWrite.All, used by the cleanup-sweeper shared-leftovers workflow to purge aged soft-deleted apps/SPs so their orphaned role assignments stop lingering for Entra's full 30-day recycle-bin window. Requires manual tenant-admin consent after deployment; see docs/ci/dev-mock-identities.md."
+          "description": "Dedicated Entra app (DEV-only today) granted Microsoft Graph Application.ReadWrite.All, used by the cleanup-sweeper shared-leftovers workflow to purge aged soft-deleted apps/SPs so their orphaned role assignments stop lingering for Entra's full 30-day recycle-bin window. Requires manual tenant-admin consent after deployment; see docs/ci/cleanup.md."
         }
       },
       "required": ["bot", "e2eSubscriptions"]

--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -243,6 +243,8 @@ clouds:
         dev:
           bot:
             applicationName: "OpenShift Release Bot"
+          cleanupSweeperDirectoryWriteApp:
+            applicationName: "aro-dev-cleanup-sweeper-directory-write"
           e2eSubscriptions:
           - name: "ARO HCP E2E Hosted Clusters (EA Subscription)"
             id: "974ebd46-8ad3-41e3-afef-7ef25fd5c371"

--- a/dev-infrastructure/configurations/cleanup-sweeper-directory-write-app-dev.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/cleanup-sweeper-directory-write-app-dev.tmpl.bicepparam
@@ -2,7 +2,7 @@ using '../modules/entra/app.bicep'
 
 // Dedicated Entra app granted Microsoft Graph Application.ReadWrite.All, used
 // by the cleanup-sweeper shared-leftovers workflow to purge aged soft-deleted
-// apps/SPs (see tooling/cleanup-sweeper/roleassignments/purge_aged_deleted.go).
+// apps/SPs (see docs/ci/cleanup.md).
 // Kept separate from the mock identities and the CI bots: it needs a
 // materially higher privilege than either, so it must not share an app with a
 // lower-privilege identity. Application.ReadWrite.All still requires manual

--- a/dev-infrastructure/configurations/cleanup-sweeper-directory-write-app-dev.tmpl.bicepparam
+++ b/dev-infrastructure/configurations/cleanup-sweeper-directory-write-app-dev.tmpl.bicepparam
@@ -1,0 +1,27 @@
+using '../modules/entra/app.bicep'
+
+// Dedicated Entra app granted Microsoft Graph Application.ReadWrite.All, used
+// by the cleanup-sweeper shared-leftovers workflow to purge aged soft-deleted
+// apps/SPs (see tooling/cleanup-sweeper/roleassignments/purge_aged_deleted.go).
+// Kept separate from the mock identities and the CI bots: it needs a
+// materially higher privilege than either, so it must not share an app with a
+// lower-privilege identity. Application.ReadWrite.All still requires manual
+// tenant-admin consent after deployment; Bicep cannot grant admin consent for
+// Graph application permissions.
+param applicationName = '{{ .ci.dev.cleanupSweeperDirectoryWriteApp.applicationName }}'
+param ownerIds = '{{ .entraAppOwnerIds }}'
+param ownerRelationshipSemantics = 'replace'
+param manageSp = true
+param requiredResourceAccess = [
+  {
+    // Microsoft Graph
+    resourceAppId: '00000003-0000-0000-c000-000000000000'
+    resourceAccess: [
+      {
+        // Application.ReadWrite.All (application permission)
+        id: '1bfefb4e-e0b5-418b-a88f-73c46d2cc8e9'
+        type: 'Role'
+      }
+    ]
+  }
+]

--- a/dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
+++ b/dev-infrastructure/dev-ci/e2e-subscription-rbac/pipeline.yaml
@@ -1,10 +1,13 @@
 $schema: "pipeline.schema.v1"
 serviceGroup: Microsoft.Azure.ARO.HCP.DevCI.E2ESubscriptionRBAC
 rolloutName: Dev CI E2E Subscription RBAC Rollout
-# Reconciles the CI bot Entra identities: the ci-bot-identity step creates the
-# bot Entra applications and service principals, and the ci-bot-secret-* steps
-# mint their client secrets. These are Entra directory-object writes, so this is
-# a privileged pipeline that the unattended dev-ci postsubmit never runs.
+# Reconciles privileged Entra directory-object writes for DEV: the
+# ci-bot-identity step creates the bot Entra applications and service
+# principals, ci-bot-secret-* mint their client secrets, and the
+# cleanup-sweeper-directory-write-* steps do the same for the dedicated
+# directory-write app used by cleanup-sweeper's purge-aged-deleted step. These
+# are Entra directory-object writes, so this is a privileged pipeline that the
+# unattended dev-ci postsubmit never runs.
 resourceGroups:
 - name: ci-bots
   resourceGroup: '{{ .global.rg }}'
@@ -21,6 +24,36 @@ resourceGroups:
     template: ../../templates/ci-bot-identity.bicep
     parameters: ../../configurations/ci-bot-identity.tmpl.bicepparam
     deploymentLevel: ResourceGroup
+  # Dedicated DEV-only app for cleanup-sweeper's shared-leftovers
+  # purge-aged-deleted step. Kept out of ci-bot-identity.bicep because it
+  # needs Application.ReadWrite.All, a materially higher privilege than the
+  # CI bots' Application.ReadWrite.OwnedBy.
+  - name: cleanup-sweeper-directory-write-app
+    action: ARM
+    template: ../../modules/entra/app.bicep
+    parameters: ../../configurations/cleanup-sweeper-directory-write-app-dev.tmpl.bicepparam
+    deploymentLevel: ResourceGroup
+  - name: cleanup-sweeper-directory-write-secret
+    action: Shell
+    command: ./ci-bot-ensure-secret.sh
+    workingDir: ../../scripts
+    shellIdentity:
+      input:
+        resourceGroup: ci-bots
+        step: global-identity
+        name: globalMSIId
+    variables:
+    - name: APP_NAME
+      configRef: ci.dev.cleanupSweeperDirectoryWriteApp.applicationName
+    - name: ENV_NAME
+      value: dev
+    - name: KEY_VAULT_NAME
+      configRef: opstool.keyVault.name
+    - name: SECRET_PREFIX
+      value: cleanup-sweeper-directory-write
+    dependsOn:
+    - resourceGroup: ci-bots
+      step: cleanup-sweeper-directory-write-app
   - name: ci-bot-secret-int
     action: Shell
     command: ./ci-bot-ensure-secret.sh

--- a/dev-infrastructure/scripts/ci-bot-ensure-secret.sh
+++ b/dev-infrastructure/scripts/ci-bot-ensure-secret.sh
@@ -1,19 +1,25 @@
 #!/bin/bash
 set -euo pipefail
 
-# Ensure a CI bot application has its credentials stored in Key Vault.
-# Backfills any missing secrets without regenerating existing ones.
+# Ensure an Entra application has its credentials stored in Key Vault.
+# Backfills any missing secrets without regenerating existing ones. Despite
+# the "ci-bot" name, this is generic enough for any single-app/single-secret
+# Entra identity (e.g. the cleanup-sweeper directory-write app), selected via
+# SECRET_PREFIX.
 #
 # Required environment variables:
 #   APP_NAME       - Entra application display name (e.g. "OpenShift Release Bot - STG")
 #   ENV_NAME       - Environment label (e.g. "stg") used in KV secret names
 #   KEY_VAULT_NAME - Target Azure Key Vault name
+#
+# Optional environment variables:
+#   SECRET_PREFIX  - KV secret name prefix (default: ci-bot-${ENV_NAME})
 
 : "${APP_NAME:?APP_NAME is required}"
 : "${ENV_NAME:?ENV_NAME is required}"
 : "${KEY_VAULT_NAME:?KEY_VAULT_NAME is required}"
 
-SECRET_PREFIX="ci-bot-${ENV_NAME}"
+SECRET_PREFIX="${SECRET_PREFIX:-ci-bot-${ENV_NAME}}"
 
 # kv_secret_exists: returns 0 if the secret exists, 1 if SecretNotFound,
 # and exits on any other error.
@@ -49,15 +55,16 @@ if [[ -z "${APP_OBJECT_ID}" ]]; then
     exit 1
 fi
 
-# Admin consent for declared API permissions (e.g. Application.ReadWrite.OwnedBy).
-# This is best-effort: if the pipeline executor lacks the required Entra role
-# (e.g. Cloud Application Administrator or Global Administrator), the call will
-# fail and a tenant admin must grant consent manually before the bot is fully
-# usable. The warning below is NOT self-healing — treat it as a manual action item.
+# Admin consent for declared API permissions (e.g. Application.ReadWrite.OwnedBy,
+# Application.ReadWrite.All). This is best-effort: if the pipeline executor
+# lacks the required Entra role (e.g. Cloud Application Administrator or
+# Global Administrator), the call will fail and a tenant admin must grant
+# consent manually before the application is fully usable. The warning below
+# is NOT self-healing — treat it as a manual action item.
 echo "Granting admin consent for declared API permissions..."
 az ad app permission admin-consent --id "${APP_CLIENT_ID}" || {
     echo "WARNING: admin-consent failed — a tenant admin must grant consent manually"
-    echo "         before the bot can exercise Application.ReadWrite.OwnedBy."
+    echo "         before '${APP_NAME}' can exercise its declared Graph permissions."
     echo "         This will NOT resolve itself on subsequent pipeline runs."
 }
 

--- a/dev-infrastructure/scripts/ci-bot-ensure-secret.sh
+++ b/dev-infrastructure/scripts/ci-bot-ensure-secret.sh
@@ -9,7 +9,9 @@ set -euo pipefail
 #
 # Required environment variables:
 #   APP_NAME       - Entra application display name (e.g. "OpenShift Release Bot - STG")
-#   ENV_NAME       - Environment label (e.g. "stg") used in KV secret names
+#   ENV_NAME       - Environment label (e.g. "stg") used to compute the
+#                    default SECRET_PREFIX (ci-bot-${ENV_NAME}); ignored if
+#                    SECRET_PREFIX is set explicitly
 #   KEY_VAULT_NAME - Target Azure Key Vault name
 #
 # Optional environment variables:


### PR DESCRIPTION
[AROSLSRE-2053](https://redhat.atlassian.net/browse/AROSLSRE-2053)

### What

Adds a dedicated `aro-dev-cleanup-sweeper-directory-write` Entra app/SP for DEV, declared via the existing `modules/entra/app.bicep` module and wired into the privileged `dev-ci` `E2ESubscriptionRBAC` pipeline alongside the CI bot identities. It requests the Microsoft Graph `Application.ReadWrite.All` application permission and reuses `ci-bot-ensure-secret.sh` (now parameterized via `SECRET_PREFIX`) to mint and store its client secret in the opstool Key Vault.

### Why

Orphaned role assignments for deleted E2E test service principals build up faster than Entra's 30-day soft-delete recycle-bin window clears them, since the existing `cleanup-sweeper` `shared-leftovers` step only deletes an assignment once its principal is gone from both the active directory and Graph's `deletedItems`. [PR #6825](https://github.com/Azure/ARO-HCP/pull/6825) adds an opt-in `purge_aged_deleted.go` step that force-purges aged (7-day) soft-deleted apps/SPs so their role assignments become cleanable immediately, but it needs a dedicated, higher-privilege Graph credential that doesn't exist yet. This PR provisions that credential as code instead of via a one-off manual `az` session, so it is reproducible and owned by the same `aro-hcp-owners` group as the other pipeline-managed identities.

Kept separate from `ci-bot-identity.bicep` because `Application.ReadWrite.All` is a materially higher privilege than the CI bots' `Application.ReadWrite.OwnedBy`, so it must not share an app with a lower-privilege identity.

### Testing

- `bicep build-params` compiles the new `.tmpl.bicepparam` (with placeholders substituted) against `modules/entra/app.bicep` with no errors, producing the expected `requiredResourceAccess` shape.
- Validated the modified `config-dev-ci.yaml`/`config-dev-ci.schema.json`/pipeline YAML/shell script for JSON/YAML/bash syntax.
- `make validate-config-pipelines-dev-ci` fails identically on a clean `upstream/main` checkout (pre-existing, unrelated "range loop not allowed" errors in other `.tmpl.bicepparam` files), confirming this change introduces no new validation failures.

### Special notes for your reviewer

`Application.ReadWrite.All` still requires manual tenant-admin consent after this deploys (Bicep/the pipeline's own admin-consent attempt in `ci-bot-ensure-secret.sh` cannot grant it without a Global Administrator / Privileged Role Administrator running it). That consent step, and wiring the resulting secret into the `sweeper-shared-leftovers-dev` CI job in `openshift/release`, are tracked as follow-ups on [AROSLSRE-2053](https://redhat.atlassian.net/browse/AROSLSRE-2053).

### PR Checklist
- [x] Tests pass
- [x] Documentation is up to date
