### PR TITLE
fix: gate backend, fleet and frontend startup on Cosmos queries

### DIFF
--- a/backend/deploy/templates/backend.deployment.yaml
+++ b/backend/deploy/templates/backend.deployment.yaml
@@ -159,6 +159,19 @@ spec:
           runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
+        startupProbe:
+          httpGet:
+            path: /startupz
+            port: 8083
+          timeoutSeconds: 6
+          periodSeconds: 10
+          failureThreshold: 30
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8083
+          periodSeconds: 20
+          failureThreshold: 3
         readinessProbe:
           httpGet:
             path: /healthz

--- a/backend/pkg/app/backend.go
+++ b/backend/pkg/app/backend.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	utilsclock "k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
 
 	"github.com/Azure/ARO-HCP/backend/pkg/azure/cachedreader"
 	azureclient "github.com/Azure/ARO-HCP/backend/pkg/azure/client"
@@ -83,6 +84,7 @@ import (
 	internalazure "github.com/Azure/ARO-HCP/internal/azure"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/billingcosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/corecosmosstorage"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/fleetcosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/kubeappliercosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/informers/coreinformers"
@@ -138,6 +140,7 @@ type backendHealthzServer struct {
 	listenAddress     string
 	metricsRegisterer prometheus.Registerer
 	electionChecker   *leaderelection.HealthzAdaptor
+	resourcesDBClient corecosmosstorage.ResourcesDBClient
 }
 
 type backendMetricsServer struct {
@@ -253,6 +256,7 @@ func (b *Backend) Run(ctx context.Context) error {
 			listenAddress:     b.options.HealthzServerListenAddress,
 			metricsRegisterer: b.options.MetricsRegisterer,
 			electionChecker:   electionChecker,
+			resourcesDBClient: b.options.ResourcesDBClient,
 		}
 		wg.Add(1)
 		go func() {
@@ -307,12 +311,20 @@ func (b *Backend) Run(ctx context.Context) error {
 }
 
 func (s *backendHealthzServer) Run(ctx context.Context) error {
-	logger := utils.LoggerFromContext(ctx)
-
 	listener, err := net.Listen("tcp", s.listenAddress)
 	if err != nil {
 		return fmt.Errorf("failed to listen on %s: %w", s.listenAddress, err)
 	}
+
+	addr := listener.Addr().String()
+	server := &http.Server{Addr: addr, Handler: s.handler(ctx)}
+	return runHTTPServer(ctx, "healthz server", addr, server, func() error {
+		return server.Serve(listener)
+	})
+}
+
+func (s *backendHealthzServer) handler(ctx context.Context) http.Handler {
+	logger := utils.LoggerFromContext(ctx)
 
 	backendHealthGauge := promauto.With(s.metricsRegisterer).NewGauge(prometheus.GaugeOpts{Name: "backend_health", Help: "backend_health is 1 when healthy"})
 
@@ -328,11 +340,26 @@ func (s *backendHealthzServer) Run(ctx context.Context) error {
 		backendHealthGauge.Set(1.0)
 	})
 
-	addr := listener.Addr().String()
-	server := &http.Server{Addr: addr, Handler: mux}
-	return runHTTPServer(ctx, "healthz server", addr, server, func() error {
-		return server.Serve(listener)
+	mux.HandleFunc("/startupz", func(w http.ResponseWriter, r *http.Request) {
+		queryCtx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+		iterator, err := s.resourcesDBClient.ResourcesGlobalListers().Subscriptions().List(queryCtx, &cosmosstorageutils.DBClientListResourceDocsOptions{
+			PageSizeHint: ptr.To(int32(1)),
+		})
+		if err == nil {
+			for range iterator.Items(queryCtx) {
+				break
+			}
+			err = iterator.GetError()
+		}
+		if err != nil {
+			logger.Error(err, "Startup probe failed")
+			http.Error(w, "Cosmos DB query failed", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
 	})
+	return mux
 }
 
 func (s *backendMetricsServer) Run(ctx context.Context) error {

--- a/backend/testdata/zz_fixture_TestHelmTemplate_backend_clstr_scoped_identities_role_set_name_public.yaml
+++ b/backend/testdata/zz_fixture_TestHelmTemplate_backend_clstr_scoped_identities_role_set_name_public.yaml
@@ -255,6 +255,19 @@ spec:
           runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
+        startupProbe:
+          httpGet:
+            path: /startupz
+            port: 8083
+          timeoutSeconds: 6
+          periodSeconds: 10
+          failureThreshold: 30
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8083
+          periodSeconds: 20
+          failureThreshold: 3
         readinessProbe:
           httpGet:
             path: /healthz

--- a/backend/testdata/zz_fixture_TestHelmTemplate_backend_mi_mock_and_arm_perms_mgr_identities_unset.yaml
+++ b/backend/testdata/zz_fixture_TestHelmTemplate_backend_mi_mock_and_arm_perms_mgr_identities_unset.yaml
@@ -238,6 +238,19 @@ spec:
           runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
+        startupProbe:
+          httpGet:
+            path: /startupz
+            port: 8083
+          timeoutSeconds: 6
+          periodSeconds: 10
+          failureThreshold: 30
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8083
+          periodSeconds: 20
+          failureThreshold: 3
         readinessProbe:
           httpGet:
             path: /healthz

--- a/backend/testdata/zz_fixture_TestHelmTemplate_backend_mi_mock_ids_from_kv_secret.yaml
+++ b/backend/testdata/zz_fixture_TestHelmTemplate_backend_mi_mock_ids_from_kv_secret.yaml
@@ -255,6 +255,19 @@ spec:
           runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
+        startupProbe:
+          httpGet:
+            path: /startupz
+            port: 8083
+          timeoutSeconds: 6
+          periodSeconds: 10
+          failureThreshold: 30
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8083
+          periodSeconds: 20
+          failureThreshold: 3
         readinessProbe:
           httpGet:
             path: /healthz

--- a/backend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_backend_dev.yaml
+++ b/backend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_backend_dev.yaml
@@ -255,6 +255,19 @@ spec:
           runAsGroup: 65532
           seccompProfile:
             type: RuntimeDefault
+        startupProbe:
+          httpGet:
+            path: /startupz
+            port: 8083
+          timeoutSeconds: 6
+          periodSeconds: 10
+          failureThreshold: 30
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8083
+          periodSeconds: 20
+          failureThreshold: 3
         readinessProbe:
           httpGet:
             path: /healthz

--- a/fleet/deploy/templates/controller.deployment.yaml
+++ b/fleet/deploy/templates/controller.deployment.yaml
@@ -68,6 +68,19 @@ spec:
         - name: metrics
           containerPort: 8081
           protocol: TCP
+        startupProbe:
+          httpGet:
+            path: /startupz
+            port: healthz
+          timeoutSeconds: 6
+          periodSeconds: 10
+          failureThreshold: 30
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          periodSeconds: 20
+          failureThreshold: 3
         readinessProbe:
           httpGet:
             path: /healthz

--- a/fleet/pkg/manager/manager.go
+++ b/fleet/pkg/manager/manager.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/utils/ptr"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -45,6 +46,7 @@ import (
 	"github.com/Azure/ARO-HCP/fleet/pkg/controllers/hcpresourcerequirements"
 	"github.com/Azure/ARO-HCP/fleet/pkg/controllers/lifecycle"
 	"github.com/Azure/ARO-HCP/fleet/pkg/controllers/maestroregistration"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/cosmosstorageutils"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/fleetcosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/cosmosstorage/kubeappliercosmosstorage"
 	"github.com/Azure/ARO-HCP/internal/database/informers/fleetinformers"
@@ -79,7 +81,7 @@ type Manager struct {
 	AzureClientOptions           *policy.ClientOptions
 }
 
-// Run starts the fleet controller manager. It serves /healthz and /metrics,
+// Run starts the fleet controller manager. It serves /healthz, /startupz and /metrics,
 // then runs the controllers under a leader-election lease.
 func (m *Manager) Run(ctx context.Context) error {
 	logger := utils.LoggerFromContext(ctx)
@@ -97,21 +99,7 @@ func (m *Manager) Run(ctx context.Context) error {
 	)
 
 	if len(m.HealthzListenAddr) > 0 {
-		healthGauge := promauto.With(legacyregistry.Registerer()).NewGauge(prometheus.GaugeOpts{
-			Name: "fleet_controller_health", Help: "fleet_controller_health is 1 when healthy",
-		})
-		mux := http.NewServeMux()
-		mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-			if err := electionChecker.Check(r); err != nil {
-				logger.V(1).Info("readiness probe failed", "error", err)
-				http.Error(w, "lease not renewed", http.StatusServiceUnavailable)
-				healthGauge.Set(0)
-				return
-			}
-			w.WriteHeader(http.StatusOK)
-			healthGauge.Set(1)
-		})
-		server := &http.Server{Addr: m.HealthzListenAddr, Handler: mux}
+		server := &http.Server{Addr: m.HealthzListenAddr, Handler: m.healthHandler(ctx, electionChecker, legacyregistry.Registerer())}
 		wg.Add(1)
 		go func() {
 			defer cancel(fmt.Errorf("healthz server exited"))
@@ -160,6 +148,45 @@ func (m *Manager) Run(ctx context.Context) error {
 	wg.Wait()
 	logger.Info("stopped", "component", name, "commit", version.CommitSHA)
 	return errors.Join(errs...)
+}
+
+func (m *Manager) healthHandler(ctx context.Context, electionChecker *leaderelection.HealthzAdaptor, registerer prometheus.Registerer) http.Handler {
+	logger := utils.LoggerFromContext(ctx)
+	healthGauge := promauto.With(registerer).NewGauge(prometheus.GaugeOpts{
+		Name: "fleet_controller_health", Help: "fleet_controller_health is 1 when healthy",
+	})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		if err := electionChecker.Check(r); err != nil {
+			logger.V(1).Info("readiness probe failed", "error", err)
+			http.Error(w, "lease not renewed", http.StatusServiceUnavailable)
+			healthGauge.Set(0)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		healthGauge.Set(1)
+	})
+	mux.HandleFunc("/startupz", func(w http.ResponseWriter, r *http.Request) {
+		queryCtx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+		iterator, err := m.FleetDBClient.GlobalListers().Stamps().List(queryCtx, &cosmosstorageutils.DBClientListResourceDocsOptions{
+			PageSizeHint: ptr.To(int32(1)),
+		})
+		if err == nil {
+			for range iterator.Items(queryCtx) {
+				break
+			}
+			err = iterator.GetError()
+		}
+		if err != nil {
+			logger.Error(err, "Startup probe failed")
+			http.Error(w, "Cosmos DB query failed", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	return mux
 }
 
 func (m *Manager) runControllersUnderLeaderElection(

--- a/fleet/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_fleet.yaml
+++ b/fleet/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_fleet.yaml
@@ -147,6 +147,19 @@ spec:
         - name: metrics
           containerPort: 8081
           protocol: TCP
+        startupProbe:
+          httpGet:
+            path: /startupz
+            port: healthz
+          timeoutSeconds: 6
+          periodSeconds: 10
+          failureThreshold: 30
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          periodSeconds: 20
+          failureThreshold: 3
         readinessProbe:
           httpGet:
             path: /healthz

--- a/frontend/deploy/templates/frontend.deployment.yaml
+++ b/frontend/deploy/templates/frontend.deployment.yaml
@@ -97,8 +97,9 @@ spec:
         {{- end }}
         startupProbe:
           httpGet:
-            path: /healthz
+            path: /startupz
             port: 8443
+          timeoutSeconds: 6
           periodSeconds: 10
           failureThreshold: 30
         livenessProbe:

--- a/frontend/pkg/frontend/frontend.go
+++ b/frontend/pkg/frontend/frontend.go
@@ -220,6 +220,26 @@ func (f *Frontend) Healthz(writer http.ResponseWriter, request *http.Request) {
 	f.healthGauge.Set(1.0)
 }
 
+func (f *Frontend) Startupz(writer http.ResponseWriter, request *http.Request) {
+	ctx, cancel := context.WithTimeout(request.Context(), 5*time.Second)
+	defer cancel()
+	iterator, err := f.resourcesDBClient.ResourcesGlobalListers().Subscriptions().List(ctx, &cosmosstorageutils.DBClientListResourceDocsOptions{
+		PageSizeHint: metadataapi.Ptr(int32(1)),
+	})
+	if err == nil {
+		for range iterator.Items(ctx) {
+			break
+		}
+		err = iterator.GetError()
+	}
+	if err != nil {
+		utils.LoggerFromContext(request.Context()).Error(err, "Startup probe failed")
+		http.Error(writer, "Cosmos DB query failed", http.StatusServiceUnavailable)
+		return
+	}
+	writer.WriteHeader(http.StatusOK)
+}
+
 func (f *Frontend) Location(writer http.ResponseWriter, request *http.Request) {
 	// This is strictly for development environments to help discover
 	// the frontend's Azure region when port forwarding with kubectl.

--- a/frontend/pkg/frontend/routes.go
+++ b/frontend/pkg/frontend/routes.go
@@ -499,6 +499,7 @@ func (f *Frontend) routes(r prometheus.Registerer) http.Handler {
 	// These endpoints do not use middleware. They are only called
 	// from within the service cluster or via kubectl port forwarding.
 	mux.HandleFunc(MuxPattern(http.MethodGet, "healthz"), f.Healthz)
+	mux.HandleFunc(MuxPattern(http.MethodGet, "startupz"), f.Startupz)
 	mux.HandleFunc(MuxPattern(http.MethodGet, "location"), f.Location)
 
 	return mux

--- a/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_connect_socket.yaml
+++ b/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_connect_socket.yaml
@@ -163,8 +163,9 @@ spec:
             mountPath: /var/run/mdsd
         startupProbe:
           httpGet:
-            path: /healthz
+            path: /startupz
             port: 8443
+          timeoutSeconds: 6
           periodSeconds: 10
           failureThreshold: 30
         livenessProbe:

--- a/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_mise_enabled.yaml
+++ b/frontend/testdata/zz_fixture_TestHelmTemplate_frontend_mise_enabled.yaml
@@ -160,8 +160,9 @@ spec:
             type: RuntimeDefault
         startupProbe:
           httpGet:
-            path: /healthz
+            path: /startupz
             port: 8443
+          timeoutSeconds: 6
           periodSeconds: 10
           failureThreshold: 30
         livenessProbe:

--- a/frontend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_frontend_dev.yaml
+++ b/frontend/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_aro_hcp_frontend_dev.yaml
@@ -160,8 +160,9 @@ spec:
             type: RuntimeDefault
         startupProbe:
           httpGet:
-            path: /healthz
+            path: /startupz
             port: 8443
+          timeoutSeconds: 6
           periodSeconds: 10
           failureThreshold: 30
         livenessProbe:


### PR DESCRIPTION
Backend, Fleet, and frontend could become Ready without successfully accessing Cosmos DB, allowing database connectivity or permission failures to go unnoticed during rollout. This change requires a successful data-plane query before Kubernetes enables readiness and liveness probes.

Tickets: [AROSLSRE-1111](https://redhat.atlassian.net/browse/AROSLSRE-1111), [AROSLSRE-1112](https://redhat.atlassian.net/browse/AROSLSRE-1112), [AROSLSRE-1114](https://redhat.atlassian.net/browse/AROSLSRE-1114).

### What

- Add `/startupz` using each service's existing Cosmos client: Resources subscriptions for backend/frontend and Fleet stamps for Fleet. Execute a single-page query; successful empty results are healthy, and query failures return 503.
- Add backend/Fleet liveness probes and switch frontend startup to `/startupz`. Keep readiness and liveness on `/healthz`, independent of Cosmos availability.
- Regenerate all eight affected Helm fixtures.




### PR Checklist

- [x] PR is scoped to a single task (Cosmos-gated startup across the three services)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant tickets
- [x] Screenshots included if applicable (not applicable)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used while live verification is pending
- [x] Commit history is clean
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge


