### PR TITLE
ARO-29505 - fix(validation): reject Azure Key Vault URLs in KMS key fields

### DIFF
--- a/internal/validation/validate_cluster.go
+++ b/internal/validation/validate_cluster.go
@@ -1048,11 +1048,25 @@ func validateKmsKey(ctx context.Context, op operation.Operation, fldPath *field.
 	errs = append(errs, immutableByCompare(ctx, op, fldPath.Child("name"), &newObj.Name, safe.Field(oldObj, toKmsKeyName))...)
 	errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("name"), &newObj.Name, nil)...)
 	errs = append(errs, MaxLen(ctx, op, fldPath.Child("name"), &newObj.Name, nil, 255)...)
+	// Reject URLs or paths in key name to prevent similar confusion as with version field
+	if strings.Contains(newObj.Name, "://") || strings.Contains(newObj.Name, "/") {
+		errs = append(errs, field.Invalid(fldPath.Child("name"), newObj.Name, "must be a bare key name, not a URL or path"))
+	}
 
 	//VaultName string `json:"vaultName"`
 	errs = append(errs, immutableByCompare(ctx, op, fldPath.Child("vaultName"), &newObj.VaultName, safe.Field(oldObj, toKmsKeyVaultName))...)
 	errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("vaultName"), &newObj.VaultName, nil)...)
 	errs = append(errs, MaxLen(ctx, op, fldPath.Child("vaultName"), &newObj.VaultName, nil, 255)...)
+	// Azure Key Vault names have specific constraints:
+	// - 3-24 characters
+	// - Alphanumeric and hyphens only
+	// - Must start with a letter
+	// - Must not end with a hyphen
+	// - No consecutive hyphens
+	// Reject URLs or paths in vaultName to prevent similar confusion as with version field
+	if strings.Contains(newObj.VaultName, "://") || strings.Contains(newObj.VaultName, "/") || strings.Contains(newObj.VaultName, ".") {
+		errs = append(errs, field.Invalid(fldPath.Child("vaultName"), newObj.VaultName, "must be a bare Key Vault name, not a URL or FQDN (e.g., 'myvault' not 'myvault.vault.azure.net')"))
+	}
 
 	//Version   string `json:"version"`
 	// The version field was made mutable in version 2026-06-30-preview.
@@ -1062,6 +1076,16 @@ func validateKmsKey(ctx context.Context, op operation.Operation, fldPath *field.
 	}
 	errs = append(errs, validate.RequiredValue(ctx, op, fldPath.Child("version"), &newObj.Version, nil)...)
 	errs = append(errs, MaxLen(ctx, op, fldPath.Child("version"), &newObj.Version, nil, 255)...)
+	// Reject complete Azure Key Vault key URLs; only accept bare key-version identifiers.
+	// Azure Key Vault key URLs follow the pattern: https://{vault-name}.vault.azure.net/keys/{key-name}/{key-version}
+	// The version field must contain only the key-version identifier, not the full URL.
+	// We check for:
+	// 1. URL scheme indicators (://)
+	// 2. Path separators (/)
+	// 3. Whitespace characters (which are never valid in key versions)
+	if strings.Contains(newObj.Version, "://") || strings.Contains(newObj.Version, "/") || strings.ContainsAny(newObj.Version, " \t\n\r\f\v") {
+		errs = append(errs, field.Invalid(fldPath.Child("version"), newObj.Version, "must be a bare key-version identifier, not a complete Azure Key Vault key URL or path"))
+	}
 
 	return errs
 }

--- a/internal/validation/validate_cluster_comprehensive_test.go
+++ b/internal/validation/validate_cluster_comprehensive_test.go
@@ -1362,6 +1362,180 @@ func TestValidateClusterCreate(t *testing.T) {
 				{Message: "Unsupported value", FieldPath: "customerProperties.ingress.type"},
 			},
 		},
