### PR TITLE
refactor: remove redundant Copilot session send gate

### DIFF
--- a/tooling/hcpctl/pkg/agent/agent.go
+++ b/tooling/hcpctl/pkg/agent/agent.go
@@ -157,7 +157,6 @@ type Session struct {
 	client          *CopilotClient
 	logger          logr.Logger
 	lastMessages    json.RawMessage
-	sendGate        chan struct{}
 	usageMu         sync.RWMutex
 	usage           UsageReport
 	usageProvider   string
@@ -220,7 +219,6 @@ func (c *CopilotClient) CreateSession(ctx context.Context, logger logr.Logger, c
 		inner:           session,
 		client:          c,
 		logger:          logger,
-		sendGate:        make(chan struct{}, 1),
 		usageProvider:   usageProvider,
 		usageDimensions: usageDimensions,
 		usageModel:      sessionCfg.Model,
@@ -338,13 +336,6 @@ func (s *Session) Usage() UsageReport {
 // If ctx is cancelled, the in-flight work is aborted.
 // Returns the final assistant message content.
 func (s *Session) SendAndWait(ctx context.Context, prompt string) (string, error) {
-	// A temporary event subscription associates provider errors with this
-	// request, so calls must not overlap on the same session.
-	if err := s.acquireSendGate(ctx); err != nil {
-		return "", err
-	}
-	defer s.releaseSendGate()
-
 	s.logger.V(1).Info("Sending message to Copilot session.", "promptLength", len(prompt))
 
 	errorCapture := &copilotSessionErrorCapture{provider: s.usageProvider}
@@ -402,26 +393,6 @@ func (s *Session) SendAndWait(ctx context.Context, prompt string) (string, error
 		s.snapshotMessages()
 		return data.Content, nil
 	}
-}
-
-func (s *Session) acquireSendGate(ctx context.Context) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	select {
-	case s.sendGate <- struct{}{}:
-		if err := ctx.Err(); err != nil {
-			s.releaseSendGate()
-			return err
-		}
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
-
-func (s *Session) releaseSendGate() {
-	<-s.sendGate
 }
 
 // Disconnect releases in-memory session resources. Session state is preserved

--- a/tooling/hcpctl/pkg/agent/copilot_session_error_test.go
+++ b/tooling/hcpctl/pkg/agent/copilot_session_error_test.go
@@ -15,7 +15,6 @@
 package agent
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -156,22 +155,6 @@ func TestCopilotSessionErrorCaptureIgnoresUnrelatedEvents(t *testing.T) {
 	}
 	if got, want := err.Error(), "copilot session failed: session failed"; got != want {
 		t.Errorf("Error() = %q, want %q", got, want)
-	}
-}
-
-func TestCopilotSendGateHonorsContextCancellation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	for _, gateOccupied := range []bool{false, true} {
-		session := &Session{sendGate: make(chan struct{}, 1)}
-		if gateOccupied {
-			session.sendGate <- struct{}{}
-		}
-
-		if err := session.acquireSendGate(ctx); !errors.Is(err, context.Canceled) {
-			t.Errorf("acquireSendGate() with gateOccupied=%t error = %v, want context.Canceled", gateOccupied, err)
-		}
 	}
 }
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-2027

## Why

`agent.Analyze` invokes `LLMSession.SendAndWait` synchronously: each initial, correction, compaction, and review prompt completes before the next begins. The Copilot-specific per-session send gate therefore adds no protection to the supported analysis flow.

## What

- remove the unused `Session.sendGate` state and acquire/release helpers
- remove its dedicated cancellation test
- retain the existing per-send structured error capture

See #6892 for a complex version

## Validation

- `go test ./pkg/agent`
- `go test ./cmd/snapshot`