### PR TITLE
test: bump to a locally built CS image to test latest version of CS integration with read desire

### DIFF
--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_azuredb.yaml
@@ -7971,7 +7971,7 @@ spec:
             secretProviderClass: cs-keyvault
       initContainers:
       - name: clusters-service-init
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
@@ -8006,7 +8006,7 @@ spec:
         - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
       containers:
       - name: clusters-service-server
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         - name: DENYASSIGNMENTS
@@ -8257,7 +8257,7 @@ spec:
   acr:
     environment: PublicCloud
     server: 'arohcpsvcdev.azurecr.io'
-    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+    scope: 'repository:mchitimb/cs:pull'
   auth:
     workloadIdentity:
       serviceAccountRef: 'clusters-service'

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_containerdb.yaml
@@ -8072,7 +8072,7 @@ spec:
             secretProviderClass: cs-keyvault
       initContainers:
       - name: clusters-service-init
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
@@ -8107,7 +8107,7 @@ spec:
         - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
       containers:
       - name: clusters-service-server
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         - name: DENYASSIGNMENTS
@@ -8358,7 +8358,7 @@ spec:
   acr:
     environment: PublicCloud
     server: 'arohcpsvcdev.azurecr.io'
-    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+    scope: 'repository:mchitimb/cs:pull'
   auth:
     workloadIdentity:
       serviceAccountRef: 'clusters-service'

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_distinct_arm_helper.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_distinct_arm_helper.yaml
@@ -7971,7 +7971,7 @@ spec:
             secretProviderClass: cs-keyvault
       initContainers:
       - name: clusters-service-init
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
@@ -8006,7 +8006,7 @@ spec:
         - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
       containers:
       - name: clusters-service-server
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         - name: DENYASSIGNMENTS
@@ -8257,7 +8257,7 @@ spec:
   acr:
     environment: PublicCloud
     server: 'arohcpsvcdev.azurecr.io'
-    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+    scope: 'repository:mchitimb/cs:pull'
   auth:
     workloadIdentity:
       serviceAccountRef: 'clusters-service'

--- a/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_shared_arm_helper.yaml
+++ b/cluster-service/testdata/zz_fixture_TestHelmTemplate_cs_shared_arm_helper.yaml
@@ -7971,7 +7971,7 @@ spec:
             secretProviderClass: cs-keyvault
       initContainers:
       - name: clusters-service-init
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
@@ -8006,7 +8006,7 @@ spec:
         - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
       containers:
       - name: clusters-service-server
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         - name: DENYASSIGNMENTS
@@ -8257,7 +8257,7 @@ spec:
   acr:
     environment: PublicCloud
     server: 'arohcpsvcdev.azurecr.io'
-    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+    scope: 'repository:mchitimb/cs:pull'
   auth:
     workloadIdentity:
       serviceAccountRef: 'clusters-service'

--- a/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
+++ b/cluster-service/zz_fixture_TestHelmTemplate_dev_westus3_svc_1_cluster_service.yaml
@@ -7971,7 +7971,7 @@ spec:
             secretProviderClass: cs-keyvault
       initContainers:
       - name: clusters-service-init
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         # We set AZURE_TOKEN_CREDENTIALS to WorkloadIdentityCredential to force workload identity because this pod uses
@@ -8006,7 +8006,7 @@ spec:
         - --azure-first-party-application-certificate-bundle-path=/secrets/keyvault/firstPartyApplicationCertificateBundle
       containers:
       - name: clusters-service-server
-        image: 'arohcpsvcdev.azurecr.io/app-sre/aro-hcp-clusters-service@sha256:1234567890'
+        image: 'arohcpsvcdev.azurecr.io/mchitimb/cs@sha256:1234567890'
         imagePullPolicy: IfNotPresent
         env:
         - name: DENYASSIGNMENTS
@@ -8257,7 +8257,7 @@ spec:
   acr:
     environment: PublicCloud
     server: 'arohcpsvcdev.azurecr.io'
-    scope: 'repository:app-sre/aro-hcp-clusters-service:pull'
+    scope: 'repository:mchitimb/cs:pull'
   auth:
     workloadIdentity:
       serviceAccountRef: 'clusters-service'

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1102,9 +1102,9 @@ defaults:
   # Cluster Service
   clustersService:
     image:
