### PR TITLE
feat(slot-manager): add weighted multi-region DEV E2E selection

### DIFF
--- a/docs/ci/identity-leasing.md
+++ b/docs/ci/identity-leasing.md
@@ -130,13 +130,15 @@ The current model is:
 - each slot pool has a Boskos `resource_type`, a customer `subscription_name`, slot count, and identity-container settings
 - `slot-manager acquire` maps `ARO_HCP_DEPLOY_ENV` to the catalog environment and builds an ordered candidate pool list
 - `ALLOWED_SUBSCRIPTIONS` narrows the candidate pool set when a job needs to pin or restrict shard selection
-- when `region_mode: runtime-selected` is used, the concrete runtime region is driven by the job's runtime override and exported as `SELECTED_LOCATION`
+- `fixed` pools take their runtime region from the catalog
+- `runtime-selected` pools take their runtime region from the job override, with the catalog region as fallback
+- `weighted` pools select deterministically from the catalog regions using per-job `LOCATION_WEIGHTS` and `BUILD_ID`; an explicit location override remains highest precedence
 
-The current slot-manager rollout intentionally keeps the implementation details in [slot-manager design](../../test/cmd/aro-hcp-tests/slot-manager/DESIGN.md). For day-to-day CI understanding, the important points are:
+The implementation details live in [slot-manager design](../../test/cmd/aro-hcp-tests/slot-manager/DESIGN.md). For day-to-day CI understanding, the important points are:
 
 - subscription sharding is driven by the slot catalog and slot-manager candidate pool selection
 - candidate pools are tried in catalog order when more than one pool is eligible
-- the active runtime region is controlled by the live `openshift/release` job configuration
+- the active runtime region is determined from the catalog mode and the live `openshift/release` job configuration
 
 This document intentionally does not freeze the current region value in prose. If you need the current runtime override for a job, inspect the live `openshift/release` config rather than relying on a doc snapshot.
 

--- a/test/cmd/aro-hcp-tests/slot-manager/DESIGN.md
+++ b/test/cmd/aro-hcp-tests/slot-manager/DESIGN.md
@@ -1,303 +1,258 @@
-# Slot Manager — Design Context
+# Slot Manager
 
-## Status
+Slot manager assigns an E2E job a customer-subscription slot and an Azure
+runtime region. It uses Boskos for exclusive slot ownership and
+`test/e2e-config/e2e-slots.yaml` as the canonical inventory.
 
-The slot-based runtime leasing foundation is code complete but still
-pending test/merge. It scales customer-subscription usage and later
-enables deterministic failover/failback.
+Its responsibilities are:
 
-## Epic Goals (E2E-relevant subset)
+- select an eligible customer-subscription pool,
+- acquire one slot from that pool,
+- select the runtime region according to the pool's region mode,
+- resolve the cluster profile that owns the selected subscription,
+- export the non-secret runtime contract for downstream CI steps, and
+- release the exact Boskos resource acquired by the job.
 
-1. Support environment-appropriate use of subscription and region coordinates across E2E execution.
-2. Increase total CI throughput without sacrificing reproducibility or debuggability.
-3. Make subscription and region routing deterministic.
-4. Use provision-phase health rather than full test pass rate for region/pool health decisions.
-5. Leave room for future automation only after the signal quality is good enough.
+Slot manager does not enforce regional concurrency, evaluate region health, or
+change routing weights automatically.
 
-## Non-goals
+## Catalog contract
 
-- Full automation in phase 1.
-- Replacing Boskos global ownership model.
-- Solving all test flakes inside functional test logic.
+The catalog groups pools into logical environments and maps deploy environment
+names such as `ci01`, `int`, `stg`, and `prod` to one of them.
 
