### PR TITLE
chore: keep test/OWNERS up to date

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,6 +1,4 @@
 approvers:
-- deads2k
-- bennerv
 - patriksuba
 - miquelsi
 - mgahagan73


### PR DESCRIPTION
### What

removing bennerv and deads2k from test/OWNERS file

### Why

bennerv has left and deads2k is part of ARO-HCP global approvers

### Testing

No testing required.

### PR Checklist

- [X] PR is scoped to a single task (no mixed concerns)
- [X] Title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
- [X] Summary explains the "Why" behind the change
- [ ] Linked to relevant ticket/issue (NA)
- [ ] Screenshots included (NA)
- [X] Self-reviewed the diff
- [ ] CI/CD checks are passing (ignore Tide)
- [x] Draft PR used for WIP (if applicable)
- [X] Commit history is clean (rebased/squashed)
- [X] Tricky code blocks are commented
- [x] Specific reviewers tagged
- [ ] All comment threads resolved before merge
