### PR TITLE
fix: exclude soft-deleted MI's from sweeper retention

### DIFF
--- a/tooling/cleanup-sweeper/pkg/engine/steps/roleassignments/delete.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/roleassignments/delete.go
@@ -26,6 +26,7 @@ import (
 	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
 	graphdirectoryobjects "github.com/microsoftgraph/msgraph-sdk-go/directoryobjects"
 	graphgroups "github.com/microsoftgraph/msgraph-sdk-go/groups"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	graphodataerrors "github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -45,6 +46,11 @@ const (
 	graphGetByIDsBatchSize    = 1000
 	preflightGroupDisplayName = "aro-hcp-engineering-App Developer"
 	preflightFailureMessage   = "Refusing to run cleanup: directory visibility is insufficient. This tool must be run with directory read permissions (e.g. Directory.Read.All)."
+	// managedIdentityServicePrincipalType is the servicePrincipalType Microsoft
+	// Graph reports for the service principal backing a user-assigned managed
+	// identity. These are excluded from soft-delete retention (see
+	// newGraphDeletedPrincipalLookup).
+	managedIdentityServicePrincipalType = "ManagedIdentity"
 )
 
 // DeleteOrphanedStepConfig configures orphaned role-assignment cleanup.
@@ -181,11 +187,17 @@ func (s *deleteOrphanedStep) Delete(ctx context.Context, target runner.Target, _
 }
 
 // SAFETY CONTRACT:
-// A role assignment is deletable only when its principal is absent from both
-// the active directory and deletedItems. The active directory is checked again
-// after deletedItems to avoid deleting assignments while a principal is being
-// restored. An explicit Graph visibility preflight is also enforced and cannot
-// be bypassed.
+// A role assignment is deletable when its principal is absent from the active
+// directory and is not a retainable soft-deleted principal. A principal is
+// retainable while it is recoverable from deletedItems AND is of a type that is
+// actually restored back into service - app registrations, users, groups, and
+// service principals other than managed identities. Managed identities are
+// excluded: their backing object is system-managed and never restored (a
+// redeploy provisions a new principal ID), so retaining their assignments only
+// leaks quota (see deletedPrincipalIsRetainable). The active directory is
+// checked again after deletedItems to avoid deleting assignments while a
+// retainable principal is being restored. An explicit Graph visibility
+// preflight is also enforced and cannot be bypassed.
 func discoverOrphanedRoleAssignments(
 	ctx context.Context,
 	roleAssignmentsClient *armauthorization.RoleAssignmentsClient,
@@ -231,7 +243,11 @@ func discoverOrphanedRoleAssignments(
 		return nil, fmt.Errorf("failed resolving role assignment principals with Microsoft Graph getByIds: %w", err)
 	}
 
-	// 4) Protect principals that are still recoverable from Graph deletedItems.
+	// 4) Protect principals that are still recoverable from Graph deletedItems
+	// and are of a restorable type. The lookup treats a soft-deleted managed
+	// identity as not retainable (never restored into service), so its
+	// assignments remain eligible for cleanup; app registrations, users, and
+	// groups stay protected. See newGraphDeletedPrincipalLookup.
 	unresolvedPrincipalIDs := principalIDs.Difference(resolvedPrincipalIDs)
 	softDeletedPrincipalIDs, err := resolveSoftDeletedPrincipalIDs(
 		ctx,
@@ -478,6 +494,12 @@ func resolvePrincipalIDsWithGraphGetByIDs(
 	return resolvedPrincipalIDs, nil
 }
 
+// deletedPrincipalLookup reports whether a principal is a *retainable*
+// soft-deleted principal: recoverable from Graph deletedItems AND of a type that
+// is restored back into service. It returns false when the principal is absent
+// from deletedItems, or is present only as a managed identity (never restored),
+// so those assignments stay eligible for deletion. See
+// newGraphDeletedPrincipalLookup / deletedPrincipalIsRetainable.
 type deletedPrincipalLookup func(context.Context, string) (bool, error)
 
 type activePrincipalLookup func(context.Context, string) (bool, error)
@@ -531,8 +553,37 @@ func newGraphDeletedPrincipalLookup(graphClient *msgraphsdk.GraphServiceClient) 
 				resolvedID,
 			)
 		}
+		if !deletedPrincipalIsRetainable(object) {
+			return false, nil
+		}
 		return true, nil
 	}
