### PR TITLE
chore(api): Backport SDK client name overrides

### DIFF
--- a/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/client.tsp
+++ b/api/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/client.tsp
@@ -1,3 +1,4 @@
+import "./main.tsp";
 import "@azure-tools/typespec-client-generator-core";
 import "@typespec/versioning";
 
@@ -7,6 +8,228 @@ using TypeSpec.Versioning;
 using Azure.ClientGenerator.Core;
 using Azure.ResourceManager;
 using Microsoft.RedHatOpenShift;
+
+// Client name overrides for azure-sdk-for-net
+namespace Microsoft.RedHatOpenShift {
+  // request-body model names must not end with 'Request'
+  @@clientName(
+    HcpOpenShiftClusterAdminCredentialRequest,
+    "HcpOpenShiftClusterAdminCredentialRequestContent",
+    "csharp"
+  );
+
+  // boolean property missing an "Is/Has/Should/Can" prefix
+  @@clientName(NodePoolProperties.autoRepair, "canAutoRepair", "csharp");
+
+  // DateTimeOffset properties must end in "On"
+  @@clientName(
+    HcpOpenShiftClusterAdminCredential.expirationTimestamp,
+    "expirationTimestampOn",
+    "csharp"
+  );
+  @@clientName(
+    HcpOpenShiftVersionProperties.endOfLifeTimestamp,
+    "endOfLifeTimestampOn",
+    "csharp"
+  );
+
+  // Add top-level resource name prefix to cluster model and type names
+  @@clientName(ApiProfile, "HcpOpenShiftClusterApiProfile", "csharp");
+  @@clientName(
+    ClusterAutoscalingProfile,
+    "HcpOpenShiftClusterAutoscalingProfile",
+    "csharp"
+  );
+  @@clientName(
+    ClusterImageRegistryProfile,
+    "HcpOpenShiftClusterImageRegistryProfile",
+    "csharp"
+  );
+  @@clientName(
+    ClusterImageRegistryState,
+    "HcpOpenShiftClusterImageRegistryState",
+    "csharp"
+  );
+  @@clientName(Condition, "HcpOpenShiftClusterCondition", "csharp");
+  @@clientName(ConditionType, "HcpOpenShiftClusterConditionType", "csharp");
+  @@clientName(ConsoleProfile, "HcpOpenShiftClusterConsoleProfile", "csharp");
+  @@clientName(
+    CustomerManagedEncryptionProfile,
+    "HcpOpenShiftClusterCustomerManagedEncryptionProfile",
+    "csharp"
+  );
+  @@clientName(
+    CustomerManagedEncryptionType,
+    "HcpOpenShiftClusterCustomerManagedEncryptionType",
+    "csharp"
+  );
+  @@clientName(DnsProfile, "HcpOpenShiftClusterDnsProfile", "csharp");
+  @@clientName(
+    EtcdDataEncryptionKeyManagementModeType,
+    "HcpOpenShiftClusterEtcdDataEncryptionKeyManagementModeType",
+    "csharp"
+  );
+  @@clientName(
+    EtcdDataEncryptionProfile,
+    "HcpOpenShiftClusterEtcdDataEncryptionProfile",
+    "csharp"
+  );
+  @@clientName(EtcdProfile, "HcpOpenShiftClusterEtcdProfile", "csharp");
+  @@clientName(
+    ImageDigestMirror,
+    "HcpOpenShiftClusterImageDigestMirror",
+    "csharp"
+  );
+  @@clientName(ImageRepository, "HcpOpenShiftClusterImageRepository", "csharp");
+  @@clientName(IngressProfile, "HcpOpenShiftClusterIngressProfile", "csharp");
+  @@clientName(IngressType, "HcpOpenShiftClusterIngressType", "csharp");
+  @@clientName(
+    KeyVaultVisibility,
+    "HcpOpenShiftClusterKeyVaultVisibility",
+    "csharp"
+  );
+  @@clientName(
+    KmsEncryptionProfile,
+    "HcpOpenShiftClusterKmsEncryptionProfile",
+    "csharp"
+  );
+  @@clientName(KmsKey, "HcpOpenShiftClusterKmsKey", "csharp");
+  @@clientName(NetworkProfile, "HcpOpenShiftClusterNetworkProfile", "csharp");
+  @@clientName(NetworkType, "HcpOpenShiftClusterNetworkType", "csharp");
+  @@clientName(
+    OperatorsAuthenticationProfile,
+    "HcpOpenShiftClusterOperatorsAuthenticationProfile",
+    "csharp"
+  );
+  @@clientName(OutboundType, "HcpOpenShiftClusterOutboundType", "csharp");
+  @@clientName(PlatformProfile, "HcpOpenShiftClusterPlatformProfile", "csharp");
+  @@clientName(ResourceStatus, "HcpOpenShiftClusterResourceStatus", "csharp");
+  @@clientName(StatusType, "HcpOpenShiftClusterConditionStatusType", "csharp");
+  @@clientName(
+    UserAssignedIdentitiesProfile,
+    "HcpOpenShiftClusterUserAssignedIdentitiesProfile",
+    "csharp"
+  );
+  @@clientName(VersionProfile, "HcpOpenShiftClusterVersionProfile", "csharp");
+  @@clientName(Visibility, "HcpOpenShiftClusterApiVisibility", "csharp");
+
+  // Add top-level resource name prefix to node pool model and type names
+  @@clientName(
+    DiskStorageAccountType,
+    "HcpOpenShiftClusterNodePoolDiskStorageAccountType",
+    "csharp"
+  );
+  @@clientName(Effect, "HcpOpenShiftClusterNodePoolTaintEffect", "csharp");
+  @@clientName(Label, "HcpOpenShiftClusterNodePoolLabel", "csharp");
+  @@clientName(NodePool, "HcpOpenShiftClusterNodePool", "csharp");
+  @@clientName(
+    NodePoolAutoScaling,
+    "HcpOpenShiftClusterNodePoolAutoScaling",
+    "csharp"
+  );
+  @@clientName(
+    NodePoolPlatformProfile,
+    "HcpOpenShiftClusterNodePoolPlatformProfile",
+    "csharp"
+  );
+  @@clientName(
+    NodePoolProperties,
+    "HcpOpenShiftClusterNodePoolProperties",
+    "csharp"
+  );
+  @@clientName(
+    NodePoolVersionProfile,
+    "HcpOpenShiftClusterNodePoolVersionProfile",
+    "csharp"
+  );
+  @@clientName(NodePools, "HcpOpenShiftClusterNodePools", "csharp");
+  @@clientName(
+    OsDiskProfile,
+    "HcpOpenShiftClusterNodePoolOsDiskProfile",
+    "csharp"
+  );
+  @@clientName(OsDiskType, "HcpOpenShiftClusterNodePoolOsDiskType", "csharp");
+  @@clientName(Taint, "HcpOpenShiftClusterNodePoolTaint", "csharp");
+
+  // Add top-level resource name prefix to external auth model and type names
+  @@clientName(ExternalAuth, "HcpOpenShiftClusterExternalAuth", "csharp");
+  @@clientName(
+    ExternalAuthClaimProfile,
+    "HcpOpenShiftClusterExternalAuthClaimProfile",
+    "csharp"
+  );
+  @@clientName(
+    ExternalAuthClientComponentProfile,
+    "HcpOpenShiftClusterExternalAuthClientComponentProfile",
+    "csharp"
+  );
+  @@clientName(
+    ExternalAuthClientProfile,
+    "HcpOpenShiftClusterExternalAuthClientProfile",
+    "csharp"
+  );
+  @@clientName(
+    ExternalAuthClientType,
+    "HcpOpenShiftClusterExternalAuthClientType",
+    "csharp"
+  );
+  @@clientName(
+    ExternalAuthCondition,
+    "HcpOpenShiftClusterExternalAuthCondition",
+    "csharp"
+  );
+  @@clientName(
+    ExternalAuthConditionType,
+    "HcpOpenShiftClusterExternalAuthConditionType",
+    "csharp"
+  );
+  @@clientName(
+    ExternalAuthProperties,
+    "HcpOpenShiftClusterExternalAuthProperties",
+    "csharp"
+  );
+  @@clientName(ExternalAuths, "HcpOpenShiftClusterExternalAuths", "csharp");
+  @@clientName(
+    GroupClaimProfile,
+    "HcpOpenShiftClusterExternalAuthGroupClaimProfile",
+    "csharp"
+  );
+  @@clientName(
+    TokenClaimMappingsProfile,
+    "HcpOpenShiftClusterExternalAuthTokenClaimMappingsProfile",
+    "csharp"
+  );
+  @@clientName(
+    TokenClaimValidationRule,
+    "HcpOpenShiftClusterExternalAuthTokenClaimValidationRule",
+    "csharp"
+  );
+  @@clientName(
+    TokenIssuerProfile,
+    "HcpOpenShiftClusterExternalAuthTokenIssuerProfile",
+    "csharp"
+  );
+  @@clientName(
+    TokenRequiredClaim,
+    "HcpOpenShiftClusterExternalAuthTokenRequiredClaim",
+    "csharp"
+  );
+  @@clientName(
+    TokenValidationRuleType,
+    "HcpOpenShiftClusterExternalAuthTokenValidationRuleType",
+    "csharp"
+  );
+  @@clientName(
+    UsernameClaimPrefixPolicy,
+    "HcpOpenShiftClusterExternalAuthUsernameClaimPrefixPolicy",
+    "csharp"
+  );
+  @@clientName(
+    UsernameClaimProfile,
+    "HcpOpenShiftClusterExternalAuthUsernameClaimProfile",
+    "csharp"
+  );
+}
 
 // JavaScript SDK visibility workaround:
 // For write operations whose body models contain server-side read-only properties
@@ -206,4 +429,10 @@ model HcpOpenShiftClusterUpdate is UpdateableProperties<HcpOpenShiftCluster>;
   NodePools.update::parameters.properties,
   UpdateableProperties<NodePoolProperties>,
   "javascript"
+);
+
+@@clientName(
+  Microsoft.RedHatOpenShift,
+  "RedHatOpenShiftHcpMgmtClient",
+  "python"
 );


### PR DESCRIPTION
### What

Backport SDK client name overrides from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/redhatopenshift/resource-manager/Microsoft.RedHatOpenShift/hcpopenshiftclusters/client.tsp).  These are mostly for the .NET SDK.

### Why

These overrides were necessary to complete the [2026-09-01-preview release plan](https://azsdk-releaseplan-dashboard-hveph5aqhhcfhtgu.westus-01.azurewebsites.net/?releasePlan=36142).

### Testing

No additional tests required.  This is merely to synchronize with another git repo.

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
