### PR TITLE
fix(hcpctl): correlate Copilot session errors

### DIFF
--- a/tooling/hcpctl/pkg/agent/agent.go
+++ b/tooling/hcpctl/pkg/agent/agent.go
@@ -22,6 +22,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -31,8 +32,6 @@ import (
 
 	copilot "github.com/github/copilot-sdk/go"
 	"github.com/go-logr/logr"
-
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -156,8 +155,9 @@ type Session struct {
 	inner           *copilot.Session
 	client          *CopilotClient
 	logger          logr.Logger
+	messagesMu      sync.RWMutex
 	lastMessages    json.RawMessage
-	sendGate        chan struct{}
+	sendDispatcher  *copilotSendDispatcher
 	usageMu         sync.RWMutex
 	usage           UsageReport
 	usageProvider   string
@@ -220,16 +220,15 @@ func (c *CopilotClient) CreateSession(ctx context.Context, logger logr.Logger, c
 		inner:           session,
 		client:          c,
 		logger:          logger,
-		sendGate:        make(chan struct{}, 1),
 		usageProvider:   usageProvider,
 		usageDimensions: usageDimensions,
 		usageModel:      sessionCfg.Model,
 		seenUsageKeys:   make(map[string]struct{}),
 	}
-	// Register before the first SendAndWait. The SDK dispatches handlers in
-	// registration order, so all preceding usage events are recorded before
-	// SendAndWait's temporary session.idle handler returns to the caller.
+	// Register before the dispatcher so usage is recorded before a terminal
+	// event wakes a SendAndWait caller.
 	s.inner.On(s.recordUsageEvent)
+	s.sendDispatcher = newCopilotSendDispatcher(s.inner, usageProvider)
 
 	// When verbosity is high enough, trace every session event for debugging.
 	if c.cfg.Verbosity >= 5 {
@@ -338,18 +337,7 @@ func (s *Session) Usage() UsageReport {
 // If ctx is cancelled, the in-flight work is aborted.
 // Returns the final assistant message content.
 func (s *Session) SendAndWait(ctx context.Context, prompt string) (string, error) {
-	// A temporary event subscription associates provider errors with this
-	// request, so calls must not overlap on the same session.
-	if err := s.acquireSendGate(ctx); err != nil {
-		return "", err
-	}
-	defer s.releaseSendGate()
-
 	s.logger.V(1).Info("Sending message to Copilot session.", "promptLength", len(prompt))
-
-	errorCapture := &copilotSessionErrorCapture{provider: s.usageProvider}
-	unsubscribe := s.inner.On(errorCapture.record)
-	defer unsubscribe()
 
 	// The SDK applies a 60s default timeout when the context has no deadline.
 	// Analysis turns routinely take 10+ minutes, so set a generous deadline
@@ -361,73 +349,37 @@ func (s *Session) SendAndWait(ctx context.Context, prompt string) (string, error
 		defer cancel()
 	}
 
-	// Run SendAndWait in a goroutine so we can select on ctx.Done() for abort.
-	type result struct {
-		event *copilot.SessionEvent
-		err   error
-	}
-	ch := make(chan result, 1)
-	go func() {
-		defer utilruntime.HandleCrash()
-		ev, err := s.inner.SendAndWait(ctx, copilot.MessageOptions{
-			Prompt: prompt,
-		})
-		ch <- result{event: ev, err: err}
-	}()
-
-	select {
-	case <-ctx.Done():
+	event, err := s.sendDispatcher.sendAndWait(ctx, copilot.MessageOptions{
+		Prompt: prompt,
+	}, func() {
 		s.logger.Info("Context cancelled, aborting Copilot session.")
 		if err := s.inner.Abort(context.Background()); err != nil {
 			s.logger.Error(err, "Failed to abort Copilot session.")
 		}
-		// Wait for SendAndWait to return after abort.
-		r := <-ch
-		if r.err != nil {
-			return "", fmt.Errorf("copilot session aborted: %w", r.err)
-		}
-		return "", ctx.Err()
-	case r := <-ch:
-		if r.err != nil {
-			return "", wrapCopilotSessionError(errorCapture, r.err)
-		}
-		if r.event == nil {
-			return "", fmt.Errorf("copilot session returned no response")
-		}
-		data, ok := r.event.Data.(*copilot.AssistantMessageData)
-		if !ok {
-			return "", fmt.Errorf("copilot session returned unexpected event type %T", r.event.Data)
-		}
-		s.logger.V(1).Info("Copilot session responded.", "responseLength", len(data.Content))
-		s.snapshotMessages()
-		return data.Content, nil
+	})
+	if err != nil {
+		return "", err
 	}
-}
-
-func (s *Session) acquireSendGate(ctx context.Context) error {
-	if err := ctx.Err(); err != nil {
-		return err
+	if event == nil {
+		return "", fmt.Errorf("copilot session returned no response")
 	}
-	select {
-	case s.sendGate <- struct{}{}:
-		if err := ctx.Err(); err != nil {
-			s.releaseSendGate()
-			return err
-		}
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
+	data, ok := event.Data.(*copilot.AssistantMessageData)
+	if !ok {
+		return "", fmt.Errorf("copilot session returned unexpected event type %T", event.Data)
 	}
-}
-
-func (s *Session) releaseSendGate() {
-	<-s.sendGate
+	s.logger.V(1).Info("Copilot session responded.", "responseLength", len(data.Content))
+	s.snapshotMessages()
+	return data.Content, nil
 }
 
 // Disconnect releases in-memory session resources. Session state is preserved
 // on disk and can be resumed later.
 func (s *Session) Disconnect() error {
-	return s.inner.Disconnect()
+	err := s.inner.Disconnect()
+	if s.sendDispatcher != nil {
+		s.sendDispatcher.failAll(errors.New("copilot session disconnected"))
+	}
+	return err
 }
 
 // Delete permanently removes all session data from disk.
@@ -454,6 +406,8 @@ func (s *Session) snapshotMessages() {
 		s.logger.Error(err, "Failed to marshal session messages for snapshot.")
 		return
 	}
+	s.messagesMu.Lock()
+	defer s.messagesMu.Unlock()
 	s.lastMessages = data
 }
 
@@ -642,7 +596,10 @@ func copilotUsageEventKeys(event copilot.SessionEvent) []string {
 // successful turn, this works even after the CLI subprocess has exited.
 // This is best-effort: errors are logged but not returned.
 func (s *Session) SaveConversation(path string) {
-	if s.lastMessages == nil {
+	s.messagesMu.RLock()
+	lastMessages := append(json.RawMessage(nil), s.lastMessages...)
+	s.messagesMu.RUnlock()
+	if lastMessages == nil {
 		s.logger.Info("No conversation messages to save.")
 		return
 	}
@@ -652,12 +609,12 @@ func (s *Session) SaveConversation(path string) {
 		return
 	}
 
-	if err := os.WriteFile(path, s.lastMessages, 0644); err != nil {
+	if err := os.WriteFile(path, lastMessages, 0644); err != nil {
 		s.logger.Error(err, "Failed to write conversation to disk.", "path", path)
 		return
 	}
 
-	s.logger.Info("Wrote conversation to disk.", "path", path, "size", len(s.lastMessages))
+	s.logger.Info("Wrote conversation to disk.", "path", path, "size", len(lastMessages))
 }
 
 // traceEvents subscribes to all session events and logs them at V(5) for

--- a/tooling/hcpctl/pkg/agent/copilot_send_dispatcher.go
+++ b/tooling/hcpctl/pkg/agent/copilot_send_dispatcher.go
@@ -1,0 +1,450 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	copilot "github.com/github/copilot-sdk/go"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+type copilotSendSession interface {
+	Send(context.Context, copilot.MessageOptions) (string, error)
+	On(copilot.SessionEventHandler) func()
+}
+
+type copilotSendResult struct {
+	event *copilot.SessionEvent
+	err   error
+}
+
+type copilotSendRequest struct {
+	messageID         string
+	interactionID     string
+	turnID            string
+	messageIDs        map[string]struct{}
+	serviceRequestIDs map[string]struct{}
+	providerCallIDs   map[string]struct{}
+	lastAssistant     *copilot.SessionEvent
+	result            chan copilotSendResult
+	completed         bool
+}
+
+// copilotSendDispatcher owns the session-wide event subscription and routes
+// terminal events to the Send call that initiated the corresponding turn.
+type copilotSendDispatcher struct {
+	inner     copilotSendSession
+	provider  string
+	abortWait time.Duration
+
+	// Serialize only session.send submission so user.message events can be
+	// bound to the request whose RPC is in progress. Requests wait concurrently.
+	submitGate chan struct{}
+
+	mu                 sync.Mutex
+	requests           []*copilotSendRequest
+	byMessageID        map[string]*copilotSendRequest
+	byInteractionID    map[string]*copilotSendRequest
+	byTurnID           map[string]*copilotSendRequest
+	byServiceRequestID map[string]*copilotSendRequest
+	byProviderCallID   map[string]*copilotSendRequest
+	openTurns          map[string]*copilotSendRequest
+}
+
+func newCopilotSendDispatcher(inner copilotSendSession, provider string) *copilotSendDispatcher {
+	d := &copilotSendDispatcher{
+		inner:              inner,
+		provider:           provider,
+		abortWait:          5 * time.Second,
+		submitGate:         make(chan struct{}, 1),
+		byMessageID:        make(map[string]*copilotSendRequest),
+		byInteractionID:    make(map[string]*copilotSendRequest),
+		byTurnID:           make(map[string]*copilotSendRequest),
+		byServiceRequestID: make(map[string]*copilotSendRequest),
+		byProviderCallID:   make(map[string]*copilotSendRequest),
+		openTurns:          make(map[string]*copilotSendRequest),
+	}
+	inner.On(d.record)
+	return d
+}
+
+func (d *copilotSendDispatcher) sendAndWait(
+	ctx context.Context,
+	options copilot.MessageOptions,
+	abort func(),
+) (*copilot.SessionEvent, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	select {
+	case d.submitGate <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	releaseSubmission := func() {
+		<-d.submitGate
+	}
+
+	request := &copilotSendRequest{
+		messageIDs:        make(map[string]struct{}),
+		serviceRequestIDs: make(map[string]struct{}),
+		providerCallIDs:   make(map[string]struct{}),
+		result:            make(chan copilotSendResult, 1),
+	}
+	d.add(request)
+
+	type sendResult struct {
+		messageID string
+		err       error
+	}
+	sent := make(chan sendResult, 1)
+	go func() {
+		defer utilruntime.HandleCrash()
+		messageID, err := d.inner.Send(ctx, options)
+		sent <- sendResult{messageID: messageID, err: err}
+	}()
+
+	var send sendResult
+	cancelled := false
+	select {
+	case send = <-sent:
+	case <-ctx.Done():
+		cancelled = true
+		abort()
+		send = <-sent
+	}
+	if send.err != nil {
+		d.remove(request)
+		releaseSubmission()
+		if cancelled {
+			return nil, fmt.Errorf("copilot session aborted: %w", send.err)
+		}
+		return nil, fmt.Errorf("copilot session failed to send message: %w", send.err)
+	}
+	d.bindMessageID(request, send.messageID)
+	releaseSubmission()
+	if cancelled {
+		return d.waitAfterAbort(ctx, request)
+	}
+
+	select {
+	case result := <-request.result:
+		return result.event, result.err
+	default:
+	}
+	select {
+	case result := <-request.result:
+		return result.event, result.err
+	case <-ctx.Done():
+		abort()
+		return d.waitAfterAbort(ctx, request)
+	}
+}
+
+func (d *copilotSendDispatcher) waitAfterAbort(ctx context.Context, request *copilotSendRequest) (*copilot.SessionEvent, error) {
+	timer := time.NewTimer(d.abortWait)
+	defer timer.Stop()
+	select {
+	case result := <-request.result:
+		if result.err != nil {
+			return nil, fmt.Errorf("copilot session aborted: %w", result.err)
+		}
+		return nil, ctx.Err()
+	case <-timer.C:
+		d.remove(request)
+		return nil, ctx.Err()
+	}
+}
+
+func (d *copilotSendDispatcher) add(request *copilotSendRequest) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.requests = append(d.requests, request)
+}
+
+func (d *copilotSendDispatcher) bindMessageID(request *copilotSendRequest, messageID string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	request.messageID = messageID
+	if !request.completed {
+		request.messageIDs[messageID] = struct{}{}
+		d.byMessageID[messageID] = request
+	}
+}
+
+func (d *copilotSendDispatcher) remove(request *copilotSendRequest) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.removeLocked(request)
+}
+
+func (d *copilotSendDispatcher) record(event copilot.SessionEvent) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	switch data := event.Data.(type) {
+	case *copilot.UserMessageData:
+		if data.IsAutopilotContinuation != nil && *data.IsAutopilotContinuation {
+			return
+		}
+		request := d.byMessageID[event.ID]
+		if request == nil {
+			request = d.firstUnboundLocked()
+		}
+		if request == nil {
+			return
+		}
+		request.messageID = event.ID
+		request.messageIDs[event.ID] = struct{}{}
+		d.byMessageID[event.ID] = request
+		if data.InteractionID != nil {
+			request.interactionID = *data.InteractionID
+			d.byInteractionID[*data.InteractionID] = request
+		}
+
+	case *copilot.AssistantTurnStartData:
+		request := d.lookupExactLocked("", "", "", pointerValue(data.InteractionID))
+		if request == nil {
+			request = d.firstPendingLocked()
+		}
+		if request == nil {
+			return
+		}
+		request.turnID = data.TurnID
+		d.byTurnID[data.TurnID] = request
+		if data.InteractionID != nil {
+			request.interactionID = *data.InteractionID
+			d.byInteractionID[*data.InteractionID] = request
+		}
+		d.openTurns[data.TurnID] = request
+
+	case *copilot.AssistantMessageData:
+		request := d.lookupExactLocked(
+			pointerValue(data.ServiceRequestID),
+			pointerValue(data.RequestID),
+			pointerValue(data.TurnID),
+			pointerValue(data.InteractionID),
+		)
+		if request == nil {
+			request = d.onlyOpenTurnLocked()
+		}
+		if request == nil {
+			return
+		}
+		d.bindProviderIDsLocked(request, pointerValue(data.ServiceRequestID), pointerValue(data.RequestID))
+		eventCopy := event
+		request.lastAssistant = &eventCopy
+
+	case *copilot.AssistantUsageData:
+		if request := d.onlyOpenTurnLocked(); request != nil {
+			d.bindProviderIDsLocked(request, pointerValue(data.ServiceRequestID), pointerValue(data.ProviderCallID))
+		}
+
+	case *copilot.ModelCallFailureData:
+		if request := d.onlyOpenTurnLocked(); request != nil {
+			d.bindProviderIDsLocked(request, pointerValue(data.ServiceRequestID), pointerValue(data.ProviderCallID))
+		}
+
+	case *copilot.SessionErrorData:
+		request := d.lookupExactLocked(
+			pointerValue(data.ServiceRequestID),
+			pointerValue(data.ProviderCallID),
+			"",
+			"",
+		)
+		if request == nil {
+			d.failAmbiguousLocked(data)
+			return
+		}
+		cause := fmt.Errorf("session error: %s", data.Message)
+		d.completeLocked(request, copilotSendResult{
+			err: wrapCopilotSessionErrorData(d.provider, data, cause),
+		})
+
+	case *copilot.AssistantTurnEndData:
+		request := d.byTurnID[data.TurnID]
+		if request == nil {
+			return
+		}
+		delete(d.openTurns, data.TurnID)
+		if request.lastAssistant == nil {
+			d.completeLocked(request, copilotSendResult{
+				err: errors.New("copilot session returned no response"),
+			})
+			return
+		}
+		d.completeLocked(request, copilotSendResult{event: request.lastAssistant})
+
+	case *copilot.SessionIdleData:
+		pending := append([]*copilotSendRequest(nil), d.requests...)
+		for _, request := range pending {
+			if request.completed {
+				continue
+			}
+			if request.lastAssistant == nil {
+				d.completeLocked(request, copilotSendResult{
+					err: errors.New("copilot session returned no response"),
+				})
+				continue
+			}
+			d.completeLocked(request, copilotSendResult{event: request.lastAssistant})
+		}
+	}
+}
+
+func (d *copilotSendDispatcher) lookupExactLocked(serviceRequestID, providerCallID, turnID, interactionID string) *copilotSendRequest {
+	if serviceRequestID != "" {
+		if request := d.byServiceRequestID[serviceRequestID]; request != nil && !request.completed {
+			return request
+		}
+	}
+	if providerCallID != "" {
+		if request := d.byProviderCallID[providerCallID]; request != nil && !request.completed {
+			return request
+		}
+	}
+	if turnID != "" {
+		if request := d.byTurnID[turnID]; request != nil && !request.completed {
+			return request
+		}
+	}
+	if interactionID != "" {
+		if request := d.byInteractionID[interactionID]; request != nil && !request.completed {
+			return request
+		}
+	}
+	return nil
+}
+
+func (d *copilotSendDispatcher) bindProviderIDsLocked(request *copilotSendRequest, serviceRequestID, providerCallID string) {
+	if serviceRequestID != "" {
+		request.serviceRequestIDs[serviceRequestID] = struct{}{}
+		d.byServiceRequestID[serviceRequestID] = request
+	}
+	if providerCallID != "" {
+		request.providerCallIDs[providerCallID] = struct{}{}
+		d.byProviderCallID[providerCallID] = request
+	}
+}
+
+func (d *copilotSendDispatcher) firstUnboundLocked() *copilotSendRequest {
+	for _, request := range d.requests {
+		if !request.completed && request.messageID == "" {
+			return request
+		}
+	}
+	return nil
+}
+
+func (d *copilotSendDispatcher) firstPendingLocked() *copilotSendRequest {
+	for _, request := range d.requests {
+		if !request.completed && request.turnID == "" {
+			return request
+		}
+	}
+	return nil
+}
+
+func (d *copilotSendDispatcher) onlyOpenTurnLocked() *copilotSendRequest {
+	var found *copilotSendRequest
+	for _, request := range d.openTurns {
+		if request.completed {
+			continue
+		}
+		if found != nil && found != request {
+			return nil
+		}
+		found = request
+	}
+	return found
+}
+
+func (d *copilotSendDispatcher) failAmbiguousLocked(data *copilot.SessionErrorData) {
+	pending := make([]*copilotSendRequest, 0, len(d.requests))
+	for _, request := range d.requests {
+		if !request.completed {
+			pending = append(pending, request)
+		}
+	}
+	if len(pending) == 1 {
+		cause := fmt.Errorf("session error: %s", data.Message)
+		d.completeLocked(pending[0], copilotSendResult{
+			err: wrapCopilotSessionErrorData(d.provider, data, cause),
+		})
+		return
+	}
+
+	err := fmt.Errorf(
+		"copilot session emitted an uncorrelated error while %d requests were pending: %s",
+		len(pending),
+		data.Message,
+	)
+	for _, request := range pending {
+		d.completeLocked(request, copilotSendResult{err: err})
+	}
+}
+
+func (d *copilotSendDispatcher) completeLocked(request *copilotSendRequest, result copilotSendResult) {
+	if request.completed {
+		return
+	}
+	request.completed = true
+	d.removeLocked(request)
+	request.result <- result
+}
+
+func (d *copilotSendDispatcher) removeLocked(request *copilotSendRequest) {
+	for messageID := range request.messageIDs {
+		delete(d.byMessageID, messageID)
+	}
+	delete(d.byInteractionID, request.interactionID)
+	delete(d.byTurnID, request.turnID)
+	delete(d.openTurns, request.turnID)
+	for serviceRequestID := range request.serviceRequestIDs {
+		delete(d.byServiceRequestID, serviceRequestID)
+	}
+	for providerCallID := range request.providerCallIDs {
+		delete(d.byProviderCallID, providerCallID)
+	}
+	for i, existing := range d.requests {
+		if existing == request {
+			d.requests = append(d.requests[:i], d.requests[i+1:]...)
+			break
+		}
+	}
+}
+
+func (d *copilotSendDispatcher) failAll(err error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	pending := append([]*copilotSendRequest(nil), d.requests...)
+	for _, request := range pending {
+		d.completeLocked(request, copilotSendResult{err: err})
+	}
+}
+
+func pointerValue[T ~string](value *T) string {
+	if value == nil {
+		return ""
+	}
+	return string(*value)
+}

--- a/tooling/hcpctl/pkg/agent/copilot_send_dispatcher_test.go
+++ b/tooling/hcpctl/pkg/agent/copilot_send_dispatcher_test.go
@@ -1,0 +1,350 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	copilot "github.com/github/copilot-sdk/go"
+)
+
+type fakeCopilotSendSession struct {
+	mu      sync.Mutex
+	handler copilot.SessionEventHandler
+	send    func(context.Context, copilot.MessageOptions) (string, error)
+}
+
+func (f *fakeCopilotSendSession) Send(ctx context.Context, options copilot.MessageOptions) (string, error) {
+	return f.send(ctx, options)
+}
+
+func (f *fakeCopilotSendSession) On(handler copilot.SessionEventHandler) func() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.handler = handler
+	return func() {}
+}
+
+func (f *fakeCopilotSendSession) emit(event copilot.SessionEvent) {
+	f.mu.Lock()
+	handler := f.handler
+	f.mu.Unlock()
+	handler(event)
+}
+
+func TestCopilotSendDispatcherHandlesEventsBeforeSendReturns(t *testing.T) {
+	fake := &fakeCopilotSendSession{}
+	fake.send = func(context.Context, copilot.MessageOptions) (string, error) {
+		interactionID := "interaction-1"
+		turnID := "turn-1"
+		serviceRequestID := "service-request-1"
+		requestID := "provider-call-1"
+		fake.emit(copilot.SessionEvent{
+			ID: "message-1",
+			Data: &copilot.UserMessageData{
+				InteractionID: &interactionID,
+			},
+		})
+		fake.emit(copilot.SessionEvent{
+			Data: &copilot.AssistantTurnStartData{
+				InteractionID: &interactionID,
+				TurnID:        turnID,
+			},
+		})
+		fake.emit(copilot.SessionEvent{
+			Data: &copilot.AssistantMessageData{
+				Content:          "answer",
+				MessageID:        "assistant-message-1",
+				InteractionID:    &interactionID,
+				TurnID:           &turnID,
+				ServiceRequestID: &serviceRequestID,
+				RequestID:        &requestID,
+			},
+		})
+		fake.emit(copilot.SessionEvent{Data: &copilot.SessionIdleData{}})
+		return "message-1", nil
+	}
+
+	dispatcher := newCopilotSendDispatcher(fake, "github-copilot")
+	event, err := dispatcher.sendAndWait(t.Context(), copilot.MessageOptions{Prompt: "prompt"}, func() {})
+	if err != nil {
+		t.Fatalf("sendAndWait() error = %v", err)
+	}
+	data, ok := event.Data.(*copilot.AssistantMessageData)
+	if !ok {
+		t.Fatalf("event data type = %T, want *copilot.AssistantMessageData", event.Data)
+	}
+	if data.Content != "answer" {
+		t.Errorf("Content = %q, want %q", data.Content, "answer")
+	}
+}
+
+func TestCopilotSendDispatcherReturnsCorrelatedStructuredError(t *testing.T) {
+	fake := &fakeCopilotSendSession{}
+	fake.send = func(context.Context, copilot.MessageOptions) (string, error) {
+		interactionID := "interaction-1"
+		serviceRequestID := "service-request-1"
+		providerCallID := "provider-call-1"
+		fake.emit(copilot.SessionEvent{
+			ID: "message-1",
+			Data: &copilot.UserMessageData{
+				InteractionID: &interactionID,
+			},
+		})
+		fake.emit(copilot.SessionEvent{
+			Data: &copilot.AssistantTurnStartData{
+				InteractionID: &interactionID,
+				TurnID:        "turn-1",
+			},
+		})
+		fake.emit(copilot.SessionEvent{
+			Data: &copilot.ModelCallFailureData{
+				ServiceRequestID: &serviceRequestID,
+				ProviderCallID:   &providerCallID,
+			},
+		})
+		fake.emit(copilot.SessionEvent{
+			Data: &copilot.SessionErrorData{
+				ErrorType:        CopilotSessionErrorTypeRateLimit,
+				Message:          "request rate limited",
+				ServiceRequestID: &serviceRequestID,
+				ProviderCallID:   &providerCallID,
+			},
+		})
+		return "message-1", nil
+	}
+
+	dispatcher := newCopilotSendDispatcher(fake, "github-copilot")
+	_, err := dispatcher.sendAndWait(t.Context(), copilot.MessageOptions{Prompt: "prompt"}, func() {})
+	var sessionErr *CopilotSessionError
+	if !errors.As(err, &sessionErr) {
+		t.Fatalf("errors.As() = false for %v, want true", err)
+	}
+	if sessionErr.ServiceRequestID == nil || *sessionErr.ServiceRequestID != "service-request-1" {
+		t.Errorf("ServiceRequestID = %v, want %q", sessionErr.ServiceRequestID, "service-request-1")
+	}
+	if sessionErr.ProviderCallID == nil || *sessionErr.ProviderCallID != "provider-call-1" {
+		t.Errorf("ProviderCallID = %v, want %q", sessionErr.ProviderCallID, "provider-call-1")
+	}
+}
+
+func TestCopilotSendDispatcherSeparatesConcurrentRequests(t *testing.T) {
+	fake := &fakeCopilotSendSession{}
+	sent := make(chan string, 2)
+	var sendMu sync.Mutex
+	sendCount := 0
+	fake.send = func(context.Context, copilot.MessageOptions) (string, error) {
+		sendMu.Lock()
+		sendCount++
+		id := fmt.Sprintf("message-%d", sendCount)
+		interactionID := fmt.Sprintf("interaction-%d", sendCount)
+		sendMu.Unlock()
+		fake.emit(copilot.SessionEvent{
+			ID: id,
+			Data: &copilot.UserMessageData{
+				InteractionID: &interactionID,
+			},
+		})
+		sent <- id
+		return id, nil
+	}
+
+	dispatcher := newCopilotSendDispatcher(fake, "github-copilot")
+	type result struct {
+		event *copilot.SessionEvent
+		err   error
+	}
+	results := make(chan result, 2)
+	for range 2 {
+		go func() {
+			event, err := dispatcher.sendAndWait(t.Context(), copilot.MessageOptions{Prompt: "prompt"}, func() {})
+			results <- result{event: event, err: err}
+		}()
+	}
+	<-sent
+	<-sent
+
+	interactionID1 := "interaction-1"
+	serviceRequestID1 := "service-request-1"
+	fake.emit(copilot.SessionEvent{
+		Data: &copilot.AssistantTurnStartData{
+			InteractionID: &interactionID1,
+			TurnID:        "turn-1",
+		},
+	})
+	fake.emit(copilot.SessionEvent{
+		Data: &copilot.ModelCallFailureData{
+			ServiceRequestID: &serviceRequestID1,
+		},
+	})
+	fake.emit(copilot.SessionEvent{
+		Data: &copilot.SessionErrorData{
+			ErrorType:        CopilotSessionErrorTypeRateLimit,
+			Message:          "first request failed",
+			ServiceRequestID: &serviceRequestID1,
+		},
+	})
+
+	interactionID2 := "interaction-2"
+	turnID2 := "turn-2"
+	fake.emit(copilot.SessionEvent{
+		Data: &copilot.AssistantTurnStartData{
+			InteractionID: &interactionID2,
+			TurnID:        turnID2,
+		},
+	})
+	fake.emit(copilot.SessionEvent{
+		Data: &copilot.AssistantMessageData{
+			Content:       "second request succeeded",
+			MessageID:     "assistant-message-2",
+			InteractionID: &interactionID2,
+			TurnID:        &turnID2,
+		},
+	})
+	fake.emit(copilot.SessionEvent{
+		Data: &copilot.AssistantTurnEndData{TurnID: turnID2},
+	})
+
+	var successCount, errorCount int
+	for range 2 {
+		result := <-results
+		switch {
+		case result.err != nil:
+			var sessionErr *CopilotSessionError
+			if !errors.As(result.err, &sessionErr) {
+				t.Fatalf("error = %v, want CopilotSessionError", result.err)
+			}
+			if sessionErr.Message != "first request failed" {
+				t.Errorf("error message = %q, want %q", sessionErr.Message, "first request failed")
+			}
+			errorCount++
+		case result.event != nil:
+			data, ok := result.event.Data.(*copilot.AssistantMessageData)
+			if !ok || data.Content != "second request succeeded" {
+				t.Errorf("event = %#v, want second request response", result.event)
+			}
+			successCount++
+		default:
+			t.Fatal("result has neither event nor error")
+		}
+	}
+	if successCount != 1 || errorCount != 1 {
+		t.Errorf("successes = %d, errors = %d, want 1 each", successCount, errorCount)
+	}
+}
+
+func TestCopilotSendDispatcherCancellationDoesNotHangWithoutTerminalEvent(t *testing.T) {
+	fake := &fakeCopilotSendSession{}
+	sent := make(chan struct{})
+	fake.send = func(context.Context, copilot.MessageOptions) (string, error) {
+		fake.emit(copilot.SessionEvent{ID: "message-1", Data: &copilot.UserMessageData{}})
+		close(sent)
+		return "message-1", nil
+	}
+
+	dispatcher := newCopilotSendDispatcher(fake, "github-copilot")
+	dispatcher.abortWait = 10 * time.Millisecond
+	ctx, cancel := context.WithCancel(t.Context())
+	result := make(chan error, 1)
+	go func() {
+		_, err := dispatcher.sendAndWait(ctx, copilot.MessageOptions{Prompt: "prompt"}, func() {})
+		result <- err
+	}()
+	<-sent
+	cancel()
+
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("sendAndWait() did not return after cancellation")
+	}
+}
+
+func TestCopilotSendDispatcherRemovesAllProviderIDMappings(t *testing.T) {
+	fake := &fakeCopilotSendSession{}
+	dispatcher := newCopilotSendDispatcher(fake, "github-copilot")
+	request := &copilotSendRequest{
+		messageIDs:        make(map[string]struct{}),
+		serviceRequestIDs: make(map[string]struct{}),
+		providerCallIDs:   make(map[string]struct{}),
+		result:            make(chan copilotSendResult, 1),
+	}
+	dispatcher.add(request)
+
+	dispatcher.mu.Lock()
+	dispatcher.bindProviderIDsLocked(request, "service-1", "provider-1")
+	dispatcher.bindProviderIDsLocked(request, "service-2", "provider-2")
+	dispatcher.completeLocked(request, copilotSendResult{})
+	if len(dispatcher.byServiceRequestID) != 0 {
+		t.Errorf("service request mappings = %v, want empty", dispatcher.byServiceRequestID)
+	}
+	if len(dispatcher.byProviderCallID) != 0 {
+		t.Errorf("provider call mappings = %v, want empty", dispatcher.byProviderCallID)
+	}
+	dispatcher.mu.Unlock()
+}
+
+func TestCopilotSendDispatcherRejectsAmbiguousError(t *testing.T) {
+	fake := &fakeCopilotSendSession{}
+	sent := make(chan struct{}, 2)
+	var sendMu sync.Mutex
+	sendCount := 0
+	fake.send = func(context.Context, copilot.MessageOptions) (string, error) {
+		sendMu.Lock()
+		sendCount++
+		id := fmt.Sprintf("message-%d", sendCount)
+		sendMu.Unlock()
+		fake.emit(copilot.SessionEvent{ID: id, Data: &copilot.UserMessageData{}})
+		sent <- struct{}{}
+		return id, nil
+	}
+
+	dispatcher := newCopilotSendDispatcher(fake, "github-copilot")
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, err := dispatcher.sendAndWait(t.Context(), copilot.MessageOptions{Prompt: "prompt"}, func() {})
+			results <- err
+		}()
+	}
+	<-sent
+	<-sent
+	fake.emit(copilot.SessionEvent{
+		Data: &copilot.SessionErrorData{
+			ErrorType: CopilotSessionErrorTypeRateLimit,
+			Message:   "request rate limited",
+		},
+	})
+
+	for range 2 {
+		err := <-results
+		if err == nil || !strings.Contains(err.Error(), "uncorrelated error while 2 requests were pending") {
+			t.Errorf("error = %v, want ambiguous correlation error", err)
+		}
+		var sessionErr *CopilotSessionError
+		if errors.As(err, &sessionErr) {
+			t.Errorf("errors.As() = true with %#v, want uncorrelated error", sessionErr)
+		}
+	}
+}

--- a/tooling/hcpctl/pkg/agent/copilot_session_error.go
+++ b/tooling/hcpctl/pkg/agent/copilot_session_error.go
@@ -16,7 +16,6 @@ package agent
 
 import (
 	"fmt"
-	"sync"
 
 	copilot "github.com/github/copilot-sdk/go"
 )
@@ -56,21 +55,9 @@ func (e *CopilotSessionError) Unwrap() error {
 	return e.Err
 }
 
-type copilotSessionErrorCapture struct {
-	provider string
-
-	mu    sync.Mutex
-	first *CopilotSessionError
-}
-
-func (c *copilotSessionErrorCapture) record(event copilot.SessionEvent) {
-	data, ok := event.Data.(*copilot.SessionErrorData)
-	if !ok {
-		return
-	}
-
+func wrapCopilotSessionErrorData(provider string, data *copilot.SessionErrorData, cause error) error {
 	captured := &CopilotSessionError{
-		Provider:              c.provider,
+		Provider:              provider,
 		ErrorType:             data.ErrorType,
 		ErrorCode:             clonePointer(data.ErrorCode),
 		StatusCode:            clonePointer(data.StatusCode),
@@ -80,32 +67,9 @@ func (c *copilotSessionErrorCapture) record(event copilot.SessionEvent) {
 		Stack:                 clonePointer(data.Stack),
 		URL:                   clonePointer(data.URL),
 		EligibleForAutoSwitch: clonePointer(data.EligibleForAutoSwitch),
+		Err:                   cause,
 	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.first == nil {
-		c.first = captured
-	}
-}
-
-func (c *copilotSessionErrorCapture) withCause(cause error) *CopilotSessionError {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.first == nil {
-		return nil
-	}
-
-	captured := *c.first
-	captured.Err = cause
-	return &captured
-}
-
-func wrapCopilotSessionError(capture *copilotSessionErrorCapture, cause error) error {
-	if sessionErr := capture.withCause(cause); sessionErr != nil {
-		return fmt.Errorf("copilot session failed: %w", sessionErr)
-	}
-	return fmt.Errorf("copilot session failed: %w", cause)
+	return fmt.Errorf("copilot session failed: %w", captured)
 }
 
 func clonePointer[T any](value *T) *T {

--- a/tooling/hcpctl/pkg/agent/copilot_session_error_test.go
+++ b/tooling/hcpctl/pkg/agent/copilot_session_error_test.go
@@ -15,7 +15,6 @@
 package agent
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -30,23 +29,18 @@ func TestCopilotSessionErrorCapture(t *testing.T) {
 	stack := "provider stack"
 	url := "https://example.invalid/rate-limit"
 	eligibleForAutoSwitch := true
-	capture := &copilotSessionErrorCapture{provider: "github-copilot"}
-	capture.record(copilot.SessionEvent{
-		Data: &copilot.SessionErrorData{
-			ErrorType:             CopilotSessionErrorTypeRateLimit,
-			ErrorCode:             &errorCode,
-			StatusCode:            &statusCode,
-			Message:               "request rate limited",
-			ProviderCallID:        &providerCallID,
-			ServiceRequestID:      &serviceRequestID,
-			Stack:                 &stack,
-			URL:                   &url,
-			EligibleForAutoSwitch: &eligibleForAutoSwitch,
-		},
-	})
-
 	providerErr := errors.New("CAPIError: 429")
-	err := wrapCopilotSessionError(capture, providerErr)
+	err := wrapCopilotSessionErrorData("github-copilot", &copilot.SessionErrorData{
+		ErrorType:             CopilotSessionErrorTypeRateLimit,
+		ErrorCode:             &errorCode,
+		StatusCode:            &statusCode,
+		Message:               "request rate limited",
+		ProviderCallID:        &providerCallID,
+		ServiceRequestID:      &serviceRequestID,
+		Stack:                 &stack,
+		URL:                   &url,
+		EligibleForAutoSwitch: &eligibleForAutoSwitch,
+	}, providerErr)
 
 	var sessionErr *CopilotSessionError
 	if !errors.As(err, &sessionErr) {
@@ -91,17 +85,13 @@ func TestCopilotSessionErrorCapture(t *testing.T) {
 }
 
 func TestCopilotSessionErrorCapturePreservesMissingOptionalFields(t *testing.T) {
-	capture := &copilotSessionErrorCapture{provider: "github-copilot"}
-	capture.record(copilot.SessionEvent{
-		Data: &copilot.SessionErrorData{
-			ErrorType: CopilotSessionErrorTypeRateLimit,
-			Message:   "request rate limited",
-		},
-	})
-
-	sessionErr := capture.withCause(errors.New("session failed"))
-	if sessionErr == nil {
-		t.Fatal("withCause() = nil, want CopilotSessionError")
+	err := wrapCopilotSessionErrorData("github-copilot", &copilot.SessionErrorData{
+		ErrorType: CopilotSessionErrorTypeRateLimit,
+		Message:   "request rate limited",
+	}, errors.New("session failed"))
+	var sessionErr *CopilotSessionError
+	if !errors.As(err, &sessionErr) {
+		t.Fatal("errors.As() = false, want true")
 	}
 	if sessionErr.ErrorCode != nil ||
 		sessionErr.StatusCode != nil ||
@@ -111,67 +101,6 @@ func TestCopilotSessionErrorCapturePreservesMissingOptionalFields(t *testing.T) 
 		sessionErr.URL != nil ||
 		sessionErr.EligibleForAutoSwitch != nil {
 		t.Fatalf("optional fields = %#v, want all nil", sessionErr)
-	}
-}
-
-func TestCopilotSessionErrorCapturePreservesFirstError(t *testing.T) {
-	capture := &copilotSessionErrorCapture{provider: "github-copilot"}
-	capture.record(copilot.SessionEvent{
-		Data: &copilot.SessionErrorData{
-			ErrorType: CopilotSessionErrorTypeRateLimit,
-			Message:   "first error",
-		},
-	})
-	capture.record(copilot.SessionEvent{
-		Data: &copilot.SessionErrorData{
-			ErrorType: "authentication",
-			Message:   "second error",
-		},
-	})
-
-	sessionErr := capture.withCause(errors.New("session failed"))
-	if sessionErr == nil {
-		t.Fatal("withCause() = nil, want CopilotSessionError")
-	}
-	if sessionErr.ErrorType != CopilotSessionErrorTypeRateLimit {
-		t.Errorf("ErrorType = %q, want %q", sessionErr.ErrorType, CopilotSessionErrorTypeRateLimit)
-	}
-	if sessionErr.Message != "first error" {
-		t.Errorf("Message = %q, want %q", sessionErr.Message, "first error")
-	}
-}
-
-func TestCopilotSessionErrorCaptureIgnoresUnrelatedEvents(t *testing.T) {
-	capture := &copilotSessionErrorCapture{provider: "github-copilot"}
-	capture.record(copilot.SessionEvent{Data: &copilot.SessionIdleData{}})
-
-	providerErr := errors.New("session failed")
-	err := wrapCopilotSessionError(capture, providerErr)
-	var sessionErr *CopilotSessionError
-	if errors.As(err, &sessionErr) {
-		t.Fatalf("errors.As() = true with %#v, want false", sessionErr)
-	}
-	if !errors.Is(err, providerErr) {
-		t.Fatal("errors.Is() = false, want original provider error in the chain")
-	}
-	if got, want := err.Error(), "copilot session failed: session failed"; got != want {
-		t.Errorf("Error() = %q, want %q", got, want)
-	}
-}
-
-func TestCopilotSendGateHonorsContextCancellation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	for _, gateOccupied := range []bool{false, true} {
-		session := &Session{sendGate: make(chan struct{}, 1)}
-		if gateOccupied {
-			session.sendGate <- struct{}{}
-		}
-
-		if err := session.acquireSendGate(ctx); !errors.Is(err, context.Canceled) {
-			t.Errorf("acquireSendGate() with gateOccupied=%t error = %v, want context.Canceled", gateOccupied, err)
-		}
 	}
 }
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-2027

## Why

`hcpctl` currently installs a temporary `session.error` listener around every Copilot SDK `SendAndWait` call. The listener receives session-wide events, so overlapping sends can observe and return another request's structured provider error.

This draft explores request-aware error routing instead of relying on a whole-turn send lock. There is no tracking ticket yet; the PR is intentionally draft to validate the Copilot event protocol and correlation assumptions with reviewers.

In case #6887 proves insufficient.

## What

- replace SDK `SendAndWait` with `Send` plus one permanent session event dispatcher
- correlate requests through message, interaction, turn, service request, and provider call identifiers
- return the existing structured `CopilotSessionError` to the matched caller
- terminate successful requests on `assistant.turn_end`, with `session.idle` as a session-wide fallback
- reject uncorrelated errors when several requests are pending rather than assigning them arbitrarily
- bound cancellation cleanup and fail pending requests when the session disconnects
- protect conversation snapshots when request waits overlap

## Important assumptions and limitations

- `session.send` submissions are serialized until the returned message ID is registered; request waits may overlap
- provider IDs are only associated with a request when exactly one turn is open, unless an event already carries an interaction or turn ID
- `Abort` remains session-scoped in the SDK, so cancelling one of several overlapping requests may affect the entire session
- the current `hcpctl snapshot analyze` flow remains sequential; concurrency tests exercise the dispatcher rather than changing that caller

## Validation

```text
go test -race ./pkg/agent ./cmd/snapshot
```

## Copilot
vault / 31418bd8-f6df-4bfd-a607-9a46b585a0b0
