### PR TITLE
chore(dev-infrastructure): pin bicep version in CI base image (AROSLSRE-1972)

### DIFF
--- a/dev-infrastructure/openshift-ci/Dockerfile
+++ b/dev-infrastructure/openshift-ci/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir -p /etc/yum.repos.art/ci/ /etc/yum.repos.art/localdev/ && \
     ln -s /etc/yum.repos.d/microsoft-prod.repo /etc/yum.repos.art/localdev/
 RUN dnf install -y azure-cli libicu make git procps-ng
 RUN ARCH=$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "x64") && \
-    curl -fsSL -o /usr/local/bin/bicep "https://github.com/Azure/bicep/releases/download/v${BICEP_VERSION}/bicep-linux-${ARCH}" && \
+    curl -fsSL --retry 3 -o /usr/local/bin/bicep "https://github.com/Azure/bicep/releases/download/v${BICEP_VERSION}/bicep-linux-${ARCH}" && \
     chmod +x /usr/local/bin/bicep
 # Install kubectl and kubelogin
 RUN ARCH=$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "amd64") && \

--- a/dev-infrastructure/openshift-ci/Dockerfile
+++ b/dev-infrastructure/openshift-ci/Dockerfile
@@ -3,6 +3,7 @@ FROM registry.ci.openshift.org/ocp/builder:${BUILDER_IMAGE_TAG}
 
 # Tool versions - defaults here must be kept in sync with /versions.mk
 ARG PROMTOOL_VERSION=3.2.1
+ARG BICEP_VERSION=0.47.16
 
 USER root
 RUN cat /etc/dnf/dnf.conf || true
@@ -12,7 +13,9 @@ RUN mkdir -p /etc/yum.repos.art/ci/ /etc/yum.repos.art/localdev/ && \
     ln -s /etc/yum.repos.d/microsoft-prod.repo /etc/yum.repos.art/ci/ && \
     ln -s /etc/yum.repos.d/microsoft-prod.repo /etc/yum.repos.art/localdev/
 RUN dnf install -y azure-cli libicu make git procps-ng
