### PR TITLE
Add API version x Operations statistics to e2e tests output

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -22,6 +22,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/Azure/ARO-HCP/test/util/framework"
 )
 
 func TestE2E(t *testing.T) {
@@ -36,5 +38,6 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
+	framework.WriteHCPAPIVersionUsageReport(GinkgoWriter)
 	// Cleanup is done by Resource Group DeferCleanup
 })

--- a/test/util/framework/api_version_usage.go
+++ b/test/util/framework/api_version_usage.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	azcorepolicy "github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	azcoreruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+// hcpAPIVersionUsage records logical calls made through the HCP ARM SDK
+// pipelines. It deliberately runs as a per-call policy, before the Azure SDK
+// retry policy, so a transport retry does not inflate operation usage.
+type hcpAPIVersionUsage struct {
+	mu     sync.Mutex
+	counts map[apiVersionOperation]int
+}
+
+type apiVersionOperation struct {
+	version   string
+	operation string
+}
+
+func newHCPAPIVersionUsage() *hcpAPIVersionUsage {
+	return &hcpAPIVersionUsage{counts: make(map[apiVersionOperation]int)}
+}
+
+func (u *hcpAPIVersionUsage) Do(req *azcorepolicy.Request) (*http.Response, error) {
+	u.record(req)
+	return req.Next()
+}
+
+func (u *hcpAPIVersionUsage) record(req *azcorepolicy.Request) {
+	raw := req.Raw()
+	version := raw.URL.Query().Get("api-version")
+	if version == "" {
+		return
+	}
+
+	operation, _ := raw.Context().Value(azcoreruntime.CtxAPINameKey{}).(string)
+	if operation == "" {
+		operation = fallbackOperationName(raw.Method, raw.URL.Path)
+	}
+
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.counts[apiVersionOperation{version: version, operation: operation}]++
+}
+
+func fallbackOperationName(method, requestPath string) string {
+	resourceID, err := azcorearm.ParseResourceID(requestPath)
+	if err == nil && resourceID.ResourceType.String() != "" {
+		return fmt.Sprintf("%s %s", method, resourceID.ResourceType)
+	}
+	return fmt.Sprintf("%s %s", method, requestPath)
+}
+
+// WriteHCPAPIVersionUsage writes a deterministic API-version-by-operation
+// table. It is safe to call while E2E specs are executing.
+func (u *hcpAPIVersionUsage) WriteHCPAPIVersionUsage(w io.Writer) {
+	u.mu.Lock()
+	entries := make([]apiVersionOperation, 0, len(u.counts))
+	counts := make(map[apiVersionOperation]int, len(u.counts))
+	for entry, count := range u.counts {
+		entries = append(entries, entry)
+		counts[entry] = count
+	}
+	u.mu.Unlock()
+
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "HCP API version usage: no HCP API calls were made")
+		return
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].version != entries[j].version {
+			return entries[i].version < entries[j].version
+		}
+		return entries[i].operation < entries[j].operation
+	})
+
+	versionWidth, operationWidth := len("API version"), len("Operation")
+	for _, entry := range entries {
+		versionWidth = max(versionWidth, len(entry.version))
+		operationWidth = max(operationWidth, len(entry.operation))
+	}
+
+	fmt.Fprintln(w, "HCP API version usage (logical SDK calls; transport retries excluded):")
+	fmt.Fprintf(w, "%-*s  %-*s  %s\n", versionWidth, "API version", operationWidth, "Operation", "Count")
+	fmt.Fprintf(w, "%s  %s  %s\n", strings.Repeat("-", versionWidth), strings.Repeat("-", operationWidth), "-----")
+	for _, entry := range entries {
+		fmt.Fprintf(w, "%-*s  %-*s  %d\n", versionWidth, entry.version, operationWidth, entry.operation, counts[entry])
+	}
+}
+
+var suiteHCPAPIVersionUsage = newHCPAPIVersionUsage()
+
+// WriteHCPAPIVersionUsageReport writes usage accumulated by all HCP client
+// factories created by the E2E framework during this process.
+func WriteHCPAPIVersionUsageReport(w io.Writer) {
+	suiteHCPAPIVersionUsage.WriteHCPAPIVersionUsage(w)
+}

