### PR TITLE
fix: gate fleet registration on full management cluster readiness

### DIFF
--- a/fleet/registration/pipeline.yaml
+++ b/fleet/registration/pipeline.yaml
@@ -123,9 +123,19 @@ resourceGroups:
     - resourceGroup: global
       step: mirror-image
     externalDependsOn:
+    # we wait for CS installation because fleet needs to register the MC with CS
+    - serviceGroup: Microsoft.Azure.ARO.HCP.ClusterService
+      resourceGroup: service
+      step: deploy
+    # we wait for Maestro Server installation because fleet needs to register the MC with Maestro Server
+    - serviceGroup: Microsoft.Azure.ARO.HCP.Maestro.Server
+      resourceGroup: service
+      step: deploy
+    # we wait for the fleet service because the registration runs towards that
     - serviceGroup: Microsoft.Azure.ARO.HCP.Fleet
       resourceGroup: service
       step: deploy
+    # the rest of the deps make sure the MC installation is complete
     - serviceGroup: Microsoft.Azure.ARO.HCP.ACM
       resourceGroup: management
       step: deploy-policies
@@ -136,6 +146,15 @@ resourceGroups:
       resourceGroup: management
       step: deploy
     - serviceGroup: Microsoft.Azure.ARO.HCP.Maestro.Agent
+      resourceGroup: management
+      step: deploy
+    - serviceGroup: Microsoft.Azure.ARO.HCP.MgmtAgent
+      resourceGroup: management
+      step: deploy
+    - serviceGroup: Microsoft.Azure.ARO.HCP.Velero
+      resourceGroup: management
+      step: deploy-velero
+    - serviceGroup: Microsoft.Azure.ARO.HCP.SecretSyncController
       resourceGroup: management
       step: deploy
     identityFrom:

--- a/tooling/templatize/internal/well_formed_test.go
+++ b/tooling/templatize/internal/well_formed_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/Azure/ARO-Tools/config"
 	"github.com/Azure/ARO-Tools/config/ev2config"
+	configtypes "github.com/Azure/ARO-Tools/config/types"
 	"github.com/Azure/ARO-Tools/pipelines/graph"
 	"github.com/Azure/ARO-Tools/pipelines/topology"
 	"github.com/Azure/ARO-Tools/pipelines/types"
@@ -28,8 +29,15 @@ import (
 	"github.com/Azure/ARO-HCP/tooling/templatize/cmd/entrypoint/entrypointutils"
 )
 