-## Design Principles
-
-- Determinism over randomness.
-- Manual controls first, automation after signal quality is proven.
-- Region health is based on provision outcomes only.
-- Model capacity as composite subscription+region cells where that is the natural execution unit.
-- Keep Boskos and CI global config minimal and stable.
-- Prefer config-driven and inventory-driven selection over ad hoc runtime overrides.
-
-## Vault Cluster Profile Secret Contract
-
-The cluster profile secret provides the authoritative customer-subscription
-inventory for slot-based routing.
-
-- **Customer subscription shard keys**
-  - `customer-shardN-subscription-id`
-  - `customer-shardN-subscription-name`
-  - Examples:
-    - `customer-shard1-subscription-id`
-    - `customer-shard1-subscription-name`
-    - `customer-shard2-subscription-id`
-  - These keys declare the pool of customer subscriptions that E2E jobs can consume through slot-based routing and leasing.
-
-- E2E slot logic and related tooling select from the `customer-shardN-*` inventory when deciding which customer subscription pool a leased slot belongs to.
-
-## E2E Tests: Multi-Subscription and Multi-Region
-
-### Why this workstream exists
-
-Even after infrastructure is decoupled, E2E scale is still limited by the
-**customer subscription** and sometimes the **region** where tests create
-and manage HCP clusters.
-
-The test-side design therefore introduces a runtime leasing model that can
-scale independently from the infrastructure-subscription work.
-
-### Current design
-
-- The canonical E2E slot inventory lives in ARO-HCP.
-- Runtime leasing is done through `aro-hcp-tests slot-manager` and the ci-operator Boskos proxy.
-- The E2E workflow in `openshift/release` uses dedicated acquire/release steps that wrap the CLI.
-- Pool selection is now driven by an explicit selector contract:
-  - `ALLOWED_SUBSCRIPTIONS`
-    - candidate-pool allowlist keyed by catalog `subscription_name`
-  - `ALLOWED_LOCATIONS`
-    - fixed-mode candidate-pool allowlist keyed by region
-  - `MULTISTAGE_PARAM_OVERRIDE_LOCATION`
-    - highest-precedence concrete runtime location
-    - when set it overrides `ALLOWED_LOCATIONS` for fixed-mode pool selection
-    - for runtime-selected pools it does not change pool identity, but it does become the concrete runtime location
-  - `CLUSTER_PROFILE_DIRS`
-    - optional comma/newline-separated list of cluster profile dirs to resolve the leased
-      subscription's owning tenant/service-principal across
-    - falls back to the single `CLUSTER_PROFILE_DIR` when unset (backward compatible)
-    - used by the cross-tenant prod gating job so a single job can lease slots that live
-      in more than one Azure tenant (RH-tenant subs + MSFT Test-Tenant sub); acquire matches
-      the leased `subscription_name` against the `customer-*-subscription-name` files across
-      all listed dirs and exports the single matching dir as `SELECTED_CLUSTER_PROFILE_DIR`
-- The runtime env contract is intentionally narrow and non-secret:
-  - `CUSTOMER_SUBSCRIPTION`
-  - `SELECTED_LOCATION`
-  - `SELECTED_CLUSTER_PROFILE_DIR`
-    - the single cluster profile dir whose `customer-*-subscription-name` matched the leased
-      subscription; downstream steps load the owning tenant/service-principal credentials from
-      it (`tenant`, `client-id`, `client-secret`) instead of a job-fixed profile
-  - `LEASED_MSI_CONTAINERS`
-  - `ARO_HCP_E2E_SLOT_NAME`
-  - `ARO_HCP_E2E_SLOT_RESOURCE_TYPE`
-- Downstream `openshift/release` steps still mostly consume `LOCATION` today, so the release-side scripts map `SELECTED_LOCATION` back into `LOCATION` where needed.
-
-### Coordinate model by environment
-
-- **Subscription coordinate**
-  - The main reason to add more customer subscriptions is to bypass Azure role-assignment limit pressure and unlock higher E2E suite parallelism while still keeping enough job concurrency.
-- **Region coordinate**
-  - **DEV**
-    - Start with one primary region and one backup region.
-    - Failover is manual first.
-    - Keep the door open to several active primary regions later if that becomes useful.
-  - **INT / STG**
-    - Region remains fixed to `uksouth` because these are persistent environments that only exist in `uksouth`.
-    - These environments use gating tests that are triggered on demand after service rollout through Gangway-backed execution of the `aro-hcp-e2e` jobs in `openshift/release`.
-    - `stg` also has periodic E2E jobs pinned to `uksouth` today, declared in `release/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml`.
-  - **PROD**
-    - Prod has presence in many regions, so region is a real routing coordinate here.
-    - `prod` also has periodic E2E jobs pinned to `uksouth` today, declared in `release/ci-operator/config/Azure/ARO-HCP/Azure-ARO-HCP-main__periodic.yaml`.
-    - Concurrency for a particular region is usually `1` (although it can be higher for `uksouth` due to periodics), but several customer subscriptions are still needed to run tests against multiple prod regions concurrently.
-    - The expectation is that Gangway-triggered prod gating jobs set `MULTISTAGE_PARAM_OVERRIDE_LOCATION` per target region when invoking the job. `slot-manager acquire` gives that override precedence over `ALLOWED_LOCATIONS` on the acquire side, and the leased slot then exports the authoritative runtime `SELECTED_LOCATION` for downstream steps.
-    - This also means we need to watch for any step that bypasses that contract and accidentally uses a stale/default `LOCATION` instead of the release-mapped `SELECTED_LOCATION`.
-
-### Pool selection and lease acquisition flow
-
-```mermaid
-flowchart TD
-    Start["slot-manager acquire"]
-    --> LoadCatalog["Load e2e-slots.yaml catalog"]
-    --> ResolveEnv["Resolve --deploy-env to\nslot environment name"]
-    --> DetectMode["Read region_mode\nfrom environment pools"]
-
-    DetectMode --> IsFixed{region_mode?}
-
-    IsFixed -->|fixed| FixedFilter["Fixed-mode filter:\n1. allowed subscriptions\n2. override location if set\n3. else allowed locations"]
-    IsFixed -->|runtime-selected| RSFilter["Runtime-selected filter:\n1. allowed subscriptions\n2. ignore allowed locations\nfor pool identity"]
-
-    FixedFilter --> Candidates["Candidate pool list\nwith rotated starting point"]
-    RSFilter --> Candidates
-
-    Candidates --> PassStart["Start pass N over candidates"]
-    PassStart --> TryPool["Try AcquireLease for\nnext candidate pool"]
-    TryPool --> LeaseResult{Result?}
-
-    LeaseResult -->|success| ResolveRegion{region_mode?}
-    ResolveRegion -->|fixed| UsePoolRegion["Runtime region =\npool.Region"]
-    ResolveRegion -->|runtime-selected| HasOverride{Override location set?}
-    HasOverride -->|yes| UseOverride["Runtime region =\noverride location"]
-    HasOverride -->|no| UseFallback["Runtime region =\npool.Region as default"]
-
-    UsePoolRegion --> Finalize
-    UseOverride --> Finalize
-    UseFallback --> Finalize
-
-    Finalize["Finalize:\n1. Verify subscription in cluster profile\n2. Write state file\n3. Write env file"]
-
-    LeaseResult -->|no immediate lease| Unavailable["Temporarily unavailable now:\nproxy timeout,\nretry budget exhaustion,\nor retryable proxy response"]
-    Unavailable --> MorePools{More candidate\npools?}
-    MorePools -->|yes| TryPool
-    MorePools -->|no| WaitCheck{max_wait_for_lease\nexpired?}
-    WaitCheck -->|no| Sleep["Sleep lease_wait_interval"] --> PassStart
-    WaitCheck -->|yes| Fail["Fail: no pool yielded an\nimmediate lease within budget"]
-
-    LeaseResult -->|fatal error| Abort["Abort: non-retryable error"]
+```yaml
+version: 1
+environments:
+  dev:
+    deploy_envs:
+    - ci00
+    - ci01
+    pools:
+    - subscription_name: "ARO HCP E2E Hosted Clusters (EA Subscription)"
+      region_mode: weighted
+      regions:
+      - westus3
+      - centralus
+      - canadacentral
+      identity_provisioning_region: westus3
+      resource_type: aro-hcp-dev-shard0-slot
+      slot_count: 5
+      identity_container_prefix: aro-hcp-msi-container-dev-shard0
+      identity_container_count: 60
 ```
 
-### Current implementation state
+Each pool defines:
 
-- The current branch now implements the broader slot-based runtime leasing model:
-  - canonical slot catalog and `slot-manager` CLI,
-  - `region_mode: fixed|runtime-selected` plus optional `identity_provisioning_region`,
-  - Boskos managed-block sync/validation tooling,
-  - release step wiring,
-  - formalized non-secret runtime contract centered on `SELECTED_LOCATION`.
-- Multi-pool candidate selection and fallback are implemented:
-  - fixed-mode environments filter candidate pools by `ALLOWED_SUBSCRIPTIONS` and either `ALLOWED_LOCATIONS` or `MULTISTAGE_PARAM_OVERRIDE_LOCATION`, then rotate the starting pool once per acquire run while preserving the remaining catalog order for fallback,
-  - runtime-selected environments use `ALLOWED_SUBSCRIPTIONS` for pool identity, ignore `ALLOWED_LOCATIONS` for candidate selection, and use `MULTISTAGE_PARAM_OVERRIDE_LOCATION` only as the concrete runtime location; they use the same rotated-start probing model,
-  - the dev catalog now uses one runtime-selected pool per customer subscription, with `westus3` as the default runtime region,
-  - those shared dev pools provision their MSI container stacks in `westus3` via `identity_provisioning_region`,
-  - that intentionally optimizes the current rollout for multi-subscription, single-region operation first; multi-region CI behavior will need a follow-up job strategy.
-- Pool fallback is now adapted to the Boskos proxy's blocking acquire behavior:
-  - the proxy does not reliably give `slot-manager` a distinct immediate "pool exhausted" signal for candidate failover,
-  - each candidate pool probe is therefore bounded by `lease-proxy-timeout` and interpreted through the client-side `ErrLeasePoolUnavailableNow` classification,
-  - timeout-budget exhaustion and retryable proxy/server failures now mean "this pool did not yield an immediate lease now; try the next candidate pool",
-  - one full pass over the candidate pools is the retry unit when every candidate is temporarily unavailable.
-- Waiting is now explicit and separated from transient proxy/network retry handling:
-  - per-request `lease-proxy-timeout` plus exponential backoff covers one bounded probe of a single candidate pool,
-  - repeated full-pass waiting now uses `lease_wait_interval` and `max_wait_for_lease`,
-  - the default per-pool `lease-proxy-timeout` is now `30s`,
-  - the current defaults are `lease_wait_interval=1m` and `max_wait_for_lease=30m`,
-  - `max_wait_for_lease=0` means wait forever,
-  - `openshift/release` now exposes `ARO_HCP_SLOT_MANAGER_LEASE_WAIT_INTERVAL` and `ARO_HCP_SLOT_MANAGER_MAX_WAIT_FOR_LEASE` as optional per-job overrides.
-- Current rollout limitation:
-  - migration is still staged while legacy leases are retired, so the active slot inventory is being brought up gradually even though the code path now supports the broader multi-pool model.
+| Field | Meaning |
+| --- | --- |
+| `subscription_name` | Name used to resolve the customer subscription from cluster profiles. |
+| `region_mode` | `fixed`, `runtime-selected`, or `weighted`. Defaults to `fixed` when omitted. |
+| `region` | Required for `fixed` and `runtime-selected`; the fixed or fallback runtime region. |
+| `regions` | Ordered runtime-region allowlist for `weighted`. |
+| `resource_type` | Boskos resource type containing the pool's slots. |
+| `slot_count` | Number of independently leasable jobs in the pool. |
+| `identity_container_prefix` | Prefix used to derive identity-container resource-group names. |
+| `identity_container_count` | Number of identity containers assigned to each slot. |
+| `identity_provisioning_region` | Location for identity-pool infrastructure, independent of the runtime region. It defaults to `region`; weighted pools must set it explicitly. |
+| `identity_provisioning: unmanaged` | Marks identity infrastructure as externally managed. It does not remove the pool from runtime selection. |
 
-### Identity pool reconciliation and recovery
+All pools in one environment must use the same `region_mode`. Weighted pools
+must also declare the same non-empty, duplicate-free, ordered `regions` list.
+Resource types are unique across the complete catalog.
 
-An E2E job can fail before cluster provisioning when its leased managed identity
-container resource group is missing. The nested ARM error normally contains:
+For slot index `N`, slot manager expands a pool into:
 
 ```text
-ResourceGroupNotFound: Resource group '<identity-container-resource-group>' could not be found.
+resource name:             <resource_type>-<N, two digits>
+identity container prefix: <identity_container_prefix>-<N, two digits>
+identity containers:       <slot prefix>-<M, two digits>
 ```
 
-The canonical pool shape comes from `test/e2e-config/e2e-slots.yaml`. For each
-pool, the slot manager expands:
+## Acquire inputs
+
+The CI acquire step provides these selectors and runtime inputs:
+
+| Environment variable | Purpose |
+| --- | --- |
+| `ARO_HCP_DEPLOY_ENV` | Resolves the catalog environment. |
+| `ALLOWED_SUBSCRIPTIONS` | Optional comma/newline-separated allowlist of catalog `subscription_name` values. |
+| `ALLOWED_LOCATIONS` | Optional location allowlist used only by `fixed` mode. |
+| `MULTISTAGE_PARAM_OVERRIDE_LOCATION` | Highest-precedence concrete runtime location. |
+| `LOCATION_WEIGHTS` | Weighted-mode entries in `location=weight` form, required only when no explicit location override is set. |
+| `BUILD_ID` | Stable per-Prow-run key for deterministic weighted selection. |
+| `CLUSTER_PROFILE_DIRS` | Optional comma/newline-separated cluster profile directories. |
+| `CLUSTER_PROFILE_DIR` | Backward-compatible single profile directory used when `CLUSTER_PROFILE_DIRS` is unset. |
+| `LEASE_PROXY_SERVER_URL` | Ci-operator Boskos proxy endpoint. |
+| `SHARED_DIR` | Directory for the state and exported environment files. |
+
+Equivalent command-line flags exist for the acquire options. Explicit location
+override takes precedence over other location selectors.
+
+## Region modes
+
+### `fixed`
+
+The pool represents a subscription+region coordinate:
+
+- `region` is the runtime region.
+- `ALLOWED_SUBSCRIPTIONS` filters by subscription.
+- `MULTISTAGE_PARAM_OVERRIDE_LOCATION`, when set, filters pools to that region.
+- Otherwise `ALLOWED_LOCATIONS` can restrict eligible regions.
+
+The leased pool determines `SELECTED_LOCATION`.
+
+### `runtime-selected`
+
+The pool represents subscription capacity; the caller chooses the runtime
+region:
+
+- `ALLOWED_SUBSCRIPTIONS` filters candidate pools.
+- `ALLOWED_LOCATIONS` does not affect pool selection.
+- `MULTISTAGE_PARAM_OVERRIDE_LOCATION` becomes `SELECTED_LOCATION`.
+- If no override is supplied, the pool's `region` is the fallback.
+
+This mode is intended for jobs, such as regional gating, whose external caller
+already knows the target region.
+
+### `weighted`
+
+The pool represents subscription capacity and the job supplies the desired
+regional distribution:
+
+- `ALLOWED_SUBSCRIPTIONS` filters candidate pools.
+- The catalog `regions` list is the authoritative location allowlist.
+- Without an explicit override, `LOCATION_WEIGHTS` controls the approximate
+  distribution for new runs.
+- `ALLOWED_LOCATIONS` is ignored.
+- `MULTISTAGE_PARAM_OVERRIDE_LOCATION` bypasses weighted selection but must
+  name a catalog-allowed region.
+
+Example equal distribution:
 
 ```text
