### PR TITLE
fix: lowercase name in node pool scoped readdesire

### DIFF
--- a/backend/pkg/controllers/nodepool/readdesires/create_nodepool_scoped_read_desires_controller.go
+++ b/backend/pkg/controllers/nodepool/readdesires/create_nodepool_scoped_read_desires_controller.go
@@ -142,7 +142,10 @@ func (c *createNodePoolScopedReadDesiresSyncer) SyncOnce(ctx context.Context, ke
 	}
 	csClusterID := existingNodePool.ServiceProviderProperties.ClusterServiceID.ClusterID()
 
-	target := nodePoolTarget(c.hostedClusterNamespaceEnvIdentifier, csClusterID, csClusterDomainPrefix, existingNodePool.ID.Name)
+	// CS lowercases the ARM node pool name for both its internal node pool ID and the
+	// AzureNodePool.ResourceName it derives the Hypershift NodePool object's name from
+	// (see internal/ocm/convert.go's BuildCSNodePool), so the target name here must match.
+	target := nodePoolTarget(c.hostedClusterNamespaceEnvIdentifier, csClusterID, csClusterDomainPrefix, strings.ToLower(existingNodePool.ID.Name))
 
 	kaClient := c.kubeApplierDBClients.For(ctx, mcResourceID)
 	if kaClient == nil {

--- a/backend/pkg/controllers/nodepool/readdesires/create_nodepool_scoped_read_desires_controller_test.go
+++ b/backend/pkg/controllers/nodepool/readdesires/create_nodepool_scoped_read_desires_controller_test.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package readdesires
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	azcorearm "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+
+	"github.com/Azure/ARO-HCP/backend/pkg/utils/controllerutils"
+	"github.com/Azure/ARO-HCP/internal/api/coreapi"
+	"github.com/Azure/ARO-HCP/internal/api/fleetapi"
+	"github.com/Azure/ARO-HCP/internal/api/metadataapi"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/corecosmosstoragetesting"
+	"github.com/Azure/ARO-HCP/internal/database/cosmosstoragetesting/kubeappliercosmosstoragetesting"
+	"github.com/Azure/ARO-HCP/internal/database/listertesting/corelistertesting"
+	"github.com/Azure/ARO-HCP/internal/database/listertesting/fleetlistertesting"
+	"github.com/Azure/ARO-HCP/internal/database/listertesting/kubeapplierlistertesting"
+	"github.com/Azure/ARO-HCP/internal/utils"
+)
+
+const (
+	nodePoolReadDesireTestSubscriptionID    = "00000000-0000-0000-0000-000000000000"
+	nodePoolReadDesireTestResourceGroupName = "test-rg"
+	nodePoolReadDesireTestClusterName       = "test-cluster"
+	nodePoolReadDesireTestEnvIdentifier     = "int"
+	nodePoolReadDesireTestDomainPrefix      = "cluster1"
+	nodePoolReadDesireTestClusterServiceID  = "/api/clusters_mgmt/v1/clusters/abc123"
+)
+
+var nodePoolReadDesireTestManagementClusterResourceID = metadataapi.Must(azcorearm.ParseResourceID(
+	"/providers/microsoft.redhatopenshift/stamps/1/managementclusters/default",
+))
+
+func nodePoolReadDesireTestKey(nodePoolName string) controllerutils.HCPNodePoolKey {
+	return controllerutils.HCPNodePoolKey{
+		SubscriptionID:    nodePoolReadDesireTestSubscriptionID,
+		ResourceGroupName: nodePoolReadDesireTestResourceGroupName,
+		HCPClusterName:    nodePoolReadDesireTestClusterName,
+		HCPNodePoolName:   nodePoolName,
+	}
+}
+
+func newTestNodePoolCluster(opts ...func(*coreapi.HCPOpenShiftCluster)) *coreapi.HCPOpenShiftCluster {
+	resourceID := metadataapi.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + nodePoolReadDesireTestSubscriptionID +
+			"/resourceGroups/" + nodePoolReadDesireTestResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + nodePoolReadDesireTestClusterName,
+	))
+	cluster := &coreapi.HCPOpenShiftCluster{
+		CosmosMetadata: coreapi.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+		},
+		TrackedResource: coreapi.TrackedResource{
+			Resource: coreapi.Resource{
+				ID:   resourceID,
+				Name: nodePoolReadDesireTestClusterName,
+				Type: resourceID.ResourceType.String(),
+			},
+		},
+		ServiceProviderProperties: coreapi.HCPOpenShiftClusterServiceProviderProperties{
+			ClusterServiceID: metadataapi.Ptr(metadataapi.Must(metadataapi.NewInternalID(nodePoolReadDesireTestClusterServiceID))),
+		},
+		CustomerProperties: coreapi.HCPOpenShiftClusterCustomerProperties{
+			DNS: coreapi.CustomerDNSProfile{
+				BaseDomainPrefix: nodePoolReadDesireTestDomainPrefix,
+			},
+		},
+	}
+	for _, opt := range opts {
+		opt(cluster)
+	}
+	return cluster
+}
+
+func newTestNodePoolSPC(mcResourceID *azcorearm.ResourceID, opts ...func(*coreapi.ServiceProviderCluster)) *coreapi.ServiceProviderCluster {
+	spcResourceID := metadataapi.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + nodePoolReadDesireTestSubscriptionID +
+			"/resourceGroups/" + nodePoolReadDesireTestResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + nodePoolReadDesireTestClusterName +
+			"/serviceProviderClusters/" + coreapi.ServiceProviderClusterResourceName,
+	))
+	spc := &coreapi.ServiceProviderCluster{
+		CosmosMetadata: coreapi.CosmosMetadata{
+			ResourceID:   spcResourceID,
+			PartitionKey: strings.ToLower(spcResourceID.SubscriptionID),
+		},
+		Status: coreapi.ServiceProviderClusterStatus{
+			ManagementClusterResourceID: mcResourceID,
+		},
+	}
+	for _, opt := range opts {
+		opt(spc)
+	}
+	return spc
+}
+
+// newTestNodePool builds an HCPOpenShiftClusterNodePool named name. name is used verbatim
+// (not lowercased) so tests can exercise ARM node pool names containing uppercase letters,
+// which Cluster Service lowercases when naming the corresponding Hypershift NodePool object.
+func newTestNodePool(name string, opts ...func(*coreapi.HCPOpenShiftClusterNodePool)) *coreapi.HCPOpenShiftClusterNodePool {
+	resourceID := metadataapi.Must(azcorearm.ParseResourceID(
+		"/subscriptions/" + nodePoolReadDesireTestSubscriptionID +
+			"/resourceGroups/" + nodePoolReadDesireTestResourceGroupName +
+			"/providers/Microsoft.RedHatOpenShift/hcpOpenShiftClusters/" + nodePoolReadDesireTestClusterName +
+			"/nodePools/" + name,
+	))
+	nodePool := &coreapi.HCPOpenShiftClusterNodePool{
+		CosmosMetadata: coreapi.CosmosMetadata{
+			ResourceID:   resourceID,
+			PartitionKey: strings.ToLower(resourceID.SubscriptionID),
+		},
+		TrackedResource: coreapi.TrackedResource{
+			Resource: coreapi.Resource{
+				ID:   resourceID,
+				Name: name,
+				Type: resourceID.ResourceType.String(),
+			},
+		},
+		ServiceProviderProperties: coreapi.HCPOpenShiftClusterNodePoolServiceProviderProperties{
+			ClusterServiceID: metadataapi.Ptr(metadataapi.Must(metadataapi.NewInternalID(
+				nodePoolReadDesireTestClusterServiceID + "/node_pools/" + name,
+			))),
+		},
+	}
+	for _, opt := range opts {
+		opt(nodePool)
+	}
+	return nodePool
+}
+
+func TestCreateNodePoolScopedReadDesires_SyncOnce(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		nodePoolName   string
+		wantTargetName string
+	}{
+		{
+			name:           "already-lowercase node pool name",
+			nodePoolName:   "test-nodepool",
+			wantTargetName: nodePoolReadDesireTestDomainPrefix + "-test-nodepool",
+		},
+		{
+			// Regression test: Cluster Service lowercases the ARM node pool name for
+			// both its internal node pool ID and the AzureNodePool.ResourceName it
+			// derives the Hypershift NodePool object's name from (see
+			// internal/ocm/convert.go's BuildCSNodePool). ARM node pool names may
+			// contain uppercase letters (e.g. "nodepool-128GiB"), so the ReadDesire's
+			// target must lowercase the name too, or kube-applier will watch a
+			// mixed-case object name that never matches the real (lowercase) object
+			// on the management cluster and the NodePool will never be observed.
+			name:           "mixed-case node pool name is lowercased in the ReadDesire target",
+			nodePoolName:   "Test-NodePool",
+			wantTargetName: nodePoolReadDesireTestDomainPrefix + "-test-nodepool",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := utils.ContextWithLogger(context.Background(), testr.New(t))
+
+			mockResourcesDBClient, err := corecosmosstoragetesting.NewMockResourcesDBClientWithResources(ctx, []any{
+				newTestNodePoolCluster(),
+				newTestNodePool(tt.nodePoolName),
+			})
+			require.NoError(t, err)
+
+			mockKubeApplierDBClients := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClients()
+			mockKubeApplierClient, err := kubeappliercosmosstoragetesting.NewMockKubeApplierDBClientWithResources(ctx, nil)
+			require.NoError(t, err)
+			mockKubeApplierDBClients.Register(nodePoolReadDesireTestManagementClusterResourceID, mockKubeApplierClient)
+
+			serviceProviderClusterListerStub := &corelistertesting.SliceServiceProviderClusterLister{
+				ServiceProviderClusters: []*coreapi.ServiceProviderCluster{newTestNodePoolSPC(nodePoolReadDesireTestManagementClusterResourceID)},
+			}
+
+			mcLister := &fleetlistertesting.SliceManagementClusterLister{
+				ManagementClusters: []*fleetapi.ManagementCluster{{CosmosMetadata: coreapi.CosmosMetadata{ResourceID: nodePoolReadDesireTestManagementClusterResourceID}}},
+			}
+
+			syncer := &createNodePoolScopedReadDesiresSyncer{
+				resourcesDBClient:                   mockResourcesDBClient,
+				kubeApplierDBClients:                mockKubeApplierDBClients,
+				serviceProviderClusterLister:        serviceProviderClusterListerStub,
+				readDesireLister:                    &kubeapplierlistertesting.DBReadDesireLister{Clients: mockKubeApplierDBClients, Lister: mcLister},
+				hostedClusterNamespaceEnvIdentifier: nodePoolReadDesireTestEnvIdentifier,
+			}
+
+			err = syncer.SyncOnce(ctx, nodePoolReadDesireTestKey(tt.nodePoolName))
+			require.NoError(t, err)
+
+			crud, err := mockKubeApplierClient.ReadDesiresForNodePool(nodePoolReadDesireTestSubscriptionID, nodePoolReadDesireTestResourceGroupName, nodePoolReadDesireTestClusterName, tt.nodePoolName)
+			require.NoError(t, err)
+
+			readDesire, err := crud.Get(ctx, readDesireNameReadonlyNodePool)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTargetName, readDesire.Spec.TargetItem.Name, "ReadDesire target name must match the (lowercased) name Cluster Service gives the Hypershift NodePool object")
+		})
+	}
+}