+		{
+			name: "kms key version with full HTTPS URL - create",
+			cluster: func() *coreapi.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = metadataapi.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &coreapi.CustomerManagedEncryptionProfile{
+					EncryptionType: metadataapi.CustomerManagedEncryptionTypeKMS,
+					Kms: &coreapi.KmsEncryptionProfile{
+						Visibility: metadataapi.KeyVaultVisibilityPublic,
+						ActiveKey: coreapi.KmsKey{
+							Name:      "test-key",
+							VaultName: "test-vault",
+							Version:   "https://test-vault.vault.azure.net/keys/test-key/abc123",
+						},
+					},
+				}
+				return c
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be a bare key-version identifier, not a complete Azure Key Vault key URL", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged.kms.activeKey.version"},
+			},
+		},
+		{
+			name: "kms key version with full HTTP URL - create",
+			cluster: func() *coreapi.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = metadataapi.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &coreapi.CustomerManagedEncryptionProfile{
+					EncryptionType: metadataapi.CustomerManagedEncryptionTypeKMS,
+					Kms: &coreapi.KmsEncryptionProfile{
+						Visibility: metadataapi.KeyVaultVisibilityPublic,
+						ActiveKey: coreapi.KmsKey{
+							Name:      "test-key",
+							VaultName: "test-vault",
+							Version:   "http://test-vault.vault.azure.net/keys/test-key/abc123",
+						},
+					},
+				}
+				return c
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be a bare key-version identifier, not a complete Azure Key Vault key URL", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged.kms.activeKey.version"},
+			},
+		},
+		{
+			name: "kms key version with forward slashes - create",
+			cluster: func() *coreapi.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = metadataapi.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &coreapi.CustomerManagedEncryptionProfile{
+					EncryptionType: metadataapi.CustomerManagedEncryptionTypeKMS,
+					Kms: &coreapi.KmsEncryptionProfile{
+						Visibility: metadataapi.KeyVaultVisibilityPublic,
+						ActiveKey: coreapi.KmsKey{
+							Name:      "test-key",
+							VaultName: "test-vault",
+							Version:   "keys/test-key/abc123",
+						},
+					},
+				}
+				return c
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be a bare key-version identifier, not a complete Azure Key Vault key URL", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged.kms.activeKey.version"},
+			},
+		},
+		{
+			name: "kms key version with bare identifier - create",
+			cluster: func() *coreapi.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = metadataapi.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &coreapi.CustomerManagedEncryptionProfile{
+					EncryptionType: metadataapi.CustomerManagedEncryptionTypeKMS,
+					Kms: &coreapi.KmsEncryptionProfile{
+						Visibility: metadataapi.KeyVaultVisibilityPublic,
+						ActiveKey: coreapi.KmsKey{
+							Name:      "test-key",
+							VaultName: "test-vault",
+							Version:   "abc123def456",
+						},
+					},
+				}
+				return c
+			}(),
+			expectErrors: []utils.ExpectedError{},
+		},
+		{
+			name: "kms key version with whitespace - create",
+			cluster: func() *coreapi.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = metadataapi.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &coreapi.CustomerManagedEncryptionProfile{
+					EncryptionType: metadataapi.CustomerManagedEncryptionTypeKMS,
+					Kms: &coreapi.KmsEncryptionProfile{
+						Visibility: metadataapi.KeyVaultVisibilityPublic,
+						ActiveKey: coreapi.KmsKey{
+							Name:      "test-key",
+							VaultName: "test-vault",
+							Version:   "abc 123",
+						},
+					},
+				}
+				return c
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be a bare key-version identifier, not a complete Azure Key Vault key URL or path", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged.kms.activeKey.version"},
+			},
+		},
+		{
+			name: "kms vault name with FQDN - create",
+			cluster: func() *coreapi.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = metadataapi.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &coreapi.CustomerManagedEncryptionProfile{
+					EncryptionType: metadataapi.CustomerManagedEncryptionTypeKMS,
+					Kms: &coreapi.KmsEncryptionProfile{
+						Visibility: metadataapi.KeyVaultVisibilityPublic,
+						ActiveKey: coreapi.KmsKey{
+							Name:      "test-key",
+							VaultName: "test-vault.vault.azure.net",
+							Version:   "abc123",
+						},
+					},
+				}
+				return c
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be a bare Key Vault name, not a URL or FQDN", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged.kms.activeKey.vaultName"},
+			},
+		},
+		{
+			name: "kms vault name with URL - create",
+			cluster: func() *coreapi.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = metadataapi.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &coreapi.CustomerManagedEncryptionProfile{
+					EncryptionType: metadataapi.CustomerManagedEncryptionTypeKMS,
+					Kms: &coreapi.KmsEncryptionProfile{
+						Visibility: metadataapi.KeyVaultVisibilityPublic,
+						ActiveKey: coreapi.KmsKey{
+							Name:      "test-key",
+							VaultName: "https://test-vault.vault.azure.net",
+							Version:   "abc123",
+						},
+					},
+				}
+				return c
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be a bare Key Vault name, not a URL or FQDN", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged.kms.activeKey.vaultName"},
+			},
+		},
+		{
+			name: "kms key name with URL - create",
+			cluster: func() *coreapi.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = metadataapi.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &coreapi.CustomerManagedEncryptionProfile{
+					EncryptionType: metadataapi.CustomerManagedEncryptionTypeKMS,
+					Kms: &coreapi.KmsEncryptionProfile{
+						Visibility: metadataapi.KeyVaultVisibilityPublic,
+						ActiveKey: coreapi.KmsKey{
+							Name:      "https://vault.vault.azure.net/keys/test-key",
+							VaultName: "test-vault",
+							Version:   "abc123",
+						},
+					},
+				}
+				return c
+			}(),
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be a bare key name, not a URL or path", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged.kms.activeKey.name"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1998,6 +2172,45 @@ func TestValidateClusterUpdate(t *testing.T) {
 			opOptions: []string{metadataapi.APIVersionOption(metadataapi.APIVersionV20251223Preview)},
 			expectErrors: []utils.ExpectedError{
 				{Message: "field is immutable", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged.kms.activeKey.version"},
+			},
+		},
+		{
+			name: "kms key version with full URL - update",
+			newCluster: func() *coreapi.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = metadataapi.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &coreapi.CustomerManagedEncryptionProfile{
+					EncryptionType: metadataapi.CustomerManagedEncryptionTypeKMS,
+					Kms: &coreapi.KmsEncryptionProfile{
+						Visibility: metadataapi.KeyVaultVisibilityPublic,
+						ActiveKey: coreapi.KmsKey{
+							Name:      "test-key",
+							VaultName: "test-vault",
+							Version:   "https://test-vault.vault.azure.net/keys/test-key/newversion",
+						},
+					},
+				}
+				return c
+			}(),
+			oldCluster: func() *coreapi.HCPOpenShiftCluster {
+				c := createValidCluster()
+				c.CustomerProperties.Etcd.DataEncryption.KeyManagementMode = metadataapi.EtcdDataEncryptionKeyManagementModeTypeCustomerManaged
+				c.CustomerProperties.Etcd.DataEncryption.CustomerManaged = &coreapi.CustomerManagedEncryptionProfile{
+					EncryptionType: metadataapi.CustomerManagedEncryptionTypeKMS,
+					Kms: &coreapi.KmsEncryptionProfile{
+						Visibility: metadataapi.KeyVaultVisibilityPublic,
+						ActiveKey: coreapi.KmsKey{
+							Name:      "test-key",
+							VaultName: "test-vault",
+							Version:   "oldversion",
+						},
+					},
+				}
+				return c
+			}(),
+			opOptions: []string{metadataapi.APIVersionOption(metadataapi.APIVersionV20260630Preview)},
+			expectErrors: []utils.ExpectedError{
+				{Message: "must be a bare key-version identifier, not a complete Azure Key Vault key URL", FieldPath: "customerProperties.etcd.dataEncryption.customerManaged.kms.activeKey.version"},
 			},
 		},
 		{


### PR DESCRIPTION
<!-- Link to Jira issue -->

### What

The ARM API accepted complete Azure Key Vault key URLs in the etcd.dataEncryption.customerManaged.kms.activeKey fields instead of bare identifiers. This caused the KMS provider to build malformed endpoints (containing the URL twice), resulting in HTTP 400 errors from Azure Key Vault and cluster provisioning failures.

Add validation to reject:
- Full URLs (https://...) in version, vaultName, and name fields
- Path separators (/) that indicate partial URLs or paths
- FQDN format (vault.vault.azure.net) in vaultName
- Whitespace characters in version field

The validation provides clear error messages directing users to supply bare identifiers (e.g., "abc123def456" for version, "myvault" for vaultName) instead of complete URLs.
### Why

<!-- Briefly explain why this change is needed -->

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
