### PR TITLE
chore: add machi1990 as backend approver

### DIFF
--- a/backend/OWNERS
+++ b/backend/OWNERS
@@ -2,4 +2,5 @@ approvers:
 - mbarnes
 - geoberle
 - janboll
+- machi1990
 - miguelsorianod


### PR DESCRIPTION
## Summary

- Add Manyanda Chitimbo (@machi1990) as an approver to `backend/OWNERS`
- Manyanda is the 5th most active contributor to `backend/` with 52 non-bot commits, representing 5.4% of total backend commits

  ## Contribution stats

  ### By commit count (952 total non-bot commits)

  | # | Contributor | Commits | % |
  |---|------------|---------|---|
  | 1 | David Eads | 235 | 24.6% |
  | 2 | Miguel Soriano | 111 | 11.6% |
  | 3 | Matthew Barnes | 85 | 8.9% |
  | 4 | Gerd Oberlechner | 85 | 8.9% |
  | **5** | **Manyanda Chitimbo** | **52** | **5.4%** |

  ### By lines changed (239,842 total non-bot lines)

  | # | Contributor | Lines | % |
  |---|------------|-------|---|
  | 1 | David Eads | 59,745 | 24.9% |
  | 2 | Miguel Soriano | 55,869 | 23.2% |
  | 3 | Chai Bot | 32,224 | 13.4% |
  | **4** | **Manyanda Chitimbo** | **16,776** | **6.9%** |
  | 5 | Suraj Patil | 11,887 | 4.9% |

## Test plan

- [ ] Verify OWNERS file is valid YAML
- [ ] Verify `machi1990` is a valid GitHub handle

🤖 Generated with [Claude Code](https://claude.com/claude-code)