--- a/test/e2e/nodepool_update_nodes.go
+++ b/test/e2e/nodepool_update_nodes.go
@@ -40,8 +40,9 @@ var _ = Describe("Customer", func() {
 		labels.MIContainers(1),
 		func(ctx context.Context) {
 			const (
-				customerClusterName  = "np-update-nodes-hcp-cluster"
-				customerNodePoolName = "np-update-nodes"
+				customerClusterName = "np-update-nodes-hcp-cluster"
+				// Upper casing is intentional to regress casing bug: ARO-29572
+				customerNodePoolName = "np-update-NODES"
 				oneNodePoolName      = "np-one-node"
 			)
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ARO-29572

### What

CS lowercases the ARM node pool name for both its internal node pool ID and the AzureNodePool.ResourceName it derives the Hypershift NodePool object's name from (see internal/ocm/convert.go's BuildCSNodePool). The target name used in the node pool scoped readdesire did not do the same, which resulted in no status returned for node pools with uppercase characters in their name.

### Why

Without this fix node pool update operations will perpetually be in an `Updating` state until they timeout.

### Testing

Unit test was added for the readdesire controller.

E2e test `nodepool_update_nodes.go` was updated to use upper case in the node pool name:
```
const (
    customerClusterName  = "np-update-nodes-hcp-cluster"
    customerNodePoolName = "np-update-NODES"
    oneNodePoolName      = "np-one-node"
)
```

Without the fix the test fails due to the update operation timing out, backend logs show the readdesire never observed the node pool:
```
{
...
	"msg": "picked node pool update operation status",
...
	"resource_name": "np-update-nodes",
...
	"message": "[hypershiftNodePool] Hypershift NodePool has not been observed yet",
	"operation_id": "df6c683b-f079-46ba-9586-e3040d2473d9",
	"provisioningState": "Updating"
}
```

With the fix the test succeeds, backend logs show the appropriate `Updating` hypershift status:
```
{
...
	"msg": "picked node pool update operation status",
...
	"provisioningState": "Updating",
	"message": "[hypershiftNodePool] hypershift NodePool status replicas is 2, want 3"
}
```

### PR Checklist

- [x] PR is scoped to a single task (no mixed concerns)
- [x] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Summary explains the "Why" behind the change
- [x] Linked to relevant ticket/issue
- [x] Screenshots included (if dashboards or other UI changes)
- [x] Self-reviewed the diff
- [x] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [x] Commit history is clean (rebased/squashed)
- [x] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [x] All comment threads resolved before merge

If E2E tests are included:

- [x] E2E tests follow [Principles of Good E2E Test Case Design](https://github.com/Azure/ARO-HCP/blob/main/test/AGENTS.md)
- [x] If new E2E use case is covered (via a new test or new check/verifier),
  demonstrate that the test is able to detect a defect/error and fail with
  proper error message and logs which communicates nature of the problem.
