### PR TITLE
fix: increase pipeline step timeout to accommodate slower provisioning

### DIFF
--- a/tooling/templatize/pkg/pipeline/istio.go
+++ b/tooling/templatize/pkg/pipeline/istio.go
@@ -112,7 +112,7 @@ func runIstioUpgradeStep(id graph.Identifier, step *types.IstioUpgradeStep, ctx 
 		opts.OverallTimeout = d
 	} else {
 		// Rely on the pipeline runner context; DefaultUpgradeOptions uses 60m which would
-		// disagree with the runner's 30m default when timeout is unset in YAML.
+		// disagree with the runner's 45m default when timeout is unset in YAML.
 		opts.OverallTimeout = 0
 	}
 

--- a/tooling/templatize/pkg/pipeline/run.go
+++ b/tooling/templatize/pkg/pipeline/run.go
@@ -53,7 +53,7 @@ var DefaultDeploymentTimeoutSeconds = 30 * 6
 
 // defaultStepContextTimeout is the outer sanity timeout for a pipeline step when
 // the step definition does not specify a type-specific override.
-const defaultStepContextTimeout = 30 * time.Minute
+const defaultStepContextTimeout = 45 * time.Minute
 
 func compressTimingMetadata() bool {
 	ret, _ := strconv.ParseBool(os.Getenv("COMPRESS_TIMING_METADATA"))

--- a/tooling/templatize/pkg/pipeline/run_test.go
+++ b/tooling/templatize/pkg/pipeline/run_test.go
@@ -1140,12 +1140,14 @@ func TestStepContextTimeout(t *testing.T) {
 	t.Run("helm with timeout still uses default outer", func(t *testing.T) {
 		d, err := stepContextTimeout(&types.HelmStep{Timeout: "10m"})
 		assert.NoError(t, err)
+		assert.Equal(t, 45*time.Minute, d)
 		assert.Equal(t, defaultStepContextTimeout, d)
 	})
 
 	t.Run("shell uses default outer", func(t *testing.T) {
 		d, err := stepContextTimeout(&types.ShellStep{Timeout: "10m"})
 		assert.NoError(t, err)
+		assert.Equal(t, 45*time.Minute, d)
 		assert.Equal(t, defaultStepContextTimeout, d)
 	})
 
@@ -1155,9 +1157,10 @@ func TestStepContextTimeout(t *testing.T) {
 		assert.Equal(t, 60*time.Minute, d)
 	})
 
-	t.Run("istio upgrade unset defaults to 30m", func(t *testing.T) {
+	t.Run("istio upgrade unset defaults to 45m", func(t *testing.T) {
 		d, err := stepContextTimeout(&types.IstioUpgradeStep{})
 		assert.NoError(t, err)
+		assert.Equal(t, 45*time.Minute, d)
 		assert.Equal(t, defaultStepContextTimeout, d)
 	})
 


### PR DESCRIPTION
Provisioning is taking longer than usual, so the existing 30-minute pipeline step timeout  is failing at provisioning before it completes. Increase the default outer step timeout to 45 minutes to give these steps more time to finish.

This changes the shared default for pipeline steps without a type-specific override. It provides additional time for provisioning; it does not address the underlying slowdown. The E2E run will help validate whether the additional time is sufficient.

Validation: unit tests, integration tests, lint, and verify passed when checked; the E2E parallel check was still pending.

Tracking: no issue is linked yet; this PR is a focused timeout mitigation for the observed provisioning slowdown.