+}
+
+// deletedPrincipalIsRetainable reports whether a soft-deleted directory object
+// should keep its role assignments while it remains recoverable.
+//
+// Managed-identity service principals are excluded: deleting the user-assigned
+// identity soft-deletes this backing object, but it is never restored to bring a
+// workload back - a redeploy provisions a brand-new identity with a new
+// principal ID and new role assignments. Retaining their assignments therefore
+// protects nothing and only leaks the subscription's role-assignment quota.
+//
+// Every other soft-deleted principal (app registrations, users, groups, and
+// service principals of any other type) is retained, since those can be restored
+// and would lose their access - that is the AROSLSRE-1969 case this guard exists
+// for. Anything that is not a service principal, or a service principal without a
+// reported type, fails safe to retained.
+func deletedPrincipalIsRetainable(object models.DirectoryObjectable) bool {
+	sp, ok := object.(models.ServicePrincipalable)
+	if !ok {
+		return true
+	}
+	spType := sp.GetServicePrincipalType()
+	if spType == nil {
+		return true
+	}
+	return !strings.EqualFold(*spType, managedIdentityServicePrincipalType)
 }
 
 func principalRequiresRoleAssignmentRetention(

--- a/tooling/cleanup-sweeper/pkg/engine/steps/roleassignments/delete_test.go
+++ b/tooling/cleanup-sweeper/pkg/engine/steps/roleassignments/delete_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	msgraphsdk "github.com/microsoftgraph/msgraph-sdk-go"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	graphodataerrors "github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -385,6 +386,57 @@ func TestSelectOrphanedRoleAssignments(t *testing.T) {
 	}
 	if got[0].ID != "absent-assignment" {
 		t.Fatalf("expected permanently absent principal's assignment, got %q", got[0].ID)
+	}
+}
+
+func TestDeletedPrincipalIsRetainable(t *testing.T) {
+	t.Parallel()
+
+	servicePrincipalOfType := func(spType *string) models.DirectoryObjectable {
+		sp := models.NewServicePrincipal()
+		sp.SetServicePrincipalType(spType)
+		return sp
+	}
+
+	testCases := []struct {
+		name   string
+		object models.DirectoryObjectable
+		want   bool
+	}{
+		{
+			name:   "managed identity service principal is not retained",
+			object: servicePrincipalOfType(strPtr("ManagedIdentity")),
+			want:   false,
+		},
+		{
+			name:   "managed identity type comparison is case-insensitive",
+			object: servicePrincipalOfType(strPtr("managedidentity")),
+			want:   false,
+		},
+		{
+			name:   "application service principal is retained",
+			object: servicePrincipalOfType(strPtr("Application")),
+			want:   true,
+		},
+		{
+			name:   "service principal without a type fails safe to retained",
+			object: servicePrincipalOfType(nil),
+			want:   true,
+		},
+		{
+			name:   "non service principal directory object is retained",
+			object: models.NewUser(),
+			want:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := deletedPrincipalIsRetainable(tc.object); got != tc.want {
+				t.Fatalf("expected retainable=%t, got %t", tc.want, got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-2071

### What

Exclude soft-deleted **managed identities** from the cleanup-sweeper's role-assignment retention. `newGraphDeletedPrincipalLookup` now routes through a new pure helper, `deletedPrincipalIsRetainable`, which reports a soft-deleted directory object as retainable *unless* it is a service principal whose `servicePrincipalType` is `ManagedIdentity`. All other soft-deleted principals (app registrations, users, groups, and service principals of any other type) are still retained, and anything that is not a service principal — or a service principal without a reported type — fails safe to retained.

Because both retention paths (the `Discover` deletedItems pass and the immediately-before-delete revalidation) go through that single lookup, this one change covers both. No behavior changes for non-managed-identity principals.

### Why
PR #6762 ([AROSLSRE-1969](https://redhat.atlassian.net/browse/AROSLSRE-1969)) made the sweeper retain the RBAC of *any* soft-deleted principal, to stop background cleanup from stripping access from a shared service principal that is still recoverable and about to be restored. That protection is correct for the incident it was written for: five **app-registration-backed** mock service principals were soft-deleted, restored via Graph, and needed their RBAC intact.

On teardown a managed identity's backing service principal is soft-deleted and sits in the recycle bin for ~30 days. Assignments the sweeper used to delete immediately are now retained for that whole window — even though a managed identity is never restored (a redeploy provisions a new principal ID with fresh assignments), so retaining its RBAC protects nothing and only consumes role-assignment quota.

This change narrows retention back to genuinely restorable principals (app registrations, users, groups), keeping the [AROSLSRE-1969](https://redhat.atlassian.net/browse/AROSLSRE-1969) protection while letting the sweeper reclaim managed-identity grants on its normal hourly run.

### Testing
• New unit test `TestDeletedPrincipalIsRetainable` covering: managed identity (not retained), case-insensitive type match, application SP (retained), SP with no reported type (fail-safe retained), and a non-SP directory object (retained). Existing retention tests (`TestPrincipalRequiresRoleAssignmentRetention`, `TestResolveSoftDeletedPrincipalIDs`, fail-closed variants) unchanged and pass.
• `cd tooling/cleanup-sweeper && go build ./... && go test ./...` — all pass.
• Validated against the live DEV subscription: of 2,881 orphaned assignments (principal absent from the active directory), classifying each principal via Graph `deletedItems` yielded 2,879 `ManagedIdentity` + 2 already-purged and **0** app registrations / users / groups — i.e. this change makes exactly the managed-identity backlog reclaimable and touches nothing restorable.
• Cross-checked the five [AROSLSRE-1969](https://redhat.atlassian.net/browse/AROSLSRE-1969) principals: none appear in the reclaimable set, and the ones spot-checked are currently active (restored) — confirming the incident's protected identities are unaffected.
### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