--- a/test/util/framework/api_version_usage_test.go
+++ b/test/util/framework/api_version_usage_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package framework
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+func TestHCPAPIVersionUsageRecordsAPINameAndRendersSortedTable(t *testing.T) {
+	usage := newHCPAPIVersionUsage()
+	usage.record(newPolicyRequest(t, "2026-09-01-preview", "HcpOpenShiftClustersClient.Get"))
+	usage.record(newPolicyRequest(t, "2024-06-10-preview", "NodePoolsClient.Get"))
+	usage.record(newPolicyRequest(t, "2026-09-01-preview", "HcpOpenShiftClustersClient.Get"))
+
+	var report bytes.Buffer
+	usage.WriteHCPAPIVersionUsage(&report)
+
+	expected := "HCP API version usage (logical SDK calls; transport retries excluded):\n" +
+		"API version         Operation                       Count\n" +
+		"------------------  ------------------------------  -----\n" +
+		"2024-06-10-preview  NodePoolsClient.Get             1\n" +
+		"2026-09-01-preview  HcpOpenShiftClustersClient.Get  2\n"
+	if report.String() != expected {
+		t.Fatalf("unexpected report:\n%s", report.String())
+	}
+}
+
+func TestHCPAPIVersionUsageFallsBackToHTTPMethodAndResourceType(t *testing.T) {
+	usage := newHCPAPIVersionUsage()
+	req, err := runtime.NewRequest(context.Background(), http.MethodGet, "https://management.azure.com/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster?api-version=2026-09-01-preview")
+	if err != nil {
+		t.Fatal(err)
+	}
+	usage.record(req)
+
+	var report bytes.Buffer
+	usage.WriteHCPAPIVersionUsage(&report)
+	if want := "GET Microsoft.RedHatOpenShift/hcpOpenShiftClusters"; !bytes.Contains(report.Bytes(), []byte(want)) {
+		t.Fatalf("report did not contain fallback operation %q:\n%s", want, report.String())
+	}
+}
+
+func newPolicyRequest(t *testing.T, apiVersion, operation string) *policy.Request {
+	t.Helper()
+	ctx := context.WithValue(context.Background(), runtime.CtxAPINameKey{}, operation)
+	req, err := runtime.NewRequest(ctx, http.MethodGet, "https://management.azure.com/subscriptions/sub/resourceGroups/rg/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/cluster?api-version="+apiVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return req
+}

--- a/test/util/framework/per_invocation_framework.go
+++ b/test/util/framework/per_invocation_framework.go
@@ -229,6 +229,7 @@ func (tc *perBinaryInvocationTestContext) getHCPClientFactoryOptions() *azcorear
 		}
 	}
 	clientOpts.PerCallPolicies = []policy.Policy{
+		suiteHCPAPIVersionUsage,
 		NewRetryVersionNotFoundPolicy(),
 		&sanitizeAuthHeaderPolicy{},
 	}
@@ -257,6 +258,7 @@ func (tc *perBinaryInvocationTestContext) getHCPClientFactoryOptions() *azcorear
 			&requestIDPolicy{},
 			&armSystemDataPolicy{},
 			&armResourceGroupValidationPolicy{rgClient: &defaultResourceGroupClient{cred: tc.azureCredentials}},
+			suiteHCPAPIVersionUsage,
 			NewRetryVersionNotFoundPolicy(),
 			&sanitizeAuthHeaderPolicy{},
 		}


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

<!-- Briefly describe what this PR does -->

At suite teardown it now prints a table like:
```
  HCP API version usage (logical SDK calls; transport retries excluded):
  API version         Operation                       Count
  ------------------  ------------------------------  -----
  2024-06-10-preview  NodePoolsClient.Get             12
  2026-09-01-preview  HcpOpenShiftClustersClient.Get  34
```

### Why

To be able to quickly figure out the API version usage in e2e tests (important during new API version introduction & old API version retirement).

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
