### PR TITLE
fix(ci): use GOPROXY pipe fallback to mitigate HTTP/2 proxy.golang.org stream errors

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -4,6 +4,7 @@ FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azure
 COPY internal/go.mod internal/go.sum internal/
 COPY sessiongate/go.mod sessiongate/go.sum sessiongate/
 COPY admin/server/go.mod admin/server/go.sum admin/server/
+ENV GOPROXY='https://proxy.golang.org|direct'
 RUN cd admin/server && go mod download
 WORKDIR /app
 COPY internal/ internal/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,7 @@ ARG PLATFORM
 FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
 COPY internal/go.mod internal/go.sum internal/
 COPY backend/go.mod backend/go.sum backend/
+ENV GOPROXY='https://proxy.golang.org|direct'
 RUN cd backend && go mod download
 WORKDIR /app
 COPY internal/ internal/

--- a/dev-infrastructure/openshift-ci/Dockerfile
+++ b/dev-infrastructure/openshift-ci/Dockerfile
@@ -34,6 +34,10 @@ RUN ARCH=$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "amd64") && \
     mv prometheus-${PROMTOOL_VERSION}.linux-${ARCH}/promtool /usr/local/bin/promtool && \
     chmod +x /usr/local/bin/promtool && \
     rm -rf prometheus-${PROMTOOL_VERSION}.linux-${ARCH}
+# Fall back to direct VCS fetch on any proxy error (pipe separator), not just
+# 404/410 (comma separator). Mitigates chronic HTTP/2 INTERNAL_ERROR stream
+# resets from proxy.golang.org on CI build farms.
+ENV GOPROXY='https://proxy.golang.org|direct'
 # Install Go-based development tools (bingo-managed)
 COPY . /tmp/aro-hcp
 RUN cd /tmp/aro-hcp && \

--- a/fleet/Dockerfile
+++ b/fleet/Dockerfile
@@ -4,6 +4,7 @@ FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25.10-1-
 COPY internal/go.mod internal/go.sum internal/
 COPY mgmt-agent/go.mod mgmt-agent/go.sum mgmt-agent/
 COPY fleet/go.mod fleet/go.sum fleet/
+ENV GOPROXY='https://proxy.golang.org|direct'
 RUN cd fleet && go mod download
 WORKDIR /app
 COPY internal/ internal/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,6 +3,7 @@ ARG PLATFORM
 FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
 COPY internal/go.mod internal/go.sum internal/
 COPY frontend/go.mod frontend/go.sum frontend/
+ENV GOPROXY='https://proxy.golang.org|direct'
 RUN cd frontend && go mod download
 WORKDIR /app
 COPY internal/ internal/

--- a/image-sync/oc-mirror/Dockerfile
+++ b/image-sync/oc-mirror/Dockerfile
@@ -33,6 +33,7 @@ RUN curl -sfL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq
 FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS gobuilder
 WORKDIR /src
 COPY acrauth/go.mod acrauth/go.sum acrauth/
+ENV GOPROXY='https://proxy.golang.org|direct'
 RUN cd acrauth && go mod download
 COPY acrauth/ acrauth/
 # https://github.com/microsoft/go/tree/microsoft/main/eng/doc/fips#build-option-to-require-fips-mode

--- a/kube-applier/Dockerfile
+++ b/kube-applier/Dockerfile
@@ -4,6 +4,7 @@ ARG PLATFORM
 FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
 COPY internal/go.mod internal/go.sum internal/
 COPY kube-applier/go.mod kube-applier/go.sum kube-applier/
+ENV GOPROXY='https://proxy.golang.org|direct'
 RUN cd kube-applier && go mod download
 WORKDIR /app
 COPY internal/ internal/

--- a/mgmt-agent/Dockerfile
+++ b/mgmt-agent/Dockerfile
@@ -4,6 +4,7 @@ ARG PLATFORM
 FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
 COPY internal/go.mod internal/go.sum internal/
 COPY mgmt-agent/go.mod mgmt-agent/go.sum mgmt-agent/