-<identity_container_prefix>-<two-digit-slot>-<two-digit-container>
+LOCATION_WEIGHTS=westus3=1,centralus=1,canadacentral=1
 ```
 
-For example, a pool with `slot_count: 5` and
-`identity_container_count: 60` expects slot suffixes `00` through `04`, each
-with container suffixes `00` through `59`.
-
-#### Reconcile a pool
-
-Use the Make target rather than invoking `go run` or a previously built binary.
-The target regenerates the Bicep-derived ARM template before rebuilding
-`aro-hcp-tests`, preventing a stale embedded `msi-pools.json` from being
-applied.
-
-```bash
-make -C test apply-identity-pool \
-  ENVIRONMENT=<dev|int|stg|prod> \
-  SUBSCRIPTION="<catalog subscription_name>"
-```
-
-`SUBSCRIPTION` limits the operation to matching catalog pools. Omitting it
-reconciles every managed pool in the selected environment and skips pools with
-`identity_provisioning: unmanaged`. Supplying it can include a matching
-unmanaged pool, so only do that when the subscription owner intends to manage
-that pool with this command.
-
-The command applies one subscription-scoped deployment stack per slot. Each
-stack creates or updates the slot's resource groups and the 13 well-known
-user-assigned managed identities in every group:
+Example drain:
 
 ```text
-cluster-api-azure
-control-plane
-cloud-controller-manager
-ingress
-disk-csi-driver
-file-csi-driver
-image-registry
-cloud-network-config
-kms
-dp-disk-csi-driver
-dp-file-csi-driver
-dp-image-registry
-service
+LOCATION_WEIGHTS=westus3=0,centralus=1,canadacentral=1
 ```
 
-Before applying, confirm that the selected Azure credential can resolve the
-catalog subscription and has permission to create subscription deployment
-stacks, resource groups, and managed identities. Also confirm required resource
-providers and subscription quotas are available.
+When an explicit override is set, `LOCATION_WEIGHTS` and `BUILD_ID` are not
+required and any supplied weights are ignored. This allows callers already
+pinned to a valid catalog region to continue working when an environment moves
+from `runtime-selected` to `weighted`.
 
-Deployment stacks use `ActionOnUnmanage: delete` for resources and resource
-groups. A later catalog change that reduces a pool or changes its naming can
-therefore delete resources no longer managed by the stack. Review the catalog
-diff and always scope a recovery to the intended subscription.
+Without an explicit override, weights are required and must be non-negative
+integers. Every catalog region must appear exactly once, unknown regions are
+rejected, and at least one weight must be non-zero. Duplicate, missing,
+negative, non-integer, and overflowing values are errors. `BUILD_ID` must also
+be non-empty. Slot manager uses 64-bit FNV-1a over its UTF-8 bytes:
 
-#### Validate the complete pool
-
-Do not validate only the resource group named in the original failure. Use the
-read-only validation target to compare the complete slot-expanded catalog
-inventory with Azure:
-
-```bash
-make -C test validate-identity-pool \
-  ENVIRONMENT=<dev|int|stg|prod> \
-  SUBSCRIPTION="<catalog subscription_name>"
+```text
+bucket = fnv1a64(BUILD_ID) % sum(weights)
 ```
 
-The target uses bulk Azure list operations and does not create, update, or
-delete resources. It validates every matching catalog pool in the subscription,
-including the complete resource-group inventory and the exact 13 identity names
-in every existing expected group. It reports sorted missing and unexpected
-resources, prints per-subscription counts, and exits non-zero when drift is
-detected.
+The selected region is the first region in catalog order whose cumulative
+positive weight contains `bucket`. Map iteration order must not affect the
+result.
 
-`SUBSCRIPTION` has the same selection semantics as the apply target. Omitting it
-validates every managed pool in the environment; setting it limits validation to
-matching pools and can include an externally managed pool.
+This produces a reproducible choice within one Prow run and approximate
+weighted distribution over time. It does not provide exact distribution or a
+hard per-region concurrency limit. A retry is a new Prow run and may select a
+different subscription or region. Setting a weight to zero affects new runs
+only.
 
-If reconciliation or validation fails, retain the deployment stack error and
-inspect the first nested Azure error rather than retrying blindly. Common
-blockers are insufficient RBAC, an unregistered `Microsoft.ManagedIdentity`
-provider, subscription quota exhaustion, or another deployment operation
-holding the stack in a non-terminal state.
+## Pool selection and lease acquisition
 