-      registry: quay.io
-      repository: app-sre/aro-hcp-clusters-service
-      digest: sha256:85366fe2c5dcc316267cc12985fccf8a1dfe15eee5465f0bffdf6cf1f7609fbd # a677ee1f199daa3722f7cf213afc3028ac2ad7f4 (2026-09-07 09:17)
+      registry: arohcpsvcdev.azurecr.io
+      repository: mchitimb/cs
+      digest: sha256:ebc9ca2e63d1eeadd804c28373a540c29231ffdd6d0c43ae033606eaa14e0c80
     # controls how many HCPs can be placed on an MC, sadly not configurable per MC
     provisionShardClusterLimit: 100
     provisionShardStatus: active

--- a/config/rendered/dev/ci00/centralus.yaml
+++ b/config/rendered/dev/ci00/centralus.yaml
@@ -188,9 +188,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci00
   image:
-    digest: sha256:85366fe2c5dcc316267cc12985fccf8a1dfe15eee5465f0bffdf6cf1f7609fbd
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:ebc9ca2e63d1eeadd804c28373a540c29231ffdd6d0c43ae033606eaa14e0c80
+    registry: arohcpsvcdev.azurecr.io
+    repository: mchitimb/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/ci01/centralus.yaml
+++ b/config/rendered/dev/ci01/centralus.yaml
@@ -188,9 +188,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpci01
   image:
-    digest: sha256:85366fe2c5dcc316267cc12985fccf8a1dfe15eee5465f0bffdf6cf1f7609fbd
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:ebc9ca2e63d1eeadd804c28373a540c29231ffdd6d0c43ae033606eaa14e0c80
+    registry: arohcpsvcdev.azurecr.io
+    repository: mchitimb/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/cspr/westus3.yaml
+++ b/config/rendered/dev/cspr/westus3.yaml
@@ -188,9 +188,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpcspr
   image:
-    digest: sha256:85366fe2c5dcc316267cc12985fccf8a1dfe15eee5465f0bffdf6cf1f7609fbd
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:ebc9ca2e63d1eeadd804c28373a540c29231ffdd6d0c43ae033606eaa14e0c80
+    registry: arohcpsvcdev.azurecr.io
+    repository: mchitimb/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/dev/westus3.yaml
+++ b/config/rendered/dev/dev/westus3.yaml
@@ -188,9 +188,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpdev
   image:
-    digest: sha256:85366fe2c5dcc316267cc12985fccf8a1dfe15eee5465f0bffdf6cf1f7609fbd
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:ebc9ca2e63d1eeadd804c28373a540c29231ffdd6d0c43ae033606eaa14e0c80
+    registry: arohcpsvcdev.azurecr.io
+    repository: mchitimb/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/perf/westus3.yaml
+++ b/config/rendered/dev/perf/westus3.yaml
@@ -188,9 +188,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcpperf
   image:
-    digest: sha256:85366fe2c5dcc316267cc12985fccf8a1dfe15eee5465f0bffdf6cf1f7609fbd
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:ebc9ca2e63d1eeadd804c28373a540c29231ffdd6d0c43ae033606eaa14e0c80
+    registry: arohcpsvcdev.azurecr.io
+    repository: mchitimb/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:

--- a/config/rendered/dev/pers/westus3.yaml
+++ b/config/rendered/dev/pers/westus3.yaml
@@ -188,9 +188,9 @@ clustersService:
   deployDebugJobs: false
   environment: arohcppers
   image:
-    digest: sha256:85366fe2c5dcc316267cc12985fccf8a1dfe15eee5465f0bffdf6cf1f7609fbd
-    registry: quay.io
-    repository: app-sre/aro-hcp-clusters-service
+    digest: sha256:ebc9ca2e63d1eeadd804c28373a540c29231ffdd6d0c43ae033606eaa14e0c80
+    registry: arohcpsvcdev.azurecr.io
+    repository: mchitimb/cs
   k8s:
     deploymentStrategy:
       rollingUpdate:


### PR DESCRIPTION
Retesting https://gitlab.cee.redhat.com/service/aro-hcp-clusters-service/-/merge_requests/446 following latest addition after reviews.

Same as https://github.com/Azure/ARO-HCP/pull/6832 and not intended for merge