### PR TITLE
chore: unpin eastus2 e2e from test tenant

### DIFF
--- a/config/config.msft.clouds-overlay.yaml
+++ b/config/config.msft.clouds-overlay.yaml
@@ -150,25 +150,11 @@ clouds:
             audit:
               connectSocket: true
         regions:
-          eastus2:
-            e2e:
-              regionTest:
-                # eastus2 is pinned to the Test-Tenant sub ("ARO HCP E2E") because
-                # the RH-tenant PROD subs (Prod-00/Prod-01) have every RP-allowed
-                # x64 general-purpose VM SKU restricted (NotAvailableForSubscription)
-                # in this region, which makes node pool creation fail there. The
-                # Test-Tenant sub is unrestricted in eastus2 (it also backs the
-                # eastus2euap canary), so routing eastus2 to it unblocks the gating
-                # job. Revert once the RH subs' SKU restriction is lifted (ARO-28614).
-                allowedSubscriptions: "ARO HCP E2E"
           eastus2euap:
             e2e:
               regionTest:
                 # Canary: eastus2euap is pinned to the Test-Tenant sub, the only
-                # PROD sub onboarded into the canary program. This currently
-                # matches the gating job's baseline ALLOWED_SUBSCRIPTIONS, so it
-                # is a no-op until the non-canary regions are switched to the RH
-                # PROD subs (ARO-28614).
+                # PROD sub onboarded into the canary program.
                 allowedSubscriptions: "ARO HCP E2E"
             kusto:
               location: "eastus2"


### PR DESCRIPTION
## Why

Azure has approved compatible Dsv5 capacity for the Red Hat PROD E2E subscriptions in East US 2. Keeping the temporary Test-Tenant override would unnecessarily prevent the slot manager from leasing the normal `Prod - 00` and `Prod - 01` pools for that region.

## What changed

- Remove the `eastus2` `allowedSubscriptions` override so it inherits the normal PROD subscription pool selection.
- Keep `eastus2euap` pinned to `ARO HCP E2E`, since that remains the only subscription onboarded for the canary region.

## Validation

- `make -C config materialize`
- `make -C config validate`

Tracking: [ARO-29058](https://issues.redhat.com/browse/ARO-29058)