### PR TITLE
fix: reduce DEV E2E slot capacity

### DIFF
--- a/test/e2e-config/e2e-slots.yaml
+++ b/test/e2e-config/e2e-slots.yaml
@@ -7,33 +7,33 @@ environments:
     pools:
     # Jobs choose the runtime region; `region` is only the default when no runtime override is provided.
     # Identity containers are provisioned in westus3.
-    # Each managed subscription keeps 300 containers split into five 60-container job slots.
+    # Each managed subscription exposes 120 containers split into two 60-container job slots.
     - subscription_name: "ARO HCP E2E Hosted Clusters (EA Subscription)"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard0-slot
-      slot_count: 5
+      slot_count: 2
       identity_container_prefix: aro-hcp-msi-container-dev-shard0
       identity_container_count: 60
     - subscription_name: "ARO HCP E2E Hosted Clusters 2 (EA Subscription)"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard1-slot
-      slot_count: 5
+      slot_count: 2
       identity_container_prefix: aro-hcp-msi-container-dev-shard1
       identity_container_count: 60
     - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 02"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard2-slot
-      slot_count: 5
+      slot_count: 2
       identity_container_prefix: aro-hcp-msi-container-dev-shard2
       identity_container_count: 60
     - subscription_name: "ARO HCP E2E Hosted Clusters - Dev - 03"
       region: westus3
       region_mode: runtime-selected
       resource_type: aro-hcp-dev-shard3-slot
-      slot_count: 5
+      slot_count: 2
       identity_container_prefix: aro-hcp-msi-container-dev-shard3
       identity_container_count: 60
     - subscription_name: "Hypershift Managed Azure"


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AROSLSRE-2093

### What

Reduce each of the four managed DEV E2E customer-subscription pools from five slots to two. This lowers the slot-manager catalog ceiling from 20 concurrent E2E jobs to eight while retaining 60 managed-identity containers per job.

### Why

All DEV `e2e-parallel` jobs provision their `ci01` service and management AKS clusters in the same infrastructure subscription and currently target `canadacentral`. Allowing 20 environments to provision concurrently creates overlapping AKS cluster and agent-pool operations and has produced operation-status throttling and provisioning timeouts.

Reducing the per-subscription slot count limits shared underlay provisioning pressure without reducing within-run test parallelism or deleting existing Azure identity-container resources.

### Testing

- `go test ./cmd/aro-hcp-tests/slot-manager/...` from `test/`
- `make verify-yamlfmt`

No new test was added because this changes catalog capacity only; the existing slot-manager catalog and expansion tests cover slot enumeration.

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows Conventional Commits format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots not applicable (configuration-only change)
- [x] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR not required; implementation and local validation are complete
- [x] Commit history is clean
- [x] No tricky code blocks added
- [x] Specific reviewer requested
- [x] No open comment threads