-This recovery procedure was added after
-[AROSLSRE-1895](https://redhat.atlassian.net/browse/AROSLSRE-1895).
+Acquire follows this sequence:
 
-### Dev subscription onboarding note
+1. Load and validate the catalog.
+2. Resolve `ARO_HCP_DEPLOY_ENV` to one slot environment.
+3. Validate mode-specific selectors before acquiring a lease.
+4. Build the candidate pool list:
+   - all modes apply `ALLOWED_SUBSCRIPTIONS`;
+   - only `fixed` applies location filtering to pool identity.
+5. Rotate the initial candidate once per acquire invocation, preserving catalog
+   order for the remaining candidates.
+6. Probe each candidate's Boskos resource type until one returns a lease.
+7. Resolve the leased resource name back to an expanded catalog slot.
+8. Resolve the runtime region according to the environment's region mode.
+9. Find exactly one cluster profile whose
+   `customer-*-subscription-name` matches the pool's `subscription_name`.
+10. Persist the acquired state, then write the downstream environment file.
 
-- Adding a new **dev** customer subscription to the slot catalog is **not** sufficient by itself.
-- Historical reference: commit `d6f6aede7eab13c9d591048d08f87ceb2cd1023e` ("Additional subscription for dev/operator roles") captured the same requirement when the original extra hosted-cluster/E2E subscription was introduced.
-- In addition to catalog, Vault, and Boskos updates, the new subscription must also be wired into the dev identity/bootstrap layer:
-  - add the subscription to the relevant `assignableScopes` for the dev mock/operator roles,
-  - grant the corresponding dev first-party, ARM-helper, and MSI-mock identities access on that subscription.
-- Without that bootstrap, local/dev flows can fail with Azure `AuthorizationFailed` errors even though the slot inventory itself is correct.
+Candidate rotation spreads subscription demand without changing the stable
+fallback order. Region selection is independent from subscription selection in
+`runtime-selected` and `weighted` modes.
 
-## Open Decisions and Deferred Work
+### Waiting and errors
 
-- **Lease timeout tuning**
-  - Lease acquisition timeout is no longer a platform unknown because the Boskos proxy client is under ARO-HCP control.
-  - Initial bounded waiting defaults are now implemented: `lease_wait_interval=1m`, `max_wait_for_lease=30m`, and `0` means wait forever.
-  - The remaining choice is whether real CI data justifies different defaults or per-job overrides for particular environments.
-- **Automation level**
-  - Manual controls and manual failover come first.
-  - Automated routing should only be introduced after enough telemetry and operational experience exist.
+One candidate probe is bounded by `lease-proxy-timeout`, which defaults to
+`30s`. Proxy timeouts and retryable proxy/server responses mean that the pool
+did not yield an immediate lease; slot manager continues with the next
+candidate.
+
+After every candidate is temporarily unavailable, slot manager waits
+`lease_wait_interval` (default `1m`) and retries the full candidate list.
+`max_wait_for_lease` defaults to `30m`; zero means wait indefinitely.
+
+Non-retryable proxy errors, invalid configuration, unknown leased resources,
+and ambiguous or missing cluster-profile matches fail immediately. If
+finalization fails before durable state is written, slot manager attempts to
+return the lease.
+
+## Runtime output contract
+
+Acquire writes `${SHARED_DIR}/aro-hcp-slot.env` with:
+
+| Variable | Meaning |
+| --- | --- |
+| `CUSTOMER_SUBSCRIPTION` | Selected catalog subscription name, verified against the cluster profile. |
+| `SELECTED_LOCATION` | Authoritative runtime region. |
+| `SELECTED_CLUSTER_PROFILE_DIR` | Profile containing the selected subscription's tenant and service-principal credentials. |
+| `LEASED_MSI_CONTAINERS` | Space-separated identity-container resource groups assigned to the slot. |
+| `ARO_HCP_E2E_SLOT_NAME` | Leased Boskos resource name. |
+| `ARO_HCP_E2E_SLOT_RESOURCE_TYPE` | Boskos resource type used for acquisition. |
+
+Downstream steps may map `SELECTED_LOCATION` to `LOCATION`, but must not repeat
+region selection or substitute a job default.
+
+The selection log must include the candidate pool, catalog region order,
+normalized weights when applicable, whether an override was used, the
+selection-key source, and the selected runtime region. These values are
+non-secret.
+
+## State and release
+
+Acquire writes `${SHARED_DIR}/aro-hcp-slot-state.yaml` before writing the env
+file. The state records:
+
+- deploy environment,
+- runtime region,
+- expanded slot,
+- exact Boskos resource name.
+
+Writing state first ensures the post-step can return the lease if the process
+stops before the env file is complete.
+
+`slot-manager release` loads the state file, returns the exact leased resource
+through the Boskos proxy, and removes both state files. A missing state file is
+treated as nothing to release. A failed lease return is an error; failure to
+remove local files after a successful return is logged.
+
+## Inventory maintenance
+
+The ARO-HCP catalog is the source of truth for slot shape. Slot-manager commands
+derive related infrastructure from it:
+
+- `sync-boskos-config` and `validate-boskos-config` reconcile the managed block
+  in `openshift/release`.
+- `apply-identity-pool` and `validate-identity-pool` reconcile or inspect the
+  slot-expanded managed identity containers.
+
+Operational onboarding, capacity calculations, and recovery procedures live in
+[`docs/ci/identity-leasing.md`](../../../../docs/ci/identity-leasing.md) and
+[`docs/ci/e2e-subscription-onboarding.md`](../../../../docs/ci/e2e-subscription-onboarding.md).

--- a/test/cmd/aro-hcp-tests/slot-manager/acquire.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/acquire.go
@@ -18,7 +18,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
+	"math"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -44,6 +47,8 @@ func DefaultAcquireOptions() *RawAcquireOptions {
 		AllowedSubscriptions: allowedSubscriptions,
 		AllowedLocations:     allowedLocations,
 		SelectedLocation:     selectedLocation,
+		LocationWeights:      strings.TrimSpace(os.Getenv("LOCATION_WEIGHTS")),
+		BuildID:              strings.TrimSpace(os.Getenv("BUILD_ID")),
 		SharedDir:            strings.TrimSpace(os.Getenv("SHARED_DIR")),
 
 		LeaseProxyServerURL: strings.TrimSpace(os.Getenv("LEASE_PROXY_SERVER_URL")),
@@ -95,6 +100,8 @@ func BindAcquireOptions(opts *RawAcquireOptions, cmd *cobra.Command) error {
 	cmd.Flags().StringVar(&opts.DeployEnv, "deploy-env", opts.DeployEnv, "Deploy environment name (ci00, ci01, int, stg, prod)")
 	cmd.Flags().StringSliceVar(&opts.AllowedSubscriptions, "allowed-subscriptions", opts.AllowedSubscriptions, "Optional catalog subscription_name values allowed for candidate pool selection.")
 	cmd.Flags().StringSliceVar(&opts.AllowedLocations, "allowed-locations", opts.AllowedLocations, "Optional Azure regions allowed for fixed-mode candidate pool selection.")
+	cmd.Flags().StringVar(&opts.LocationWeights, "location-weights", opts.LocationWeights, "Weighted-mode location weights as comma-separated location=weight entries.")
+	cmd.Flags().StringVar(&opts.BuildID, "build-id", opts.BuildID, "Stable per-run key used for deterministic weighted location selection.")
 	cmd.Flags().StringVar(&opts.SharedDir, "shared-dir", opts.SharedDir, "Path to SHARED_DIR")
 	cmd.Flags().StringVar(&opts.CatalogPath, "slot-catalog", opts.CatalogPath, "Path to the canonical E2E slot catalog")
 	cmd.Flags().StringVar(&opts.LeaseProxyServerURL, "lease-proxy-server-url", opts.LeaseProxyServerURL, "Lease proxy server URL")
@@ -111,6 +118,8 @@ type RawAcquireOptions struct {
 	AllowedSubscriptions []string
 	AllowedLocations     []string
 	SelectedLocation     string
+	LocationWeights      string
+	BuildID              string
 	SharedDir            string
 	CatalogPath          string
 	LeaseProxyServerURL  string
@@ -129,20 +138,23 @@ type ValidatedAcquireOptions struct {
 }
 
 type completedAcquireOptions struct {
-	ClusterProfileDirs []string
-	DeployEnvironment  string
-	SharedDir          string
-	LeaseProxyURL      string
-	LeaseProxyTimeout  time.Duration
-	MaxWaitForLease    time.Duration
-	LeaseWaitInterval  time.Duration
-	// RuntimeLocationOverride carries the concrete runtime region when pool
-	// identity is decoupled from region selection.
-	RuntimeLocationOverride string
-	CandidatePools          []slots.Pool
-	PoolEnvironment         string
-	Now                     func() time.Time
-	Sleep                   func(context.Context, time.Duration) error
+	ClusterProfileDirs   []string
+	DeployEnvironment    string
+	SharedDir            string
+	LeaseProxyURL        string
+	LeaseProxyTimeout    time.Duration
+	MaxWaitForLease      time.Duration
+	LeaseWaitInterval    time.Duration
+	RuntimeRegion        string
+	RegionMode           string
+	CatalogRegions       []string
+	NormalizedWeights    []string
+	LocationOverrideUsed bool
+	SelectionKeySource   string
+	CandidatePools       []slots.Pool
+	PoolEnvironment      string
+	Now                  func() time.Time
+	Sleep                func(context.Context, time.Duration) error
 }
 
 type AcquireOptions struct {
@@ -224,32 +236,164 @@ func (o *ValidatedAcquireOptions) Complete(_ context.Context) (*AcquireOptions, 
 		return nil, err
 	}
 
+	selectedLocation := strings.TrimSpace(o.SelectedLocation)
 	environment, err := catalog.ResolveEnvironmentForDeployEnv(o.DeployEnv)
 	if err != nil {
 		return nil, err
 	}
 
-	candidatePools, err := catalog.CandidatePools(environment, sets.New(o.AllowedSubscriptions...), sets.New(o.AllowedLocations...), o.SelectedLocation)
+	candidatePools, err := catalog.CandidatePools(environment, sets.New(o.AllowedSubscriptions...), sets.New(o.AllowedLocations...), selectedLocation)
+	if err != nil {
+		return nil, err
+	}
+
+	regionMode, err := catalog.RegionModeForEnvironment(environment)
+	if err != nil {
+		return nil, err
+	}
+	regionSelection, err := resolveRegionSelection(catalog, environment, regionMode, selectedLocation, o.LocationWeights, o.BuildID)
 	if err != nil {
 		return nil, err
 	}
 
 	return &AcquireOptions{
 		completedAcquireOptions: &completedAcquireOptions{
-			ClusterProfileDirs:      o.effectiveClusterProfileDirs(),
-			DeployEnvironment:       o.DeployEnv,
-			SharedDir:               o.SharedDir,
-			LeaseProxyURL:           o.LeaseProxyServerURL,
-			LeaseProxyTimeout:       o.LeaseProxyTimeout,
-			MaxWaitForLease:         o.MaxWaitForLease,
-			LeaseWaitInterval:       o.LeaseWaitInterval,
-			RuntimeLocationOverride: o.SelectedLocation,
-			CandidatePools:          candidatePools,
-			PoolEnvironment:         environment,
-			Now:                     o.Now,
-			Sleep:                   sleepContext,
+			ClusterProfileDirs:   o.effectiveClusterProfileDirs(),
+			DeployEnvironment:    o.DeployEnv,
+			SharedDir:            o.SharedDir,
+			LeaseProxyURL:        o.LeaseProxyServerURL,
+			LeaseProxyTimeout:    o.LeaseProxyTimeout,
+			MaxWaitForLease:      o.MaxWaitForLease,
+			LeaseWaitInterval:    o.LeaseWaitInterval,
+			RuntimeRegion:        regionSelection.RuntimeRegion,
+			RegionMode:           regionMode,
+			CatalogRegions:       regionSelection.CatalogRegions,
+			NormalizedWeights:    regionSelection.NormalizedWeights,
+			LocationOverrideUsed: selectedLocation != "",
+			SelectionKeySource:   regionSelection.SelectionKeySource,
+			CandidatePools:       candidatePools,
+			PoolEnvironment:      environment,
+			Now:                  o.Now,
+			Sleep:                sleepContext,
 		},
 	}, nil
+}
+
+type regionSelection struct {
+	RuntimeRegion      string
+	CatalogRegions     []string
+	NormalizedWeights  []string
+	SelectionKeySource string
+}
+
+type locationWeight struct {
+	Location string
+	Weight   uint64
+}
+
+func resolveRegionSelection(catalog *slots.Catalog, environment, regionMode, override, rawWeights, buildID string) (*regionSelection, error) {
+	if regionMode != slots.RegionModeWeighted {
+		return &regionSelection{RuntimeRegion: override}, nil
+	}
+
+	regions, err := catalog.RegionsForEnvironment(environment)
+	if err != nil {
+		return nil, err
+	}
+	if override != "" {
+		if !sets.New(regions...).Has(override) {
+			return nil, fmt.Errorf("location override %q is not allowed for weighted environment %q; allowed locations: %s", override, environment, strings.Join(regions, ","))
+		}
+		return &regionSelection{
+			RuntimeRegion:  override,
+			CatalogRegions: regions,
+		}, nil
+	}
+
+	weights, totalWeight, err := parseLocationWeights(rawWeights, regions)
+	if err != nil {
+		return nil, fmt.Errorf("invalid LOCATION_WEIGHTS for weighted environment %q: %w", environment, err)
+	}
+	buildID = strings.TrimSpace(buildID)
+	if buildID == "" {
+		return nil, fmt.Errorf("BUILD_ID must not be empty for weighted environment %q without a location override", environment)
+	}
+
+	hasher := fnv.New64a()
+	_, _ = hasher.Write([]byte(buildID))
+	bucket := hasher.Sum64() % totalWeight
+
+	var cumulative uint64
+	for _, weight := range weights {
+		cumulative += weight.Weight
+		if bucket < cumulative {
+			return &regionSelection{
+				RuntimeRegion:      weight.Location,
+				CatalogRegions:     regions,
+				NormalizedWeights:  normalizedWeightsForCatalog(weights),
+				SelectionKeySource: "BUILD_ID",
+			}, nil
+		}
+	}
+
+	return nil, errors.New("weighted location selection did not resolve a region")
+}
+
+func parseLocationWeights(raw string, regions []string) ([]locationWeight, uint64, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, 0, errors.New("LOCATION_WEIGHTS must not be empty")
+	}
+
+	allowedRegions := sets.New(regions...)
+	parsedWeights := make(map[string]uint64, len(regions))
+	for _, entry := range strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == '\n'
+	}) {
+		location, rawWeight, found := strings.Cut(entry, "=")
+		location = strings.TrimSpace(location)
+		rawWeight = strings.TrimSpace(rawWeight)
+		switch {
+		case !found || location == "" || rawWeight == "":
+			return nil, 0, fmt.Errorf("entry %q must use location=weight format", strings.TrimSpace(entry))
+		case !allowedRegions.Has(location):
+			return nil, 0, fmt.Errorf("unknown location %q; allowed locations: %s", location, strings.Join(regions, ","))
+		}
+		if _, found := parsedWeights[location]; found {
+			return nil, 0, fmt.Errorf("location %q is declared more than once", location)
+		}
+
+		weight, err := strconv.ParseUint(rawWeight, 10, 64)
+		if err != nil {
+			return nil, 0, fmt.Errorf("weight for location %q must be a non-negative integer: %w", location, err)
+		}
+		parsedWeights[location] = weight
+	}
+
+	weights := make([]locationWeight, 0, len(regions))
+	var totalWeight uint64
+	for _, region := range regions {
+		weight, found := parsedWeights[region]
+		if !found {
+			return nil, 0, fmt.Errorf("missing weight for location %q", region)
+		}
+		if math.MaxUint64-totalWeight < weight {
+			return nil, 0, errors.New("location weight sum overflows uint64")
+		}
+		totalWeight += weight
+		weights = append(weights, locationWeight{Location: region, Weight: weight})
+	}
+	if totalWeight == 0 {
+		return nil, 0, errors.New("at least one location weight must be greater than zero")
+	}
+	return weights, totalWeight, nil
+}
+
+func normalizedWeightsForCatalog(weights []locationWeight) []string {
+	normalized := make([]string, 0, len(weights))
+	for _, weight := range weights {
+		normalized = append(normalized, fmt.Sprintf("%s=%d", weight.Location, weight.Weight))
+	}
+	return normalized
 }
 
 func (o *AcquireOptions) ResolveLeasedSlot(pool slots.Pool, resourceName string) (*slots.ExpandedSlot, error) {
@@ -385,8 +529,8 @@ func rotatedCandidatePools(pools []slots.Pool, now time.Time) []slots.Pool {
 }
 
 func (o *AcquireOptions) runtimeRegionForPool(pool slots.Pool) string {
-	if o.RuntimeLocationOverride != "" {
-		return o.RuntimeLocationOverride
+	if o.RuntimeRegion != "" {
+		return o.RuntimeRegion
 	}
 	return pool.Region
 }
@@ -439,6 +583,11 @@ func (o *AcquireOptions) finalizeAcquiredLease(ctx context.Context, logger logr.
 		"slotName", slot.ResourceName,
 		"environment", o.PoolEnvironment,
 		"pool", describePool(pool),
+		"regionMode", o.RegionMode,
+		"catalogRegions", strings.Join(o.CatalogRegions, ","),
+		"locationWeights", strings.Join(o.NormalizedWeights, ","),
+		"locationOverrideUsed", o.LocationOverrideUsed,
+		"selectionKeySource", o.SelectionKeySource,
 		"runtimeRegion", state.RuntimeRegion,
 		"sharedDir", o.SharedDir,
 	)
@@ -446,10 +595,14 @@ func (o *AcquireOptions) finalizeAcquiredLease(ctx context.Context, logger logr.
 }
 
 func describePool(pool slots.Pool) string {
-	if pool.EffectiveRegionMode() == slots.RegionModeRuntimeSelected {
+	switch pool.EffectiveRegionMode() {
+	case slots.RegionModeRuntimeSelected:
 		return fmt.Sprintf("subscription_name=%q, region_mode=%q, default_region=%q", pool.SubscriptionName, pool.EffectiveRegionMode(), pool.Region)
+	case slots.RegionModeWeighted:
+		return fmt.Sprintf("subscription_name=%q, region_mode=%q, regions=%q", pool.SubscriptionName, pool.EffectiveRegionMode(), strings.Join(pool.Regions, ","))
+	default:
+		return fmt.Sprintf("subscription_name=%q, region=%q", pool.SubscriptionName, pool.Region)
 	}
-	return fmt.Sprintf("subscription_name=%q, region=%q", pool.SubscriptionName, pool.Region)
 }
 
 func sleepContext(ctx context.Context, duration time.Duration) error {

--- a/test/cmd/aro-hcp-tests/slot-manager/acquire_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/acquire_test.go
@@ -252,6 +252,8 @@ func TestDefaultAcquireOptionsLeaseWaitDefaults(t *testing.T) {
 func TestDefaultAcquireOptionsSelectorDefaults(t *testing.T) {
 	t.Setenv("ALLOWED_SUBSCRIPTIONS", "dev-sub-a, dev-sub-b, dev-sub-a")
 	t.Setenv("ALLOWED_LOCATIONS", "centralus, eastus2")
+	t.Setenv("LOCATION_WEIGHTS", "westus3=1, centralus=2")
+	t.Setenv("BUILD_ID", "12345")
 
 	opts := DefaultAcquireOptions()
 
@@ -263,6 +265,180 @@ func TestDefaultAcquireOptionsSelectorDefaults(t *testing.T) {
 	}
 	if opts.SelectedLocation != "" {
 		t.Fatalf("expected empty selected location by default, got %q", opts.SelectedLocation)
+	}
+	if opts.LocationWeights != "westus3=1, centralus=2" {
+		t.Fatalf("expected location weights from environment, got %q", opts.LocationWeights)
+	}
+	if opts.BuildID != "12345" {
+		t.Fatalf("expected build ID from environment, got %q", opts.BuildID)
+	}
+}
+
+func TestResolveRegionSelectionWeightedOverride(t *testing.T) {
+	t.Parallel()
+
+	catalog := loadWeightedAcquireTestCatalog(t)
+	selection, err := resolveRegionSelection(
+		catalog,
+		"dev",
+		slots.RegionModeWeighted,
+		"canadacentral",
+		"not-valid-and-must-be-ignored",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("expected valid override to bypass weighted inputs: %v", err)
+	}
+	if selection.RuntimeRegion != "canadacentral" {
+		t.Fatalf("expected override region %q, got %q", "canadacentral", selection.RuntimeRegion)
+	}
+	if len(selection.NormalizedWeights) != 0 {
+		t.Fatalf("expected override path to ignore weights, got %v", selection.NormalizedWeights)
+	}
+	if selection.SelectionKeySource != "" {
+		t.Fatalf("expected override path not to use a selection key, got %q", selection.SelectionKeySource)
+	}
+
+	_, err = resolveRegionSelection(catalog, "dev", slots.RegionModeWeighted, "eastus2", "", "")
+	if err == nil {
+		t.Fatal("expected override outside the catalog regions to fail")
+	}
+	if !strings.Contains(err.Error(), "is not allowed") {
+		t.Fatalf("expected invalid override error, got %v", err)
+	}
+}
+
+func TestResolveRegionSelectionWeightedDeterministic(t *testing.T) {
+	t.Parallel()
+
+	catalog := loadWeightedAcquireTestCatalog(t)
+	tests := []struct {
+		buildID string
+		want    string
+	}{
+		{buildID: "3", want: "westus3"},
+		{buildID: "1", want: "centralus"},
+		{buildID: "0", want: "canadacentral"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.buildID, func(t *testing.T) {
+			t.Parallel()
+			selection, err := resolveRegionSelection(
+				catalog,
+				"dev",
+				slots.RegionModeWeighted,
+				"",
+				"canadacentral=1,westus3=1,centralus=1",
+				tc.buildID,
+			)
+			if err != nil {
+				t.Fatalf("expected weighted selection to succeed: %v", err)
+			}
+			if selection.RuntimeRegion != tc.want {
+				t.Fatalf("expected build ID %q to select %q, got %q", tc.buildID, tc.want, selection.RuntimeRegion)
+			}
+			if got, want := selection.NormalizedWeights, []string{"westus3=1", "centralus=1", "canadacentral=1"}; !equalStrings(got, want) {
+				t.Fatalf("unexpected normalized weights: got %v want %v", got, want)
+			}
+			if selection.SelectionKeySource != "BUILD_ID" {
+				t.Fatalf("expected BUILD_ID selection source, got %q", selection.SelectionKeySource)
+			}
+		})
+	}
+}
+
+func TestParseLocationWeights(t *testing.T) {
+	t.Parallel()
+
+	regions := []string{"westus3", "centralus", "canadacentral"}
+	tests := []struct {
+		name      string
+		raw       string
+		want      []locationWeight
+		wantTotal uint64
+		wantError string
+	}{
+		{
+			name:      "catalog order and zero weight",
+			raw:       "canadacentral=0, westus3=2\ncentralus=1",
+			want:      []locationWeight{{Location: "westus3", Weight: 2}, {Location: "centralus", Weight: 1}, {Location: "canadacentral", Weight: 0}},
+			wantTotal: 3,
+		},
+		{name: "empty", wantError: "must not be empty"},
+		{name: "missing", raw: "westus3=1,centralus=1", wantError: "missing weight"},
+		{name: "unknown", raw: "westus3=1,centralus=1,eastus2=1", wantError: "unknown location"},
+		{name: "duplicate", raw: "westus3=1,centralus=1,canadacentral=1,westus3=2", wantError: "more than once"},
+		{name: "negative", raw: "westus3=-1,centralus=1,canadacentral=1", wantError: "non-negative integer"},
+		{name: "non-integer", raw: "westus3=1.5,centralus=1,canadacentral=1", wantError: "non-negative integer"},
+		{name: "all zero", raw: "westus3=0,centralus=0,canadacentral=0", wantError: "greater than zero"},
+		{name: "overflow", raw: "westus3=18446744073709551615,centralus=1,canadacentral=0", wantError: "overflows"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, total, err := parseLocationWeights(tc.raw, regions)
+			if tc.wantError != "" {
+				if err == nil {
+					t.Fatalf("expected weight parsing to fail with %q", tc.wantError)
+				}
+				if !strings.Contains(err.Error(), tc.wantError) {
+					t.Fatalf("expected error to contain %q, got %v", tc.wantError, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected weight parsing to succeed: %v", err)
+			}
+			if !equalLocationWeights(got, tc.want) {
+				t.Fatalf("unexpected parsed weights: got %v want %v", got, tc.want)
+			}
+			if total != tc.wantTotal {
+				t.Fatalf("expected total weight %d, got %d", tc.wantTotal, total)
+			}
+		})
+	}
+}
+
+func TestAcquireCompleteWeightedRequiresInputsWithoutOverride(t *testing.T) {
+	t.Parallel()
+
+	clusterProfileDir := writeAcquireTestClusterProfile(t, "dev-sub")
+	catalogPath := writeWeightedAcquireTestCatalog(t)
+	baseOptions := func() *RawAcquireOptions {
+		return &RawAcquireOptions{
+			ClusterProfileDir:   clusterProfileDir,
+			DeployEnv:           "ci01",
+			SharedDir:           t.TempDir(),
+			CatalogPath:         catalogPath,
+			LeaseProxyServerURL: "http://lease-proxy.example.com",
+			LeaseProxyTimeout:   slots.DefaultLeaseProxyTimeout,
+			MaxWaitForLease:     DefaultMaxWaitForLease,
+			LeaseWaitInterval:   DefaultLeaseWaitInterval,
+		}
+	}
+
+	opts := baseOptions()
+	opts.BuildID = "123"
+	if _, err := completeAcquireOptions(opts); err == nil || !strings.Contains(err.Error(), "LOCATION_WEIGHTS") {
+		t.Fatalf("expected missing weights error, got %v", err)
+	}
+
+	opts = baseOptions()
+	opts.LocationWeights = "westus3=1,centralus=1,canadacentral=1"
+	if _, err := completeAcquireOptions(opts); err == nil || !strings.Contains(err.Error(), "BUILD_ID") {
+		t.Fatalf("expected missing BUILD_ID error, got %v", err)
+	}
+
+	opts = baseOptions()
+	opts.SelectedLocation = "westus3"
+	opts.LocationWeights = "invalid"
+	completed, err := completeAcquireOptions(opts)
+	if err != nil {
+		t.Fatalf("expected override to bypass weighted inputs: %v", err)
+	}
+	if completed.RuntimeRegion != "westus3" {
+		t.Fatalf("expected override runtime region %q, got %q", "westus3", completed.RuntimeRegion)
 	}
 }
 
@@ -557,6 +733,90 @@ environments:
 	}
 	if state.Slot.Region != "uksouth" {
 		t.Fatalf("expected slot catalog region %q, got %q", "uksouth", state.Slot.Region)
+	}
+}
+
+func TestAcquireRunWeightedSelectsRegionAndFallsBackAcrossSubscriptions(t *testing.T) {
+	t.Parallel()
+
+	clusterProfileDir := writeAcquireTestClusterProfiles(t, "dev-sub-b")
+	catalogPath := writeAcquireTestCatalogFromYAML(t, `version: 1
+environments:
+  dev:
+    deploy_envs: [ci01]
+    pools:
+      - subscription_name: dev-sub-a
+        region_mode: weighted
+        regions: [westus3, centralus, canadacentral]
+        identity_provisioning_region: westus3
+        resource_type: aro-hcp-dev-shard0-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-a
+        identity_container_count: 2
+      - subscription_name: dev-sub-b
+        region_mode: weighted
+        regions: [westus3, centralus, canadacentral]
+        identity_provisioning_region: westus3
+        resource_type: aro-hcp-dev-shard1-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-b
+        identity_container_count: 2
+`)
+
+	server, acquireCalls, _ := newTestLeaseProxyServer(t, map[string][]leaseProxyReply{
+		"aro-hcp-dev-shard0-slot": {
+			unavailableAcquireReply("aro-hcp-dev-shard0-slot"),
+		},
+		"aro-hcp-dev-shard1-slot": {
+			successAcquireReply("aro-hcp-dev-shard1-slot-00"),
+		},
+	})
+	defer server.Close()
+
+	sharedDir := t.TempDir()
+	err := Acquire(context.Background(), &RawAcquireOptions{
+		ClusterProfileDir:   clusterProfileDir,
+		DeployEnv:           "ci01",
+		AllowedLocations:    []string{"eastus2"},
+		LocationWeights:     "westus3=1,centralus=1,canadacentral=1",
+		BuildID:             "0",
+		SharedDir:           sharedDir,
+		CatalogPath:         catalogPath,
+		LeaseProxyServerURL: server.URL,
+		LeaseProxyTimeout:   50 * time.Millisecond,
+		MaxWaitForLease:     DefaultMaxWaitForLease,
+		LeaseWaitInterval:   DefaultLeaseWaitInterval,
+		Now:                 staticNow(time.Unix(0, 0)),
+	})
+	if err != nil {
+		t.Fatalf("expected weighted acquire to succeed: %v", err)
+	}
+
+	if got, want := *acquireCalls, []string{"aro-hcp-dev-shard0-slot", "aro-hcp-dev-shard1-slot"}; !equalStrings(got, want) {
+		t.Fatalf("unexpected acquire call order: got %v want %v", got, want)
+	}
+
+	state, err := slots.LoadAcquiredSlotState(sharedDir)
+	if err != nil {
+		t.Fatalf("expected acquired slot state to load: %v", err)
+	}
+	if state.RuntimeRegion != "canadacentral" {
+		t.Fatalf("expected weighted runtime region %q, got %q", "canadacentral", state.RuntimeRegion)
+	}
+	if state.Slot.ResourceType != "aro-hcp-dev-shard1-slot" {
+		t.Fatalf("expected fallback subscription pool, got %q", state.Slot.ResourceType)
+	}
+
+	envFile, err := slots.EnvFile(sharedDir)
+	if err != nil {
+		t.Fatalf("expected env file path: %v", err)
+	}
+	envContents, err := os.ReadFile(envFile)
+	if err != nil {
+		t.Fatalf("expected env file read to succeed: %v", err)
+	}
+	if !strings.Contains(string(envContents), `export SELECTED_LOCATION='canadacentral'`) {
+		t.Fatalf("expected selected weighted location in env file, got:\n%s", envContents)
 	}
 }
 
@@ -1066,6 +1326,35 @@ environments:
 `, region, regionMode))
 }
 
+func writeWeightedAcquireTestCatalog(t *testing.T) string {
+	t.Helper()
+
+	return writeAcquireTestCatalogFromYAML(t, `version: 1
+environments:
+  dev:
+    deploy_envs: [ci00, ci01]
+    pools:
+      - subscription_name: dev-sub
+        region_mode: weighted
+        regions: [westus3, centralus, canadacentral]
+        identity_provisioning_region: westus3
+        resource_type: aro-hcp-dev-shard0-slot
+        slot_count: 2
+        identity_container_prefix: aro-hcp-msi-container-dev
+        identity_container_count: 2
+`)
+}
+
+func loadWeightedAcquireTestCatalog(t *testing.T) *slots.Catalog {
+	t.Helper()
+
+	catalog, err := slots.LoadCatalog(writeWeightedAcquireTestCatalog(t))
+	if err != nil {
+		t.Fatalf("expected weighted catalog to load: %v", err)
+	}
+	return catalog
+}
+
 func writeAcquireTestCatalogFromYAML(t *testing.T, catalog string) string {
 	t.Helper()
 
@@ -1098,15 +1387,31 @@ func writeAcquireTestClusterProfiles(t *testing.T, subscriptionNames ...string) 
 func completeAcquireForTest(t *testing.T, raw *RawAcquireOptions) *AcquireOptions {
 	t.Helper()
 
-	validated, err := raw.Validate()
-	if err != nil {
-		t.Fatalf("expected acquire options validation to succeed: %v", err)
-	}
-	completed, err := validated.Complete(context.Background())
+	completed, err := completeAcquireOptions(raw)
 	if err != nil {
 		t.Fatalf("expected acquire options completion to succeed: %v", err)
 	}
 	return completed
+}
+
+func completeAcquireOptions(raw *RawAcquireOptions) (*AcquireOptions, error) {
+	validated, err := raw.Validate()
+	if err != nil {
+		return nil, err
+	}
+	return validated.Complete(context.Background())
+}
+
+func equalLocationWeights(left, right []locationWeight) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 type leaseProxyReply struct {

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/catalog.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/catalog.go
@@ -37,6 +37,7 @@ const (
 
 	RegionModeFixed           = "fixed"
 	RegionModeRuntimeSelected = "runtime-selected"
+	RegionModeWeighted        = "weighted"
 )
 
 type Catalog struct {
@@ -50,15 +51,16 @@ type Environment struct {
 }
 
 type Pool struct {
-	SubscriptionName           string `yaml:"subscription_name"`
-	Region                     string `yaml:"region"`
-	RegionMode                 string `yaml:"region_mode,omitempty"`
-	IdentityProvisioningRegion string `yaml:"identity_provisioning_region,omitempty"`
-	IdentityProvisioning       string `yaml:"identity_provisioning,omitempty"`
-	ResourceType               string `yaml:"resource_type"`
-	SlotCount                  int    `yaml:"slot_count"`
-	IdentityContainerPrefix    string `yaml:"identity_container_prefix"`
-	IdentityContainerCount     int    `yaml:"identity_container_count"`
+	SubscriptionName           string   `yaml:"subscription_name"`
+	Region                     string   `yaml:"region,omitempty"`
+	Regions                    []string `yaml:"regions,omitempty"`
+	RegionMode                 string   `yaml:"region_mode,omitempty"`
+	IdentityProvisioningRegion string   `yaml:"identity_provisioning_region,omitempty"`
+	IdentityProvisioning       string   `yaml:"identity_provisioning,omitempty"`
+	ResourceType               string   `yaml:"resource_type"`
+	SlotCount                  int      `yaml:"slot_count"`
+	IdentityContainerPrefix    string   `yaml:"identity_container_prefix"`
+	IdentityContainerCount     int      `yaml:"identity_container_count"`
 }
 
 const (
@@ -157,10 +159,12 @@ func (c *Catalog) Validate() error {
 
 		seenPoolKeys := map[string]struct{}{}
 		environmentRegionMode := ""
+		var environmentRegions []string
 		for i := range environment.Pools {
 			pool := &environment.Pools[i]
 			pool.SubscriptionName = strings.TrimSpace(pool.SubscriptionName)
 			pool.Region = strings.TrimSpace(pool.Region)
+			pool.Regions = trimValues(pool.Regions)
 			pool.RegionMode = strings.TrimSpace(pool.RegionMode)
 			if pool.RegionMode == "" {
 				pool.RegionMode = RegionModeFixed
@@ -175,10 +179,20 @@ func (c *Catalog) Validate() error {
 				return fmt.Errorf("environment %q has a pool with empty subscription_name", environmentName)
 			case pool.IdentityProvisioning != "" && pool.IdentityProvisioning != IdentityProvisioningUnmanaged:
 				return fmt.Errorf("environment %q pool %s has invalid identity_provisioning %q (must be empty or %q)", environmentName, describePool(*pool), pool.IdentityProvisioning, IdentityProvisioningUnmanaged)
-			case pool.Region == "":
-				return fmt.Errorf("environment %q has a pool with empty region", environmentName)
-			case pool.RegionMode != RegionModeFixed && pool.RegionMode != RegionModeRuntimeSelected:
+			case pool.RegionMode != RegionModeFixed && pool.RegionMode != RegionModeRuntimeSelected && pool.RegionMode != RegionModeWeighted:
 				return fmt.Errorf("environment %q pool %s has invalid region_mode %q", environmentName, describePool(*pool), pool.RegionMode)
+			case pool.RegionMode == RegionModeWeighted && pool.Region != "":
+				return fmt.Errorf("environment %q weighted pool %s must not declare region", environmentName, describePool(*pool))
+			case pool.RegionMode == RegionModeWeighted && len(pool.Regions) == 0:
+				return fmt.Errorf("environment %q weighted pool %s has no regions", environmentName, describePool(*pool))
+			case pool.RegionMode == RegionModeWeighted && hasDuplicateOrEmptyValue(pool.Regions):
+				return fmt.Errorf("environment %q weighted pool %s has empty or duplicate regions", environmentName, describePool(*pool))
+			case pool.RegionMode == RegionModeWeighted && pool.IdentityProvisioningRegion == "":
+				return fmt.Errorf("environment %q weighted pool %s must declare identity_provisioning_region", environmentName, describePool(*pool))
+			case pool.RegionMode != RegionModeWeighted && pool.Region == "":
+				return fmt.Errorf("environment %q has a pool with empty region", environmentName)
+			case pool.RegionMode != RegionModeWeighted && len(pool.Regions) > 0:
+				return fmt.Errorf("environment %q non-weighted pool %s must not declare regions", environmentName, describePool(*pool))
 			case pool.ResourceType == "":
 				return fmt.Errorf("environment %q has a pool with empty resource_type", environmentName)
 			case pool.SlotCount <= 0:
@@ -191,12 +205,20 @@ func (c *Catalog) Validate() error {
 
 			if environmentRegionMode == "" {
 				environmentRegionMode = pool.RegionMode
+				environmentRegions = append([]string(nil), pool.Regions...)
 			} else if pool.RegionMode != environmentRegionMode {
 				return fmt.Errorf(
 					"environment %q mixes region_mode values %q and %q; keep a single selection mode per environment",
 					environmentName,
 					environmentRegionMode,
 					pool.RegionMode,
+				)
+			} else if pool.RegionMode == RegionModeWeighted && !equalValues(pool.Regions, environmentRegions) {
+				return fmt.Errorf(
+					"environment %q weighted pools must declare the same ordered regions; got %q and %q",
+					environmentName,
+					strings.Join(environmentRegions, ","),
+					strings.Join(pool.Regions, ","),
 				)
 			}
 
@@ -216,6 +238,37 @@ func (c *Catalog) Validate() error {
 	}
 
 	return nil
+}
+
+func trimValues(values []string) []string {
+	trimmed := make([]string, len(values))
+	for i, value := range values {
+		trimmed[i] = strings.TrimSpace(value)
+	}
+	return trimmed
+}
+
+func hasDuplicateOrEmptyValue(values []string) bool {
+	seen := sets.New[string]()
+	for _, value := range values {
+		if value == "" || seen.Has(value) {
+			return true
+		}
+		seen.Insert(value)
+	}
+	return false
+}
+
+func equalValues(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *Catalog) EnvironmentNames() []string {
@@ -266,7 +319,7 @@ func (c *Catalog) ResolvePool(environment string, allowedSubscriptions, allowedL
 		if err != nil {
 			return Pool{}, err
 		}
-		if environmentRegionMode == RegionModeRuntimeSelected {
+		if environmentRegionMode == RegionModeRuntimeSelected || environmentRegionMode == RegionModeWeighted {
 			return Pool{}, fmt.Errorf("environment %q has %d matching pools; narrow ALLOWED_SUBSCRIPTIONS to a single pool", environment, len(matches))
 		}
 		return Pool{}, fmt.Errorf("environment %q has %d matching pools; narrow ALLOWED_SUBSCRIPTIONS and/or ALLOWED_LOCATIONS to a single pool", environment, len(matches))
@@ -337,6 +390,21 @@ func (c *Catalog) RegionModeForEnvironment(environment string) (string, error) {
 		}
 	}
 	return regionMode, nil
+}
+
+func (c *Catalog) RegionsForEnvironment(environment string) ([]string, error) {
+	environmentConfig, found := c.Environments[environment]
+	if !found {
+		return nil, fmt.Errorf("unknown environment %q", environment)
+	}
+	if len(environmentConfig.Pools) == 0 {
+		return nil, fmt.Errorf("environment %q has no pools", environment)
+	}
+
+	if environmentConfig.Pools[0].EffectiveRegionMode() != RegionModeWeighted {
+		return nil, fmt.Errorf("environment %q is not in weighted region mode", environment)
+	}
+	return append([]string(nil), environmentConfig.Pools[0].Regions...), nil
 }
 
 func ExpandSlotsForPool(environment string, pool Pool) []ExpandedSlot {
@@ -437,14 +505,18 @@ func SlotStateFile(sharedDir string) (string, error) {
 }
 
 func describePool(pool Pool) string {
-	if pool.EffectiveRegionMode() == RegionModeRuntimeSelected {
+	switch pool.EffectiveRegionMode() {
+	case RegionModeRuntimeSelected:
 		return fmt.Sprintf("(subscription_name=%q, region_mode=%q, default_region=%q)", pool.SubscriptionName, pool.EffectiveRegionMode(), pool.Region)
+	case RegionModeWeighted:
+		return fmt.Sprintf("(subscription_name=%q, region_mode=%q, regions=%q)", pool.SubscriptionName, pool.EffectiveRegionMode(), strings.Join(pool.Regions, ","))
+	default:
+		return fmt.Sprintf("(subscription_name=%q, region=%q)", pool.SubscriptionName, pool.Region)
 	}
-	return fmt.Sprintf("(subscription_name=%q, region=%q)", pool.SubscriptionName, pool.Region)
 }
 
 func poolIdentity(pool Pool) string {
-	if pool.EffectiveRegionMode() == RegionModeRuntimeSelected {
+	if pool.EffectiveRegionMode() == RegionModeRuntimeSelected || pool.EffectiveRegionMode() == RegionModeWeighted {
 		return pool.SubscriptionName
 	}
 	return fmt.Sprintf("%s/%s", pool.SubscriptionName, pool.Region)

--- a/test/cmd/aro-hcp-tests/slot-manager/slots/catalog_test.go
+++ b/test/cmd/aro-hcp-tests/slot-manager/slots/catalog_test.go
@@ -17,6 +17,7 @@ package slots
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -361,6 +362,120 @@ environments:
 	}
 	if pools[0].ResourceType != "aro-hcp-prod-shard0-slot" || pools[1].ResourceType != "aro-hcp-prod-shard1-slot" {
 		t.Fatalf("unexpected candidate pool ordering: %q, %q", pools[0].ResourceType, pools[1].ResourceType)
+	}
+}
+
+func TestLoadCatalogWeightedMode(t *testing.T) {
+	t.Parallel()
+
+	catalog := loadCatalogFromYAML(t, `version: 1
+environments:
+  dev:
+    deploy_envs: [ci01]
+    pools:
+      - subscription_name: dev-sub-1
+        region_mode: weighted
+        regions: [westus3, centralus, canadacentral]
+        identity_provisioning_region: westus3
+        resource_type: aro-hcp-dev-shard0-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-a
+        identity_container_count: 1
+      - subscription_name: dev-sub-2
+        region_mode: weighted
+        regions: [westus3, centralus, canadacentral]
+        identity_provisioning_region: westus3
+        identity_provisioning: unmanaged
+        resource_type: aro-hcp-dev-shard1-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-b
+        identity_container_count: 1
+`)
+
+	if got, want := catalog.Environments["dev"].Pools[0].EffectiveRegionMode(), RegionModeWeighted; got != want {
+		t.Fatalf("expected region mode %q, got %q", want, got)
+	}
+	regions, err := catalog.RegionsForEnvironment("dev")
+	if err != nil {
+		t.Fatalf("expected weighted regions to resolve: %v", err)
+	}
+	if got, want := regions, []string{"westus3", "centralus", "canadacentral"}; !equalValues(got, want) {
+		t.Fatalf("unexpected weighted regions: got %v want %v", got, want)
+	}
+
+	pools, err := catalog.CandidatePools("dev", nil, sets.New("eastus2"), "")
+	if err != nil {
+		t.Fatalf("expected weighted candidates to ignore ALLOWED_LOCATIONS: %v", err)
+	}
+	if len(pools) != 2 {
+		t.Fatalf("expected 2 weighted candidate pools, got %d", len(pools))
+	}
+}
+
+func TestLoadCatalogRejectsInvalidWeightedPools(t *testing.T) {
+	t.Parallel()
+
+	basePool := `      - subscription_name: dev-sub-1
+        region_mode: weighted
+        regions: [westus3, centralus, canadacentral]
+        identity_provisioning_region: westus3
+        resource_type: aro-hcp-dev-shard0-slot
+        slot_count: 1
+        identity_container_prefix: aro-hcp-msi-container-dev-a
+        identity_container_count: 1
+`
+	tests := []struct {
+		name      string
+		pools     string
+		wantError string
+	}{
+		{
+			name:      "region is not allowed",
+			pools:     strings.Replace(basePool, "        regions:", "        region: westus3\n        regions:", 1),
+			wantError: "must not declare region",
+		},
+		{
+			name:      "regions are required",
+			pools:     strings.Replace(basePool, "        regions: [westus3, centralus, canadacentral]\n", "", 1),
+			wantError: "has no regions",
+		},
+		{
+			name:      "regions must be unique",
+			pools:     strings.Replace(basePool, "[westus3, centralus, canadacentral]", "[westus3, centralus, westus3]", 1),
+			wantError: "empty or duplicate regions",
+		},
+		{
+			name:      "pool needs provisioning region",
+			pools:     strings.Replace(basePool, "        identity_provisioning_region: westus3\n", "        identity_provisioning: unmanaged\n", 1),
+			wantError: "must declare identity_provisioning_region",
+		},
+		{
+			name: "weighted pools use identical ordered regions",
+			pools: strings.Replace(basePool, "[westus3, centralus, canadacentral]", "[centralus, westus3, canadacentral]", 1) +
+				strings.ReplaceAll(
+					strings.Replace(basePool, "dev-sub-1", "dev-sub-2", 1),
+					"aro-hcp-dev-shard0-slot", "aro-hcp-dev-shard1-slot",
+				),
+			wantError: "same ordered regions",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			catalogPath := filepath.Join(t.TempDir(), "e2e-slots.yaml")
+			catalogYAML := "version: 1\nenvironments:\n  dev:\n    deploy_envs: [ci01]\n    pools:\n" + tc.pools
+			if err := os.WriteFile(catalogPath, []byte(catalogYAML), 0o644); err != nil {
+				t.Fatalf("expected invalid catalog write to succeed: %v", err)
+			}
+			_, err := LoadCatalog(catalogPath)
+			if err == nil {
+				t.Fatalf("expected weighted catalog validation to fail with %q", tc.wantError)
+			}
+			if !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("expected error to contain %q, got %v", tc.wantError, err)
+			}
+		})
 	}
 }
 

--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -5,40 +5,61 @@ environments:
     - ci00
     - ci01
     pools:
-    # Jobs choose the runtime region; `region` is only the default when no runtime override is provided.
-    # Identity containers are provisioned in westus3.
+    # Jobs select the runtime region from these weighted pools. Existing jobs
+    # with an explicit location override remain pinned during rollout.
+    # Identity containers remain provisioned in westus3.
     # Each managed subscription keeps 300 containers split into five 60-container job slots.
     - subscription_name: "ARO HCP E2E Hosted Clusters (EA Subscription)"
-      region: westus3
-      region_mode: runtime-selected
+      region_mode: weighted
+      regions:
+      - westus3
+      - centralus
+      - canadacentral
+      identity_provisioning_region: westus3
       resource_type: aro-hcp-dev-shard0-slot
       slot_count: 5
       identity_container_prefix: aro-hcp-msi-container-dev-shard0
       identity_container_count: 60
     - subscription_name: "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
-      region: westus3
-      region_mode: runtime-selected
+      region_mode: weighted
+      regions:
+      - westus3
+      - centralus
+      - canadacentral
+      identity_provisioning_region: westus3
       resource_type: aro-hcp-dev-shard1-slot
       slot_count: 5
       identity_container_prefix: aro-hcp-msi-container-dev-shard1
       identity_container_count: 60
     - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 02"
-      region: westus3
-      region_mode: runtime-selected
+      region_mode: weighted
+      regions:
+      - westus3
+      - centralus
+      - canadacentral
+      identity_provisioning_region: westus3
       resource_type: aro-hcp-dev-shard2-slot
       slot_count: 5
       identity_container_prefix: aro-hcp-msi-container-dev-shard2
       identity_container_count: 60
     - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 03"
-      region: westus3
-      region_mode: runtime-selected
+      region_mode: weighted
+      regions:
+      - westus3
+      - centralus
+      - canadacentral
+      identity_provisioning_region: westus3
       resource_type: aro-hcp-dev-shard3-slot
       slot_count: 5
       identity_container_prefix: aro-hcp-msi-container-dev-shard3
       identity_container_count: 60
     - subscription_name: "Hypershift Managed Azure"
-      region: westus3
-      region_mode: runtime-selected
+      region_mode: weighted
+      regions:
+      - westus3
+      - centralus
+      - canadacentral
+      identity_provisioning_region: westus3
       resource_type: aro-hcp-dev-hypershift-westus3-slot
       slot_count: 1
       identity_container_prefix: aro-hcp-msi-container-dev


### PR DESCRIPTION
## Why

DEV E2E is infrastructure-heavy: RP bring-up and each test cluster generate substantial Azure control-plane and data-plane load. Concentrating up to 20 concurrent runs in one region increases exposure to regional throttling, quota pressure, and temporary compute scarcity. This change spreads approximately the same workload across the three supported DEV regions while allowing operators to reduce a region weight to zero when it is unhealthy.

Tracking: [AROSLSRE-2127](https://redhat.atlassian.net/browse/AROSLSRE-2127). The Jira description captures the motivation and design contract; implementation progress is tracked in Jira comments.

## What this PR does

- adds a `weighted` slot-manager region mode with an ordered catalog region allowlist
- selects regions deterministically from strict per-job `LOCATION_WEIGHTS` using `BUILD_ID`
- preserves explicit location overrides as the highest-precedence rollout-compatible path
- moves DEV slot pools to `westus3`, `centralus`, and `canadacentral` while keeping identity provisioning in `westus3`
- updates the slot-manager contract, operational recovery documentation, validation, and focused tests

## Rollout

Merge this PR before [openshift/release#85368](https://github.com/openshift/release/pull/85368). Existing DEV jobs remain pinned by `MULTISTAGE_PARAM_OVERRIDE_LOCATION` until their release configuration supplies weights. After this PR merges, merging openshift/release#85368 removes the main `e2e-parallel` override and activates equal weighted distribution across the three DEV regions.

The previously missed CAPZ DEV consumer remains pinned explicitly by openshift/release#85295, which has already merged. CAPZ retains its separate `LOCATION` value because shared CAPZ steps consume it directly.

## Validation

- `go test ./cmd/aro-hcp-tests/slot-manager/...`
- YAML formatting check for `test/e2e-config/e2e-slots.yaml`
- slot catalog validation against the release Boskos configuration