-RUN az bicep install && mv /root/.azure/bin/bicep /usr/local/bin
+RUN ARCH=$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "x64") && \
+    curl -fsSL -o /usr/local/bin/bicep "https://github.com/Azure/bicep/releases/download/v${BICEP_VERSION}/bicep-linux-${ARCH}" && \
+    chmod +x /usr/local/bin/bicep
 # Install kubectl and kubelogin
 RUN ARCH=$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "amd64") && \
     KUBECTL_VER=$(curl -fsSL --retry 3 https://dl.k8s.io/release/stable.txt) && \

--- a/dev-infrastructure/openshift-ci/Makefile
+++ b/dev-infrastructure/openshift-ci/Makefile
@@ -8,7 +8,7 @@ PLATFORM ?= "linux/amd64"
 
 GO_WORK_VERSION := $(shell sed -n 's/^go //p' ../../go.work)
 
-VERSION_ARGS = BUILDER_IMAGE_TAG PROMTOOL_VERSION
+VERSION_ARGS = BUILDER_IMAGE_TAG PROMTOOL_VERSION BICEP_VERSION
 
 .PHONY: verify build test
 
@@ -28,6 +28,12 @@ verify: ## Verify versions are consistent across config files
 		exit 1; \
 	fi
 	@echo "  promtool   $(PROMTOOL_VERSION) OK"
+	@actual=$$(grep -oP 'ARG BICEP_VERSION=\K.*' Dockerfile); \
+	if [ "$$actual" != "$(BICEP_VERSION)" ]; then \
+		echo "ERROR: Dockerfile ARG BICEP_VERSION=$$actual ≠ versions.mk $(BICEP_VERSION)"; \
+		exit 1; \
+	fi
+	@echo "  bicep      $(BICEP_VERSION) OK"
 
 ##@ Build
 

--- a/dev-infrastructure/openshift-ci/Makefile
+++ b/dev-infrastructure/openshift-ci/Makefile
@@ -22,7 +22,7 @@ verify: ## Verify versions are consistent across config files
 		exit 1; \
 	fi; \
 	echo "  go version $$GO_WORK_MINOR OK"
-	@actual=$$(grep -oP 'ARG PROMTOOL_VERSION=\K.*' Dockerfile); \
+	@actual=$$(grep -oP 'ARG PROMTOOL_VERSION=\K\S*' Dockerfile); \
 	if [ "$$actual" != "$(PROMTOOL_VERSION)" ]; then \
 		echo "ERROR: Dockerfile ARG PROMTOOL_VERSION=$$actual ≠ versions.mk $(PROMTOOL_VERSION)"; \
 		exit 1; \

--- a/dev-infrastructure/openshift-ci/Makefile
+++ b/dev-infrastructure/openshift-ci/Makefile
@@ -28,7 +28,7 @@ verify: ## Verify versions are consistent across config files
 		exit 1; \
 	fi
 	@echo "  promtool   $(PROMTOOL_VERSION) OK"
-	@actual=$$(grep -oP 'ARG BICEP_VERSION=\K.*' Dockerfile); \
+	@actual=$$(grep -oP 'ARG BICEP_VERSION=\K\S*' Dockerfile); \
 	if [ "$$actual" != "$(BICEP_VERSION)" ]; then \
 		echo "ERROR: Dockerfile ARG BICEP_VERSION=$$actual ≠ versions.mk $(BICEP_VERSION)"; \
 		exit 1; \

--- a/dev-infrastructure/openshift-ci/versions.mk
+++ b/dev-infrastructure/openshift-ci/versions.mk
@@ -7,6 +7,8 @@
 # Upstream release pages:
 #   Builder:   .ci-operator.yaml (build_root_image.tag)
 #   promtool:  https://github.com/prometheus/prometheus/releases
+#   bicep:     https://github.com/Azure/bicep/releases
 
 BUILDER_IMAGE_TAG ?= $(shell yq '.build_root_image.tag' ../../.ci-operator.yaml)
 PROMTOOL_VERSION  ?= 3.2.1
+BICEP_VERSION     ?= 0.47.16


### PR DESCRIPTION
Jira: [AROSLSRE-1972](https://redhat.atlassian.net/browse/AROSLSRE-1972)

### What

Pins the `bicep` CLI version used inside the `openshift-ci` CI base image, replacing the unversioned `az bicep install` call with a versioned direct binary download. Adds `BICEP_VERSION` to `versions.mk` and the Dockerfile `ARG`, and extends the existing `verify` target to cross-check them, the same pattern already used for `promtool`.

### Why

`az bicep install` grabs whatever bicep build is current at image-build time, with no version pin, no audit trail, and no bump automation. This is the first phase of the broader tooling version-bump gap tracked in [AROSLSRE-1972](https://redhat.atlassian.net/browse/AROSLSRE-1972).

### Testing

Ran `make verify` in `dev-infrastructure/openshift-ci` locally, passes for both `promtool` and `bicep`. Downloaded the pinned `bicep-linux-x64` binary directly and confirmed `bicep --version` reports `0.47.16`. Compiled all bicep sources under `demo/bicep` with the pinned binary and diffed the output against the checked-in fixtures in `test/e2e/test-artifacts/generated-test-artifacts/standard-cluster-create/`: the only differences are the compiler `version`/`templateHash` metadata fields, no structural change to any generated template.

### Special notes for your reviewer

Scoped to bicep only (Phase 1 of the [AROSLSRE-1972](https://redhat.atlassian.net/browse/AROSLSRE-1972) plan). The base image isn't currently rebuilt on the `PROMTOOL_VERSION`/`BICEP_VERSION` verify check by any Prow job (that wiring is Phase 2), so this PR only changes what gets pinned, not when the image rebuilds.

### PR Checklist
- [x] Tests pass (`make verify`)
- [x] Documentation updated (versions.mk comment)
