### PR TITLE
feat: snapshot resources in "route.openshift.io"

### DIFF
--- a/mgmt-agent/pkg/controller/resourcewatcher.go
+++ b/mgmt-agent/pkg/controller/resourcewatcher.go
@@ -42,6 +42,7 @@ var watchedGroupSuffixes = []string{
 	"multicluster.openshift.io",
 	"multitenancy.acn.azure.com",
 	"velero.io",
+	"route.openshift.io",
 }
 
 // watchedBuiltinGVRs is the hardcoded list of built-in (non-CRD)

--- a/mgmt-agent/pkg/controller/resourcewatcher_test.go
+++ b/mgmt-agent/pkg/controller/resourcewatcher_test.go
@@ -44,6 +44,7 @@ func TestMatchesGroupSuffix(t *testing.T) {
 		{"fake-open-cluster-management.io", false},
 		{"notcluster.x-k8s.io", false},
 		{"x-k8s.io", false},
+		{"route.openshift.io", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### What

feat: snapshot resources in "route.openshift.io"

### Why

So that we can debug situations like HostedCluster not being available because kas loadbalancer health is failing

```
{"lastTransitionTime":"2026-09-11T06:05:57.0000000Z","message":"APIServer external route not admitted","reason":"KASLoadBalancerNotReachable","status":"False","type":"Available","observedGeneration":6}
```

Along side this PR, we need the sharedingress snapshot as well and that will be taken care of by https://github.com/Azure/ARO-HCP/pull/6894

### Testing

Testing is required for feature completion and tests should be part of the pull
request along with the feature changes.

Describe the testing provided. If you did not add tests, provide a clear
justification.

- Unit tests
- [Integration tests](https://github.com/Azure/ARO-HCP/tree/main/test-integration)
- [E2E tests](https://github.com/Azure/ARO-HCP/blob/main/test/e2e/README.md)

### Special notes for your reviewer

<!-- optional -->

### PR Checklist

- [ ] PR is scoped to a single task (no mixed concerns)
- [ ] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [ ] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue
- [ ] Screenshots included (if dashboards or other UI changes)
- [ ] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [ ] Draft PR used for WIP (if applicable)
- [ ] Commit history is clean (rebased/squashed)
- [ ] Tricky code blocks are commented
- [ ] Specific reviewers tagged
- [ ] All comment threads resolved before merge

If E2E tests are included:

- [ ] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [ ] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
