### PR TITLE
test: add integration test for node pool availabilityZone JSON type error

### DIFF
--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/00-httpCreate-subscription/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/00-httpCreate-subscription/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+	"resourceID": "/subscriptions/85176f51-8b54-4150-b6b5-b4ff5d007f5b"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/00-httpCreate-subscription/subscription.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/00-httpCreate-subscription/subscription.json
@@ -1,0 +1,6 @@
+{
+	"properties": null,
+	"registrationDate": "2025-12-19T19:53:15+00:00",
+	"resourceId": "/subscriptions/85176f51-8b54-4150-b6b5-b4ff5d007f5b",
+	"state": "Registered"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/01-httpCreate-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/01-httpCreate-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+	"resourceID": "/subscriptions/85176f51-8b54-4150-b6b5-b4ff5d007f5b/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/invalid-availability-zone-type"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/01-httpCreate-cluster/cluster.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/01-httpCreate-cluster/cluster.json
@@ -1,0 +1,50 @@
+{
+	"identity": {
+		"type": "UserAssigned",
+		"userAssignedIdentities": {}
+	},
+	"name": "invalid-availability-zone-type",
+	"properties": {
+		"api": {
+			"visibility": "Public"
+		},
+		"clusterImageRegistry": {
+			"state": "Disabled"
+		},
+		"console": {},
+		"dns": {},
+		"etcd": {
+			"dataEncryption": {
+				"customerManaged": {
+					"encryptionType": "KMS",
+					"kms": {
+						"activeKey": {
+							"name": "encryptionKeyName",
+							"vaultName": "keyVaultName",
+							"version": "2024-12-01-preview"
+						}
+					}
+				},
+				"keyManagementMode": "CustomerManaged"
+			}
+		},
+		"network": {
+			"hostPrefix": 23,
+			"machineCidr": "10.0.0.0/16",
+			"networkType": "OVNKubernetes",
+			"podCidr": "10.128.0.0/14",
+			"serviceCidr": "172.30.0.0/16"
+		},
+		"platform": {
+			"managedResourceGroup": "managed-resource-group-name",
+			"networkSecurityGroupId": "/subscriptions/85176f51-8b54-4150-b6b5-b4ff5d007f5b/resourceGroups/bar/providers/Microsoft.Network/networkSecurityGroups/nsg",
+			"outboundType": "LoadBalancer",
+			"subnetId": "/subscriptions/85176f51-8b54-4150-b6b5-b4ff5d007f5b/resourceGroups/bar/providers/Microsoft.Network/virtualNetworks/vnet/subnets/subnet"
+		},
+		"version": {
+			"channelGroup": "stable",
+			"id": "4.20"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/02-setClusterServiceID-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/02-setClusterServiceID-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"_artifactStep": "setClusterServiceID",
+	"resourceID": "/subscriptions/85176f51-8b54-4150-b6b5-b4ff5d007f5b/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/invalid-availability-zone-type"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/03-completeOperation-cluster/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/03-completeOperation-cluster/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+	"resourceID": "/subscriptions/85176f51-8b54-4150-b6b5-b4ff5d007f5b/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/invalid-availability-zone-type"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/04-httpCreate-nodepool/00-key.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/04-httpCreate-nodepool/00-key.json
@@ -1,0 +1,4 @@
+{
+	"id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+	"resourceID": "/subscriptions/85176f51-8b54-4150-b6b5-b4ff5d007f5b/resourceGroups/resourceGroupName/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/invalid-availability-zone-type/nodePools/worker"
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/04-httpCreate-nodepool/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/04-httpCreate-nodepool/expected-error.txt
@@ -1,0 +1,6 @@
+{
+  "error": {
+    "code": "InvalidRequestContent",
+    "message": "The request content was invalid and could not be deserialized: \"unmarshalling type *generated.NodePool: struct field Properties: unmarshalling type *generated.NodePoolProperties: struct field Platform: unmarshalling type *generated.NodePoolPlatformProfile: struct field AvailabilityZone: json: cannot unmarshal number into Go value of type string\""
+  }
+}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/04-httpCreate-nodepool/expected-error.txt
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/04-httpCreate-nodepool/expected-error.txt
@@ -1,6 +1,4 @@
 {
-  "error": {
     "code": "InvalidRequestContent",
     "message": "The request content was invalid and could not be deserialized: \"unmarshalling type *generated.NodePool: struct field Properties: unmarshalling type *generated.NodePoolProperties: struct field Platform: unmarshalling type *generated.NodePoolPlatformProfile: struct field AvailabilityZone: json: cannot unmarshal number into Go value of type string\""
   }
-}

--- a/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/04-httpCreate-nodepool/nodepool.json
+++ b/test-integration/frontend/artifacts/FrontendCRUD/NodePool/invalid-availability-zone-type/04-httpCreate-nodepool/nodepool.json
@@ -1,0 +1,17 @@
+{
+	"name": "worker",
+	"properties": {
+		"autoScaling": {
+			"max": 3,
+			"min": 1
+		},
+		"platform": {
+			"availabilityZone": 1,
+			"vmSize": "Standard_D8s_v3"
+		},
+		"version": {
+			"id": "4.20"
+		}
+	},
+	"type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
+}


### PR DESCRIPTION
## Summary

- Adds a frontend integration test artifact under `FrontendCRUD/NodePool/invalid-availability-zone-type` that sends a node pool create with numeric `availabilityZone` and expects HTTP 400 with `InvalidRequestContent` (not 500).
- Covers [ARO-28157](https://redhat.atlassian.net/browse/ARO-28157); the frontend fix is already on `main` (`coreapi.NewInvalidRequestContentError` on JSON unmarshal in node pool create/replace).

## Test plan

- [x] `cd test-integration && go test ./frontend/... -run 'TestFrontendCRUD/WithMock/NodePool/invalid-availability-zone-type' -count=1`

``` /De/S/H/ARO-HCP/test-integration  ARO-28157-fr…az-errortype  ─╮
❯❯ cd /Users/shsayyed/Desktop/SS7/HCP/ARO-HCP/test-integration && go test ./frontend/... -run 'TestFrontendCRUD/WithMock/NodePool/invalid-availability-zone-type' -count=1 -v 2>&1 | tail -8
    utils.go:137: "ts"="2026-09-14 17:04:02.539965" "level"=0 "msg"="go func completed" "message"="http: Server closed"
    utils.go:137: "ts"="2026-09-14 17:04:02.539977" "level"=0 "msg"="go func completed" "message"="http: Server closed"
--- PASS: TestFrontendCRUD (0.15s)
    --- PASS: TestFrontendCRUD/WithMock (0.15s)
        --- PASS: TestFrontendCRUD/WithMock/NodePool (0.15s)
            --- PASS: TestFrontendCRUD/WithMock/NodePool/invalid-availability-zone-type (0.15s)
PASS
ok      github.com/Azure/ARO-HCP/test-integration/frontend      1.428s
```

- [x] Manual curl on personal dev → 400 + InvalidRequestContent

```
❯ curl -sS -o /tmp/aro28157.json -w "HTTP_STATUS:%{http_code}\n" -X PUT \
 "http://127.0.0.1:8443/subscriptions/${SUB}/resourceGroups/${RG}/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/${CLUSTER}/nodePools/${NP}?api-version=${API}" \
  -H "Content-Type: application/json" \
  -H "X-Ms-Home-Tenant-Id: ${TENANT}" \
  -H "X-Ms-Identity-Url: https://fake.identity.url" \
  -H 'X-Ms-Arm-Resource-System-Data: {"createdByType":"User","createdBy":"local-test","createdAt":"2026-01-01T00:00:00Z"}' \
  -d '{
    "name": "'"${NP}"'",
    "properties": {
      "autoScaling": { "max": 3, "min": 1 },
      "platform": {
        "availabilityZone": 1,
        "vmSize": "Standard_D8s_v3"
      },
      "version": { "id": "4.20" }
    },
    "type": "Microsoft.RedHatOpenShift/hcpOpenShiftClusters/nodePools"
  }'

jq . /tmp/aro28157.json
HTTP_STATUS:400
{
  "error": {
    "code": "InvalidRequestContent",
    "message": "The request content was invalid and could not be deserialized: \"unmarshalling type *generated.NodePool: struct field Properties: unmarshalling type *generated.NodePoolProperties: struct field Platform: unmarshalling type *generated.NodePoolPlatformProfile: struct field AvailabilityZone: json: cannot unmarshal number into Go value of type string\""
  }
}```