+ENV GOPROXY='https://proxy.golang.org|direct'
 RUN cd mgmt-agent && go mod download
 WORKDIR /app
 COPY internal/ internal/

--- a/sessiongate/Dockerfile
+++ b/sessiongate/Dockerfile
@@ -4,6 +4,7 @@ ARG PLATFORM
 FROM --platform=${PLATFORM} mcr.microsoft.com/oss/go/microsoft/golang:1.25-azurelinux3.0 AS builder
 COPY internal/go.mod internal/go.sum internal/
 COPY sessiongate/go.mod sessiongate/go.sum sessiongate/
+ENV GOPROXY='https://proxy.golang.org|direct'
 RUN cd sessiongate && go mod download
 WORKDIR /app
 COPY internal/ internal/

--- a/test/Containerfile.e2e
+++ b/test/Containerfile.e2e
@@ -3,6 +3,7 @@ USER root
 WORKDIR /opt/app-root/src/github.com/Azure/ARO-HCP
 COPY . .
 ENV GOFLAGS='-mod=readonly'
+ENV GOPROXY='https://proxy.golang.org|direct'
 RUN make build-hcpctl && \
     make -C tooling/templatize templatize && \
     make -C test/ build && \

--- a/tooling/aro-hcp-exporter/Dockerfile
+++ b/tooling/aro-hcp-exporter/Dockerfile
@@ -5,6 +5,7 @@ COPY hcpctl/go.mod hcpctl/go.sum hcpctl/
 COPY metricscache/go.mod metricscache/go.sum metricscache/
 COPY utilitytypes/go.mod utilitytypes/
 COPY aro-hcp-exporter/go.mod aro-hcp-exporter/go.sum aro-hcp-exporter/
+ENV GOPROXY='https://proxy.golang.org|direct'
 RUN cd aro-hcp-exporter && go mod download
 WORKDIR /app
 COPY --exclude=hcpctl/hcpctl hcpctl/ hcpctl/

--- a/tooling/tenant-quota/Dockerfile
+++ b/tooling/tenant-quota/Dockerfile
@@ -6,6 +6,7 @@ COPY internal/go.mod internal/go.sum internal/
 COPY tooling/azutils/go.mod tooling/azutils/go.sum tooling/azutils/
 COPY tooling/metricscache/go.mod tooling/metricscache/go.sum tooling/metricscache/
 COPY tooling/tenant-quota/go.mod tooling/tenant-quota/go.sum tooling/tenant-quota/
+ENV GOPROXY='https://proxy.golang.org|direct'
 RUN cd tooling/tenant-quota && go mod download
 WORKDIR /app
 COPY tooling/azutils/ tooling/azutils/


### PR DESCRIPTION
  ## What

  - Set `GOPROXY='https://proxy.golang.org|direct'` across all Dockerfiles and the CI base image to fall back to direct VCS fetch on any Go module proxy error

  ## Why

  CI builds across multiple build farms are experiencing chronic HTTP/2 stream errors when downloading Go modules from
  `proxy.golang.org : stream error: stream ID NNN; INTERNAL_ERROR; received from peer`

  The Go default `GOPROXY=https://proxy.golang.org,direct` uses a **comma** separator, which only falls back to direct fetch on HTTP 404/410 (module not found). An HTTP/2 `INTERNAL_ERROR` is not a 404, so Go fails hard instead of falling back.

  ## Fix

  The **pipe** (`|`) separator tells Go to fall back to direct VCS fetch on **any** error from the proxy, including HTTP/2 stream resets. The proxy is still tried first for speed and caching, but transient failures no longer block builds.

  Changed in:
  - `dev-infrastructure/openshift-ci/Dockerfile` — CI base image (covers test/lint/e2e jobs)
  - All 10 service Dockerfiles — image builds
  - `test/Containerfile.e2e` — E2E test container


  ## Test plan

  - [ ] CI image builds succeed (`images`, `e2e-images`, `image-updater-images`)
  - [ ] E2E tests pass (`e2e-parallel`)
  - [ ] Verify no regression in module integrity (go.sum still enforced)
