### PR TITLE
fix: stabilize CIHealth deployment

### DIFF
--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -131,7 +131,7 @@ clouds:
           image:
             registry: "quay.io"
             repository: "roivaz/cihealth"
-            digest: sha256:d6be00b644b6b69bd412fc475629905ab5225e2de2ffbdfda66850f4bb9d53d0 # d07a0f1 (2026-08-05 13:40)
+            digest: sha256:df1626692af5f6254797afd24dfd544599a50a3e3ed6e89599b6b36972b79887 # a895e5f (2026-09-09 11:48)
           disableRuntimeWorkloads: false
           app:
             replicas: 2

--- a/config/config-dev-ci.yaml
+++ b/config/config-dev-ci.yaml
@@ -131,7 +131,7 @@ clouds:
           image:
             registry: "quay.io"
             repository: "roivaz/cihealth"
-            digest: sha256:df1626692af5f6254797afd24dfd544599a50a3e3ed6e89599b6b36972b79887 # a895e5f (2026-09-09 11:48)
+            digest: sha256:bf999ec87b4b629ae0925359081424c886d4484cc18db874bbdd2f892e617617 # a54d860 (2026-09-09 19:18)
           disableRuntimeWorkloads: false
           app:
             replicas: 2

--- a/dev-infrastructure/dev-ci/cihealth/deploy/templates/app-deployment.yaml
+++ b/dev-infrastructure/dev-ci/cihealth/deploy/templates/app-deployment.yaml
@@ -78,14 +78,23 @@ spec:
             httpGet:
               path: /readyz
               port: http
-            initialDelaySeconds: 5
             periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
           livenessProbe:
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 15
-            periodSeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 5
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 24
           volumeMounts:
             - name: secrets-store
               mountPath: {{ include "cihealth.secretsStoreMountPath" . | quote }}

--- a/dev-infrastructure/dev-ci/cihealth/deploy/values.yaml
+++ b/dev-infrastructure/dev-ci/cihealth/deploy/values.yaml
@@ -33,7 +33,7 @@ postgres:
   persistence:
     size: 20Gi
     accessModes:
-    - ReadWriteOnce
+      - ReadWriteOnce
     storageClass: "managed-premium"
   resources:
     requests:
@@ -50,11 +50,11 @@ app:
   service:
     type: ClusterIP
     port: 8082
+  # Cache refreshes can temporarily retain the old and replacement snapshots.
+  # Reserve steady-state memory without imposing an OOM-kill ceiling.
   resources:
     requests:
-      cpu: 50m
-      memory: 128Mi
-    limits:
+      cpu: 500m
       memory: 512Mi
   extraEnv: []
   extraArgs: []
@@ -70,10 +70,10 @@ controllers:
   historyWeeks: 4
   source:
     envs:
-    - dev
-    - int
-    - stg
-    - prod
+      - dev
+      - int
+      - stg
+      - prod
     sippyBaseUrl: https://sippy.dptools.openshift.org
     sippyOrg: Azure
     sippyRepo: ARO-HCP
@@ -92,11 +92,11 @@ controllers:
     factsRuns: 1
     factsRawFailures: 1
     metricsRollupDaily: 1
+  # Controller memory follows the volume of imported CI data and has reached
+  # the previous 1Gi limit. Reserve observed usage without forcing restarts.
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
+      cpu: 250m
       memory: 1Gi
   extraEnv: []
   extraArgs: []

--- a/dev-infrastructure/dev-ci/cihealth/deploy/values.yaml
+++ b/dev-infrastructure/dev-ci/cihealth/deploy/values.yaml
@@ -33,7 +33,7 @@ postgres:
   persistence:
     size: 20Gi
     accessModes:
-      - ReadWriteOnce
+    - ReadWriteOnce
     storageClass: "managed-premium"
   resources:
     requests:
@@ -70,10 +70,10 @@ controllers:
   historyWeeks: 4
   source:
     envs:
-      - dev
-      - int
-      - stg
-      - prod
+    - dev
+    - int
+    - stg
+    - prod
     sippyBaseUrl: https://sippy.dptools.openshift.org
     sippyOrg: Azure
     sippyRepo: ARO-HCP


### PR DESCRIPTION
Related application changes:
- https://github.com/roivaz/ARO-HCP-CIHealth/pull/10
- https://github.com/roivaz/ARO-HCP-CIHealth/pull/11

### What

- deploy CIHealth image `a54d860` (`sha256:bf999ec87b4b629ae0925359081424c886d4484cc18db874bbdd2f892e617617`) produced by [workflow run 34394204585](https://github.com/roivaz/ARO-HCP-CIHealth/actions/runs/34394204585)
- add an app startup probe and make readiness/liveness probes tolerant of sustained preparation and GC pressure
- raise app requests to `500m` CPU and `512Mi` memory and controller requests to `250m` CPU and `1Gi` memory
- remove app and controller memory limits so snapshot replacement and growing controller data do not trigger avoidable OOM restarts

| Name | Old Digest | New Digest | Tag | Date | Status |
| --- | --- | --- | --- | --- | --- |
| cihealth | d6be00b644b6… | bf999ec87b4b… | a54d860 | 2026-09-09 19:18 | updated |

### Why

The live deployment was repeatedly removing app backends and restarting processes during expensive failure-pattern preparation. Profiling showed that the existing 512 MiB app limit can be exceeded while old and replacement cache snapshots coexist, and the controller had already reached its 1 GiB limit and been OOM-killed.

The application image includes both the preparation-performance work and the follow-up semantic clustering fixes. Representative 35-day cold preparation improved from about 103 seconds to about 12-15 seconds, with cumulative allocation volume reduced from about 9.4 GiB to about 1.03 GiB. The deployment changes provide realistic scheduling requests while avoiding hard memory ceilings for these data-dependent workloads. PostgreSQL resources remain unchanged because database loading completed in about 1.2 seconds and showed no resource pressure.

On the restored production database, the semantic fixes reduced the seven-day dev pattern count from 255 to 179 and review signals from 216 to 138 while retaining all 1,948 matched occurrences. Generated Cosmos alert identities, Cosmos database paths, Azure retry delays, quota counters, timestamps, and stamp ordinals now cluster without removing meaningful deployment component or failure-lane distinctions.

### Testing

- `make -C config materialize`
- `AZURE_TOKEN_CREDENTIALS=AzureCLICredential go test ./...` in `tooling/image-updater`
- `helm lint dev-infrastructure/dev-ci/cihealth/deploy`
- `make verify-yamlfmt`
- rendered the chart with the new digest and asserted the probe/resource settings
- validated and rendered `config/config-dev-ci.yaml` with `templatize configuration validate`

`make validate-config-pipelines-dev-ci` reaches unrelated pre-existing restricted-template errors in CI bot RBAC, mock identity RBAC, and resource-group tag policy bicepparam templates. No pipeline or bicepparam files are changed here.

### Special notes for your reviewer

The readiness probe now requires six consecutive failures (roughly one minute) before removing a backend. Liveness requires five consecutive 30-second failures after startup-probe success (roughly 150 seconds) before restarting the container.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to the related application changes; no separate Jira for this deployment follow-up
- [x] Screenshots not applicable (backend deployment configuration only)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR not required; implementation and targeted validation are complete
- [x] Commit history is clean
- [x] Non-obvious resource-limit rationale is documented inline
- [x] Specific infrastructure reviewer requested
- [ ] All comment threads resolved before merge
