### PR TITLE
Fix: Cilium CNI conflist `cniVersion` mismatch with Multus

### DIFF
--- a/test/e2e/cluster_create_cni_cilium.go
+++ b/test/e2e/cluster_create_cni_cilium.go
@@ -104,6 +104,10 @@ var _ = Describe("Customer", func() {
 			kubeconfigContent, err := framework.GenerateKubeconfig(adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred(), "failed to generate kubeconfig for cluster %q", customerClusterName)
 
+			By("providing a Multus-compatible custom CNI conflist for Cilium")
+			err = framework.EnsureCiliumCNIConfigMap(ctx, adminRESTConfig, ciliumNamespace, framework.CiliumCNIConfigMapName, framework.CiliumConflistPortmap)
+			Expect(err).NotTo(HaveOccurred(), "failed to create Cilium CNI conflist ConfigMap")
+
 			By("installing Cilium via Helm")
 			ciliumValues := map[string]any{
 				"debug": map[string]any{
@@ -138,6 +142,7 @@ var _ = Describe("Customer", func() {
 					"binPath":      "/var/lib/cni/bin",
 					"confPath":     "/var/run/multus/cni/net.d",
 					"chainingMode": "portmap",
+					"configMap":    framework.CiliumCNIConfigMapName,
 				},
 				"prometheus": map[string]any{
 					"serviceMonitor": map[string]any{

--- a/test/e2e/cluster_create_complex_cilium_kv.go
+++ b/test/e2e/cluster_create_complex_cilium_kv.go
@@ -128,6 +128,11 @@ var _ = Describe("Customer", func() {
 			Expect(err).NotTo(HaveOccurred(), "failed to disable kube-proxy via network operator patch")
 			GinkgoLogr.Info("Disabled kube-proxy via network operator patch")
 
+			By("providing a Multus-compatible custom CNI conflist for Cilium")
+			const ciliumNamespace = "kube-system"
+			err = framework.EnsureCiliumCNIConfigMap(ctx, adminRESTConfig, ciliumNamespace, framework.CiliumCNIConfigMapName, framework.CiliumConflistNone)
+			Expect(err).NotTo(HaveOccurred(), "failed to create Cilium CNI conflist ConfigMap")
+
 			By("installing Cilium via helm SDK")
 			kubeconfigContent, err := framework.GenerateKubeconfig(adminRESTConfig)
 			Expect(err).NotTo(HaveOccurred(), "failed to generate kubeconfig for Helm installation")
@@ -136,6 +141,7 @@ var _ = Describe("Customer", func() {
 					"uninstall": false,
 					"binPath":   "/var/lib/cni/bin",
 					"confPath":  "/var/run/multus/cni/net.d",
+					"configMap": framework.CiliumCNIConfigMapName,
 				},
 				"kubeProxyReplacement": true,
 				"k8sServiceHost":       "172.20.0.1",

--- a/test/e2e/cluster_create_feature_aggregation.go
+++ b/test/e2e/cluster_create_feature_aggregation.go
@@ -307,6 +307,10 @@ var _ = Describe("Customer", func() {
 				g.Expect(patchErr).NotTo(HaveOccurred(), "failed to disable kube-proxy via network operator patch")
 			}, 5*time.Minute, 10*time.Second).Should(Succeed(), "kube-proxy disable patch should succeed")
 
+			By("providing a Multus-compatible custom CNI conflist for Cilium")
+			err = framework.EnsureCiliumCNIConfigMap(ctx, adminRESTConfig, ciliumNamespace, framework.CiliumCNIConfigMapName, framework.CiliumConflistNone)
+			Expect(err).NotTo(HaveOccurred(), "failed to create Cilium CNI conflist ConfigMap")
+
 			By("installing cilium with kube-proxy replacement enabled via Helm SDK")
 			// k8sServiceHost/k8sServicePort must point at the local kube-apiserver-proxy
 			// static pod (HAProxy) that HyperShift embeds via ignition/MachineConfig on
@@ -336,6 +340,7 @@ var _ = Describe("Customer", func() {
 					"uninstall": false,
 					"binPath":   "/var/lib/cni/bin",
 					"confPath":  "/var/run/multus/cni/net.d",
+					"configMap": framework.CiliumCNIConfigMapName,
 				},
 				"kubeProxyReplacement": true,
 				"k8sServiceHost":       "172.20.0.1",

--- a/test/util/framework/cilium_helper.go
+++ b/test/util/framework/cilium_helper.go
@@ -16,6 +16,7 @@ package framework
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -26,6 +27,7 @@ import (
 	"helm.sh/helm/v4/pkg/cli"
 	"helm.sh/helm/v4/pkg/kube"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 
@@ -99,6 +102,86 @@ func InstallCiliumChart(ctx context.Context, chartVersion string, values map[str
 		return fmt.Errorf("failed to install cilium chart: %w", err)
 	}
 
+	return nil
+}
+
+const (
+	MultusCompatibleCNIVersion = "1.0.0"
+
+	// CiliumCNIConfigMapName is the ConfigMap name passed as Helm cni.configMap.
+	// Keep it in sync with EnsureCiliumCNIConfigMap callers and the Helm values.
+	CiliumCNIConfigMapName = "cilium-cni-conf"
+
+	ciliumCNIConfigMapKey = "cni-config"
+)
+
+// CiliumConflistNone is the CNI conflist Cilium writes when chaining is off.
+var CiliumConflistNone = map[string]any{
+	"cniVersion": MultusCompatibleCNIVersion,
+	"name":       "cilium",
+	"plugins": []any{
+		map[string]any{
+			"type":         "cilium-cni",
+			"enable-debug": false,
+			"log-file":     "/var/run/cilium/cilium-cni.log",
+		},
+	},
+}
+
+// CiliumConflistPortmap is the CNI conflist Cilium writes when portmap chaining is on.
+var CiliumConflistPortmap = map[string]any{
+	"cniVersion": MultusCompatibleCNIVersion,
+	"name":       "portmap",
+	"plugins": []any{
+		map[string]any{
+			"type":         "cilium-cni",
+			"enable-debug": false,
+			"log-file":     "/var/run/cilium/cilium-cni.log",
+		},
+		map[string]any{
+			"type":         "portmap",
+			"capabilities": map[string]any{"portMappings": true},
+		},
+	},
+}
+
+// EnsureCiliumCNIConfigMap creates (or updates, if already present) a
+// ConfigMap holding a custom CNI conflist for Cilium to write verbatim to
+// disk, bypassing its own built-in conflist generation. Pass
+// CiliumCNIConfigMapName as the "cni.configMap" Helm value (with
+// "cni.configMapKey" left at its default of "cni-config") when installing
+// the Cilium chart via InstallCiliumChart, so the agent reads the marshaled
+// conflist instead of rendering its hard-coded (and, as of Cilium v1.19.x,
+// Multus-incompatible) template. See MultusCompatibleCNIVersion for why
+// this is necessary.
+func EnsureCiliumCNIConfigMap(ctx context.Context, adminRESTConfig *rest.Config, namespace, name string, conflist map[string]any) error {
+	clientset, err := kubernetes.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes clientset: %w", err)
+	}
+
+	conflistJSON, err := json.Marshal(conflist)
+	if err != nil {
+		return fmt.Errorf("failed to marshal CNI conflist for ConfigMap %s/%s: %w", namespace, name, err)
+	}
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			ciliumCNIConfigMapKey: string(conflistJSON),
+		},
+	}
+
+	_, err = clientset.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		_, err = clientset.CoreV1().ConfigMaps(namespace).Update(ctx, configMap, metav1.UpdateOptions{})
+	}
+	if err != nil {
+		return fmt.Errorf("failed to create/update ConfigMap %s/%s: %w", namespace, name, err)
+	}
 	return nil
 }
 

--- a/test/util/framework/cilium_helper_test.go
+++ b/test/util/framework/cilium_helper_test.go
@@ -15,12 +15,76 @@
 package framework
 
 import (
+	"encoding/json"
 	"testing"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+func TestCiliumConflistJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		conflist map[string]any
+		wantName string
+		plugins  []string
+	}{
+		{
+			name:     "none",
+			conflist: CiliumConflistNone,
+			wantName: "cilium",
+			plugins:  []string{"cilium-cni"},
+		},
+		{
+			name:     "portmap",
+			conflist: CiliumConflistPortmap,
+			wantName: "portmap",
+			plugins:  []string{"cilium-cni", "portmap"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			raw, err := json.Marshal(tt.conflist)
+			if err != nil {
+				t.Fatalf("json.Marshal(%s) failed: %v", tt.name, err)
+			}
+
+			var parsed map[string]any
+			if err := json.Unmarshal(raw, &parsed); err != nil {
+				t.Fatalf("marshaled %s conflist is not valid JSON: %v\n%s", tt.name, err, raw)
+			}
+
+			if got := parsed["cniVersion"]; got != MultusCompatibleCNIVersion {
+				t.Errorf("cniVersion = %v, want %s", got, MultusCompatibleCNIVersion)
+			}
+			if got := parsed["name"]; got != tt.wantName {
+				t.Errorf("name = %v, want %s", got, tt.wantName)
+			}
+
+			plugins, ok := parsed["plugins"].([]any)
+			if !ok {
+				t.Fatalf("plugins is %T, want []any", parsed["plugins"])
+			}
+			if len(plugins) != len(tt.plugins) {
+				t.Fatalf("len(plugins) = %d, want %d", len(plugins), len(tt.plugins))
+			}
+			for i, wantType := range tt.plugins {
+				plugin, ok := plugins[i].(map[string]any)
+				if !ok {
+					t.Fatalf("plugins[%d] is %T, want map[string]any", i, plugins[i])
+				}
+				if got := plugin["type"]; got != wantType {
+					t.Errorf("plugins[%d].type = %v, want %s", i, got, wantType)
+				}
+			}
+		})
+	}
+}
 
 func TestIsRetryableCiliumNetworkPolicyCreateError(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

All ARO-HCP e2e tests that install Cilium via Helm (`cluster_create_cni_cilium.go`,
`cluster_create_feature_aggregation.go`, `cluster_create_complex_cilium_kv.go`) were
failing deterministically against recent OCP builds: worker nodes never became `Ready`
because Multus (the OCP CNI meta-plugin) crash-looped on every node.

The fix supplies Cilium with a custom CNI configuration list (conflist) via the
`cni.configMap` Helm value, pinning its `cniVersion` field to `"1.0.0"` instead of
letting Cilium generate its own (incompatible) default.

## What changed

- **`test/util/framework/cilium_helper.go`**
  - Added `EnsureCiliumCNIConfigMap(ctx, adminRESTConfig, namespace, name, conflistJSON)` —
    creates (or updates) a Kubernetes `ConfigMap` holding a full CNI conflist for Cilium
    to read and write to disk verbatim, bypassing Cilium's own built-in template
    rendering.
  - Added two conflist constants matching Cilium's own built-in templates, but with a
    fixed, Multus-compatible `cniVersion`:
    - `CiliumConflistNone` — for Cilium's default (unchained) mode.
    - `CiliumConflistPortmap` — for Cilium's `portmap` chaining mode.
  - Added `MultusCompatibleCNIVersion = "1.0.0"` documenting the chosen version and why.

- **`test/e2e/cluster_create_cni_cilium.go`**
  - Before installing the Cilium Helm chart, calls `EnsureCiliumCNIConfigMap` with
    `CiliumConflistPortmap` (this test uses `cni.chainingMode: "portmap"`).
  - Adds `"configMap": ciliumCNIConfigMapName` to the Helm values' `cni` block.

- **`test/e2e/cluster_create_feature_aggregation.go`**
  - Same pattern, using `CiliumConflistNone` (this test does not set `chainingMode`, so
    Cilium runs in its default "none" mode).

- **`test/e2e/cluster_create_complex_cilium_kv.go`**
  - Same pattern as `cluster_create_feature_aggregation.go`, using `CiliumConflistNone`.

## Why this change is necessary

### The failure

On affected clusters, worker nodes stayed `NotReady` indefinitely with kubelet
reporting:

```
KubeletNotReady: container runtime network not ready: NetworkReady=false
reason:NetworkPluginNotReady message:Network plugin returns error: no CNI
configuration file in /etc/kubernetes/cni/net.d/. Has your network provider
started?
```

The `openshift-multus` DaemonSet pods were in `CrashLoopBackOff`, and their logs
showed the root cause:

```
[error] failed to create the configuration manager for the primary CNI plugin:
failed to load the primary CNI configuration as a multus delegate with error
'delegate cni version is 0.3.1 while top level cni version is 1.1.0'
```

### Root cause

Two independent pieces changed relative to one another:

1. **Cilium (pinned at v1.19.x in these tests)** hard-codes `"cniVersion": "0.3.1"` in
   every one of its built-in conflist templates
   (`daemon/cmd/cni/config.go` in `cilium/cilium`), for every chaining mode ("none",
   "flannel", "portmap"). This is **not configurable via any Helm value** — there is no
   `cni.cniVersion` key in the chart. (Cilium only changed this default itself in
   v1.20.0, via commit `3cd4de85a0`, "cni: Bump default version to 1.0.0".)

2. **OCP's `cluster-network-operator`** ships the Multus manifest
   (`bindata/network/multus/multus.yaml`) with its own top-level `cniVersion`. This was
   bumped from `"0.3.1"` to `"1.1.0"` by commit `a5d3f195`
   ("[NVIDIA-616](https://redhat.atlassian.net/browse/NVIDIA-616): Bump Multus CNI API version to 1.1.0"). That commit is present on
   `master`, `release-4.23`, `release-5.0`, `release-5.1`, and `release-5.2` — i.e. it
   affects **every currently active OCP release line**, not something specific to OCP
   5.0. It is absent from `release-4.20`/`4.21`/`4.22`.

Multus's own delegate-version compatibility check
(`multus-cni`'s `pkg/server/config/generator.go`, `CheckVersionCompatibility`) is
one-directional:

```go
if multusCNIVersion.GTE(v040) {        // only runs if Multus's own version >= 0.4.0
    if delegateVersion.LT(v040) {      // ...and only fails if delegate is < 0.4.0
        return fmt.Errorf(versionFmt, delegateVersion, mc.CNIVersion)
    }
}
```

- On **older OCP builds** (Multus top-level `cniVersion` still `0.3.1`), this check is
  skipped entirely (`0.3.1 >= 0.4.0` is false) — a `0.3.1` Cilium delegate is silently
  accepted. This is why the bug was never observed there.
- On **OCP builds with the CNO bump** (Multus top-level `cniVersion` now `1.1.0`), the
  check activates, and Cilium's `0.3.1` delegate conflist now fails it — every time,
  deterministically.

### Why the fix works, and why it's safe on older OCP too

Since Cilium doesn't expose a way to change its own generated `cniVersion`, the fix uses
Cilium's documented "bring your own conflist" mechanism: setting the `cni.configMap`
Helm value points Cilium at a `ConfigMap` whose content it writes to
`/etc/cni/net.d/05-cilium.conflist` (via multus's confPath) unmodified, instead of
rendering its own hard-coded template.

The custom conflists used here are functionally identical to Cilium's own built-in
"none" and "portmap" templates, with only the `cniVersion` field changed from `0.3.1` to
`1.0.0`. `1.0.0` was chosen because:

- It satisfies Multus's `>= 0.4.0` check, and
- `cilium-cni` itself explicitly advertises support for CNI spec versions up to `1.1.0`
  (`plugins/cilium-cni/cmd/cmd.go`), so `1.0.0` is safely within what the binary
  understands — no functional regression.

Because Multus's check is one-directional (only fails when its own version is new *and*
the delegate's is old), always declaring a modern `1.0.0` delegate version is safe
regardless of which OCP build runs the test:

- **Pre-bump OCP (e.g. 4.21)**: Multus's own version is still `0.3.1`, so the check is
  skipped entirely — a `1.0.0` delegate is accepted the same as a `0.3.1` one would be.
- **Post-bump OCP (4.23+, 5.x)**: Multus's own version is `1.1.0`, so the check runs and
  `1.0.0 >= 0.4.0` passes.


### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
