### PR TITLE
fix(e2e): make missing lease releases idempotent (AROSLSRE-2075)

### DIFF
--- a/test/cmd/aro-hcp-tests/slot-manager/slots/leaseproxy.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/leaseproxy.go
@@ -152,6 +152,10 @@ func ReleaseLease(ctx context.Context, leaseProxyServerURL, name string, timeout
 			if response.StatusCode >= 200 && response.StatusCode < 300 {
 				return true, nil
 			}
+			if response.StatusCode == http.StatusInternalServerError &&
+				strings.Contains(strings.ToLower(string(responseBody)), "no resource name") {
+				return true, nil
+			}
 			if response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= 500 {
 				return false, nil // retryable
 			}

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/leaseproxy_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/leaseproxy_test.go
@@ -67,6 +67,34 @@ func TestAcquireAndReleaseLease(t *testing.T) {
 	}
 }
 
+func TestReleaseLeaseTreatsMissingLeaseAsReleased(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`no resource name aro-hcp-dev-westus3-slot-00`))
+	}))
+	defer server.Close()
+
+	if err := ReleaseLease(context.Background(), server.URL, "aro-hcp-dev-westus3-slot-00", DefaultLeaseProxyTimeout); err != nil {
+		t.Fatalf("expected release of an already absent lease to succeed: %v", err)
+	}
+}
+
+func TestReleaseLeaseRetainsGenericServerFailures(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`lease storage is unavailable`))
+	}))
+	defer server.Close()
+
+	if err := ReleaseLease(context.Background(), server.URL, "aro-hcp-dev-westus3-slot-00", 50*time.Millisecond); err == nil {
+		t.Fatal("expected generic server failure to remain an error")
+	}
+}
+
 func TestAcquireLeaseRetriesRetryableStatus(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### What

Treat the lease proxy's explicit `no resource name` response as a successful release.

### Why

The E2E lease-release post step retries this proxy response as an HTTP 500 and can fail after the lease is already absent. Other HTTP 500 responses remain retryable failures.

### Testing

`go test -count=1 ./test/cmd/aro-hcp-tests/slot-manager/...`

### Special notes for your reviewer

Jira: [AROSLSRE-2075](https://redhat.atlassian.net/browse/AROSLSRE-2075)

### PR Checklist

- [x] Unit tests cover the idempotent response and a generic server failure.