-func TestStepsWellFormed(t *testing.T) {
-	repoRootDir := "../../../"
+// repoRootDir is relative to this package (tooling/templatize/internal).
+const repoRootDir = "../../../"
+
+// loadDevTopologyAndConfig loads topology.yaml and a fully resolved dev configuration,
+// shared by every well-formedness test in this file. The exact cloud/region/stamp values
+// don't matter: callers only care about the static structure of pipelines and topology.
+func loadDevTopologyAndConfig(t *testing.T) (*topology.CombinedTopology, configtypes.Configuration) {
+	t.Helper()
+
 	configFile := filepath.Join(repoRootDir, "config", "config.yaml")
 	configProvider, err := config.NewConfigProvider(configFile)
 	if err != nil {
@@ -67,6 +75,12 @@ func TestStepsWellFormed(t *testing.T) {
 	if err := topo.Validate(); err != nil {
 		t.Fatalf("failed to validate topology: %v", err)
 	}
+
+	return topo, cfg
+}
+
+func TestStepsWellFormed(t *testing.T) {
+	topo, cfg := loadDevTopologyAndConfig(t)
 
 	for _, entrypoint := range topo.Entrypoints {
 		t.Run(entrypoint.Identifier, func(t *testing.T) {
@@ -109,5 +123,62 @@ func TestStepsWellFormed(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestFleetRegistrationGatesOnManagementInfraSiblings guards against a specific footgun:
+// fleet/registration/pipeline.yaml intentionally waits (via externalDependsOn) on every other
+// service deployed alongside it under Microsoft.Azure.ARO.HCP.Management.Infra, so that fleet
+// never registers a management cluster with CosmosDB before that cluster is truly ready. There is
+// no wildcard "wait for the whole resource group" dependency in the pipeline schema, so that list
+// is maintained by hand and topology.yaml is the only source of truth for what belongs in it. If a
+// new sibling is added under Management.Infra without updating fleet/registration/pipeline.yaml,
+// this test catches the drift instead of registration silently racing an unready cluster. a
+func TestFleetRegistrationGatesOnManagementInfraSiblings(t *testing.T) {
+	const (
+		globalGroup            = "Microsoft.Azure.ARO.HCP.Global"
+		managementInfraGroup   = "Microsoft.Azure.ARO.HCP.Management.Infra"
+		fleetRegistrationGroup = "Microsoft.Azure.ARO.HCP.Fleet.Registration"
+	)
+
+	topo, cfg := loadDevTopologyAndConfig(t)
+
+	managementInfra, err := topo.Lookup(managementInfraGroup)
+	if err != nil {
+		t.Fatalf("failed to look up %s in topology: %v", managementInfraGroup, err)
+	}
+
+	root, err := topo.Lookup(globalGroup)
+	if err != nil {
+		t.Fatalf("failed to look up %s in topology: %v", globalGroup, err)
+	}
+	pipelines := map[string]*types.Pipeline{}
+	if err := entrypointutils.LoadPipelines(root, topo, pipelines, cfg); err != nil {
+		t.Fatalf("failed to load pipelines: %v", err)
+	}
+
+	fleetRegistration, ok := pipelines[fleetRegistrationGroup]
+	if !ok {
+		t.Fatalf("pipeline for %s was not loaded from topology", fleetRegistrationGroup)
+	}
+
+	awaited := map[string]bool{}
+	for _, rg := range fleetRegistration.ResourceGroups {
+		for _, step := range rg.Steps {
+			for _, dep := range step.ExternalDependencies() {
+				awaited[dep.ServiceGroup] = true
+			}
+		}
+	}
+
+	for _, sibling := range managementInfra.Children {
+		if sibling.ServiceGroup == fleetRegistrationGroup {
+			continue // fleet registration cannot depend on itself
+		}
+		if !awaited[sibling.ServiceGroup] {
+			t.Errorf("%s was added under %s in topology.yaml but fleet/registration/pipeline.yaml has no "+
+				"externalDependsOn entry for it; add one (or document here why it's safe to skip) so fleet "+
+				"registration keeps gating on a fully-deployed management cluster", sibling.ServiceGroup, managementInfraGroup)
+		}
 	}
 }


### PR DESCRIPTION
### What
Add `externalDependsOn` entries to `fleet/registration/pipeline.yaml` so registration
waits for ClusterService, Maestro Server, and Fleet (service tier) plus ACM,
RP.HypershiftOperator, KubeApplier, Maestro.Agent, MgmtAgent, Velero, and
SecretSyncController (every other service under `Management.Infra` in `topology.yaml`).
Also fixes the Velero step reference (`deploy-velero`, not `deploy`).

Adds `TestFleetRegistrationGatesOnManagementInfraSiblings`
(`tooling/templatize/internal/well_formed_test.go`), which fails if a service is added
under `Management.Infra` without a matching `externalDependsOn` entry, since this list
is hand-maintained with no schema-level "wait for the whole resource group" option.

**CI/CD config change:** modifies `fleet/registration/pipeline.yaml` (EV2 pipeline
definition).

### Why
Fleet registration previously had no `externalDependsOn` at all, so it could start
before ClusterService, Maestro Server, or Fleet were up — as well as before any
management-cluster component (ACM, HyperShift operator, agents, backup/secret-sync)
had deployed. Automated retries mean this eventually self-heals, but the race produces
unnecessary noisy failures during rollout on both the svc and mgmt clusters. The new
test turns future drift in this hand-maintained list into a build failure instead of a
silent gap.

No tracking ticket exists; explaining here per CONTRIBUTING.md's allowance.

### Testing
- `go test ./internal/... -run 'TestFleetRegistrationGatesOnManagementInfraSiblings|TestStepsWellFormed' -v -count=1`
  from `tooling/templatize`: both pass. `TestStepsWellFormed` also caught the wrong
  Velero step name before it was fixed here.
- Verified the new test fails when a `Management.Infra` sibling is dropped from
  `externalDependsOn`.

### PR Checklist
- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue (none exists; explained above)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide) — pending
- [x] Commit history is clean
- [x] Tricky code blocks are commented
- [ ] Specific reviewers tagged